### PR TITLE
Fix two bugs blocking Bandit's use of erlang_quic

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1403,6 +1403,7 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
 
     %% Build transport parameters
     TransportParams0 = #{
+        original_dcid => State#state.original_dcid,  %% RFC 9000 §7.3: server MUST send this
         initial_scid => SCID,
         initial_max_data => MaxData,
         initial_max_stream_data_bidi_local => ?DEFAULT_INITIAL_MAX_STREAM_DATA,
@@ -2594,7 +2595,8 @@ process_tls_message(_Level, ?TLS_CLIENT_HELLO, Body, OriginalMsg,
             ServerHsKeys = #crypto_keys{key = ServerKey, iv = ServerIV, hp = ServerHP, cipher = Cipher},
 
             %% Update DCID from ClientHello SCID
-            ClientSCID = maps:get(scid, TP, <<>>),
+            %% quic_tls decodes the initial_source_connection_id param as initial_scid
+            ClientSCID = maps:get(initial_scid, TP, <<>>),
 
             State0 = State#state{
                 dcid = ClientSCID,


### PR DESCRIPTION
First off, incredible library! I've been overwhelmed with the idea of taking this on, it's great to see someone doing it! And with very little work, I was able to get to this with Bandit:

<img width="1086" height="88" alt="image" src="https://github.com/user-attachments/assets/a51c46cd-de9d-45b8-bdb4-b8904c577ba8" />

All of which is thanks to you! Really incredible effort.

However, in the process of adding HTTP/3 support to Bandit based on this library I've found a few small fixes that came up during testing, both of which are fixed in this PR. 

The first fix uses initial_scid in place of scid when extracting client's SCID from transport params in the ClientHello handler. There was a naming mismatch here between what quic_tls puts in the map and what we were looking for here.

The second fix adds original_dcid to server transport parameters sent in EncryptedExtensions. RFC9000§7.3 mandates that the server echoes the dcid from the client's Initial packet. This was causing curl to fail connecting

Hopefully these are uncontroversial; I *may* have a more structural PR in the near future to better integrate this lib within arbitrary process models (specifically, I'm hoping to eventually integrate most of the connection management code in here into Thousand Island and treat what's here as more of a process-free library in the spirit of Mint et al). That's a ways down the road though; for now I'm focused on a minimal implementation to at least prove out that this works (so far, it does!)