### PR TITLE
Apply erlfmt and elvis linter to codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04]
         include:
           - os: ubuntu-22.04
-            otp: '26.0'
+            otp: '26'
             rebar3: '3.24.0'
           - os: ubuntu-22.04
-            otp: '27.0'
+            otp: '27'
             rebar3: '3.24.0'
           - os: ubuntu-24.04
-            otp: '27.0'
+            otp: '27'
             rebar3: '3.24.0'
           - os: ubuntu-24.04
             otp: '28'
@@ -247,3 +247,33 @@ jobs:
 
       - name: Run XRef
         run: rebar3 xref
+
+  format:
+    name: erlfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: 'nightly'
+
+      - name: Run erlfmt check
+        run: rebar3 fmt --check
+
+  lint:
+    name: Elvis lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: 'nightly'
+
+      - name: Run elvis lint
+        run: rebar3 lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# Agents
+
+Instructions for AI coding agents working on this project.
+
+## Project Overview
+
+Pure Erlang QUIC implementation (RFC 9000/9001) with zero external dependencies. Requires Erlang/OTP 26.0+ and rebar3.
+
+## Required Checks
+
+Every change must be formatted and pass all checks before committing:
+
+```bash
+rebar3 fmt                  # Auto-format (always run first)
+rebar3 compile              # Must compile cleanly
+rebar3 eunit                # Unit tests must pass
+rebar3 lint                 # Elvis linter must pass
+rebar3 dialyzer             # Type checking must pass
+rebar3 xref                 # Cross-reference analysis must pass
+```
+
+## Build & Development Commands
+
+```bash
+rebar3 compile                                    # Build
+rebar3 eunit                                      # Run all EUnit tests
+rebar3 eunit --module=quic_varint_tests           # Run specific test module
+rebar3 eunit --module=quic_varint_tests --test=encode_0_test  # Run single test
+rebar3 proper                                     # Run PropEr property-based tests
+rebar3 ct --suite=quic_e2e_SUITE                  # Run specific Common Test suite
+rebar3 lint                                       # Elvis linter
+rebar3 fmt --check                                # Check formatting (erlfmt)
+rebar3 fmt                                        # Auto-format code
+rebar3 dialyzer                                   # Type checking
+rebar3 xref                                       # Cross-reference analysis
+rebar3 ex_doc                                     # Generate docs
+```
+
+## Architecture
+
+### Module Layers
+
+**Public API:** `quic.erl` (main client/server API), `quic_listener.erl` (server listener)
+
+**Connection Management:** `quic_connection.erl` (gen_statem state machine — the central module), `quic_stream.erl` (per-stream state), `quic_server_registry.erl` (multi-server registry)
+
+**Protocol:** `quic_packet.erl` (packet encode/decode), `quic_frame.erl` (frame encode/decode), `quic_varint.erl` (RFC 9000 §16 variable-length integers)
+
+**Crypto:** `quic_crypto.erl` (key derivation, transcript hashing), `quic_tls.erl` (TLS 1.3 messages), `quic_keys.erl` (traffic keys), `quic_aead.erl` (AEAD encryption, header protection), `quic_hkdf.erl` (HKDF expansion)
+
+**Flow Control & Loss:** `quic_flow.erl` (connection/stream flow control), `quic_cc.erl` (NewReno congestion control), `quic_loss.erl` (loss detection/recovery), `quic_ack.erl` (ACK processing)
+
+**Other:** `quic_ticket.erl` (session tickets/PSK), `quic_lb.erl` (QUIC-LB RFC 9312)
+
+### Supervision Tree
+
+`quic_app` → `quic_sup` → `quic_server_sup` → `quic_listener_sup_sup` → `quic_listener_sup` (pool). `quic_listener_manager` manages connection routing.
+
+### Key Files
+
+- `include/quic.hrl` — All protocol constants, frame types, and record definitions (`conn_state`, `quic_packet`, `stream_state`, `pn_space`, etc.)
+- `docs/DESIGN.md` — Detailed architecture, state machine diagrams, packet processing flow
+- `docs/features.md` — Feature matrix and full API reference
+
+### Connection Model
+
+Connections are `gen_statem` processes (`quic_connection.erl`) that progress through states: `handshaking` → `connected` → `closing` → `draining`. The owner process receives messages like `{quic, ConnRef, {connected, Info}}`, `{quic, ConnRef, {stream_data, StreamId, Data, Fin}}`.
+
+### Test Organization
+
+- `test/quic_*_tests.erl` — EUnit tests (unit)
+- `test/prop_quic_*.erl` — PropEr property-based tests (encoding roundtrips, reliability)
+- `test/quic_*_SUITE.erl` — Common Test suites (E2E against aioquic/quic-go via Docker, interop runner)
+- E2E tests require Docker containers (`docker/docker-compose.yml`)
+
+## Linting Notes
+
+Elvis rules are configured in `rebar.config`. Notable exceptions:
+- `quic_connection` is excluded from `dont_repeat_yourself`
+- Several modules (`quic_ack`, `quic_connection`, `quic_frame`, etc.) are excluded from `max_function_length`
+- `quic`, `quic_connection`, `quic_crypto`, `quic_stream` are excluded from `no_god_modules`
+- Atom naming regex: `^[a-z](_?[a-zA-Z0-9]+)*(_SUITE)?$`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ See [docs/features.md](docs/features.md) for the complete API reference and feat
 rebar3 compile
 ```
 
+## Formatting
+
+```bash
+rebar3 fmt
+```
+
+## Static analysis tools
+
+```bash
+rebar3 lint
+rebar3 xref
+rebar3 dialyzer
+```
+
 ## Testing
 
 ```bash

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -35,7 +35,8 @@
 -define(FRAME_STOP_SENDING, 16#05).
 -define(FRAME_CRYPTO, 16#06).
 -define(FRAME_NEW_TOKEN, 16#07).
--define(FRAME_STREAM, 16#08).  % 0x08-0x0f depending on flags
+% 0x08-0x0f depending on flags
+-define(FRAME_STREAM, 16#08).
 -define(FRAME_MAX_DATA, 16#10).
 -define(FRAME_MAX_STREAM_DATA, 16#11).
 -define(FRAME_MAX_STREAMS_BIDI, 16#12).
@@ -60,9 +61,12 @@
 %% Stream Frame Flags (bits 0-2 of frame type 0x08-0x0f)
 %%====================================================================
 
--define(STREAM_FLAG_OFF, 16#04).  % Offset field present
--define(STREAM_FLAG_LEN, 16#02).  % Length field present
--define(STREAM_FLAG_FIN, 16#01).  % Final frame for stream
+% Offset field present
+-define(STREAM_FLAG_OFF, 16#04).
+% Length field present
+-define(STREAM_FLAG_LEN, 16#02).
+% Final frame for stream
+-define(STREAM_FLAG_FIN, 16#01).
 
 %%====================================================================
 %% Transport Error Codes (RFC 9000 Section 20.1)
@@ -85,7 +89,8 @@
 -define(QUIC_KEY_UPDATE_ERROR, 16#0e).
 -define(QUIC_AEAD_LIMIT_REACHED, 16#0f).
 -define(QUIC_NO_VIABLE_PATH, 16#10).
--define(QUIC_CRYPTO_ERROR_BASE, 16#100).  % 0x100-0x1ff for TLS alerts
+% 0x100-0x1ff for TLS alerts
+-define(QUIC_CRYPTO_ERROR_BASE, 16#100).
 
 %%====================================================================
 %% HTTP/3 Error Codes (RFC 9114 Section 8.1)
@@ -138,15 +143,15 @@
 %% Initial salt for QUIC v1 (RFC 9001 Section 5.2)
 %% 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a
 -define(QUIC_V1_INITIAL_SALT,
-    <<16#38, 16#76, 16#2c, 16#f7, 16#f5, 16#59, 16#34, 16#b3,
-      16#4d, 16#17, 16#9a, 16#e6, 16#a4, 16#c8, 16#0c, 16#ad,
-      16#cc, 16#bb, 16#7f, 16#0a>>).
+    <<16#38, 16#76, 16#2c, 16#f7, 16#f5, 16#59, 16#34, 16#b3, 16#4d, 16#17, 16#9a, 16#e6, 16#a4,
+        16#c8, 16#0c, 16#ad, 16#cc, 16#bb, 16#7f, 16#0a>>
+).
 
 %% Initial salt for QUIC v2 (RFC 9369 Section 5.2)
 -define(QUIC_V2_INITIAL_SALT,
-    <<16#0d, 16#be, 16#91, 16#3e, 16#26, 16#56, 16#d1, 16#93,
-      16#83, 16#14, 16#86, 16#ac, 16#d1, 16#64, 16#9b, 16#f5,
-      16#77, 16#95, 16#c0, 16#80>>).
+    <<16#0d, 16#be, 16#91, 16#3e, 16#26, 16#56, 16#d1, 16#93, 16#83, 16#14, 16#86, 16#ac, 16#d1,
+        16#64, 16#9b, 16#f5, 16#77, 16#95, 16#c0, 16#80>>
+).
 
 %% HKDF labels
 -define(QUIC_LABEL_CLIENT_IN, <<"client in">>).
@@ -180,8 +185,10 @@
 -define(EXT_SUPPORTED_GROUPS, 10).
 -define(EXT_SIGNATURE_ALGORITHMS, 13).
 -define(EXT_ALPN, 16).
--define(EXT_PRE_SHARED_KEY, 41).       % RFC 8446 Section 4.2.11
--define(EXT_EARLY_DATA, 42).            % RFC 8446 Section 4.2.10
+% RFC 8446 Section 4.2.11
+-define(EXT_PRE_SHARED_KEY, 41).
+% RFC 8446 Section 4.2.10
+-define(EXT_EARLY_DATA, 42).
 -define(EXT_SUPPORTED_VERSIONS, 43).
 -define(EXT_PSK_KEY_EXCHANGE_MODES, 45).
 -define(EXT_KEY_SHARE, 51).
@@ -233,13 +240,17 @@
 %%====================================================================
 
 -define(DEFAULT_MAX_UDP_PAYLOAD_SIZE, 1200).
--define(DEFAULT_MAX_IDLE_TIMEOUT, 30000).  % 30 seconds
+% 30 seconds
+-define(DEFAULT_MAX_IDLE_TIMEOUT, 30000).
 -define(DEFAULT_MAX_STREAMS_BIDI, 100).
 -define(DEFAULT_MAX_STREAMS_UNI, 100).
--define(DEFAULT_INITIAL_MAX_DATA, 1048576).  % 1MB
--define(DEFAULT_INITIAL_MAX_STREAM_DATA, 262144).  % 256KB
+% 1MB
+-define(DEFAULT_INITIAL_MAX_DATA, 1048576).
+% 256KB
+-define(DEFAULT_INITIAL_MAX_STREAM_DATA, 262144).
 -define(DEFAULT_ACK_DELAY_EXPONENT, 3).
--define(DEFAULT_MAX_ACK_DELAY, 25).  % 25ms
+% 25ms
+-define(DEFAULT_MAX_ACK_DELAY, 25).
 
 %%====================================================================
 %% Records
@@ -385,7 +396,8 @@
     recv_offset :: non_neg_integer(),
     recv_max_data :: non_neg_integer(),
     recv_fin :: boolean(),
-    recv_buffer :: map(),  %% #{Offset => Data} for out-of-order reassembly
+    %% #{Offset => Data} for out-of-order reassembly
+    recv_buffer :: map(),
 
     %% Final size (set when FIN received)
     final_size :: non_neg_integer() | undefined,
@@ -432,15 +444,20 @@
     scid :: binary() | undefined,
     token :: binary() | undefined,
     pn :: non_neg_integer() | undefined,
-    payload :: binary() | [term()]  % frames list or encrypted payload
+    % frames list or encrypted payload
+    payload :: binary() | [term()]
 }).
 
 %% Connection state
 -record(conn_state, {
     %% Connection IDs
-    scid :: binary(),           % Source Connection ID
-    dcid :: binary(),           % Destination Connection ID
-    original_dcid :: binary(),  % Original DCID (for Initial packets)
+
+    % Source Connection ID
+    scid :: binary(),
+    % Destination Connection ID
+    dcid :: binary(),
+    % Original DCID (for Initial packets)
+    original_dcid :: binary(),
 
     %% Connection state
     state :: idle | handshaking | connected | draining | closed,
@@ -533,4 +550,5 @@
     reset_secret :: binary() | undefined
 }).
 
--endif.  % QUIC_HRL
+% QUIC_HRL
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -30,8 +30,11 @@
 ]}.
 
 {project_plugins, [
-    rebar3_proper,
-    rebar3_ex_doc
+    {rebar3_proper, "~> 0.12"},
+    {rebar3_hex, "~> 7.0"},
+    {rebar3_ex_doc, "~> 0.2"},
+    {rebar3_lint, "~> 4.2"},
+    {erlfmt, "~> 1.7"}
 ]}.
 
 {hex, [{doc, ex_doc}]}.
@@ -51,6 +54,119 @@
         {<<"Flow Control">>, [quic_flow, quic_cc, quic_loss, quic_ack]},
         {<<"Session">>, [quic_ticket]}
     ]}
+]}.
+
+{erlfmt, [
+    write,
+    {files, [
+        "{src,test,include,scripts}/**/*.{hrl,erl,app.src,escript}",
+        "erldns.example.config",
+        "rebar.config"
+    ]}
+]}.
+
+{elvis, [
+    #{
+        filter => "*.erl",
+        dirs => ["src/**"],
+        rules =>
+            [
+                %% Keep
+                {elvis_style, no_macros, disable},
+                {elvis_style, state_record_and_type, #{
+                    ignore => [
+                        quic_listener, quic_listener_manager, quic_server_registry, quic_connection
+                    ]
+                }},
+                {elvis_style, private_data_types, #{
+                    ignore => [quic_keys, quic_loss, quic_packet, quic_ticket, quic_lb]
+                }},
+                {elvis_style, no_receive_without_timeout, #{
+                    ignore => [quic_interop_server]
+                }},
+                {elvis_style, no_debug_call, #{
+                    ignore => [quic_interop_client, quic_interop_server]
+                }},
+                {elvis_style, atom_naming_convention, #{
+                    % public_key record field names need this
+                    regex => "^[a-z](_?[a-zA-Z0-9]+)*(_SUITE)?$"
+                }},
+                %% Since OTP28
+                {elvis_style, prefer_strict_generators, disable},
+                %% Disable rules that are too strict for this codebase
+                {elvis_style, no_common_caveats_call, disable},
+                {elvis_style, no_init_lists, disable},
+                {elvis_style, no_spec_with_records, disable},
+                {elvis_style, param_pattern_matching, disable},
+                {elvis_style, no_used_ignored_variables, disable},
+                {elvis_text_style, line_length, #{limit => 120}},
+                {elvis_style, no_if_expression, #{ignore => [quic_stream, quic_connection]}},
+                {elvis_style, no_deep_nesting, #{
+                    ignore => [quic_listener, quic_interop_client, quic_connection]
+                }},
+                {elvis_style, variable_naming_convention, #{ignore => [quic_tls]}},
+                {elvis_style, variable_casing, #{ignore => [quic_tls, quic_connection]}},
+                %% TODO: Per-module ignores; to be fixed later
+                {elvis_style, dont_repeat_yourself, #{
+                    ignore => [
+                        quic_connection,
+                        quic_cc,
+                        quic_aead,
+                        quic_packet,
+                        quic_interop_client,
+                        quic_tls
+                    ]
+                }},
+                {elvis_style, max_function_length, #{
+                    ignore =>
+                        [
+                            quic_ack,
+                            quic_cc,
+                            quic_connection,
+                            quic_frame,
+                            quic_interop_client,
+                            quic_lb,
+                            quic_listener,
+                            quic_loss,
+                            quic_packet,
+                            quic_stream,
+                            quic_tls
+                        ]
+                }},
+                {elvis_style, no_god_modules, #{
+                    ignore => [quic, quic_connection, quic_crypto, quic_stream]
+                }},
+                {elvis_style, max_function_clause_length, #{
+                    ignore =>
+                        [
+                            quic_ack,
+                            quic_connection,
+                            quic_interop_client,
+                            quic_lb,
+                            quic_listener,
+                            quic_packet,
+                            quic_stream,
+                            quic_tls,
+                            quic_loss
+                        ]
+                }},
+                {elvis_style, max_module_length, #{
+                    ignore => [quic_connection, quic_interop_client, quic_tls]
+                }},
+                {elvis_style, max_record_fields, #{ignore => [quic_connection]}}
+            ],
+        ruleset => erl_files_strict
+    },
+    #{
+        filter => "*.hrl",
+        dirs => ["include"],
+        ruleset => hrl_files
+    },
+    #{
+        filter => "rebar.config",
+        dirs => ["."],
+        ruleset => rebar_config
+    }
 ]}.
 
 {dialyzer, [

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -91,12 +91,10 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
                             quic_listener:stop(Listener),
                             halt(?EXIT_SUCCESS)
                     end;
-
                 {error, Reason} ->
                     io:format("Failed to start listener: ~p~n", [Reason]),
                     halt(?EXIT_FAILURE)
             end;
-
         _ ->
             io:format("Failed to read certificates~n"),
             halt(?EXIT_FAILURE)
@@ -159,25 +157,22 @@ connection_handler(ConnPid, ConnRef, WwwDir, TestCase) ->
         {quic, ConnRef, {connected, Info}} ->
             io:format("Handler got connected: ~p~n", [Info]),
             connection_handler(ConnPid, ConnRef, WwwDir, TestCase);
-
         {quic, ConnRef, {stream_opened, StreamId}} ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
             handle_stream(ConnPid, ConnRef, StreamId, WwwDir, TestCase);
-
         {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
-            io:format("Handler got stream_data: stream=~p size=~p fin=~p~n",
-                      [StreamId, byte_size(Data), Fin]),
+            io:format(
+                "Handler got stream_data: stream=~p size=~p fin=~p~n",
+                [StreamId, byte_size(Data), Fin]
+            ),
             %% Handle request
             handle_request(ConnPid, ConnRef, StreamId, Data, WwwDir, TestCase);
-
         {quic, ConnRef, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
-
         Other ->
             io:format("Handler got unexpected: ~p~n", [Other]),
             connection_handler(ConnPid, ConnRef, WwwDir, TestCase)
-
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
@@ -233,11 +228,12 @@ parse_request(Data) ->
             case binary:split(RequestLine, <<" ">>, [global]) of
                 [<<"GET">>, Path | _] ->
                     %% Remove leading slash for file path
-                    CleanPath = case Path of
-                        <<"/">> -> <<"index.html">>;
-                        <<"/", Rest/binary>> -> Rest;
-                        _ -> Path
-                    end,
+                    CleanPath =
+                        case Path of
+                            <<"/">> -> <<"index.html">>;
+                            <<"/", Rest/binary>> -> Rest;
+                            _ -> Path
+                        end,
                     {ok, binary_to_list(CleanPath)};
                 _ ->
                     error

--- a/src/quic_flow.erl
+++ b/src/quic_flow.erl
@@ -51,19 +51,24 @@
 ]).
 
 %% Default values
--define(WINDOW_UPDATE_THRESHOLD, 0.5).  % Send MAX_DATA when 50% consumed
+
+% Send MAX_DATA when 50% consumed
+-define(WINDOW_UPDATE_THRESHOLD, 0.5).
 
 %% Flow control state
 -record(flow_state, {
     %% Send side (our sending, limited by peer's MAX_DATA)
     bytes_sent = 0 :: non_neg_integer(),
-    send_max_data :: non_neg_integer(),  % Peer's limit on what we can send
+    % Peer's limit on what we can send
+    send_max_data :: non_neg_integer(),
     send_blocked = false :: boolean(),
 
     %% Receive side (peer's sending, limited by our MAX_DATA)
     bytes_received = 0 :: non_neg_integer(),
-    recv_max_data :: non_neg_integer(),  % Our limit on what peer can send
-    recv_max_data_sent :: non_neg_integer(),  % Last MAX_DATA we sent
+    % Our limit on what peer can send
+    recv_max_data :: non_neg_integer(),
+    % Last MAX_DATA we sent
+    recv_max_data_sent :: non_neg_integer(),
 
     %% Configuration
     initial_max_data :: non_neg_integer()
@@ -138,8 +143,10 @@ send_blocked(#flow_state{send_blocked = B}) -> B.
 %% @doc Record that we received data.
 -spec on_data_received(flow_state(), non_neg_integer()) ->
     {ok, flow_state()} | {error, flow_control_error}.
-on_data_received(#flow_state{bytes_received = Received, recv_max_data = Max} = State,
-                 Size) ->
+on_data_received(
+    #flow_state{bytes_received = Received, recv_max_data = Max} = State,
+    Size
+) ->
     NewReceived = Received + Size,
     case NewReceived > Max of
         true ->
@@ -151,9 +158,11 @@ on_data_received(#flow_state{bytes_received = Received, recv_max_data = Max} = S
 %% @doc Check if we should send a MAX_DATA update.
 %% Returns true if we've consumed more than the threshold.
 -spec should_send_max_data(flow_state()) -> boolean().
-should_send_max_data(#flow_state{bytes_received = Received,
-                                  recv_max_data_sent = SentMax,
-                                  initial_max_data = Initial}) ->
+should_send_max_data(#flow_state{
+    bytes_received = Received,
+    recv_max_data_sent = SentMax,
+    initial_max_data = Initial
+}) ->
     %% Send update when we've consumed > threshold of the window
     WindowConsumed = Received,
     WindowGranted = SentMax,
@@ -164,8 +173,12 @@ should_send_max_data(#flow_state{bytes_received = Received,
 %% Returns {NewMaxData, UpdatedState}.
 -spec generate_max_data(flow_state()) ->
     {non_neg_integer(), flow_state()}.
-generate_max_data(#flow_state{bytes_received = Received,
-                              initial_max_data = Initial} = State) ->
+generate_max_data(
+    #flow_state{
+        bytes_received = Received,
+        initial_max_data = Initial
+    } = State
+) ->
     %% Grant a new window based on bytes consumed
     NewMax = Received + Initial,
     NewState = State#flow_state{

--- a/src/quic_frame.erl
+++ b/src/quic_frame.erl
@@ -26,47 +26,37 @@
 
 %% Frame types
 -type frame() ::
-    padding |
-    ping |
-    {ack, AckRanges :: [{non_neg_integer(), non_neg_integer()}],
-          AckDelay :: non_neg_integer(), ECNCounts :: ecn_counts() | undefined} |
-    {reset_stream, StreamId :: non_neg_integer(),
-                   ErrorCode :: non_neg_integer(),
-                   FinalSize :: non_neg_integer()} |
-    {stop_sending, StreamId :: non_neg_integer(),
-                   ErrorCode :: non_neg_integer()} |
-    {crypto, Offset :: non_neg_integer(), Data :: binary()} |
-    {new_token, Token :: binary()} |
-    {stream, StreamId :: non_neg_integer(),
-             Offset :: non_neg_integer(),
-             Data :: binary(),
-             Fin :: boolean()} |
-    {max_data, MaxData :: non_neg_integer()} |
-    {max_stream_data, StreamId :: non_neg_integer(),
-                      MaxData :: non_neg_integer()} |
-    {max_streams, bidi | uni, MaxStreams :: non_neg_integer()} |
-    {data_blocked, Limit :: non_neg_integer()} |
-    {stream_data_blocked, StreamId :: non_neg_integer(),
-                          Limit :: non_neg_integer()} |
-    {streams_blocked, bidi | uni, Limit :: non_neg_integer()} |
-    {new_connection_id, SeqNum :: non_neg_integer(),
-                        RetirePrior :: non_neg_integer(),
-                        CID :: binary(),
-                        StatelessResetToken :: binary()} |
-    {retire_connection_id, SeqNum :: non_neg_integer()} |
-    {path_challenge, Data :: binary()} |
-    {path_response, Data :: binary()} |
-    {connection_close, transport | application,
-                       ErrorCode :: non_neg_integer(),
-                       FrameType :: non_neg_integer() | undefined,
-                       Reason :: binary()} |
-    handshake_done |
-    {datagram, Data :: binary()} |
-    {datagram_with_length, Data :: binary()}.
+    padding
+    | ping
+    | {ack, AckRanges :: [{non_neg_integer(), non_neg_integer()}], AckDelay :: non_neg_integer(),
+        ECNCounts :: ecn_counts() | undefined}
+    | {reset_stream, StreamId :: non_neg_integer(), ErrorCode :: non_neg_integer(),
+        FinalSize :: non_neg_integer()}
+    | {stop_sending, StreamId :: non_neg_integer(), ErrorCode :: non_neg_integer()}
+    | {crypto, Offset :: non_neg_integer(), Data :: binary()}
+    | {new_token, Token :: binary()}
+    | {stream, StreamId :: non_neg_integer(), Offset :: non_neg_integer(), Data :: binary(),
+        Fin :: boolean()}
+    | {max_data, MaxData :: non_neg_integer()}
+    | {max_stream_data, StreamId :: non_neg_integer(), MaxData :: non_neg_integer()}
+    | {max_streams, bidi | uni, MaxStreams :: non_neg_integer()}
+    | {data_blocked, Limit :: non_neg_integer()}
+    | {stream_data_blocked, StreamId :: non_neg_integer(), Limit :: non_neg_integer()}
+    | {streams_blocked, bidi | uni, Limit :: non_neg_integer()}
+    | {new_connection_id, SeqNum :: non_neg_integer(), RetirePrior :: non_neg_integer(),
+        CID :: binary(), StatelessResetToken :: binary()}
+    | {retire_connection_id, SeqNum :: non_neg_integer()}
+    | {path_challenge, Data :: binary()}
+    | {path_response, Data :: binary()}
+    | {connection_close, transport | application, ErrorCode :: non_neg_integer(),
+        FrameType :: non_neg_integer() | undefined, Reason :: binary()}
+    | handshake_done
+    | {datagram, Data :: binary()}
+    | {datagram_with_length, Data :: binary()}.
 
--type ecn_counts() :: {ECT0 :: non_neg_integer(),
-                       ECT1 :: non_neg_integer(),
-                       ECNCE :: non_neg_integer()}.
+-type ecn_counts() :: {
+    ECT0 :: non_neg_integer(), ECT1 :: non_neg_integer(), ECNCE :: non_neg_integer()
+}.
 
 %% Maximum frame data length to prevent memory exhaustion
 -define(MAX_FRAME_DATA_LEN, 65535).
@@ -81,144 +71,112 @@
 %% PADDING (0x00)
 encode(padding) ->
     <<0>>;
-
 %% PING (0x01)
 encode(ping) ->
     <<1>>;
-
 %% ACK (0x02 or 0x03)
 encode({ack, Ranges, AckDelay, undefined}) ->
     encode_ack(Ranges, AckDelay, false);
 encode({ack, Ranges, AckDelay, {ECT0, ECT1, ECNCE}}) ->
     AckBin = encode_ack(Ranges, AckDelay, true),
-    ECNBin = <<(quic_varint:encode(ECT0))/binary,
-               (quic_varint:encode(ECT1))/binary,
-               (quic_varint:encode(ECNCE))/binary>>,
+    ECNBin = <<
+        (quic_varint:encode(ECT0))/binary,
+        (quic_varint:encode(ECT1))/binary,
+        (quic_varint:encode(ECNCE))/binary
+    >>,
     <<AckBin/binary, ECNBin/binary>>;
-
 %% RESET_STREAM (0x04)
 encode({reset_stream, StreamId, ErrorCode, FinalSize}) ->
-    <<?FRAME_RESET_STREAM,
-      (quic_varint:encode(StreamId))/binary,
-      (quic_varint:encode(ErrorCode))/binary,
-      (quic_varint:encode(FinalSize))/binary>>;
-
+    <<?FRAME_RESET_STREAM, (quic_varint:encode(StreamId))/binary,
+        (quic_varint:encode(ErrorCode))/binary, (quic_varint:encode(FinalSize))/binary>>;
 %% STOP_SENDING (0x05)
 encode({stop_sending, StreamId, ErrorCode}) ->
-    <<?FRAME_STOP_SENDING,
-      (quic_varint:encode(StreamId))/binary,
-      (quic_varint:encode(ErrorCode))/binary>>;
-
+    <<?FRAME_STOP_SENDING, (quic_varint:encode(StreamId))/binary,
+        (quic_varint:encode(ErrorCode))/binary>>;
 %% CRYPTO (0x06)
 encode({crypto, Offset, Data}) ->
-    <<?FRAME_CRYPTO,
-      (quic_varint:encode(Offset))/binary,
-      (quic_varint:encode(byte_size(Data)))/binary,
-      Data/binary>>;
-
+    <<?FRAME_CRYPTO, (quic_varint:encode(Offset))/binary,
+        (quic_varint:encode(byte_size(Data)))/binary, Data/binary>>;
 %% NEW_TOKEN (0x07)
 encode({new_token, Token}) ->
-    <<?FRAME_NEW_TOKEN,
-      (quic_varint:encode(byte_size(Token)))/binary,
-      Token/binary>>;
-
+    <<?FRAME_NEW_TOKEN, (quic_varint:encode(byte_size(Token)))/binary, Token/binary>>;
 %% STREAM (0x08-0x0f)
 encode({stream, StreamId, Offset, Data, Fin}) ->
-    Type = ?FRAME_STREAM bor
-           (case Offset of 0 -> 0; _ -> ?STREAM_FLAG_OFF end) bor
-           ?STREAM_FLAG_LEN bor
-           (case Fin of true -> ?STREAM_FLAG_FIN; false -> 0 end),
-    OffsetBin = case Offset of
-        0 -> <<>>;
-        _ -> quic_varint:encode(Offset)
-    end,
-    <<Type,
-      (quic_varint:encode(StreamId))/binary,
-      OffsetBin/binary,
-      (quic_varint:encode(byte_size(Data)))/binary,
-      Data/binary>>;
-
+    Type =
+        ?FRAME_STREAM bor
+            (case Offset of
+                0 -> 0;
+                _ -> ?STREAM_FLAG_OFF
+            end) bor
+            ?STREAM_FLAG_LEN bor
+            (case Fin of
+                true -> ?STREAM_FLAG_FIN;
+                false -> 0
+            end),
+    OffsetBin =
+        case Offset of
+            0 -> <<>>;
+            _ -> quic_varint:encode(Offset)
+        end,
+    <<Type, (quic_varint:encode(StreamId))/binary, OffsetBin/binary,
+        (quic_varint:encode(byte_size(Data)))/binary, Data/binary>>;
 %% MAX_DATA (0x10)
 encode({max_data, MaxData}) ->
     <<?FRAME_MAX_DATA, (quic_varint:encode(MaxData))/binary>>;
-
 %% MAX_STREAM_DATA (0x11)
 encode({max_stream_data, StreamId, MaxData}) ->
-    <<?FRAME_MAX_STREAM_DATA,
-      (quic_varint:encode(StreamId))/binary,
-      (quic_varint:encode(MaxData))/binary>>;
-
+    <<?FRAME_MAX_STREAM_DATA, (quic_varint:encode(StreamId))/binary,
+        (quic_varint:encode(MaxData))/binary>>;
 %% MAX_STREAMS (0x12 bidi, 0x13 uni)
 encode({max_streams, bidi, MaxStreams}) ->
     <<?FRAME_MAX_STREAMS_BIDI, (quic_varint:encode(MaxStreams))/binary>>;
 encode({max_streams, uni, MaxStreams}) ->
     <<?FRAME_MAX_STREAMS_UNI, (quic_varint:encode(MaxStreams))/binary>>;
-
 %% DATA_BLOCKED (0x14)
 encode({data_blocked, Limit}) ->
     <<?FRAME_DATA_BLOCKED, (quic_varint:encode(Limit))/binary>>;
-
 %% STREAM_DATA_BLOCKED (0x15)
 encode({stream_data_blocked, StreamId, Limit}) ->
-    <<?FRAME_STREAM_DATA_BLOCKED,
-      (quic_varint:encode(StreamId))/binary,
-      (quic_varint:encode(Limit))/binary>>;
-
+    <<?FRAME_STREAM_DATA_BLOCKED, (quic_varint:encode(StreamId))/binary,
+        (quic_varint:encode(Limit))/binary>>;
 %% STREAMS_BLOCKED (0x16 bidi, 0x17 uni)
 encode({streams_blocked, bidi, Limit}) ->
     <<?FRAME_STREAMS_BLOCKED_BIDI, (quic_varint:encode(Limit))/binary>>;
 encode({streams_blocked, uni, Limit}) ->
     <<?FRAME_STREAMS_BLOCKED_UNI, (quic_varint:encode(Limit))/binary>>;
-
 %% NEW_CONNECTION_ID (0x18)
-encode({new_connection_id, SeqNum, RetirePrior, CID, StatelessResetToken})
-  when byte_size(StatelessResetToken) =:= 16 ->
+encode({new_connection_id, SeqNum, RetirePrior, CID, StatelessResetToken}) when
+    byte_size(StatelessResetToken) =:= 16
+->
     CIDLen = byte_size(CID),
-    <<?FRAME_NEW_CONNECTION_ID,
-      (quic_varint:encode(SeqNum))/binary,
-      (quic_varint:encode(RetirePrior))/binary,
-      CIDLen,
-      CID/binary,
-      StatelessResetToken/binary>>;
-
+    <<?FRAME_NEW_CONNECTION_ID, (quic_varint:encode(SeqNum))/binary,
+        (quic_varint:encode(RetirePrior))/binary, CIDLen, CID/binary, StatelessResetToken/binary>>;
 %% RETIRE_CONNECTION_ID (0x19)
 encode({retire_connection_id, SeqNum}) ->
     <<?FRAME_RETIRE_CONNECTION_ID, (quic_varint:encode(SeqNum))/binary>>;
-
 %% PATH_CHALLENGE (0x1a)
 encode({path_challenge, Data}) when byte_size(Data) =:= 8 ->
     <<?FRAME_PATH_CHALLENGE, Data/binary>>;
-
 %% PATH_RESPONSE (0x1b)
 encode({path_response, Data}) when byte_size(Data) =:= 8 ->
     <<?FRAME_PATH_RESPONSE, Data/binary>>;
-
 %% CONNECTION_CLOSE (0x1c transport, 0x1d application)
 encode({connection_close, transport, ErrorCode, FrameType, Reason}) ->
-    <<?FRAME_CONNECTION_CLOSE,
-      (quic_varint:encode(ErrorCode))/binary,
-      (quic_varint:encode(FrameType))/binary,
-      (quic_varint:encode(byte_size(Reason)))/binary,
-      Reason/binary>>;
+    <<?FRAME_CONNECTION_CLOSE, (quic_varint:encode(ErrorCode))/binary,
+        (quic_varint:encode(FrameType))/binary, (quic_varint:encode(byte_size(Reason)))/binary,
+        Reason/binary>>;
 encode({connection_close, application, ErrorCode, _FrameType, Reason}) ->
-    <<?FRAME_CONNECTION_CLOSE_APP,
-      (quic_varint:encode(ErrorCode))/binary,
-      (quic_varint:encode(byte_size(Reason)))/binary,
-      Reason/binary>>;
-
+    <<?FRAME_CONNECTION_CLOSE_APP, (quic_varint:encode(ErrorCode))/binary,
+        (quic_varint:encode(byte_size(Reason)))/binary, Reason/binary>>;
 %% HANDSHAKE_DONE (0x1e)
 encode(handshake_done) ->
     <<?FRAME_HANDSHAKE_DONE>>;
-
 %% DATAGRAM (0x30 - no length, data to end of packet)
 encode({datagram, Data}) ->
     <<?FRAME_DATAGRAM, Data/binary>>;
-
 %% DATAGRAM_WITH_LENGTH (0x31 - includes length)
 encode({datagram_with_length, Data}) ->
-    <<?FRAME_DATAGRAM_WITH_LEN,
-      (quic_varint:encode(byte_size(Data)))/binary,
-      Data/binary>>.
+    <<?FRAME_DATAGRAM_WITH_LEN, (quic_varint:encode(byte_size(Data)))/binary, Data/binary>>.
 
 %% @doc Decode a single frame from binary.
 %% Returns {Frame, Rest} or {error, Reason}.
@@ -226,27 +184,21 @@ encode({datagram_with_length, Data}) ->
 
 decode(<<0, Rest/binary>>) ->
     {padding, Rest};
-
 decode(<<1, Rest/binary>>) ->
     {ping, Rest};
-
 decode(<<2, Rest/binary>>) ->
     decode_ack(Rest, false);
-
 decode(<<3, Rest/binary>>) ->
     decode_ack(Rest, true);
-
 decode(<<?FRAME_RESET_STREAM, Rest/binary>>) ->
     {StreamId, Rest1} = quic_varint:decode(Rest),
     {ErrorCode, Rest2} = quic_varint:decode(Rest1),
     {FinalSize, Rest3} = quic_varint:decode(Rest2),
     {{reset_stream, StreamId, ErrorCode, FinalSize}, Rest3};
-
 decode(<<?FRAME_STOP_SENDING, Rest/binary>>) ->
     {StreamId, Rest1} = quic_varint:decode(Rest),
     {ErrorCode, Rest2} = quic_varint:decode(Rest1),
     {{stop_sending, StreamId, ErrorCode}, Rest2};
-
 decode(<<?FRAME_CRYPTO, Rest/binary>>) ->
     {Offset, Rest1} = quic_varint:decode(Rest),
     {Length, Rest2} = quic_varint:decode(Rest1),
@@ -257,7 +209,6 @@ decode(<<?FRAME_CRYPTO, Rest/binary>>) ->
             <<Data:Length/binary, Rest3/binary>> = Rest2,
             {{crypto, Offset, Data}, Rest3}
     end;
-
 decode(<<?FRAME_NEW_TOKEN, Rest/binary>>) ->
     {Length, Rest1} = quic_varint:decode(Rest),
     case Length > ?MAX_FRAME_DATA_LEN of
@@ -267,16 +218,16 @@ decode(<<?FRAME_NEW_TOKEN, Rest/binary>>) ->
             <<Token:Length/binary, Rest2/binary>> = Rest1,
             {{new_token, Token}, Rest2}
     end;
-
 decode(<<Type, Rest/binary>>) when Type >= ?FRAME_STREAM, Type =< 16#0f ->
     HasOff = (Type band ?STREAM_FLAG_OFF) =/= 0,
     HasLen = (Type band ?STREAM_FLAG_LEN) =/= 0,
     Fin = (Type band ?STREAM_FLAG_FIN) =/= 0,
     {StreamId, Rest1} = quic_varint:decode(Rest),
-    {Offset, Rest2} = case HasOff of
-        true -> quic_varint:decode(Rest1);
-        false -> {0, Rest1}
-    end,
+    {Offset, Rest2} =
+        case HasOff of
+            true -> quic_varint:decode(Rest1);
+            false -> {0, Rest1}
+        end,
     case HasLen of
         true ->
             {Length, R} = quic_varint:decode(Rest2),
@@ -291,58 +242,45 @@ decode(<<Type, Rest/binary>>) when Type >= ?FRAME_STREAM, Type =< 16#0f ->
             %% Data extends to end of packet
             {{stream, StreamId, Offset, Rest2, Fin}, <<>>}
     end;
-
 decode(<<?FRAME_MAX_DATA, Rest/binary>>) ->
     {MaxData, Rest1} = quic_varint:decode(Rest),
     {{max_data, MaxData}, Rest1};
-
 decode(<<?FRAME_MAX_STREAM_DATA, Rest/binary>>) ->
     {StreamId, Rest1} = quic_varint:decode(Rest),
     {MaxData, Rest2} = quic_varint:decode(Rest1),
     {{max_stream_data, StreamId, MaxData}, Rest2};
-
 decode(<<?FRAME_MAX_STREAMS_BIDI, Rest/binary>>) ->
     {MaxStreams, Rest1} = quic_varint:decode(Rest),
     {{max_streams, bidi, MaxStreams}, Rest1};
-
 decode(<<?FRAME_MAX_STREAMS_UNI, Rest/binary>>) ->
     {MaxStreams, Rest1} = quic_varint:decode(Rest),
     {{max_streams, uni, MaxStreams}, Rest1};
-
 decode(<<?FRAME_DATA_BLOCKED, Rest/binary>>) ->
     {Limit, Rest1} = quic_varint:decode(Rest),
     {{data_blocked, Limit}, Rest1};
-
 decode(<<?FRAME_STREAM_DATA_BLOCKED, Rest/binary>>) ->
     {StreamId, Rest1} = quic_varint:decode(Rest),
     {Limit, Rest2} = quic_varint:decode(Rest1),
     {{stream_data_blocked, StreamId, Limit}, Rest2};
-
 decode(<<?FRAME_STREAMS_BLOCKED_BIDI, Rest/binary>>) ->
     {Limit, Rest1} = quic_varint:decode(Rest),
     {{streams_blocked, bidi, Limit}, Rest1};
-
 decode(<<?FRAME_STREAMS_BLOCKED_UNI, Rest/binary>>) ->
     {Limit, Rest1} = quic_varint:decode(Rest),
     {{streams_blocked, uni, Limit}, Rest1};
-
 decode(<<?FRAME_NEW_CONNECTION_ID, Rest/binary>>) ->
     {SeqNum, Rest1} = quic_varint:decode(Rest),
     {RetirePrior, Rest2} = quic_varint:decode(Rest1),
     <<CIDLen, Rest3/binary>> = Rest2,
     <<CID:CIDLen/binary, StatelessResetToken:16/binary, Rest4/binary>> = Rest3,
     {{new_connection_id, SeqNum, RetirePrior, CID, StatelessResetToken}, Rest4};
-
 decode(<<?FRAME_RETIRE_CONNECTION_ID, Rest/binary>>) ->
     {SeqNum, Rest1} = quic_varint:decode(Rest),
     {{retire_connection_id, SeqNum}, Rest1};
-
 decode(<<?FRAME_PATH_CHALLENGE, Data:8/binary, Rest/binary>>) ->
     {{path_challenge, Data}, Rest};
-
 decode(<<?FRAME_PATH_RESPONSE, Data:8/binary, Rest/binary>>) ->
     {{path_response, Data}, Rest};
-
 decode(<<?FRAME_CONNECTION_CLOSE, Rest/binary>>) ->
     {ErrorCode, Rest1} = quic_varint:decode(Rest),
     {FrameType, Rest2} = quic_varint:decode(Rest1),
@@ -354,7 +292,6 @@ decode(<<?FRAME_CONNECTION_CLOSE, Rest/binary>>) ->
             <<Reason:ReasonLen/binary, Rest4/binary>> = Rest3,
             {{connection_close, transport, ErrorCode, FrameType, Reason}, Rest4}
     end;
-
 decode(<<?FRAME_CONNECTION_CLOSE_APP, Rest/binary>>) ->
     {ErrorCode, Rest1} = quic_varint:decode(Rest),
     {ReasonLen, Rest2} = quic_varint:decode(Rest1),
@@ -365,14 +302,11 @@ decode(<<?FRAME_CONNECTION_CLOSE_APP, Rest/binary>>) ->
             <<Reason:ReasonLen/binary, Rest3/binary>> = Rest2,
             {{connection_close, application, ErrorCode, undefined, Reason}, Rest3}
     end;
-
 decode(<<?FRAME_HANDSHAKE_DONE, Rest/binary>>) ->
     {handshake_done, Rest};
-
 %% DATAGRAM (0x30 - data extends to end of packet)
 decode(<<?FRAME_DATAGRAM, Data/binary>>) ->
     {{datagram, Data}, <<>>};
-
 %% DATAGRAM_WITH_LENGTH (0x31)
 decode(<<?FRAME_DATAGRAM_WITH_LEN, Rest/binary>>) ->
     {Length, Rest1} = quic_varint:decode(Rest),
@@ -383,10 +317,8 @@ decode(<<?FRAME_DATAGRAM_WITH_LEN, Rest/binary>>) ->
             <<Data:Length/binary, Rest2/binary>> = Rest1,
             {{datagram_with_length, Data}, Rest2}
     end;
-
 decode(<<Type, _/binary>>) ->
     {error, {unknown_frame_type, Type}};
-
 decode(<<>>) ->
     {error, empty}.
 
@@ -411,28 +343,28 @@ decode_all(Bin, Acc) ->
 %%====================================================================
 
 encode_ack(Ranges, AckDelay, WithECN) ->
-    Type = case WithECN of
-        false -> ?FRAME_ACK;
-        true -> ?FRAME_ACK_ECN
-    end,
+    Type =
+        case WithECN of
+            false -> ?FRAME_ACK;
+            true -> ?FRAME_ACK_ECN
+        end,
     [{LargestAcked, FirstRange} | RestRanges] = Ranges,
     RangeCount = length(RestRanges),
     %% Encode additional ranges
     RangesBin = encode_ack_ranges(Ranges),
-    <<Type,
-      (quic_varint:encode(LargestAcked))/binary,
-      (quic_varint:encode(AckDelay))/binary,
-      (quic_varint:encode(RangeCount))/binary,
-      (quic_varint:encode(FirstRange))/binary,
-      RangesBin/binary>>.
+    <<Type, (quic_varint:encode(LargestAcked))/binary, (quic_varint:encode(AckDelay))/binary,
+        (quic_varint:encode(RangeCount))/binary, (quic_varint:encode(FirstRange))/binary,
+        RangesBin/binary>>.
 
 encode_ack_ranges([_First]) ->
     <<>>;
 encode_ack_ranges([{_Largest1, _First1}, {Gap, Range} | Rest]) ->
     %% Gap and Range are encoded as-is (adjusted by caller)
-    <<(quic_varint:encode(Gap))/binary,
-      (quic_varint:encode(Range))/binary,
-      (encode_ack_ranges([{0, 0} | Rest]))/binary>>;
+    <<
+        (quic_varint:encode(Gap))/binary,
+        (quic_varint:encode(Range))/binary,
+        (encode_ack_ranges([{0, 0} | Rest]))/binary
+    >>;
 encode_ack_ranges([_First, _ | _] = Ranges) ->
     %% For simplicity, encode remaining ranges
     encode_ack_ranges_tail(tl(Ranges)).
@@ -440,9 +372,11 @@ encode_ack_ranges([_First, _ | _] = Ranges) ->
 encode_ack_ranges_tail([]) ->
     <<>>;
 encode_ack_ranges_tail([{Gap, Range} | Rest]) ->
-    <<(quic_varint:encode(Gap))/binary,
-      (quic_varint:encode(Range))/binary,
-      (encode_ack_ranges_tail(Rest))/binary>>.
+    <<
+        (quic_varint:encode(Gap))/binary,
+        (quic_varint:encode(Range))/binary,
+        (encode_ack_ranges_tail(Rest))/binary
+    >>.
 
 decode_ack(Bin, WithECN) ->
     {LargestAcked, Rest1} = quic_varint:decode(Bin),

--- a/src/quic_hkdf.erl
+++ b/src/quic_hkdf.erl
@@ -23,7 +23,8 @@
     expand_label/5
 ]).
 
--define(HASH_LEN, 32).  % SHA-256 output length
+% SHA-256 output length
+-define(HASH_LEN, 32).
 
 %%====================================================================
 %% API
@@ -58,7 +59,8 @@ expand(_Hash, _PRK, _Info, 0) ->
 expand(Hash, PRK, Info, Length) ->
     HashLen = quic_crypto:hash_len(Hash),
     MaxLen = 255 * HashLen,
-    true = Length =< MaxLen,  % Assert valid length
+    % Assert valid length
+    true = Length =< MaxLen,
     N = ceiling(Length, HashLen),
     FullOutput = expand_loop(Hash, PRK, Info, N, 1, <<>>, <<>>),
     %% Truncate to requested length
@@ -82,8 +84,7 @@ expand_label(Hash, Secret, Label, Context, Length) ->
     FullLabel = <<"tls13 ", Label/binary>>,
     LabelLen = byte_size(FullLabel),
     ContextLen = byte_size(Context),
-    HkdfLabel = <<Length:16, LabelLen, FullLabel/binary,
-                  ContextLen, Context/binary>>,
+    HkdfLabel = <<Length:16, LabelLen, FullLabel/binary, ContextLen, Context/binary>>,
     expand(Hash, Secret, HkdfLabel, Length).
 
 %%====================================================================

--- a/src/quic_listener_sup.erl
+++ b/src/quic_listener_sup.erl
@@ -66,8 +66,11 @@ get_listeners(Sup) ->
     case lists:keyfind(quic_listener_sup_sup, 1, Children) of
         {quic_listener_sup_sup, SupSupPid, _, _} when is_pid(SupSupPid) ->
             %% Get actual listeners from the listener_sup_sup
-            [Pid || {{quic_listener, _}, Pid, _, _} <- supervisor:which_children(SupSupPid),
-                    is_pid(Pid)];
+            [
+                Pid
+             || {{quic_listener, _}, Pid, _, _} <- supervisor:which_children(SupSupPid),
+                is_pid(Pid)
+            ];
         _ ->
             []
     end.
@@ -86,7 +89,11 @@ init({Port, Opts}) ->
             ok;
         Name when is_atom(Name) ->
             %% Ignore errors in case registry isn't started (standalone listener_sup usage)
-            try quic_server_registry:register(Name, Self, Port, Opts) catch _:_ -> ok end
+            try
+                quic_server_registry:register(Name, Self, Port, Opts)
+            catch
+                _:_ -> ok
+            end
     end,
 
     SupFlags = #{strategy => rest_for_one, intensity => 10, period => 5},
@@ -101,11 +108,11 @@ init({Port, Opts}) ->
     },
 
     ListenerSupSup = #{
-            id => quic_listener_sup_sup,
-            start => {quic_listener_sup_sup, start_link, [Port, Opts, Self]},
-            restart => permanent,
-            type => supervisor,
-            modules => [quic_listener_sup_sup]
-        },
+        id => quic_listener_sup_sup,
+        start => {quic_listener_sup_sup, start_link, [Port, Opts, Self]},
+        restart => permanent,
+        type => supervisor,
+        modules => [quic_listener_sup_sup]
+    },
 
     {ok, {SupFlags, [Manager, ListenerSupSup]}}.

--- a/src/quic_listener_sup_sup.erl
+++ b/src/quic_listener_sup_sup.erl
@@ -25,7 +25,6 @@ start_link(Port, Opts, Parent) ->
 %%====================================================================
 
 init({Port, Opts, Parent}) ->
-
     PoolSize = 1 + maps:get(pool_size, Opts, 1),
     Intensity = ceil(math:log2(PoolSize)),
     SupFlags = #{strategy => one_for_one, intensity => Intensity, period => 5},
@@ -50,7 +49,7 @@ init({Port, Opts, Parent}) ->
             type => worker,
             modules => [quic_listener]
         }
-        || N <- lists:seq(1, PoolSize)
+     || N <- lists:seq(1, PoolSize)
     ],
 
     {ok, {SupFlags, Children}}.

--- a/src/quic_server_registry.erl
+++ b/src/quic_server_registry.erl
@@ -130,8 +130,10 @@ get_connections(Name) ->
             %% Collect connections from all listeners
             Connections = lists:flatmap(
                 fun(ListenerPid) ->
-                    try quic_listener:get_connections(ListenerPid)
-                    catch _:_ -> []
+                    try
+                        quic_listener:get_connections(ListenerPid)
+                    catch
+                        _:_ -> []
                     end
                 end,
                 Listeners
@@ -170,7 +172,6 @@ handle_call({register, Name, Pid, Port, Opts}, _From, State = #state{monitors = 
 
     NewMonitors = Monitors#{MonRef => Name},
     {reply, ok, State#state{monitors = NewMonitors}};
-
 handle_call({unregister, Name}, _From, State = #state{monitors = Monitors}) ->
     %% Find and remove the monitor
     case ets:lookup(?TABLE, Name) of
@@ -187,7 +188,6 @@ handle_call({unregister, Name}, _From, State = #state{monitors = Monitors}) ->
         [] ->
             {reply, ok, State}
     end;
-
 handle_call(_Request, _From, State) ->
     {reply, {error, not_implemented}, State}.
 
@@ -204,7 +204,6 @@ handle_info({'DOWN', MonRef, process, _Pid, _Reason}, State = #state{monitors = 
             NewMonitors = maps:remove(MonRef, Monitors),
             {noreply, State#state{monitors = NewMonitors}}
     end;
-
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/src/quic_ticket.erl
+++ b/src/quic_ticket.erl
@@ -75,7 +75,8 @@ lookup_ticket(ServerName, Store) ->
             Age = Now - ReceivedAt,
             case Age =< Lifetime of
                 true -> {ok, Ticket};
-                false -> error  % Expired
+                % Expired
+                false -> error
             end;
         error ->
             error
@@ -93,7 +94,9 @@ clear_expired(Store) ->
     maps:filter(
         fun(_ServerName, #session_ticket{received_at = ReceivedAt, lifetime = Lifetime}) ->
             (Now - ReceivedAt) =< Lifetime
-        end, Store).
+        end,
+        Store
+    ).
 
 %%====================================================================
 %% PSK Derivation
@@ -130,11 +133,14 @@ derive_psk(ResumptionSecret, #session_ticket{nonce = Nonce, cipher = Cipher}) ->
 %%       Extension extensions&lt;0..2^16-2&gt;;
 %%   } NewSessionTicket;
 -spec parse_new_session_ticket(binary()) ->
-    {ok, #{lifetime := non_neg_integer(),
-           age_add := non_neg_integer(),
-           nonce := binary(),
-           ticket := binary(),
-           max_early_data := non_neg_integer()}} | {error, term()}.
+    {ok, #{
+        lifetime := non_neg_integer(),
+        age_add := non_neg_integer(),
+        nonce := binary(),
+        ticket := binary(),
+        max_early_data := non_neg_integer()
+    }}
+    | {error, term()}.
 parse_new_session_ticket(<<Lifetime:32, AgeAdd:32, NonceLen, Rest/binary>>) ->
     case Rest of
         <<Nonce:NonceLen/binary, TicketLen:16, Rest1/binary>> when byte_size(Rest1) >= TicketLen ->
@@ -184,7 +190,8 @@ create_ticket(ServerName, ResumptionSecret, MaxEarlyData, Cipher, ALPN) ->
     #session_ticket{
         server_name = ServerName,
         ticket = crypto:strong_rand_bytes(32),
-        lifetime = 86400,  % 24 hours
+        % 24 hours
+        lifetime = 86400,
         age_add = AgeAdd,
         nonce = crypto:strong_rand_bytes(8),
         resumption_secret = ResumptionSecret,
@@ -208,12 +215,13 @@ build_new_session_ticket(#session_ticket{
 
     %% Build early_data extension if max_early_data > 0
     %% QUIC requires the wire value to be 0xffffffff (RFC 9001 Section 4.6.1).
-    Extensions = case MaxEarlyData of
-        0 -> <<>>;
-        _ -> <<16#00, 16#2a, 4:16, ?QUIC_MAX_EARLY_DATA_SIZE:32>>  % early_data extension
-    end,
+    Extensions =
+        case MaxEarlyData of
+            0 -> <<>>;
+            % early_data extension
+            _ -> <<16#00, 16#2a, 4:16, ?QUIC_MAX_EARLY_DATA_SIZE:32>>
+        end,
     ExtLen = byte_size(Extensions),
 
-    <<Lifetime:32, AgeAdd:32, NonceLen, Nonce/binary,
-      TicketLen:16, Ticket/binary, ExtLen:16, Extensions/binary>>.
-
+    <<Lifetime:32, AgeAdd:32, NonceLen, Nonce/binary, TicketLen:16, Ticket/binary, ExtLen:16,
+        Extensions/binary>>.

--- a/src/quic_varint.erl
+++ b/src/quic_varint.erl
@@ -29,10 +29,15 @@
 ]).
 
 %% Maximum values for each encoding length
--define(MAX_1BYTE, 63).                          % 2^6 - 1
--define(MAX_2BYTE, 16383).                       % 2^14 - 1
--define(MAX_4BYTE, 1073741823).                  % 2^30 - 1
--define(MAX_8BYTE, 4611686018427387903).         % 2^62 - 1
+
+% 2^6 - 1
+-define(MAX_1BYTE, 63).
+% 2^14 - 1
+-define(MAX_2BYTE, 16383).
+% 2^30 - 1
+-define(MAX_4BYTE, 1073741823).
+% 2^62 - 1
+-define(MAX_8BYTE, 4611686018427387903).
 
 %%====================================================================
 %% API
@@ -103,4 +108,5 @@ needed_bytes(<<First, _/binary>>) ->
         2 -> 4;
         3 -> 8
     end;
-needed_bytes(<<>>) -> 1.
+needed_bytes(<<>>) ->
+    1.

--- a/test/prop_quic_crypto.erl
+++ b/test/prop_quic_crypto.erl
@@ -51,9 +51,15 @@ salt() ->
 
 %% Label
 label() ->
-    ?LET(Len, range(1, 20),
-         ?LET(Bytes, vector(Len, range($a, $z)),
-              list_to_binary(Bytes))).
+    ?LET(
+        Len,
+        range(1, 20),
+        ?LET(
+            Bytes,
+            vector(Len, range($a, $z)),
+            list_to_binary(Bytes)
+        )
+    ).
 
 %%====================================================================
 %% AEAD Properties
@@ -61,76 +67,100 @@ label() ->
 
 %% AES-128-GCM encrypt/decrypt roundtrip
 prop_aes128_roundtrip() ->
-    ?FORALL({Key, IV, PN, AAD, Plaintext},
-            {aes128_key(), iv(), packet_number(), aad(), plaintext()},
+    ?FORALL(
+        {Key, IV, PN, AAD, Plaintext},
+        {aes128_key(), iv(), packet_number(), aad(), plaintext()},
         begin
             Ciphertext = quic_aead:encrypt(Key, IV, PN, AAD, Plaintext),
             case quic_aead:decrypt(Key, IV, PN, AAD, Ciphertext) of
                 {ok, Decrypted} -> Plaintext =:= Decrypted;
                 _ -> false
             end
-        end).
+        end
+    ).
 
 %% AES-256-GCM encrypt/decrypt roundtrip
 prop_aes256_roundtrip() ->
-    ?FORALL({Key, IV, PN, AAD, Plaintext},
-            {aes256_key(), iv(), packet_number(), aad(), plaintext()},
+    ?FORALL(
+        {Key, IV, PN, AAD, Plaintext},
+        {aes256_key(), iv(), packet_number(), aad(), plaintext()},
         begin
             Ciphertext = quic_aead:encrypt(Key, IV, PN, AAD, Plaintext),
             case quic_aead:decrypt(Key, IV, PN, AAD, Ciphertext) of
                 {ok, Decrypted} -> Plaintext =:= Decrypted;
                 _ -> false
             end
-        end).
+        end
+    ).
 
 %% Ciphertext is longer than plaintext (by tag length)
 prop_ciphertext_has_tag() ->
-    ?FORALL({Key, IV, PN, AAD, Plaintext},
-            {aes128_key(), iv(), packet_number(), aad(), plaintext()},
+    ?FORALL(
+        {Key, IV, PN, AAD, Plaintext},
+        {aes128_key(), iv(), packet_number(), aad(), plaintext()},
         begin
             Ciphertext = quic_aead:encrypt(Key, IV, PN, AAD, Plaintext),
             byte_size(Ciphertext) =:= byte_size(Plaintext) + 16
-        end).
+        end
+    ).
 
 %% Wrong key fails decryption
 prop_wrong_key_fails() ->
-    ?FORALL({Key1, Key2, IV, PN, AAD, Plaintext},
-            {aes128_key(), aes128_key(), iv(), packet_number(), aad(), plaintext()},
-        ?IMPLIES(Key1 =/= Key2,
+    ?FORALL(
+        {Key1, Key2, IV, PN, AAD, Plaintext},
+        {aes128_key(), aes128_key(), iv(), packet_number(), aad(), plaintext()},
+        ?IMPLIES(
+            Key1 =/= Key2,
             begin
                 Ciphertext = quic_aead:encrypt(Key1, IV, PN, AAD, Plaintext),
                 quic_aead:decrypt(Key2, IV, PN, AAD, Ciphertext) =:= {error, bad_tag}
-            end)).
+            end
+        )
+    ).
 
 %% Wrong AAD fails decryption
 prop_wrong_aad_fails() ->
-    ?FORALL({Key, IV, PN, AAD1, AAD2, Plaintext},
-            {aes128_key(), iv(), packet_number(), aad(), aad(), plaintext()},
-        ?IMPLIES(AAD1 =/= AAD2,
+    ?FORALL(
+        {Key, IV, PN, AAD1, AAD2, Plaintext},
+        {aes128_key(), iv(), packet_number(), aad(), aad(), plaintext()},
+        ?IMPLIES(
+            AAD1 =/= AAD2,
             begin
                 Ciphertext = quic_aead:encrypt(Key, IV, PN, AAD1, Plaintext),
                 quic_aead:decrypt(Key, IV, PN, AAD2, Ciphertext) =:= {error, bad_tag}
-            end)).
+            end
+        )
+    ).
 
 %% Wrong packet number fails decryption
 prop_wrong_pn_fails() ->
-    ?FORALL({Key, IV, PN1, PN2, AAD, Plaintext},
-            {aes128_key(), iv(), packet_number(), packet_number(), aad(), plaintext()},
-        ?IMPLIES(PN1 =/= PN2,
+    ?FORALL(
+        {Key, IV, PN1, PN2, AAD, Plaintext},
+        {aes128_key(), iv(), packet_number(), packet_number(), aad(), plaintext()},
+        ?IMPLIES(
+            PN1 =/= PN2,
             begin
                 Ciphertext = quic_aead:encrypt(Key, IV, PN1, AAD, Plaintext),
                 quic_aead:decrypt(Key, IV, PN2, AAD, Ciphertext) =:= {error, bad_tag}
-            end)).
+            end
+        )
+    ).
 
 %% Nonce computation is deterministic
 prop_nonce_deterministic() ->
-    ?FORALL({IV, PN}, {iv(), packet_number()},
-        quic_aead:compute_nonce(IV, PN) =:= quic_aead:compute_nonce(IV, PN)).
+    ?FORALL(
+        {IV, PN},
+        {iv(), packet_number()},
+        quic_aead:compute_nonce(IV, PN) =:= quic_aead:compute_nonce(IV, PN)
+    ).
 
 %% Nonce is 12 bytes
 prop_nonce_length() ->
-    ?FORALL({IV, PN}, {iv(), packet_number()},
-        byte_size(quic_aead:compute_nonce(IV, PN)) =:= 12).
+    ?FORALL(
+        {IV, PN},
+        {iv(), packet_number()},
+        byte_size(quic_aead:compute_nonce(IV, PN)) =:= 12
+    ).
 
 %%====================================================================
 %% HKDF Properties
@@ -138,24 +168,35 @@ prop_nonce_length() ->
 
 %% HKDF extract produces 32-byte output for SHA-256
 prop_hkdf_extract_length() ->
-    ?FORALL({Salt, IKM}, {salt(), secret()},
-        byte_size(quic_hkdf:extract(Salt, IKM)) =:= 32).
+    ?FORALL(
+        {Salt, IKM},
+        {salt(), secret()},
+        byte_size(quic_hkdf:extract(Salt, IKM)) =:= 32
+    ).
 
 %% HKDF expand produces requested length
 prop_hkdf_expand_length() ->
-    ?FORALL({PRK, Info, Len}, {secret(), aad(), range(1, 255)},
-        byte_size(quic_hkdf:expand(PRK, Info, Len)) =:= Len).
+    ?FORALL(
+        {PRK, Info, Len},
+        {secret(), aad(), range(1, 255)},
+        byte_size(quic_hkdf:expand(PRK, Info, Len)) =:= Len
+    ).
 
 %% HKDF is deterministic
 prop_hkdf_deterministic() ->
-    ?FORALL({Salt, IKM}, {salt(), secret()},
-        quic_hkdf:extract(Salt, IKM) =:= quic_hkdf:extract(Salt, IKM)).
+    ?FORALL(
+        {Salt, IKM},
+        {salt(), secret()},
+        quic_hkdf:extract(Salt, IKM) =:= quic_hkdf:extract(Salt, IKM)
+    ).
 
 %% HKDF expand-label produces requested length
 prop_expand_label_length() ->
-    ?FORALL({Secret, Label, Context, Len},
-            {secret(), label(), aad(), range(1, 64)},
-        byte_size(quic_hkdf:expand_label(Secret, Label, Context, Len)) =:= Len).
+    ?FORALL(
+        {Secret, Label, Context, Len},
+        {secret(), label(), aad(), range(1, 64)},
+        byte_size(quic_hkdf:expand_label(Secret, Label, Context, Len)) =:= Len
+    ).
 
 %%====================================================================
 %% Key Derivation Properties
@@ -163,41 +204,55 @@ prop_expand_label_length() ->
 
 %% Initial keys are deterministic for same DCID
 prop_initial_keys_deterministic() ->
-    ?FORALL(DCID, dcid(),
+    ?FORALL(
+        DCID,
+        dcid(),
         begin
             Keys1 = quic_keys:derive_initial_client(DCID),
             Keys2 = quic_keys:derive_initial_client(DCID),
             Keys1 =:= Keys2
-        end).
+        end
+    ).
 
 %% Client and server initial keys are different
 prop_client_server_keys_different() ->
-    ?FORALL(DCID, dcid(),
+    ?FORALL(
+        DCID,
+        dcid(),
         begin
             ClientKeys = quic_keys:derive_initial_client(DCID),
             ServerKeys = quic_keys:derive_initial_server(DCID),
             ClientKeys =/= ServerKeys
-        end).
+        end
+    ).
 
 %% Different DCIDs produce different keys
 prop_different_dcid_different_keys() ->
-    ?FORALL({DCID1, DCID2}, {dcid(), dcid()},
-        ?IMPLIES(DCID1 =/= DCID2,
+    ?FORALL(
+        {DCID1, DCID2},
+        {dcid(), dcid()},
+        ?IMPLIES(
+            DCID1 =/= DCID2,
             begin
                 Keys1 = quic_keys:derive_initial_client(DCID1),
                 Keys2 = quic_keys:derive_initial_client(DCID2),
                 Keys1 =/= Keys2
-            end)).
+            end
+        )
+    ).
 
 %% Initial keys have correct sizes
 prop_initial_key_sizes() ->
-    ?FORALL(DCID, dcid(),
+    ?FORALL(
+        DCID,
+        dcid(),
         begin
             {Key, IV, HP} = quic_keys:derive_initial_client(DCID),
             byte_size(Key) =:= 16 andalso
-            byte_size(IV) =:= 12 andalso
-            byte_size(HP) =:= 16
-        end).
+                byte_size(IV) =:= 12 andalso
+                byte_size(HP) =:= 16
+        end
+    ).
 
 %%====================================================================
 %% TLS Key Schedule Properties
@@ -205,31 +260,40 @@ prop_initial_key_sizes() ->
 
 %% Early secret is deterministic
 prop_early_secret_deterministic() ->
-    ?FORALL(PSK, secret(),
-        quic_crypto:derive_early_secret(PSK) =:= quic_crypto:derive_early_secret(PSK)).
+    ?FORALL(
+        PSK,
+        secret(),
+        quic_crypto:derive_early_secret(PSK) =:= quic_crypto:derive_early_secret(PSK)
+    ).
 
 %% Master secret derivation chain works
 prop_key_schedule_chain() ->
-    ?FORALL(SharedSecret, secret(),
+    ?FORALL(
+        SharedSecret,
+        secret(),
         begin
             Early = quic_crypto:derive_early_secret(),
             Handshake = quic_crypto:derive_handshake_secret(Early, SharedSecret),
             Master = quic_crypto:derive_master_secret(Handshake),
             byte_size(Early) =:= 32 andalso
-            byte_size(Handshake) =:= 32 andalso
-            byte_size(Master) =:= 32
-        end).
+                byte_size(Handshake) =:= 32 andalso
+                byte_size(Master) =:= 32
+        end
+    ).
 
 %% ECDHE shared secret is symmetric
 prop_ecdhe_symmetric() ->
-    ?FORALL(_, exactly(true),
+    ?FORALL(
+        _,
+        exactly(true),
         begin
             {PubA, PrivA} = quic_crypto:generate_key_pair(x25519),
             {PubB, PrivB} = quic_crypto:generate_key_pair(x25519),
             SharedA = quic_crypto:compute_shared_secret(x25519, PrivA, PubB),
             SharedB = quic_crypto:compute_shared_secret(x25519, PrivB, PubA),
             SharedA =:= SharedB
-        end).
+        end
+    ).
 
 %%====================================================================
 %% EUnit wrapper
@@ -252,12 +316,24 @@ proper_test_() ->
         ?_assert(proper:quickcheck(prop_hkdf_deterministic(), [{numtests, 200}, {to_file, user}])),
         ?_assert(proper:quickcheck(prop_expand_label_length(), [{numtests, 200}, {to_file, user}])),
         %% Key derivation tests
-        ?_assert(proper:quickcheck(prop_initial_keys_deterministic(), [{numtests, 100}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_client_server_keys_different(), [{numtests, 100}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_different_dcid_different_keys(), [{numtests, 100}, {to_file, user}])),
+        ?_assert(
+            proper:quickcheck(prop_initial_keys_deterministic(), [{numtests, 100}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_client_server_keys_different(), [
+                {numtests, 100}, {to_file, user}
+            ])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_different_dcid_different_keys(), [
+                {numtests, 100}, {to_file, user}
+            ])
+        ),
         ?_assert(proper:quickcheck(prop_initial_key_sizes(), [{numtests, 100}, {to_file, user}])),
         %% TLS key schedule tests
-        ?_assert(proper:quickcheck(prop_early_secret_deterministic(), [{numtests, 100}, {to_file, user}])),
+        ?_assert(
+            proper:quickcheck(prop_early_secret_deterministic(), [{numtests, 100}, {to_file, user}])
+        ),
         ?_assert(proper:quickcheck(prop_key_schedule_chain(), [{numtests, 100}, {to_file, user}])),
         ?_assert(proper:quickcheck(prop_ecdhe_symmetric(), [{numtests, 50}, {to_file, user}]))
     ]}.

--- a/test/prop_quic_frame.erl
+++ b/test/prop_quic_frame.erl
@@ -41,94 +41,139 @@ ping_frame() ->
 %% where Ranges = [{LargestAcked, FirstRange} | RestRanges]
 %% and ECNCounts = undefined | {ECT0, ECT1, ECNCE}
 ack_frame() ->
-    ?LET({Largest, Delay, FirstRange, RestRanges},
-         {range(0, 1000), range(0, 1000), range(0, 100), list({range(1, 10), range(0, 10)})},
-         begin
-             Ranges = [{Largest, FirstRange} | RestRanges],
-             {ack, Ranges, Delay, undefined}
-         end).
+    ?LET(
+        {Largest, Delay, FirstRange, RestRanges},
+        {range(0, 1000), range(0, 1000), range(0, 100), list({range(1, 10), range(0, 10)})},
+        begin
+            Ranges = [{Largest, FirstRange} | RestRanges],
+            {ack, Ranges, Delay, undefined}
+        end
+    ).
 
 %% Generate a CRYPTO frame
 crypto_frame() ->
-    ?LET({Offset, Data}, {offset(), stream_data()},
-         {crypto, Offset, Data}).
+    ?LET(
+        {Offset, Data},
+        {offset(), stream_data()},
+        {crypto, Offset, Data}
+    ).
 
 %% Generate a STREAM frame
 stream_frame() ->
-    ?LET({StreamId, Offset, Data, Fin},
-         {stream_id(), offset(), stream_data(), boolean()},
-         {stream, StreamId, Offset, Data, Fin}).
+    ?LET(
+        {StreamId, Offset, Data, Fin},
+        {stream_id(), offset(), stream_data(), boolean()},
+        {stream, StreamId, Offset, Data, Fin}
+    ).
 
 %% Generate a RESET_STREAM frame
 reset_stream_frame() ->
-    ?LET({StreamId, ErrorCode, FinalSize},
-         {stream_id(), error_code(), offset()},
-         {reset_stream, StreamId, ErrorCode, FinalSize}).
+    ?LET(
+        {StreamId, ErrorCode, FinalSize},
+        {stream_id(), error_code(), offset()},
+        {reset_stream, StreamId, ErrorCode, FinalSize}
+    ).
 
 %% Generate a STOP_SENDING frame
 stop_sending_frame() ->
-    ?LET({StreamId, ErrorCode},
-         {stream_id(), error_code()},
-         {stop_sending, StreamId, ErrorCode}).
+    ?LET(
+        {StreamId, ErrorCode},
+        {stream_id(), error_code()},
+        {stop_sending, StreamId, ErrorCode}
+    ).
 
 %% Generate a MAX_DATA frame
 max_data_frame() ->
-    ?LET(MaxData, range(0, 16#FFFFFFFF),
-         {max_data, MaxData}).
+    ?LET(
+        MaxData,
+        range(0, 16#FFFFFFFF),
+        {max_data, MaxData}
+    ).
 
 %% Generate a MAX_STREAM_DATA frame
 max_stream_data_frame() ->
-    ?LET({StreamId, MaxData}, {stream_id(), range(0, 16#FFFFFFFF)},
-         {max_stream_data, StreamId, MaxData}).
+    ?LET(
+        {StreamId, MaxData},
+        {stream_id(), range(0, 16#FFFFFFFF)},
+        {max_stream_data, StreamId, MaxData}
+    ).
 
 %% Generate a MAX_STREAMS frame
 max_streams_frame() ->
-    ?LET({Type, MaxStreams}, {oneof([bidi, uni]), range(0, 1000)},
-         {max_streams, Type, MaxStreams}).
+    ?LET(
+        {Type, MaxStreams},
+        {oneof([bidi, uni]), range(0, 1000)},
+        {max_streams, Type, MaxStreams}
+    ).
 
 %% Generate a DATA_BLOCKED frame
 data_blocked_frame() ->
-    ?LET(Limit, range(0, 16#FFFFFFFF),
-         {data_blocked, Limit}).
+    ?LET(
+        Limit,
+        range(0, 16#FFFFFFFF),
+        {data_blocked, Limit}
+    ).
 
 %% Generate a STREAM_DATA_BLOCKED frame
 stream_data_blocked_frame() ->
-    ?LET({StreamId, Limit}, {stream_id(), range(0, 16#FFFFFFFF)},
-         {stream_data_blocked, StreamId, Limit}).
+    ?LET(
+        {StreamId, Limit},
+        {stream_id(), range(0, 16#FFFFFFFF)},
+        {stream_data_blocked, StreamId, Limit}
+    ).
 
 %% Generate a STREAMS_BLOCKED frame
 streams_blocked_frame() ->
-    ?LET({Type, Limit}, {oneof([bidi, uni]), range(0, 1000)},
-         {streams_blocked, Type, Limit}).
+    ?LET(
+        {Type, Limit},
+        {oneof([bidi, uni]), range(0, 1000)},
+        {streams_blocked, Type, Limit}
+    ).
 
 %% Generate a NEW_CONNECTION_ID frame
 new_connection_id_frame() ->
-    ?LET({Seq, Retire, CID, Token},
-         {range(0, 100), range(0, 100), binary(8), binary(16)},
-         {new_connection_id, Seq, Retire, CID, Token}).
+    ?LET(
+        {Seq, Retire, CID, Token},
+        {range(0, 100), range(0, 100), binary(8), binary(16)},
+        {new_connection_id, Seq, Retire, CID, Token}
+    ).
 
 %% Generate a RETIRE_CONNECTION_ID frame
 retire_connection_id_frame() ->
-    ?LET(Seq, range(0, 100),
-         {retire_connection_id, Seq}).
+    ?LET(
+        Seq,
+        range(0, 100),
+        {retire_connection_id, Seq}
+    ).
 
 %% Generate a PATH_CHALLENGE frame
 path_challenge_frame() ->
-    ?LET(Data, binary(8),
-         {path_challenge, Data}).
+    ?LET(
+        Data,
+        binary(8),
+        {path_challenge, Data}
+    ).
 
 %% Generate a PATH_RESPONSE frame
 path_response_frame() ->
-    ?LET(Data, binary(8),
-         {path_response, Data}).
+    ?LET(
+        Data,
+        binary(8),
+        {path_response, Data}
+    ).
 
 %% Generate a CONNECTION_CLOSE frame
 %% Format: {connection_close, transport|application, ErrorCode, FrameType, Reason}
 connection_close_frame() ->
-    ?LET({Type, ErrorCode, FrameType, ReasonLen},
-         {oneof([transport, application]), error_code(), range(0, 255), range(0, 50)},
-         ?LET(Reason, binary(ReasonLen),
-              {connection_close, Type, ErrorCode, FrameType, Reason})).
+    ?LET(
+        {Type, ErrorCode, FrameType, ReasonLen},
+        {oneof([transport, application]), error_code(), range(0, 255), range(0, 50)},
+        ?LET(
+            Reason,
+            binary(ReasonLen),
+            {connection_close, Type, ErrorCode, FrameType, Reason}
+        )
+    ).
 
 %% Generate a HANDSHAKE_DONE frame
 handshake_done_frame() ->
@@ -164,7 +209,9 @@ any_frame() ->
 
 %% Encoding then decoding returns the original frame
 prop_frame_roundtrip() ->
-    ?FORALL(Frame, any_frame(),
+    ?FORALL(
+        Frame,
+        any_frame(),
         begin
             Encoded = quic_frame:encode(Frame),
             case quic_frame:decode(Encoded) of
@@ -173,63 +220,84 @@ prop_frame_roundtrip() ->
                 _ ->
                     false
             end
-        end).
+        end
+    ).
 
 %% STREAM frame roundtrip
 prop_stream_frame_roundtrip() ->
-    ?FORALL(Frame, stream_frame(),
+    ?FORALL(
+        Frame,
+        stream_frame(),
         begin
             Encoded = quic_frame:encode(Frame),
             {Decoded, <<>>} = quic_frame:decode(Encoded),
             frames_equal(Frame, Decoded)
-        end).
+        end
+    ).
 
 %% CRYPTO frame roundtrip
 prop_crypto_frame_roundtrip() ->
-    ?FORALL(Frame, crypto_frame(),
+    ?FORALL(
+        Frame,
+        crypto_frame(),
         begin
             Encoded = quic_frame:encode(Frame),
             {Decoded, <<>>} = quic_frame:decode(Encoded),
             frames_equal(Frame, Decoded)
-        end).
+        end
+    ).
 
 %% ACK frame roundtrip
 prop_ack_frame_roundtrip() ->
-    ?FORALL(Frame, ack_frame(),
+    ?FORALL(
+        Frame,
+        ack_frame(),
         begin
             Encoded = quic_frame:encode(Frame),
             {Decoded, <<>>} = quic_frame:decode(Encoded),
             frames_equal(Frame, Decoded)
-        end).
+        end
+    ).
 
 %% Encoding is deterministic
 prop_encode_deterministic() ->
-    ?FORALL(Frame, any_frame(),
-        quic_frame:encode(Frame) =:= quic_frame:encode(Frame)).
+    ?FORALL(
+        Frame,
+        any_frame(),
+        quic_frame:encode(Frame) =:= quic_frame:encode(Frame)
+    ).
 
 %% Decoding with extra data preserves the rest
 prop_decode_preserves_rest() ->
-    ?FORALL({Frame, Rest}, {any_frame(), binary()},
+    ?FORALL(
+        {Frame, Rest},
+        {any_frame(), binary()},
         begin
             Encoded = quic_frame:encode(Frame),
             {_, Remaining} = quic_frame:decode(<<Encoded/binary, Rest/binary>>),
             Rest =:= Remaining
-        end).
+        end
+    ).
 
 %% Multiple frames can be decoded sequentially
 prop_decode_multiple() ->
-    ?FORALL(Frames, non_empty(list(any_frame())),
+    ?FORALL(
+        Frames,
+        non_empty(list(any_frame())),
         begin
             Encoded = iolist_to_binary([quic_frame:encode(F) || F <- Frames]),
             case quic_frame:decode_all(Encoded) of
                 {ok, Decoded} ->
                     length(Decoded) =:= length(Frames) andalso
-                        lists:all(fun({F, D}) -> frames_equal(F, D) end,
-                                  lists:zip(Frames, Decoded));
+                        lists:all(
+                            fun({F, D}) -> frames_equal(F, D) end,
+                            lists:zip(Frames, Decoded)
+                        );
                 {error, _} ->
                     false
             end
-        end).
+        end
+    ).
 
 %%====================================================================
 %% Helpers
@@ -247,9 +315,12 @@ frames_equal({crypto, O1, D1}, {crypto, O2, D2}) ->
 frames_equal({connection_close, transport, E1, F1, R1}, {connection_close, transport, E2, F2, R2}) ->
     E1 =:= E2 andalso F1 =:= F2 andalso R1 =:= R2;
 %% For application close, FrameType is ignored (RFC 9000) - decoded always has undefined
-frames_equal({connection_close, application, E1, _, R1}, {connection_close, application, E2, undefined, R2}) ->
+frames_equal(
+    {connection_close, application, E1, _, R1}, {connection_close, application, E2, undefined, R2}
+) ->
     E1 =:= E2 andalso R1 =:= R2;
-frames_equal(_, _) -> false.
+frames_equal(_, _) ->
+    false.
 
 %%====================================================================
 %% EUnit wrapper
@@ -258,10 +329,18 @@ frames_equal(_, _) -> false.
 proper_test_() ->
     {timeout, 120, [
         ?_assert(proper:quickcheck(prop_frame_roundtrip(), [{numtests, 500}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_stream_frame_roundtrip(), [{numtests, 200}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_crypto_frame_roundtrip(), [{numtests, 200}, {to_file, user}])),
+        ?_assert(
+            proper:quickcheck(prop_stream_frame_roundtrip(), [{numtests, 200}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_crypto_frame_roundtrip(), [{numtests, 200}, {to_file, user}])
+        ),
         ?_assert(proper:quickcheck(prop_ack_frame_roundtrip(), [{numtests, 200}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_encode_deterministic(), [{numtests, 300}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_decode_preserves_rest(), [{numtests, 300}, {to_file, user}])),
+        ?_assert(
+            proper:quickcheck(prop_encode_deterministic(), [{numtests, 300}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_decode_preserves_rest(), [{numtests, 300}, {to_file, user}])
+        ),
         ?_assert(proper:quickcheck(prop_decode_multiple(), [{numtests, 100}, {to_file, user}]))
     ]}.

--- a/test/prop_quic_varint.erl
+++ b/test/prop_quic_varint.erl
@@ -14,8 +14,11 @@
 
 %% Generate valid varint values (0 to 2^62 - 1)
 varint_value() ->
-    ?LET(Bits, range(0, 62),
-         ?LET(V, range(0, (1 bsl Bits) - 1), V)).
+    ?LET(
+        Bits,
+        range(0, 62),
+        ?LET(V, range(0, (1 bsl Bits) - 1), V)
+    ).
 
 %% Generate small varints (1 byte, 0-63)
 small_varint() ->
@@ -39,69 +42,97 @@ xlarge_varint() ->
 
 %% Encoding then decoding returns the original value
 prop_roundtrip() ->
-    ?FORALL(V, varint_value(),
+    ?FORALL(
+        V,
+        varint_value(),
         begin
             Encoded = quic_varint:encode(V),
             {Decoded, <<>>} = quic_varint:decode(Encoded),
             V =:= Decoded
-        end).
+        end
+    ).
 
 %% Encoding produces correct length based on value
 prop_encoded_length() ->
-    ?FORALL(V, varint_value(),
+    ?FORALL(
+        V,
+        varint_value(),
         begin
             Encoded = quic_varint:encode(V),
             ExpectedLen = expected_length(V),
             byte_size(Encoded) =:= ExpectedLen
-        end).
+        end
+    ).
 
 %% Small values use 1 byte
 prop_small_uses_one_byte() ->
-    ?FORALL(V, small_varint(),
-        byte_size(quic_varint:encode(V)) =:= 1).
+    ?FORALL(
+        V,
+        small_varint(),
+        byte_size(quic_varint:encode(V)) =:= 1
+    ).
 
 %% Medium values use 2 bytes
 prop_medium_uses_two_bytes() ->
-    ?FORALL(V, medium_varint(),
-        byte_size(quic_varint:encode(V)) =:= 2).
+    ?FORALL(
+        V,
+        medium_varint(),
+        byte_size(quic_varint:encode(V)) =:= 2
+    ).
 
 %% Large values use 4 bytes
 prop_large_uses_four_bytes() ->
-    ?FORALL(V, large_varint(),
-        byte_size(quic_varint:encode(V)) =:= 4).
+    ?FORALL(
+        V,
+        large_varint(),
+        byte_size(quic_varint:encode(V)) =:= 4
+    ).
 
 %% Extra large values use 8 bytes
 prop_xlarge_uses_eight_bytes() ->
-    ?FORALL(V, xlarge_varint(),
-        byte_size(quic_varint:encode(V)) =:= 8).
+    ?FORALL(
+        V,
+        xlarge_varint(),
+        byte_size(quic_varint:encode(V)) =:= 8
+    ).
 
 %% Decoding with extra data preserves the rest
 prop_decode_preserves_rest() ->
-    ?FORALL({V, Rest}, {varint_value(), binary()},
+    ?FORALL(
+        {V, Rest},
+        {varint_value(), binary()},
         begin
             Encoded = quic_varint:encode(V),
             {Decoded, Remaining} = quic_varint:decode(<<Encoded/binary, Rest/binary>>),
             V =:= Decoded andalso Rest =:= Remaining
-        end).
+        end
+    ).
 
 %% Encoding is deterministic
 prop_encode_deterministic() ->
-    ?FORALL(V, varint_value(),
-        quic_varint:encode(V) =:= quic_varint:encode(V)).
+    ?FORALL(
+        V,
+        varint_value(),
+        quic_varint:encode(V) =:= quic_varint:encode(V)
+    ).
 
 %% First two bits indicate length
 prop_length_prefix() ->
-    ?FORALL(V, varint_value(),
+    ?FORALL(
+        V,
+        varint_value(),
         begin
             <<Prefix:2, _/bits>> = quic_varint:encode(V),
-            ExpectedPrefix = case expected_length(V) of
-                1 -> 0;
-                2 -> 1;
-                4 -> 2;
-                8 -> 3
-            end,
+            ExpectedPrefix =
+                case expected_length(V) of
+                    1 -> 0;
+                    2 -> 1;
+                    4 -> 2;
+                    8 -> 3
+                end,
             Prefix =:= ExpectedPrefix
-        end).
+        end
+    ).
 
 %%====================================================================
 %% Helpers
@@ -121,10 +152,20 @@ proper_test_() ->
         ?_assert(proper:quickcheck(prop_roundtrip(), [{numtests, 1000}, {to_file, user}])),
         ?_assert(proper:quickcheck(prop_encoded_length(), [{numtests, 1000}, {to_file, user}])),
         ?_assert(proper:quickcheck(prop_small_uses_one_byte(), [{numtests, 100}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_medium_uses_two_bytes(), [{numtests, 100}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_large_uses_four_bytes(), [{numtests, 100}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_xlarge_uses_eight_bytes(), [{numtests, 100}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_decode_preserves_rest(), [{numtests, 500}, {to_file, user}])),
-        ?_assert(proper:quickcheck(prop_encode_deterministic(), [{numtests, 500}, {to_file, user}])),
+        ?_assert(
+            proper:quickcheck(prop_medium_uses_two_bytes(), [{numtests, 100}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_large_uses_four_bytes(), [{numtests, 100}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_xlarge_uses_eight_bytes(), [{numtests, 100}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_decode_preserves_rest(), [{numtests, 500}, {to_file, user}])
+        ),
+        ?_assert(
+            proper:quickcheck(prop_encode_deterministic(), [{numtests, 500}, {to_file, user}])
+        ),
         ?_assert(proper:quickcheck(prop_length_prefix(), [{numtests, 500}, {to_file, user}]))
     ]}.

--- a/test/quic_ack_tests.erl
+++ b/test/quic_ack_tests.erl
@@ -105,7 +105,8 @@ generate_ack_single_packet_test() ->
     S1 = quic_ack:record_received(State, 0),
     {ok, {ack, Largest, _Delay, FirstRange, Ranges}} = quic_ack:generate_ack(S1),
     ?assertEqual(0, Largest),
-    ?assertEqual(0, FirstRange),  % 1 packet - 1 = 0
+    % 1 packet - 1 = 0
+    ?assertEqual(0, FirstRange),
     ?assertEqual([], Ranges).
 
 generate_ack_range_test() ->
@@ -115,7 +116,8 @@ generate_ack_range_test() ->
     S3 = quic_ack:record_received(S2, 2),
     {ok, {ack, Largest, _Delay, FirstRange, Ranges}} = quic_ack:generate_ack(S3),
     ?assertEqual(2, Largest),
-    ?assertEqual(2, FirstRange),  % 3 packets - 1 = 2
+    % 3 packets - 1 = 2
+    ?assertEqual(2, FirstRange),
     ?assertEqual([], Ranges).
 
 generate_ack_with_gap_test() ->
@@ -126,7 +128,8 @@ generate_ack_with_gap_test() ->
     S4 = quic_ack:record_received(S3, 6),
     {ok, {ack, Largest, _Delay, FirstRange, AckRanges}} = quic_ack:generate_ack(S4),
     ?assertEqual(6, Largest),
-    ?assertEqual(1, FirstRange),  % 2 packets (5,6) - 1 = 1
+    % 2 packets (5,6) - 1 = 1
+    ?assertEqual(1, FirstRange),
     ?assertEqual(1, length(AckRanges)).
 
 %%====================================================================
@@ -160,7 +163,8 @@ mark_ack_sent_test() ->
 
 process_ack_simple_test() ->
     State = quic_ack:new(),
-    AckFrame = {ack, 5, 0, 5, []},  % Acks packets 0-5
+    % Acks packets 0-5
+    AckFrame = {ack, 5, 0, 5, []},
     {NewState, AckedPNs} = quic_ack:process_ack(State, AckFrame),
     ?assertEqual(5, quic_ack:largest_acked(NewState)),
     ?assertEqual([0, 1, 2, 3, 4, 5], lists:sort(AckedPNs)).
@@ -172,7 +176,8 @@ process_ack_with_sent_packets_test() ->
         1 => #{ack_eliciting => true},
         2 => #{ack_eliciting => false}
     },
-    AckFrame = {ack, 2, 0, 2, []},  % Acks 0-2
+    % Acks 0-2
+    AckFrame = {ack, 2, 0, 2, []},
     {_NewState, AckedPNs} = quic_ack:process_ack(State, AckFrame, SentPackets),
     ?assertEqual([0, 1, 2], lists:sort(AckedPNs)).
 
@@ -239,7 +244,8 @@ full_cycle_test() ->
     %% Receive some packets
     S1 = quic_ack:record_received(State, 0, true),
     S2 = quic_ack:record_received(S1, 1, true),
-    S3 = quic_ack:record_received(S2, 2, false),  % ACK-only
+    % ACK-only
+    S3 = quic_ack:record_received(S2, 2, false),
 
     ?assert(quic_ack:needs_ack(S3)),
 

--- a/test/quic_cc_tests.erl
+++ b/test/quic_cc_tests.erl
@@ -181,7 +181,9 @@ multiple_losses_same_recovery_test() ->
     Cwnd1 = quic_cc:cwnd(S1),
 
     %% Second event with same sent time shouldn't reduce again
-    S2 = quic_cc:on_congestion_event(S1, Now - 10),  % Earlier than recovery start
+
+    % Earlier than recovery start
+    S2 = quic_cc:on_congestion_event(S1, Now - 10),
     Cwnd2 = quic_cc:cwnd(S2),
 
     ?assertEqual(Cwnd1, Cwnd2).
@@ -218,7 +220,8 @@ on_packets_lost_reduces_in_flight_test() ->
 on_packets_lost_floor_zero_test() ->
     State = quic_cc:new(),
     S1 = quic_cc:on_packet_sent(State, 1000),
-    S2 = quic_cc:on_packets_lost(S1, 2000),  % More than in flight
+    % More than in flight
+    S2 = quic_cc:on_packets_lost(S1, 2000),
     ?assertEqual(0, quic_cc:bytes_in_flight(S2)).
 
 %%====================================================================
@@ -260,21 +263,24 @@ detect_persistent_congestion_single_packet_test() ->
 
 detect_persistent_congestion_below_threshold_test() ->
     State = quic_cc:new(),
-    PTO = 100,  % 100ms
+    % 100ms
+    PTO = 100,
     %% Lost packets span 200ms, but threshold is PTO * 3 = 300ms
     LostPackets = [{1, 1000}, {2, 1200}],
     ?assertNot(quic_cc:detect_persistent_congestion(LostPackets, PTO, State)).
 
 detect_persistent_congestion_at_threshold_test() ->
     State = quic_cc:new(),
-    PTO = 100,  % 100ms
+    % 100ms
+    PTO = 100,
     %% Lost packets span exactly PTO * 3 = 300ms
     LostPackets = [{1, 1000}, {2, 1300}],
     ?assert(quic_cc:detect_persistent_congestion(LostPackets, PTO, State)).
 
 detect_persistent_congestion_above_threshold_test() ->
     State = quic_cc:new(),
-    PTO = 100,  % 100ms
+    % 100ms
+    PTO = 100,
     %% Lost packets span 500ms, threshold is PTO * 3 = 300ms
     LostPackets = [{1, 1000}, {5, 1500}],
     ?assert(quic_cc:detect_persistent_congestion(LostPackets, PTO, State)).

--- a/test/quic_cid_limit_tests.erl
+++ b/test/quic_cid_limit_tests.erl
@@ -119,7 +119,10 @@ higher_limit_test() ->
             CID = <<Seq, Seq, Seq, Seq, Seq, Seq, Seq, Seq>>,
             Token = crypto:strong_rand_bytes(16),
             handle_new_connection_id(Seq, 0, CID, Token, AccState)
-        end, {ok, State}, lists:seq(0, 7)),
+        end,
+        {ok, State},
+        lists:seq(0, 7)
+    ),
 
     ?assertEqual(8, length(FinalState#test_state.peer_cid_pool)),
 
@@ -213,11 +216,14 @@ handle_new_connection_id(SeqNum, RetirePrior, CID, ResetToken, State) ->
 
     %% Retire CIDs with seq < RetirePrior
     RetiredPool = lists:map(
-        fun(#cid_entry{seq_num = S} = Entry) when S < RetirePrior ->
+        fun
+            (#cid_entry{seq_num = S} = Entry) when S < RetirePrior ->
                 Entry#cid_entry{status = retired};
-           (Entry) ->
+            (Entry) ->
                 Entry
-        end, Pool),
+        end,
+        Pool
+    ),
 
     %% Add new CID entry
     NewEntry = #cid_entry{

--- a/test/quic_coalesce_tests.erl
+++ b/test/quic_coalesce_tests.erl
@@ -21,7 +21,9 @@ coalesce_frames_basic_test() ->
 %% Test coalescing ACK and STREAM frames
 coalesce_ack_and_stream_test() ->
     %% Create an ACK frame
-    AckRanges = [{10, 5}],  % Largest=10, FirstRange=5
+
+    % Largest=10, FirstRange=5
+    AckRanges = [{10, 5}],
     AckFrame = quic_frame:encode({ack, AckRanges, 0, undefined}),
 
     %% Create a small STREAM frame

--- a/test/quic_connection_tests.erl
+++ b/test/quic_connection_tests.erl
@@ -141,7 +141,7 @@ multiple_connections_test() ->
 %%====================================================================
 
 ipv4_tuple_address_test() ->
-    {ok, Pid} = quic_connection:start_link({127,0,0,1}, 4433, #{}, self()),
+    {ok, Pid} = quic_connection:start_link({127, 0, 0, 1}, 4433, #{}, self()),
     ?assert(is_pid(Pid)),
     quic_connection:close(Pid, normal),
     timer:sleep(100).

--- a/test/quic_e2e_SUITE.erl
+++ b/test/quic_e2e_SUITE.erl
@@ -95,13 +95,14 @@ init_per_suite(Config) ->
 
     % Path to CA certificate for verification
     PrivDir = code:priv_dir(quic),
-    CertsDir = case PrivDir of
-        {error, _} ->
-            % Fallback to relative path from test directory
-            filename:join([code:lib_dir(quic), "..", "certs"]);
-        _ ->
-            filename:join([PrivDir, "..", "certs"])
-    end,
+    CertsDir =
+        case PrivDir of
+            {error, _} ->
+                % Fallback to relative path from test directory
+                filename:join([code:lib_dir(quic), "..", "certs"]);
+            _ ->
+                filename:join([PrivDir, "..", "certs"])
+        end,
     CaCert = filename:join(CertsDir, "ca.pem"),
 
     ct:pal("E2E Test Configuration:"),
@@ -174,9 +175,11 @@ handshake_with_alpn(Config) ->
             % Verify ALPN was negotiated
             AlpnProtocol = maps:get(alpn_protocol, Info, undefined),
             ct:pal("Negotiated ALPN: ~p", [AlpnProtocol]),
-            ?assert(AlpnProtocol =:= <<"h3">> orelse
+            ?assert(
+                AlpnProtocol =:= <<"h3">> orelse
                     AlpnProtocol =:= <<"echo">> orelse
-                    AlpnProtocol =:= undefined),
+                    AlpnProtocol =:= undefined
+            ),
             quic:close(ConnRef, normal),
             ok
     after 10000 ->
@@ -447,10 +450,11 @@ wait_for_server(Host, Port, Retries) ->
     case gen_udp:open(0, [binary, {active, false}]) of
         {ok, Socket} ->
             % Try to send a packet (won't get response, but verifies route)
-            HostAddr = case inet:parse_address(Host) of
-                {ok, Addr} -> Addr;
-                {error, _} -> Host
-            end,
+            HostAddr =
+                case inet:parse_address(Host) of
+                    {ok, Addr} -> Addr;
+                    {error, _} -> Host
+                end,
             Result = gen_udp:send(Socket, HostAddr, Port, <<0:32>>),
             gen_udp:close(Socket),
             case Result of

--- a/test/quic_error_codes_tests.erl
+++ b/test/quic_error_codes_tests.erl
@@ -199,7 +199,9 @@ application_close_with_reason_test() ->
     Frame = {connection_close, application, 42, undefined, <<"application shutdown">>},
     Encoded = quic_frame:encode(Frame),
     {Decoded, <<>>} = quic_frame:decode(Encoded),
-    ?assertEqual({connection_close, application, 42, undefined, <<"application shutdown">>}, Decoded).
+    ?assertEqual(
+        {connection_close, application, 42, undefined, <<"application shutdown">>}, Decoded
+    ).
 
 %% H3 error codes (HTTP/3 specific)
 h3_no_error_test() ->

--- a/test/quic_flow_tests.erl
+++ b/test/quic_flow_tests.erl
@@ -69,10 +69,12 @@ on_max_data_received_test() ->
 
 max_data_only_increases_test() ->
     State = quic_flow:new(#{peer_initial_max_data => 10000}),
-    S1 = quic_flow:on_max_data_received(State, 5000),  % Lower
+    % Lower
+    S1 = quic_flow:on_max_data_received(State, 5000),
     ?assertEqual(10000, quic_flow:send_limit(S1)),
 
-    S2 = quic_flow:on_max_data_received(S1, 15000),  % Higher
+    % Higher
+    S2 = quic_flow:on_max_data_received(S1, 15000),
     ?assertEqual(15000, quic_flow:send_limit(S2)).
 
 %%====================================================================
@@ -88,8 +90,10 @@ on_data_received_test() ->
 on_data_received_exceeds_limit_test() ->
     State = quic_flow:new(#{initial_max_data => 5000}),
     {ok, S1} = quic_flow:on_data_received(State, 5000),
-    ?assertEqual({error, flow_control_error},
-                 quic_flow:on_data_received(S1, 1)).
+    ?assertEqual(
+        {error, flow_control_error},
+        quic_flow:on_data_received(S1, 1)
+    ).
 
 on_data_received_at_limit_test() ->
     State = quic_flow:new(#{initial_max_data => 5000}),
@@ -110,7 +114,8 @@ should_send_max_data_after_threshold_test() ->
     {ok, S1} = quic_flow:on_data_received(State, 4000),
     ?assertNot(quic_flow:should_send_max_data(S1)),
 
-    {ok, S2} = quic_flow:on_data_received(S1, 2000),  % 6000 total > 50%
+    % 6000 total > 50%
+    {ok, S2} = quic_flow:on_data_received(S1, 2000),
     ?assert(quic_flow:should_send_max_data(S2)).
 
 generate_max_data_test() ->
@@ -195,7 +200,8 @@ full_recv_cycle_test() ->
 
     %% Generate MAX_DATA
     {NewMax, S3} = quic_flow:generate_max_data(S2),
-    ?assertEqual(16000, NewMax),  % 6000 + 10000
+    % 6000 + 10000
+    ?assertEqual(16000, NewMax),
     ?assertNot(quic_flow:should_send_max_data(S3)),
 
     %% Can receive more now

--- a/test/quic_hkdf_tests.erl
+++ b/test/quic_hkdf_tests.erl
@@ -33,7 +33,9 @@ rfc5869_test1_expand_test() ->
     PRK = hexstr_to_bin("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"),
     Info = hexstr_to_bin("f0f1f2f3f4f5f6f7f8f9"),
     L = 42,
-    Expected = hexstr_to_bin("3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"),
+    Expected = hexstr_to_bin(
+        "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+    ),
     OKM = quic_hkdf:expand(PRK, Info, L),
     ?assertEqual(Expected, OKM).
 
@@ -61,7 +63,9 @@ rfc5869_test2_expand_test() ->
     PRK = hexstr_to_bin("06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"),
     Info = list_to_binary(lists:seq(16#b0, 16#ff)),
     L = 82,
-    Expected = hexstr_to_bin("b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"),
+    Expected = hexstr_to_bin(
+        "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
+    ),
     OKM = quic_hkdf:expand(PRK, Info, L),
     ?assertEqual(Expected, OKM).
 
@@ -88,7 +92,9 @@ rfc5869_test3_extract_test() ->
 rfc5869_test3_expand_test() ->
     PRK = hexstr_to_bin("19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04"),
     L = 42,
-    Expected = hexstr_to_bin("8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"),
+    Expected = hexstr_to_bin(
+        "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"
+    ),
     OKM = quic_hkdf:expand(PRK, <<>>, L),
     ?assertEqual(Expected, OKM).
 

--- a/test/quic_idle_timeout_tests.erl
+++ b/test/quic_idle_timeout_tests.erl
@@ -26,8 +26,10 @@ idle_timeout_message_format_test() ->
 
 %% Test the basic concept of idle timeout checking
 idle_timeout_check_logic_test() ->
-    IdleTimeout = 30000,  % 30 seconds
-    LastActivity = erlang:monotonic_time(millisecond) - 25000,  % 25 seconds ago
+    % 30 seconds
+    IdleTimeout = 30000,
+    % 25 seconds ago
+    LastActivity = erlang:monotonic_time(millisecond) - 25000,
     Now = erlang:monotonic_time(millisecond),
     TimeSinceActivity = Now - LastActivity,
 
@@ -35,7 +37,9 @@ idle_timeout_check_logic_test() ->
     ?assertNot(TimeSinceActivity >= IdleTimeout),
 
     %% Simulate more time passing
-    LastActivity2 = erlang:monotonic_time(millisecond) - 35000,  % 35 seconds ago
+
+    % 35 seconds ago
+    LastActivity2 = erlang:monotonic_time(millisecond) - 35000,
     TimeSinceActivity2 = Now - LastActivity2,
 
     %% Should timeout (35s >= 30s)
@@ -44,7 +48,8 @@ idle_timeout_check_logic_test() ->
 %% Test that zero idle timeout means no timeout
 zero_idle_timeout_test() ->
     IdleTimeout = 0,
-    _LastActivity = erlang:monotonic_time(millisecond) - 1000000,  % Very old
+    % Very old
+    _LastActivity = erlang:monotonic_time(millisecond) - 1000000,
     _Now = erlang:monotonic_time(millisecond),
 
     %% With 0 timeout, comparison should indicate "set but disabled"
@@ -58,7 +63,8 @@ zero_idle_timeout_test() ->
 %% Test that activity resets the idle timeout window
 activity_resets_timeout_test() ->
     InitialActivity = erlang:monotonic_time(millisecond),
-    timer:sleep(10),  % Small delay
+    % Small delay
+    timer:sleep(10),
 
     %% Simulate activity update
     NewActivity = erlang:monotonic_time(millisecond),
@@ -71,7 +77,8 @@ activity_resets_timeout_test() ->
 
 %% Test exactly at timeout boundary
 exact_timeout_boundary_test() ->
-    IdleTimeout = 1000,  % 1 second
+    % 1 second
+    IdleTimeout = 1000,
 
     %% Exactly at boundary should trigger timeout (>= comparison)
     LastActivity = erlang:monotonic_time(millisecond) - 1000,
@@ -82,10 +89,13 @@ exact_timeout_boundary_test() ->
 
 %% Test just below timeout boundary
 just_below_timeout_boundary_test() ->
-    IdleTimeout = 10000,  % 10 seconds
+    % 10 seconds
+    IdleTimeout = 10000,
 
     %% Just below boundary should NOT trigger timeout
-    LastActivity = erlang:monotonic_time(millisecond) - 9990,  % 9.99 seconds ago
+
+    % 9.99 seconds ago
+    LastActivity = erlang:monotonic_time(millisecond) - 9990,
     Now = erlang:monotonic_time(millisecond),
     TimeSinceActivity = Now - LastActivity,
 

--- a/test/quic_keys_tests.erl
+++ b/test/quic_keys_tests.erl
@@ -28,14 +28,18 @@ rfc9001_initial_secret_test() ->
 rfc9001_client_initial_secret_test() ->
     DCID = hexstr_to_bin("8394c8f03e515708"),
     InitialSecret = quic_keys:derive_initial_secret(DCID),
-    ExpectedClientSecret = hexstr_to_bin("c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"),
+    ExpectedClientSecret = hexstr_to_bin(
+        "c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"
+    ),
     ClientSecret = quic_hkdf:expand_label(InitialSecret, <<"client in">>, <<>>, 32),
     ?assertEqual(ExpectedClientSecret, ClientSecret).
 
 rfc9001_server_initial_secret_test() ->
     DCID = hexstr_to_bin("8394c8f03e515708"),
     InitialSecret = quic_keys:derive_initial_secret(DCID),
-    ExpectedServerSecret = hexstr_to_bin("3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"),
+    ExpectedServerSecret = hexstr_to_bin(
+        "3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"
+    ),
     ServerSecret = quic_hkdf:expand_label(InitialSecret, <<"server in">>, <<>>, 32),
     ?assertEqual(ExpectedServerSecret, ServerSecret).
 
@@ -117,8 +121,8 @@ derive_initial_deterministic_test() ->
     ?assertEqual(Keys1, Keys2).
 
 different_dcid_different_keys_test() ->
-    DCID1 = <<1,2,3,4,5,6,7,8>>,
-    DCID2 = <<8,7,6,5,4,3,2,1>>,
+    DCID1 = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    DCID2 = <<8, 7, 6, 5, 4, 3, 2, 1>>,
     Keys1 = quic_keys:derive_initial_client(DCID1),
     Keys2 = quic_keys:derive_initial_client(DCID2),
     ?assertNotEqual(Keys1, Keys2).
@@ -134,14 +138,14 @@ client_server_different_keys_test() ->
 %%====================================================================
 
 quic_v1_salt_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     %% Should use v1 salt
     Keys1 = quic_keys:derive_initial_client(DCID, ?QUIC_VERSION_1),
     Keys2 = quic_keys:derive_initial_client(DCID),
     ?assertEqual(Keys1, Keys2).
 
 quic_v2_different_from_v1_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     KeysV1 = quic_keys:derive_initial_client(DCID, ?QUIC_VERSION_1),
     KeysV2 = quic_keys:derive_initial_client(DCID, ?QUIC_VERSION_2),
     ?assertNotEqual(KeysV1, KeysV2).
@@ -159,7 +163,8 @@ derive_updated_secret_aes_128_test() ->
 
 %% Test key update with AES-256-GCM (uses SHA-384)
 derive_updated_secret_aes_256_test() ->
-    Secret = crypto:strong_rand_bytes(48),  % SHA-384 produces 48-byte secrets
+    % SHA-384 produces 48-byte secrets
+    Secret = crypto:strong_rand_bytes(48),
     UpdatedSecret = quic_keys:derive_updated_secret(Secret, aes_256_gcm),
     ?assertEqual(48, byte_size(UpdatedSecret)),
     ?assertNotEqual(Secret, UpdatedSecret).

--- a/test/quic_lb_tests.erl
+++ b/test/quic_lb_tests.erl
@@ -20,10 +20,11 @@ make_lb_config(ServerID, Algorithm) ->
     make_lb_config(ServerID, Algorithm, 0, 4).
 
 make_lb_config(ServerID, Algorithm, CR, NonceLen) ->
-    Key = case Algorithm of
-        plaintext -> undefined;
-        _ -> crypto:strong_rand_bytes(16)
-    end,
+    Key =
+        case Algorithm of
+            plaintext -> undefined;
+            _ -> crypto:strong_rand_bytes(16)
+        end,
     {ok, Config} = quic_lb:new_config(#{
         server_id => ServerID,
         algorithm => Algorithm,
@@ -43,118 +44,123 @@ make_cid_config(LBConfig) ->
 
 config_creation_test_() ->
     [
-        {"Create plaintext config",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             Result = quic_lb:new_config(#{server_id => ServerID, algorithm => plaintext}),
-             ?assertMatch({ok, #lb_config{
-                 server_id = ServerID,
-                 server_id_len = 4,
-                 algorithm = plaintext
-             }}, Result)
-         end},
+        {"Create plaintext config", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            Result = quic_lb:new_config(#{server_id => ServerID, algorithm => plaintext}),
+            ?assertMatch(
+                {ok, #lb_config{
+                    server_id = ServerID,
+                    server_id_len = 4,
+                    algorithm = plaintext
+                }},
+                Result
+            )
+        end},
 
-        {"Create stream cipher config",
-         fun() ->
-             ServerID = <<1,2,3,4,5>>,
-             Key = crypto:strong_rand_bytes(16),
-             Result = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => stream_cipher,
-                 key => Key
-             }),
-             ?assertMatch({ok, #lb_config{
-                 server_id = ServerID,
-                 algorithm = stream_cipher,
-                 key = Key
-             }}, Result)
-         end},
+        {"Create stream cipher config", fun() ->
+            ServerID = <<1, 2, 3, 4, 5>>,
+            Key = crypto:strong_rand_bytes(16),
+            Result = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => stream_cipher,
+                key => Key
+            }),
+            ?assertMatch(
+                {ok, #lb_config{
+                    server_id = ServerID,
+                    algorithm = stream_cipher,
+                    key = Key
+                }},
+                Result
+            )
+        end},
 
-        {"Create block cipher config",
-         fun() ->
-             ServerID = <<1,2,3,4,5,6>>,
-             Key = crypto:strong_rand_bytes(16),
-             Result = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 key => Key
-             }),
-             ?assertMatch({ok, #lb_config{
-                 server_id = ServerID,
-                 algorithm = block_cipher,
-                 key = Key
-             }}, Result)
-         end},
+        {"Create block cipher config", fun() ->
+            ServerID = <<1, 2, 3, 4, 5, 6>>,
+            Key = crypto:strong_rand_bytes(16),
+            Result = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                key => Key
+            }),
+            ?assertMatch(
+                {ok, #lb_config{
+                    server_id = ServerID,
+                    algorithm = block_cipher,
+                    key = Key
+                }},
+                Result
+            )
+        end},
 
-        {"Missing server_id fails",
-         fun() ->
-             Result = quic_lb:new_config(#{algorithm => plaintext}),
-             ?assertMatch({error, missing_server_id}, Result)
-         end},
+        {"Missing server_id fails", fun() ->
+            Result = quic_lb:new_config(#{algorithm => plaintext}),
+            ?assertMatch({error, missing_server_id}, Result)
+        end},
 
-        {"Invalid server_id length fails",
-         fun() ->
-             %% 16 bytes is too long (max is 15)
-             ServerID = crypto:strong_rand_bytes(16),
-             Result = quic_lb:new_config(#{server_id => ServerID}),
-             ?assertMatch({error, {invalid_server_id_len, 16}}, Result)
-         end},
+        {"Invalid server_id length fails", fun() ->
+            %% 16 bytes is too long (max is 15)
+            ServerID = crypto:strong_rand_bytes(16),
+            Result = quic_lb:new_config(#{server_id => ServerID}),
+            ?assertMatch({error, {invalid_server_id_len, 16}}, Result)
+        end},
 
-        {"Invalid config rotation fails",
-         fun() ->
-             Result = quic_lb:new_config(#{
-                 server_id => <<1,2,3,4>>,
-                 config_rotation => 7
-             }),
-             ?assertMatch({error, {invalid_config_rotation, 7}}, Result)
-         end},
+        {"Invalid config rotation fails", fun() ->
+            Result = quic_lb:new_config(#{
+                server_id => <<1, 2, 3, 4>>,
+                config_rotation => 7
+            }),
+            ?assertMatch({error, {invalid_config_rotation, 7}}, Result)
+        end},
 
-        {"Cipher algorithm without key fails",
-         fun() ->
-             Result = quic_lb:new_config(#{
-                 server_id => <<1,2,3,4>>,
-                 algorithm => stream_cipher
-             }),
-             ?assertMatch({error, {missing_or_invalid_key, stream_cipher}}, Result)
-         end},
+        {"Cipher algorithm without key fails", fun() ->
+            Result = quic_lb:new_config(#{
+                server_id => <<1, 2, 3, 4>>,
+                algorithm => stream_cipher
+            }),
+            ?assertMatch({error, {missing_or_invalid_key, stream_cipher}}, Result)
+        end},
 
-        {"Invalid nonce length fails",
-         fun() ->
-             Result = quic_lb:new_config(#{
-                 server_id => <<1,2,3,4>>,
-                 nonce_len => 3  % min is 4
-             }),
-             ?assertMatch({error, {invalid_nonce_len, 3}}, Result)
-         end}
+        {"Invalid nonce length fails", fun() ->
+            Result = quic_lb:new_config(#{
+                server_id => <<1, 2, 3, 4>>,
+                % min is 4
+                nonce_len => 3
+            }),
+            ?assertMatch({error, {invalid_nonce_len, 3}}, Result)
+        end}
     ].
 
 cid_config_creation_test_() ->
     [
-        {"Create CID config without LB",
-         fun() ->
-             Result = quic_lb:new_cid_config(#{}),
-             ?assertMatch({ok, #cid_config{
-                 lb_config = undefined,
-                 cid_len = 8
-             }}, Result)
-         end},
+        {"Create CID config without LB", fun() ->
+            Result = quic_lb:new_cid_config(#{}),
+            ?assertMatch(
+                {ok, #cid_config{
+                    lb_config = undefined,
+                    cid_len = 8
+                }},
+                Result
+            )
+        end},
 
-        {"Create CID config with LB",
-         fun() ->
-             LBConfig = make_lb_config(<<1,2,3,4>>, plaintext),
-             Result = quic_lb:new_cid_config(#{lb_config => LBConfig}),
-             ExpectedLen = quic_lb:expected_cid_len(LBConfig),
-             ?assertMatch({ok, #cid_config{
-                 lb_config = LBConfig,
-                 cid_len = ExpectedLen
-             }}, Result)
-         end},
+        {"Create CID config with LB", fun() ->
+            LBConfig = make_lb_config(<<1, 2, 3, 4>>, plaintext),
+            Result = quic_lb:new_cid_config(#{lb_config => LBConfig}),
+            ExpectedLen = quic_lb:expected_cid_len(LBConfig),
+            ?assertMatch(
+                {ok, #cid_config{
+                    lb_config = LBConfig,
+                    cid_len = ExpectedLen
+                }},
+                Result
+            )
+        end},
 
-        {"Invalid CID length fails",
-         fun() ->
-             Result = quic_lb:new_cid_config(#{cid_len => 21}),
-             ?assertMatch({error, {invalid_cid_len, 21}}, Result)
-         end}
+        {"Invalid CID length fails", fun() ->
+            Result = quic_lb:new_cid_config(#{cid_len => 21}),
+            ?assertMatch({error, {invalid_cid_len, 21}}, Result)
+        end}
     ].
 
 %%====================================================================
@@ -163,61 +169,57 @@ cid_config_creation_test_() ->
 
 plaintext_encoding_test_() ->
     [
-        {"Generate plaintext CID",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             LBConfig = make_lb_config(ServerID, plaintext),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             %% CID should be: 1 (first byte) + 4 (server_id) + 4 (nonce) = 9 bytes
-             ?assertEqual(9, byte_size(CID)),
-             %% Should be LB routable
-             ?assert(quic_lb:is_lb_routable(CID)),
-             %% Config rotation should be 0
-             ?assertEqual(0, quic_lb:get_config_rotation(CID))
-         end},
+        {"Generate plaintext CID", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            LBConfig = make_lb_config(ServerID, plaintext),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            %% CID should be: 1 (first byte) + 4 (server_id) + 4 (nonce) = 9 bytes
+            ?assertEqual(9, byte_size(CID)),
+            %% Should be LB routable
+            ?assert(quic_lb:is_lb_routable(CID)),
+            %% Config rotation should be 0
+            ?assertEqual(0, quic_lb:get_config_rotation(CID))
+        end},
 
-        {"Decode plaintext CID roundtrip",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             LBConfig = make_lb_config(ServerID, plaintext),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             Result = quic_lb:decode_server_id(CID, LBConfig),
-             ?assertEqual({ok, ServerID}, Result)
-         end},
+        {"Decode plaintext CID roundtrip", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            LBConfig = make_lb_config(ServerID, plaintext),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            Result = quic_lb:decode_server_id(CID, LBConfig),
+            ?assertEqual({ok, ServerID}, Result)
+        end},
 
-        {"Plaintext with config rotation",
-         fun() ->
-             ServerID = <<5,6,7,8>>,
-             LBConfig = make_lb_config(ServerID, plaintext, 3, 4),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assertEqual(3, quic_lb:get_config_rotation(CID)),
-             ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-         end},
+        {"Plaintext with config rotation", fun() ->
+            ServerID = <<5, 6, 7, 8>>,
+            LBConfig = make_lb_config(ServerID, plaintext, 3, 4),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assertEqual(3, quic_lb:get_config_rotation(CID)),
+            ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+        end},
 
-        {"Plaintext with longer nonce",
-         fun() ->
-             ServerID = <<1,2,3>>,
-             LBConfig = make_lb_config(ServerID, plaintext, 0, 8),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             %% CID should be: 1 + 3 + 8 = 12 bytes
-             ?assertEqual(12, byte_size(CID)),
-             ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-         end},
+        {"Plaintext with longer nonce", fun() ->
+            ServerID = <<1, 2, 3>>,
+            LBConfig = make_lb_config(ServerID, plaintext, 0, 8),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            %% CID should be: 1 + 3 + 8 = 12 bytes
+            ?assertEqual(12, byte_size(CID)),
+            ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+        end},
 
-        {"Plaintext with max server ID",
-         fun() ->
-             ServerID = crypto:strong_rand_bytes(15),  % max length
-             LBConfig = make_lb_config(ServerID, plaintext, 0, 4),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             %% CID should be: 1 + 15 + 4 = 20 bytes (max CID length)
-             ?assertEqual(20, byte_size(CID)),
-             ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-         end}
+        {"Plaintext with max server ID", fun() ->
+            % max length
+            ServerID = crypto:strong_rand_bytes(15),
+            LBConfig = make_lb_config(ServerID, plaintext, 0, 4),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            %% CID should be: 1 + 15 + 4 = 20 bytes (max CID length)
+            ?assertEqual(20, byte_size(CID)),
+            ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+        end}
     ].
 
 %%====================================================================
@@ -226,72 +228,74 @@ plaintext_encoding_test_() ->
 
 stream_cipher_encoding_test_() ->
     [
-        {"Generate stream cipher CID",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => stream_cipher,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assertEqual(9, byte_size(CID)),
-             ?assert(quic_lb:is_lb_routable(CID))
-         end},
+        {"Generate stream cipher CID", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => stream_cipher,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assertEqual(9, byte_size(CID)),
+            ?assert(quic_lb:is_lb_routable(CID))
+        end},
 
-        {"Decode stream cipher CID roundtrip",
-         fun() ->
-             ServerID = <<10,20,30,40,50>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => stream_cipher,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             Result = quic_lb:decode_server_id(CID, LBConfig),
-             ?assertEqual({ok, ServerID}, Result)
-         end},
+        {"Decode stream cipher CID roundtrip", fun() ->
+            ServerID = <<10, 20, 30, 40, 50>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => stream_cipher,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            Result = quic_lb:decode_server_id(CID, LBConfig),
+            ?assertEqual({ok, ServerID}, Result)
+        end},
 
-        {"Stream cipher with different nonce lengths",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             Key = crypto:strong_rand_bytes(16),
-             lists:foreach(fun(NonceLen) ->
-                 {ok, LBConfig} = quic_lb:new_config(#{
-                     server_id => ServerID,
-                     algorithm => stream_cipher,
-                     nonce_len => NonceLen,
-                     key => Key
-                 }),
-                 CIDConfig = make_cid_config(LBConfig),
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 ExpectedLen = 1 + 4 + NonceLen,
-                 ?assertEqual(ExpectedLen, byte_size(CID)),
-                 ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-             end, [4, 8, 12, 16, 18])
-         end},
+        {"Stream cipher with different nonce lengths", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            Key = crypto:strong_rand_bytes(16),
+            lists:foreach(
+                fun(NonceLen) ->
+                    {ok, LBConfig} = quic_lb:new_config(#{
+                        server_id => ServerID,
+                        algorithm => stream_cipher,
+                        nonce_len => NonceLen,
+                        key => Key
+                    }),
+                    CIDConfig = make_cid_config(LBConfig),
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    ExpectedLen = 1 + 4 + NonceLen,
+                    ?assertEqual(ExpectedLen, byte_size(CID)),
+                    ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+                end,
+                [4, 8, 12, 16, 18]
+            )
+        end},
 
-        {"Stream cipher preserves config rotation",
-         fun() ->
-             ServerID = <<1,2,3>>,
-             Key = crypto:strong_rand_bytes(16),
-             lists:foreach(fun(CR) ->
-                 {ok, LBConfig} = quic_lb:new_config(#{
-                     server_id => ServerID,
-                     algorithm => stream_cipher,
-                     config_rotation => CR,
-                     key => Key
-                 }),
-                 CIDConfig = make_cid_config(LBConfig),
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 ?assertEqual(CR, quic_lb:get_config_rotation(CID)),
-                 ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-             end, [0, 1, 2, 3, 4, 5, 6])
-         end}
+        {"Stream cipher preserves config rotation", fun() ->
+            ServerID = <<1, 2, 3>>,
+            Key = crypto:strong_rand_bytes(16),
+            lists:foreach(
+                fun(CR) ->
+                    {ok, LBConfig} = quic_lb:new_config(#{
+                        server_id => ServerID,
+                        algorithm => stream_cipher,
+                        config_rotation => CR,
+                        key => Key
+                    }),
+                    CIDConfig = make_cid_config(LBConfig),
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    ?assertEqual(CR, quic_lb:get_config_rotation(CID)),
+                    ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+                end,
+                [0, 1, 2, 3, 4, 5, 6]
+            )
+        end}
     ].
 
 %%====================================================================
@@ -300,124 +304,127 @@ stream_cipher_encoding_test_() ->
 
 block_cipher_encoding_test_() ->
     [
-        {"Generate block cipher CID (short - Feistel)",
-         fun() ->
-             %% CID < 16 bytes uses Feistel network
-             ServerID = <<1,2,3,4>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 nonce_len => 4,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             %% 1 + 4 + 4 = 9 bytes (< 16, uses Feistel)
-             ?assertEqual(9, byte_size(CID)),
-             ?assert(quic_lb:is_lb_routable(CID))
-         end},
+        {"Generate block cipher CID (short - Feistel)", fun() ->
+            %% CID < 16 bytes uses Feistel network
+            ServerID = <<1, 2, 3, 4>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                nonce_len => 4,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            %% 1 + 4 + 4 = 9 bytes (< 16, uses Feistel)
+            ?assertEqual(9, byte_size(CID)),
+            ?assert(quic_lb:is_lb_routable(CID))
+        end},
 
-        {"Decode block cipher CID roundtrip (short - Feistel)",
-         fun() ->
-             ServerID = <<10,20,30,40>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 nonce_len => 4,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             Result = quic_lb:decode_server_id(CID, LBConfig),
-             ?assertEqual({ok, ServerID}, Result)
-         end},
+        {"Decode block cipher CID roundtrip (short - Feistel)", fun() ->
+            ServerID = <<10, 20, 30, 40>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                nonce_len => 4,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            Result = quic_lb:decode_server_id(CID, LBConfig),
+            ?assertEqual({ok, ServerID}, Result)
+        end},
 
-        {"Generate block cipher CID (exact 16 bytes - direct AES)",
-         fun() ->
-             %% CID = 16 bytes uses direct AES-ECB
-             ServerID = <<1,2,3,4,5,6,7,8,9,10,11>>,  % 11 bytes
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 nonce_len => 4,  % 1 + 11 + 4 = 16 bytes
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assertEqual(16, byte_size(CID)),
-             ?assert(quic_lb:is_lb_routable(CID))
-         end},
+        {"Generate block cipher CID (exact 16 bytes - direct AES)", fun() ->
+            %% CID = 16 bytes uses direct AES-ECB
 
-        {"Decode block cipher CID roundtrip (exact 16 bytes)",
-         fun() ->
-             ServerID = <<1,2,3,4,5,6,7,8,9,10,11>>,  % 11 bytes
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 nonce_len => 4,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             Result = quic_lb:decode_server_id(CID, LBConfig),
-             ?assertEqual({ok, ServerID}, Result)
-         end},
+            % 11 bytes
+            ServerID = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                % 1 + 11 + 4 = 16 bytes
+                nonce_len => 4,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assertEqual(16, byte_size(CID)),
+            ?assert(quic_lb:is_lb_routable(CID))
+        end},
 
-        {"Generate block cipher CID (long - truncated)",
-         fun() ->
-             %% CID > 16 bytes uses truncated cipher
-             ServerID = <<1,2,3,4,5,6,7,8,9,10,11,12,13,14,15>>,  % 15 bytes
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 nonce_len => 4,  % 1 + 15 + 4 = 20 bytes
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assertEqual(20, byte_size(CID)),
-             ?assert(quic_lb:is_lb_routable(CID))
-         end},
+        {"Decode block cipher CID roundtrip (exact 16 bytes)", fun() ->
+            % 11 bytes
+            ServerID = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                nonce_len => 4,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            Result = quic_lb:decode_server_id(CID, LBConfig),
+            ?assertEqual({ok, ServerID}, Result)
+        end},
 
-        {"Decode block cipher CID roundtrip (long - truncated)",
-         fun() ->
-             ServerID = <<1,2,3,4,5,6,7,8,9,10,11,12,13,14,15>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 nonce_len => 4,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             Result = quic_lb:decode_server_id(CID, LBConfig),
-             ?assertEqual({ok, ServerID}, Result)
-         end},
+        {"Generate block cipher CID (long - truncated)", fun() ->
+            %% CID > 16 bytes uses truncated cipher
 
-        {"Block cipher with various sizes",
-         fun() ->
-             Key = crypto:strong_rand_bytes(16),
-             %% Test different server_id sizes to exercise all code paths
-             lists:foreach(fun(ServerIDLen) ->
-                 ServerID = crypto:strong_rand_bytes(ServerIDLen),
-                 {ok, LBConfig} = quic_lb:new_config(#{
-                     server_id => ServerID,
-                     algorithm => block_cipher,
-                     nonce_len => 4,
-                     key => Key
-                 }),
-                 CIDConfig = make_cid_config(LBConfig),
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 Result = quic_lb:decode_server_id(CID, LBConfig),
-                 ?assertEqual({ok, ServerID}, Result)
-             end, lists:seq(1, 15))
-         end}
+            % 15 bytes
+            ServerID = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                % 1 + 15 + 4 = 20 bytes
+                nonce_len => 4,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assertEqual(20, byte_size(CID)),
+            ?assert(quic_lb:is_lb_routable(CID))
+        end},
+
+        {"Decode block cipher CID roundtrip (long - truncated)", fun() ->
+            ServerID = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                nonce_len => 4,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            Result = quic_lb:decode_server_id(CID, LBConfig),
+            ?assertEqual({ok, ServerID}, Result)
+        end},
+
+        {"Block cipher with various sizes", fun() ->
+            Key = crypto:strong_rand_bytes(16),
+            %% Test different server_id sizes to exercise all code paths
+            lists:foreach(
+                fun(ServerIDLen) ->
+                    ServerID = crypto:strong_rand_bytes(ServerIDLen),
+                    {ok, LBConfig} = quic_lb:new_config(#{
+                        server_id => ServerID,
+                        algorithm => block_cipher,
+                        nonce_len => 4,
+                        key => Key
+                    }),
+                    CIDConfig = make_cid_config(LBConfig),
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    Result = quic_lb:decode_server_id(CID, LBConfig),
+                    ?assertEqual({ok, ServerID}, Result)
+                end,
+                lists:seq(1, 15)
+            )
+        end}
     ].
 
 %%====================================================================
@@ -426,43 +433,42 @@ block_cipher_encoding_test_() ->
 
 helper_function_test_() ->
     [
-        {"expected_cid_len calculation",
-         fun() ->
-             LBConfig = make_lb_config(<<1,2,3,4>>, plaintext, 0, 4),
-             ?assertEqual(9, quic_lb:expected_cid_len(LBConfig)),
+        {"expected_cid_len calculation", fun() ->
+            LBConfig = make_lb_config(<<1, 2, 3, 4>>, plaintext, 0, 4),
+            ?assertEqual(9, quic_lb:expected_cid_len(LBConfig)),
 
-             LBConfig2 = make_lb_config(<<1,2,3,4,5,6,7,8>>, plaintext, 0, 8),
-             ?assertEqual(17, quic_lb:expected_cid_len(LBConfig2))
-         end},
+            LBConfig2 = make_lb_config(<<1, 2, 3, 4, 5, 6, 7, 8>>, plaintext, 0, 8),
+            ?assertEqual(17, quic_lb:expected_cid_len(LBConfig2))
+        end},
 
-        {"is_lb_routable checks",
-         fun() ->
-             LBConfig = make_lb_config(<<1,2,3,4>>, plaintext),
-             CIDConfig = make_cid_config(LBConfig),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assert(quic_lb:is_lb_routable(CID)),
+        {"is_lb_routable checks", fun() ->
+            LBConfig = make_lb_config(<<1, 2, 3, 4>>, plaintext),
+            CIDConfig = make_cid_config(LBConfig),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assert(quic_lb:is_lb_routable(CID)),
 
-             %% Random CID should be unroutable (CR bits likely 7)
-             RandomCID = crypto:strong_rand_bytes(8),
-             %% Can't guarantee unroutable, but check function works
-             _ = quic_lb:is_lb_routable(RandomCID)
-         end},
+            %% Random CID should be unroutable (CR bits likely 7)
+            RandomCID = crypto:strong_rand_bytes(8),
+            %% Can't guarantee unroutable, but check function works
+            _ = quic_lb:is_lb_routable(RandomCID)
+        end},
 
-        {"get_config_rotation from CID",
-         fun() ->
-             %% Test all valid CR values
-             lists:foreach(fun(CR) ->
-                 LBConfig = make_lb_config(<<1,2,3,4>>, plaintext, CR, 4),
-                 CIDConfig = make_cid_config(LBConfig),
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 ?assertEqual(CR, quic_lb:get_config_rotation(CID))
-             end, [0, 1, 2, 3, 4, 5, 6])
-         end},
+        {"get_config_rotation from CID", fun() ->
+            %% Test all valid CR values
+            lists:foreach(
+                fun(CR) ->
+                    LBConfig = make_lb_config(<<1, 2, 3, 4>>, plaintext, CR, 4),
+                    CIDConfig = make_cid_config(LBConfig),
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    ?assertEqual(CR, quic_lb:get_config_rotation(CID))
+                end,
+                [0, 1, 2, 3, 4, 5, 6]
+            )
+        end},
 
-        {"Empty CID returns unroutable",
-         fun() ->
-             ?assertEqual(?LB_CR_UNROUTABLE, quic_lb:get_config_rotation(<<>>))
-         end}
+        {"Empty CID returns unroutable", fun() ->
+            ?assertEqual(?LB_CR_UNROUTABLE, quic_lb:get_config_rotation(<<>>))
+        end}
     ].
 
 %%====================================================================
@@ -471,19 +477,17 @@ helper_function_test_() ->
 
 no_lb_config_test_() ->
     [
-        {"Generate random CID without LB config",
-         fun() ->
-             {ok, CIDConfig} = quic_lb:new_cid_config(#{}),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assertEqual(8, byte_size(CID))
-         end},
+        {"Generate random CID without LB config", fun() ->
+            {ok, CIDConfig} = quic_lb:new_cid_config(#{}),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assertEqual(8, byte_size(CID))
+        end},
 
-        {"Generate random CID with custom length",
-         fun() ->
-             {ok, CIDConfig} = quic_lb:new_cid_config(#{cid_len => 12}),
-             CID = quic_lb:generate_cid(CIDConfig),
-             ?assertEqual(12, byte_size(CID))
-         end}
+        {"Generate random CID with custom length", fun() ->
+            {ok, CIDConfig} = quic_lb:new_cid_config(#{cid_len => 12}),
+            CID = quic_lb:generate_cid(CIDConfig),
+            ?assertEqual(12, byte_size(CID))
+        end}
     ].
 
 %%====================================================================
@@ -492,42 +496,43 @@ no_lb_config_test_() ->
 
 explicit_nonce_test_() ->
     [
-        {"Generate CID with explicit nonce",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             LBConfig = make_lb_config(ServerID, plaintext, 0, 4),
-             CIDConfig = make_cid_config(LBConfig),
-             Nonce = <<16#DE, 16#AD, 16#BE, 16#EF>>,
-             CID = quic_lb:generate_cid(CIDConfig, Nonce),
-             %% Verify the nonce is in the CID
-             <<_FirstByte, _ServerIDBytes:4/binary, NonceInCID:4/binary>> = CID,
-             ?assertEqual(Nonce, NonceInCID)
-         end},
+        {"Generate CID with explicit nonce", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            LBConfig = make_lb_config(ServerID, plaintext, 0, 4),
+            CIDConfig = make_cid_config(LBConfig),
+            Nonce = <<16#DE, 16#AD, 16#BE, 16#EF>>,
+            CID = quic_lb:generate_cid(CIDConfig, Nonce),
+            %% Verify the nonce is in the CID
+            <<_FirstByte, _ServerIDBytes:4/binary, NonceInCID:4/binary>> = CID,
+            ?assertEqual(Nonce, NonceInCID)
+        end},
 
-        {"Nonce is padded if too short",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             LBConfig = make_lb_config(ServerID, plaintext, 0, 8),
-             CIDConfig = make_cid_config(LBConfig),
-             ShortNonce = <<16#AB, 16#CD>>,  % 2 bytes, need 8
-             CID = quic_lb:generate_cid(CIDConfig, ShortNonce),
-             ?assertEqual(13, byte_size(CID)),  % 1 + 4 + 8
-             %% Should still decode correctly
-             ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-         end},
+        {"Nonce is padded if too short", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            LBConfig = make_lb_config(ServerID, plaintext, 0, 8),
+            CIDConfig = make_cid_config(LBConfig),
+            % 2 bytes, need 8
+            ShortNonce = <<16#AB, 16#CD>>,
+            CID = quic_lb:generate_cid(CIDConfig, ShortNonce),
+            % 1 + 4 + 8
+            ?assertEqual(13, byte_size(CID)),
+            %% Should still decode correctly
+            ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+        end},
 
-        {"Nonce is truncated if too long",
-         fun() ->
-             ServerID = <<1,2,3,4>>,
-             LBConfig = make_lb_config(ServerID, plaintext, 0, 4),
-             CIDConfig = make_cid_config(LBConfig),
-             LongNonce = <<1,2,3,4,5,6,7,8>>,  % 8 bytes, need 4
-             CID = quic_lb:generate_cid(CIDConfig, LongNonce),
-             ?assertEqual(9, byte_size(CID)),  % 1 + 4 + 4
-             %% Verify first 4 bytes of nonce are used
-             <<_FirstByte, _ServerIDBytes:4/binary, NonceInCID:4/binary>> = CID,
-             ?assertEqual(<<1,2,3,4>>, NonceInCID)
-         end}
+        {"Nonce is truncated if too long", fun() ->
+            ServerID = <<1, 2, 3, 4>>,
+            LBConfig = make_lb_config(ServerID, plaintext, 0, 4),
+            CIDConfig = make_cid_config(LBConfig),
+            % 8 bytes, need 4
+            LongNonce = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+            CID = quic_lb:generate_cid(CIDConfig, LongNonce),
+            % 1 + 4 + 4
+            ?assertEqual(9, byte_size(CID)),
+            %% Verify first 4 bytes of nonce are used
+            <<_FirstByte, _ServerIDBytes:4/binary, NonceInCID:4/binary>> = CID,
+            ?assertEqual(<<1, 2, 3, 4>>, NonceInCID)
+        end}
     ].
 
 %%====================================================================
@@ -536,112 +541,108 @@ explicit_nonce_test_() ->
 
 listener_integration_test_() ->
     {foreach,
-     fun() ->
-         %% Setup: ensure crypto is started
-         application:ensure_all_started(crypto),
-         ok
-     end,
-     fun(_) ->
-         %% Cleanup
-         ok
-     end,
-     [
-        {"Listener starts with plaintext LB config",
-         fun() ->
-             {Cert, PrivKey} = generate_test_cert(),
-             ServerID = <<1,2,3,4>>,
-             LBConfig = #{
-                 server_id => ServerID,
-                 algorithm => plaintext
-             },
-             Opts = #{
-                 cert => Cert,
-                 key => PrivKey,
-                 alpn => [<<"h3">>],
-                 lb_config => LBConfig
-             },
-             {ok, Listener} = quic_listener:start_link(0, Opts),
-             ?assert(is_pid(Listener)),
-             Port = quic_listener:get_port(Listener),
-             ?assert(Port > 0),
-             ok = quic_listener:stop(Listener)
-         end},
+        fun() ->
+            %% Setup: ensure crypto is started
+            application:ensure_all_started(crypto),
+            ok
+        end,
+        fun(_) ->
+            %% Cleanup
+            ok
+        end,
+        [
+            {"Listener starts with plaintext LB config", fun() ->
+                {Cert, PrivKey} = generate_test_cert(),
+                ServerID = <<1, 2, 3, 4>>,
+                LBConfig = #{
+                    server_id => ServerID,
+                    algorithm => plaintext
+                },
+                Opts = #{
+                    cert => Cert,
+                    key => PrivKey,
+                    alpn => [<<"h3">>],
+                    lb_config => LBConfig
+                },
+                {ok, Listener} = quic_listener:start_link(0, Opts),
+                ?assert(is_pid(Listener)),
+                Port = quic_listener:get_port(Listener),
+                ?assert(Port > 0),
+                ok = quic_listener:stop(Listener)
+            end},
 
-        {"Listener starts with stream cipher LB config",
-         fun() ->
-             {Cert, PrivKey} = generate_test_cert(),
-             ServerID = <<5,6,7,8,9>>,
-             Key = crypto:strong_rand_bytes(16),
-             LBConfig = #{
-                 server_id => ServerID,
-                 algorithm => stream_cipher,
-                 key => Key
-             },
-             Opts = #{
-                 cert => Cert,
-                 key => PrivKey,
-                 alpn => [<<"h3">>],
-                 lb_config => LBConfig
-             },
-             {ok, Listener} = quic_listener:start_link(0, Opts),
-             ?assert(is_pid(Listener)),
-             ok = quic_listener:stop(Listener)
-         end},
+            {"Listener starts with stream cipher LB config", fun() ->
+                {Cert, PrivKey} = generate_test_cert(),
+                ServerID = <<5, 6, 7, 8, 9>>,
+                Key = crypto:strong_rand_bytes(16),
+                LBConfig = #{
+                    server_id => ServerID,
+                    algorithm => stream_cipher,
+                    key => Key
+                },
+                Opts = #{
+                    cert => Cert,
+                    key => PrivKey,
+                    alpn => [<<"h3">>],
+                    lb_config => LBConfig
+                },
+                {ok, Listener} = quic_listener:start_link(0, Opts),
+                ?assert(is_pid(Listener)),
+                ok = quic_listener:stop(Listener)
+            end},
 
-        {"Listener starts with block cipher LB config",
-         fun() ->
-             {Cert, PrivKey} = generate_test_cert(),
-             ServerID = <<10,11,12,13,14,15>>,
-             Key = crypto:strong_rand_bytes(16),
-             LBConfig = #{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 key => Key
-             },
-             Opts = #{
-                 cert => Cert,
-                 key => PrivKey,
-                 alpn => [<<"h3">>],
-                 lb_config => LBConfig
-             },
-             {ok, Listener} = quic_listener:start_link(0, Opts),
-             ?assert(is_pid(Listener)),
-             ok = quic_listener:stop(Listener)
-         end},
+            {"Listener starts with block cipher LB config", fun() ->
+                {Cert, PrivKey} = generate_test_cert(),
+                ServerID = <<10, 11, 12, 13, 14, 15>>,
+                Key = crypto:strong_rand_bytes(16),
+                LBConfig = #{
+                    server_id => ServerID,
+                    algorithm => block_cipher,
+                    key => Key
+                },
+                Opts = #{
+                    cert => Cert,
+                    key => PrivKey,
+                    alpn => [<<"h3">>],
+                    lb_config => LBConfig
+                },
+                {ok, Listener} = quic_listener:start_link(0, Opts),
+                ?assert(is_pid(Listener)),
+                ok = quic_listener:stop(Listener)
+            end},
 
-        {"Listener with custom CID length",
-         fun() ->
-             {Cert, PrivKey} = generate_test_cert(),
-             ServerID = <<1,2,3,4>>,
-             LBConfig = #{
-                 server_id => ServerID,
-                 algorithm => plaintext,
-                 nonce_len => 12  %% Longer nonce = longer CID
-             },
-             Opts = #{
-                 cert => Cert,
-                 key => PrivKey,
-                 alpn => [<<"h3">>],
-                 lb_config => LBConfig
-             },
-             {ok, Listener} = quic_listener:start_link(0, Opts),
-             ?assert(is_pid(Listener)),
-             ok = quic_listener:stop(Listener)
-         end},
+            {"Listener with custom CID length", fun() ->
+                {Cert, PrivKey} = generate_test_cert(),
+                ServerID = <<1, 2, 3, 4>>,
+                LBConfig = #{
+                    server_id => ServerID,
+                    algorithm => plaintext,
+                    %% Longer nonce = longer CID
+                    nonce_len => 12
+                },
+                Opts = #{
+                    cert => Cert,
+                    key => PrivKey,
+                    alpn => [<<"h3">>],
+                    lb_config => LBConfig
+                },
+                {ok, Listener} = quic_listener:start_link(0, Opts),
+                ?assert(is_pid(Listener)),
+                ok = quic_listener:stop(Listener)
+            end},
 
-        {"Listener without LB config uses default CID length",
-         fun() ->
-             {Cert, PrivKey} = generate_test_cert(),
-             Opts = #{
-                 cert => Cert,
-                 key => PrivKey,
-                 alpn => [<<"h3">>]
-             },
-             {ok, Listener} = quic_listener:start_link(0, Opts),
-             ?assert(is_pid(Listener)),
-             ok = quic_listener:stop(Listener)
-         end}
-     ]}.
+            {"Listener without LB config uses default CID length", fun() ->
+                {Cert, PrivKey} = generate_test_cert(),
+                Opts = #{
+                    cert => Cert,
+                    key => PrivKey,
+                    alpn => [<<"h3">>]
+                },
+                {ok, Listener} = quic_listener:start_link(0, Opts),
+                ?assert(is_pid(Listener)),
+                ok = quic_listener:stop(Listener)
+            end}
+        ]}.
 
 generate_test_cert() ->
     Cert = <<"test_certificate_data">>,
@@ -654,46 +655,52 @@ generate_test_cert() ->
 
 stability_test_() ->
     [
-        {"Multiple plaintext roundtrips",
-         fun() ->
-             ServerID = <<100,101,102,103>>,
-             LBConfig = make_lb_config(ServerID, plaintext),
-             CIDConfig = make_cid_config(LBConfig),
-             lists:foreach(fun(_) ->
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-             end, lists:seq(1, 100))
-         end},
+        {"Multiple plaintext roundtrips", fun() ->
+            ServerID = <<100, 101, 102, 103>>,
+            LBConfig = make_lb_config(ServerID, plaintext),
+            CIDConfig = make_cid_config(LBConfig),
+            lists:foreach(
+                fun(_) ->
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+                end,
+                lists:seq(1, 100)
+            )
+        end},
 
-        {"Multiple stream cipher roundtrips",
-         fun() ->
-             ServerID = <<200,201,202,203,204>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => stream_cipher,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             lists:foreach(fun(_) ->
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-             end, lists:seq(1, 100))
-         end},
+        {"Multiple stream cipher roundtrips", fun() ->
+            ServerID = <<200, 201, 202, 203, 204>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => stream_cipher,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            lists:foreach(
+                fun(_) ->
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+                end,
+                lists:seq(1, 100)
+            )
+        end},
 
-        {"Multiple block cipher roundtrips",
-         fun() ->
-             ServerID = <<150,151,152,153,154,155>>,
-             Key = crypto:strong_rand_bytes(16),
-             {ok, LBConfig} = quic_lb:new_config(#{
-                 server_id => ServerID,
-                 algorithm => block_cipher,
-                 key => Key
-             }),
-             CIDConfig = make_cid_config(LBConfig),
-             lists:foreach(fun(_) ->
-                 CID = quic_lb:generate_cid(CIDConfig),
-                 ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
-             end, lists:seq(1, 100))
-         end}
+        {"Multiple block cipher roundtrips", fun() ->
+            ServerID = <<150, 151, 152, 153, 154, 155>>,
+            Key = crypto:strong_rand_bytes(16),
+            {ok, LBConfig} = quic_lb:new_config(#{
+                server_id => ServerID,
+                algorithm => block_cipher,
+                key => Key
+            }),
+            CIDConfig = make_cid_config(LBConfig),
+            lists:foreach(
+                fun(_) ->
+                    CID = quic_lb:generate_cid(CIDConfig),
+                    ?assertEqual({ok, ServerID}, quic_lb:decode_server_id(CID, LBConfig))
+                end,
+                lists:seq(1, 100)
+            )
+        end}
     ].

--- a/test/quic_listener_tests.erl
+++ b/test/quic_listener_tests.erl
@@ -17,7 +17,8 @@
 generate_test_cert() ->
     %% For tests, use dummy data - real certs would be loaded from files
     Cert = <<"test_certificate_data">>,
-    PrivKey = crypto:strong_rand_bytes(32),  % Simplified for tests
+    % Simplified for tests
+    PrivKey = crypto:strong_rand_bytes(32),
     {Cert, PrivKey}.
 
 %%====================================================================
@@ -214,14 +215,22 @@ cleanup_connection_removes_entries_test() ->
     Conns = ets:new(test_conns, [set, public]),
 
     %% Create fake connection PIDs
-    Pid1 = spawn(fun() -> receive stop -> ok end end),
-    Pid2 = spawn(fun() -> receive stop -> ok end end),
+    Pid1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    Pid2 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
 
     %% Insert CID entries for both connections (mimics create_connection)
-    CID1a = <<1,2,3,4,5,6,7,8>>,
-    CID1b = <<10,20,30,40,50,60,70,80>>,
-    CID2a = <<11,12,13,14,15,16,17,18>>,
-    CID2b = <<21,22,23,24,25,26,27,28>>,
+    CID1a = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    CID1b = <<10, 20, 30, 40, 50, 60, 70, 80>>,
+    CID2a = <<11, 12, 13, 14, 15, 16, 17, 18>>,
+    CID2b = <<21, 22, 23, 24, 25, 26, 27, 28>>,
 
     ets:insert(Conns, {CID1a, Pid1}),
     ets:insert(Conns, {CID1b, Pid1}),
@@ -252,9 +261,13 @@ cleanup_connection_match_spec_variants_test() ->
     %% Both '_' and '$1' work as wildcards in ETS match specs
     Conns = ets:new(test_conns, [set, public]),
 
-    Pid = spawn(fun() -> receive stop -> ok end end),
-    CID1 = <<1,2,3,4,5,6,7,8>>,
-    CID2 = <<9,10,11,12,13,14,15,16>>,
+    Pid = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    CID1 = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    CID2 = <<9, 10, 11, 12, 13, 14, 15, 16>>,
 
     %% Test with '_' wildcard
     ets:insert(Conns, {CID1, Pid}),

--- a/test/quic_loss_tests.erl
+++ b/test/quic_loss_tests.erl
@@ -148,7 +148,8 @@ ack_multiple_packets_test() ->
     S1 = quic_loss:on_packet_sent(State, 0, 500, true),
     S2 = quic_loss:on_packet_sent(S1, 1, 500, true),
     S3 = quic_loss:on_packet_sent(S2, 2, 500, true),
-    AckFrame = {ack, 2, 0, 2, []},  % Acks 0, 1, 2
+    % Acks 0, 1, 2
+    AckFrame = {ack, 2, 0, 2, []},
     Now = erlang:monotonic_time(millisecond) + 50,
     {S4, Acked, _Lost} = quic_loss:on_ack_received(S3, AckFrame, Now),
     ?assertEqual(3, length(Acked)),
@@ -285,9 +286,12 @@ retransmittable_filters_ack_test() ->
 
 retransmittable_filters_ack_variants_test() ->
     Frames = [
-        {ack, 5, 0, 5},  % 4-tuple variant
-        {ack, 5, 0, 5, []},  % 5-tuple variant
-        {ack_ecn, 5, 0, 5, [], 1, 2, 3},  % ECN variant
+        % 4-tuple variant
+        {ack, 5, 0, 5},
+        % 5-tuple variant
+        {ack, 5, 0, 5, []},
+        % ECN variant
+        {ack_ecn, 5, 0, 5, [], 1, 2, 3},
         {stream, 0, 0, <<"data">>, false}
     ],
     Result = quic_loss:retransmittable_frames(Frames),

--- a/test/quic_migration_tests.erl
+++ b/test/quic_migration_tests.erl
@@ -15,18 +15,18 @@
 
 path_state_creation_test() ->
     Path = #path_state{
-        remote_addr = {{127,0,0,1}, 4433},
+        remote_addr = {{127, 0, 0, 1}, 4433},
         status = unknown,
         bytes_sent = 0,
         bytes_received = 0
     },
     ?assertEqual(unknown, Path#path_state.status),
-    ?assertEqual({{127,0,0,1}, 4433}, Path#path_state.remote_addr).
+    ?assertEqual({{127, 0, 0, 1}, 4433}, Path#path_state.remote_addr).
 
 path_state_validating_test() ->
     ChallengeData = crypto:strong_rand_bytes(8),
     Path = #path_state{
-        remote_addr = {{192,168,1,1}, 8443},
+        remote_addr = {{192, 168, 1, 1}, 8443},
         status = validating,
         challenge_data = ChallengeData,
         challenge_count = 1
@@ -36,7 +36,7 @@ path_state_validating_test() ->
 
 path_state_validated_test() ->
     Path = #path_state{
-        remote_addr = {{10,0,0,1}, 443},
+        remote_addr = {{10, 0, 0, 1}, 443},
         status = validated,
         challenge_data = undefined
     },
@@ -64,7 +64,7 @@ cid_entry_creation_test() ->
 cid_entry_retired_test() ->
     Entry = #cid_entry{
         seq_num = 0,
-        cid = <<1,2,3,4,5,6,7,8>>,
+        cid = <<1, 2, 3, 4, 5, 6, 7, 8>>,
         status = retired
     },
     ?assertEqual(retired, Entry#cid_entry.status).
@@ -75,28 +75,31 @@ cid_entry_retired_test() ->
 
 cid_pool_add_test() ->
     Pool = [],
-    CID1 = <<1,2,3,4,5,6,7,8>>,
+    CID1 = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Token1 = crypto:strong_rand_bytes(16),
     Entry1 = #cid_entry{seq_num = 1, cid = CID1, stateless_reset_token = Token1, status = active},
     Pool1 = [Entry1 | Pool],
     ?assertEqual(1, length(Pool1)),
 
-    CID2 = <<8,7,6,5,4,3,2,1>>,
+    CID2 = <<8, 7, 6, 5, 4, 3, 2, 1>>,
     Token2 = crypto:strong_rand_bytes(16),
     Entry2 = #cid_entry{seq_num = 2, cid = CID2, stateless_reset_token = Token2, status = active},
     Pool2 = [Entry2 | Pool1],
     ?assertEqual(2, length(Pool2)).
 
 cid_retirement_test() ->
-    Entry1 = #cid_entry{seq_num = 1, cid = <<1,2,3,4>>, status = active},
-    Entry2 = #cid_entry{seq_num = 2, cid = <<5,6,7,8>>, status = active},
+    Entry1 = #cid_entry{seq_num = 1, cid = <<1, 2, 3, 4>>, status = active},
+    Entry2 = #cid_entry{seq_num = 2, cid = <<5, 6, 7, 8>>, status = active},
     Pool = [Entry1, Entry2],
 
     %% Retire entry with seq_num = 1
     NewPool = lists:map(
-        fun(#cid_entry{seq_num = 1} = E) -> E#cid_entry{status = retired};
-           (E) -> E
-        end, Pool),
+        fun
+            (#cid_entry{seq_num = 1} = E) -> E#cid_entry{status = retired};
+            (E) -> E
+        end,
+        Pool
+    ),
 
     [Retired, Active] = NewPool,
     ?assertEqual(retired, Retired#cid_entry.status),
@@ -162,13 +165,13 @@ path_challenge_data_size_test() ->
 
 path_challenge_response_match_test() ->
     %% PATH_RESPONSE must echo the exact challenge data
-    ChallengeData = <<1,2,3,4,5,6,7,8>>,
-    ResponseData = <<1,2,3,4,5,6,7,8>>,
+    ChallengeData = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ResponseData = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     ?assertEqual(ChallengeData, ResponseData).
 
 path_challenge_response_mismatch_test() ->
-    ChallengeData = <<1,2,3,4,5,6,7,8>>,
-    ResponseData = <<8,7,6,5,4,3,2,1>>,
+    ChallengeData = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    ResponseData = <<8, 7, 6, 5, 4, 3, 2, 1>>,
     ?assert(ChallengeData /= ResponseData).
 
 %%====================================================================
@@ -178,7 +181,7 @@ path_challenge_response_mismatch_test() ->
 path_validation_success_test() ->
     %% Start with unknown path
     Path = #path_state{
-        remote_addr = {{192,168,1,100}, 4433},
+        remote_addr = {{192, 168, 1, 100}, 4433},
         status = unknown
     },
 
@@ -201,9 +204,9 @@ path_validation_success_test() ->
 path_validation_timeout_test() ->
     %% Path validation can fail after timeout
     Path = #path_state{
-        remote_addr = {{192,168,1,100}, 4433},
+        remote_addr = {{192, 168, 1, 100}, 4433},
         status = validating,
-        challenge_data = <<1,2,3,4,5,6,7,8>>,
+        challenge_data = <<1, 2, 3, 4, 5, 6, 7, 8>>,
         challenge_count = 3
     },
 
@@ -217,13 +220,13 @@ path_validation_timeout_test() ->
 path_validation_failure_test() ->
     %% Path validation fails on mismatched response
     Path = #path_state{
-        remote_addr = {{192,168,1,100}, 4433},
+        remote_addr = {{192, 168, 1, 100}, 4433},
         status = validating,
-        challenge_data = <<1,2,3,4,5,6,7,8>>
+        challenge_data = <<1, 2, 3, 4, 5, 6, 7, 8>>
     },
 
     %% Mismatched response doesn't validate
-    WrongResponse = <<8,7,6,5,4,3,2,1>>,
+    WrongResponse = <<8, 7, 6, 5, 4, 3, 2, 1>>,
     ?assert(Path#path_state.challenge_data /= WrongResponse).
 
 %%====================================================================

--- a/test/quic_multi_server_SUITE.erl
+++ b/test/quic_multi_server_SUITE.erl
@@ -61,9 +61,12 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     %% Clean up all servers
-    lists:foreach(fun(Name) ->
-        quic:stop_server(Name)
-    end, quic:which_servers()),
+    lists:foreach(
+        fun(Name) ->
+            quic:stop_server(Name)
+        end,
+        quic:which_servers()
+    ),
     ok.
 
 init_per_group(_Group, Config) ->
@@ -74,10 +77,13 @@ end_per_group(_Group, _Config) ->
 
 init_per_testcase(_TestCase, Config) ->
     %% Clean up any existing servers before each test
-    lists:foreach(fun(Name) ->
-        _ = quic:stop_server(Name),
-        _ = (catch quic_server_registry:unregister(Name))
-    end, quic:which_servers()),
+    lists:foreach(
+        fun(Name) ->
+            _ = quic:stop_server(Name),
+            _ = (catch quic_server_registry:unregister(Name))
+        end,
+        quic:which_servers()
+    ),
     timer:sleep(50),
     Config.
 
@@ -232,7 +238,8 @@ server_port_reuse_after_stop(_Config) ->
     %% Stop the server
     ok = quic:stop_server(port_test_server),
     _ = (catch quic_server_registry:unregister(port_test_server)),
-    timer:sleep(200),  %% Give OS time to release the port
+    %% Give OS time to release the port
+    timer:sleep(200),
 
     %% Start a new server on the same port
     case quic:start_server(port_test_server_2, TestPort, base_opts()) of

--- a/test/quic_packet_tests.erl
+++ b/test/quic_packet_tests.erl
@@ -42,14 +42,19 @@ decode_pn_test() ->
 %%====================================================================
 
 initial_packet_roundtrip_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
-    SCID = <<10,20,30,40>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<10, 20, 30, 40>>,
     Token = <<"initial_token">>,
     Payload = <<"encrypted_payload">>,
     PN = 0,
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{token => Token, pn => PN, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => Token, pn => PN, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(initial, Packet#quic_packet.type),
@@ -61,13 +66,18 @@ initial_packet_roundtrip_test() ->
     ?assertEqual(Payload, Packet#quic_packet.payload).
 
 initial_packet_no_token_roundtrip_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
-    SCID = <<10,20,30,40>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<10, 20, 30, 40>>,
     Payload = <<"encrypted_payload">>,
     PN = 1,
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{pn => PN, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{pn => PN, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(initial, Packet#quic_packet.type),
@@ -76,13 +86,19 @@ initial_packet_no_token_roundtrip_test() ->
     ?assertEqual(Payload, Packet#quic_packet.payload).
 
 initial_packet_large_pn_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     SCID = <<>>,
     Payload = <<"data">>,
-    PN = 300,  % Requires 2 bytes
+    % Requires 2 bytes
+    PN = 300,
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{pn => PN, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{pn => PN, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(PN, Packet#quic_packet.pn).
@@ -92,13 +108,18 @@ initial_packet_large_pn_test() ->
 %%====================================================================
 
 handshake_packet_roundtrip_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
-    SCID = <<10,20,30,40>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<10, 20, 30, 40>>,
     Payload = <<"handshake_data">>,
     PN = 2,
 
-    Encoded = quic_packet:encode_long(handshake, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{pn => PN, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        handshake,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{pn => PN, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(handshake, Packet#quic_packet.type),
@@ -113,13 +134,18 @@ handshake_packet_roundtrip_test() ->
 %%====================================================================
 
 zero_rtt_packet_roundtrip_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
-    SCID = <<10,20,30,40>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<10, 20, 30, 40>>,
     Payload = <<"0rtt_data">>,
     PN = 0,
 
-    Encoded = quic_packet:encode_long(zero_rtt, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{pn => PN, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        zero_rtt,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{pn => PN, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(zero_rtt, Packet#quic_packet.type),
@@ -130,15 +156,20 @@ zero_rtt_packet_roundtrip_test() ->
 %%====================================================================
 
 retry_packet_roundtrip_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
-    SCID = <<10,20,30,40>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    SCID = <<10, 20, 30, 40>>,
     %% Retry payload = Retry Token + 16-byte Integrity Tag
     RetryToken = <<"retry_token_data">>,
     IntegrityTag = crypto:strong_rand_bytes(16),
     Payload = <<RetryToken/binary, IntegrityTag/binary>>,
 
-    Encoded = quic_packet:encode_long(retry, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        retry,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(retry, Packet#quic_packet.type),
@@ -149,7 +180,7 @@ retry_packet_roundtrip_test() ->
 %%====================================================================
 
 short_packet_roundtrip_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Payload = <<"encrypted_app_data">>,
     PN = 100,
 
@@ -161,7 +192,7 @@ short_packet_roundtrip_test() ->
     ?assertEqual(PN, Packet#quic_packet.pn).
 
 short_packet_with_spin_bit_test() ->
-    DCID = <<1,2,3,4>>,
+    DCID = <<1, 2, 3, 4>>,
     Payload = <<"data">>,
     PN = 0,
 
@@ -173,9 +204,10 @@ short_packet_with_spin_bit_test() ->
     ?assertEqual(1, SpinBit).
 
 short_packet_large_pn_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Payload = <<"data">>,
-    PN = 1000000,  % Requires 3 bytes
+    % Requires 3 bytes
+    PN = 1000000,
 
     Encoded = quic_packet:encode_short(DCID, PN, Payload, false),
 
@@ -188,15 +220,19 @@ short_packet_large_pn_test() ->
 
 long_header_detection_test() ->
     %% Long header starts with 1 in bit 7
-    LongPacket = quic_packet:encode_long(initial, ?QUIC_VERSION_1,
-                                          <<1,2,3,4>>, <<5,6,7,8>>,
-                                          #{pn => 0, payload => <<"data">>}),
+    LongPacket = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        <<1, 2, 3, 4>>,
+        <<5, 6, 7, 8>>,
+        #{pn => 0, payload => <<"data">>}
+    ),
     <<FirstByte, _/binary>> = LongPacket,
     ?assertEqual(1, (FirstByte bsr 7) band 1).
 
 short_header_detection_test() ->
     %% Short header starts with 0 in bit 7, 1 in bit 6
-    ShortPacket = quic_packet:encode_short(<<1,2,3,4>>, 0, <<"data">>, false),
+    ShortPacket = quic_packet:encode_short(<<1, 2, 3, 4>>, 0, <<"data">>, false),
     <<FirstByte, _/binary>> = ShortPacket,
     ?assertEqual(0, (FirstByte bsr 7) band 1),
     ?assertEqual(1, (FirstByte bsr 6) band 1).
@@ -207,22 +243,32 @@ short_header_detection_test() ->
 
 empty_dcid_test() ->
     DCID = <<>>,
-    SCID = <<1,2,3,4>>,
+    SCID = <<1, 2, 3, 4>>,
     Payload = <<"data">>,
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{pn => 0, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{pn => 0, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 0),
     ?assertEqual(<<>>, Packet#quic_packet.dcid).
 
 empty_scid_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     SCID = <<>>,
     Payload = <<"data">>,
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{pn => 0, payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{pn => 0, payload => Payload}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(<<>>, Packet#quic_packet.scid).
@@ -233,7 +279,7 @@ empty_scid_test() ->
 
 %% Test encoding short header with key phase 0
 encode_short_key_phase_0_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Payload = <<"data">>,
     PN = 0,
 
@@ -246,7 +292,7 @@ encode_short_key_phase_0_test() ->
 
 %% Test encoding short header with key phase 1
 encode_short_key_phase_1_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Payload = <<"data">>,
     PN = 0,
 
@@ -266,12 +312,15 @@ decode_short_key_phase_test() ->
     ?assertEqual(0, quic_packet:decode_short_key_phase(16#40)),
     ?assertEqual(1, quic_packet:decode_short_key_phase(16#44)),
     %% With spin bit set
-    ?assertEqual(0, quic_packet:decode_short_key_phase(16#60)),  % 0110 0000
-    ?assertEqual(1, quic_packet:decode_short_key_phase(16#64)).  % 0110 0100
+
+    % 0110 0000
+    ?assertEqual(0, quic_packet:decode_short_key_phase(16#60)),
+    % 0110 0100
+    ?assertEqual(1, quic_packet:decode_short_key_phase(16#64)).
 
 %% Test that 4-arity encode_short is backward compatible (uses key phase 0)
 encode_short_backward_compatible_test() ->
-    DCID = <<1,2,3,4,5,6,7,8>>,
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Payload = <<"data">>,
     PN = 0,
 
@@ -282,7 +331,7 @@ encode_short_backward_compatible_test() ->
 
 %% Test key phase and spin bit are independent
 key_phase_and_spin_bit_independent_test() ->
-    DCID = <<1,2,3,4>>,
+    DCID = <<1, 2, 3, 4>>,
     Payload = <<"data">>,
     PN = 0,
 

--- a/test/quic_preferred_address_tests.erl
+++ b/test/quic_preferred_address_tests.erl
@@ -25,12 +25,29 @@ decode_preferred_address_ipv4_and_ipv6_test() ->
     CID = crypto:strong_rand_bytes(8),
     Token = crypto:strong_rand_bytes(16),
     Binary = <<
-        192, 168, 1, 100,        % IPv4 address
-        4433:16,                 % IPv4 port
-        16#2001:16, 16#db8:16, 0:16, 0:16, 0:16, 0:16, 0:16, 1:16,  % IPv6 address
-        443:16,                  % IPv6 port
-        8:8, CID/binary,         % CID length + CID
-        Token/binary             % Stateless reset token
+        % IPv4 address
+        192,
+        168,
+        1,
+        100,
+        % IPv4 port
+        4433:16,
+        % IPv6 address
+        16#2001:16,
+        16#db8:16,
+        0:16,
+        0:16,
+        0:16,
+        0:16,
+        0:16,
+        1:16,
+        % IPv6 port
+        443:16,
+        % CID length + CID
+        8:8,
+        CID/binary,
+        % Stateless reset token
+        Token/binary
     >>,
     PA = quic_tls:decode_preferred_address(Binary),
     ?assertEqual({192, 168, 1, 100}, PA#preferred_address.ipv4_addr),
@@ -45,11 +62,19 @@ decode_preferred_address_ipv4_only_test() ->
     CID = crypto:strong_rand_bytes(8),
     Token = crypto:strong_rand_bytes(16),
     Binary = <<
-        10, 0, 0, 1,             % IPv4: 10.0.0.1
-        8443:16,                 % IPv4 port
-        0:128,                   % IPv6: all zeros
-        0:16,                    % IPv6 port: 0
-        8:8, CID/binary,
+        % IPv4: 10.0.0.1
+        10,
+        0,
+        0,
+        1,
+        % IPv4 port
+        8443:16,
+        % IPv6: all zeros
+        0:128,
+        % IPv6 port: 0
+        0:16,
+        8:8,
+        CID/binary,
         Token/binary
     >>,
     PA = quic_tls:decode_preferred_address(Binary),
@@ -63,11 +88,25 @@ decode_preferred_address_ipv6_only_test() ->
     CID = crypto:strong_rand_bytes(8),
     Token = crypto:strong_rand_bytes(16),
     Binary = <<
-        0, 0, 0, 0,              % IPv4: all zeros
-        0:16,                    % IPv4 port: 0
-        16#fe80:16, 0:16, 0:16, 0:16, 0:16, 0:16, 0:16, 1:16,  % IPv6: fe80::1
+        % IPv4: all zeros
+        0,
+        0,
+        0,
+        0,
+        % IPv4 port: 0
+        0:16,
+        % IPv6: fe80::1
+        16#fe80:16,
+        0:16,
+        0:16,
+        0:16,
+        0:16,
+        0:16,
+        0:16,
+        1:16,
         443:16,
-        8:8, CID/binary,
+        8:8,
+        CID/binary,
         Token/binary
     >>,
     PA = quic_tls:decode_preferred_address(Binary),
@@ -121,7 +160,8 @@ encode_preferred_address_ipv6_only_test() ->
     PA = #preferred_address{
         ipv4_addr = undefined,
         ipv4_port = undefined,
-        ipv6_addr = {0, 0, 0, 0, 0, 0, 0, 1},  % ::1
+        % ::1
+        ipv6_addr = {0, 0, 0, 0, 0, 0, 0, 1},
         ipv6_port = 443,
         cid = CID,
         stateless_reset_token = Token
@@ -236,11 +276,19 @@ preferred_address_port_zero_test() ->
     %% Port 0 with a valid address should still be considered valid
     %% (though unusual in practice)
     Binary = <<
-        192, 168, 1, 1,          % IPv4 address (non-zero)
-        0:16,                    % IPv4 port = 0
-        0:128,                   % IPv6: all zeros
-        0:16,                    % IPv6 port: 0
-        8:8, CID/binary,
+        % IPv4 address (non-zero)
+        192,
+        168,
+        1,
+        1,
+        % IPv4 port = 0
+        0:16,
+        % IPv6: all zeros
+        0:128,
+        % IPv6 port: 0
+        0:16,
+        8:8,
+        CID/binary,
         Token/binary
     >>,
     PA = quic_tls:decode_preferred_address(Binary),

--- a/test/quic_reset_tests.erl
+++ b/test/quic_reset_tests.erl
@@ -68,8 +68,10 @@ reset_packet_structure_test() ->
 
     %% First byte should look like short header (0|1|XXXXXX)
     <<FirstByte, _/binary>> = Packet,
-    ?assertEqual(0, (FirstByte bsr 7) band 1),  % First bit = 0 (short header)
-    ?assertEqual(1, (FirstByte bsr 6) band 1),  % Fixed bit = 1
+    % First bit = 0 (short header)
+    ?assertEqual(0, (FirstByte bsr 7) band 1),
+    % Fixed bit = 1
+    ?assertEqual(1, (FirstByte bsr 6) band 1),
 
     %% Last 16 bytes should be the token
     PacketSize = byte_size(Packet),
@@ -80,7 +82,8 @@ reset_packet_structure_test() ->
 %% Test reset packet minimum size
 reset_packet_minimum_size_test() ->
     Token = crypto:strong_rand_bytes(16),
-    TriggerSize = 25,  % Just above minimum
+    % Just above minimum
+    TriggerSize = 25,
 
     Packet = build_reset_packet(Token, TriggerSize),
 

--- a/test/quic_resumption_tests.erl
+++ b/test/quic_resumption_tests.erl
@@ -21,7 +21,8 @@ new_session_ticket_encoding_test() ->
     Ticket = #session_ticket{
         server_name = <<"example.com">>,
         ticket = crypto:strong_rand_bytes(32),
-        lifetime = 86400,  % 24 hours
+        % 24 hours
+        lifetime = 86400,
         age_add = 12345,
         nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>,
         resumption_secret = crypto:strong_rand_bytes(32),
@@ -59,8 +60,9 @@ new_session_ticket_decoding_test() ->
     EarlyDataExt = <<16#00, 16#2a, 4:16, MaxEarlyData:32>>,
     ExtLen = byte_size(EarlyDataExt),
 
-    Encoded = <<Lifetime:32, AgeAdd:32, NonceLen:8, Nonce/binary,
-                TicketLen:16, TicketData/binary, ExtLen:16, EarlyDataExt/binary>>,
+    Encoded =
+        <<Lifetime:32, AgeAdd:32, NonceLen:8, Nonce/binary, TicketLen:16, TicketData/binary,
+            ExtLen:16, EarlyDataExt/binary>>,
 
     %% Parse it
     {ok, Parsed} = quic_ticket:parse_new_session_ticket(Encoded),
@@ -81,13 +83,15 @@ resumption_secret_derivation_test() ->
 
     %% Derive resumption secret
     ResumptionSecret = quic_ticket:derive_resumption_secret(
-        Cipher, MasterSecret, TranscriptHash, <<>>),
+        Cipher, MasterSecret, TranscriptHash, <<>>
+    ),
 
     %% Should be 32 bytes for SHA-256
     ?assertEqual(32, byte_size(ResumptionSecret)),
     %% Should be deterministic
     ResumptionSecret2 = quic_ticket:derive_resumption_secret(
-        Cipher, MasterSecret, TranscriptHash, <<>>),
+        Cipher, MasterSecret, TranscriptHash, <<>>
+    ),
     ?assertEqual(ResumptionSecret, ResumptionSecret2).
 
 %% Test PSK derivation from resumption secret and ticket nonce
@@ -130,7 +134,8 @@ ticket_creation_test() ->
     ALPN = <<"h3">>,
 
     Ticket = quic_ticket:create_ticket(
-        ServerName, ResumptionSecret, MaxEarlyData, Cipher, ALPN),
+        ServerName, ResumptionSecret, MaxEarlyData, Cipher, ALPN
+    ),
 
     ?assertEqual(ServerName, Ticket#session_ticket.server_name),
     ?assertEqual(ResumptionSecret, Ticket#session_ticket.resumption_secret),
@@ -179,7 +184,8 @@ new_session_ticket_no_early_data_test() ->
         age_add = 11111,
         nonce = <<1, 2, 3, 4>>,
         resumption_secret = crypto:strong_rand_bytes(32),
-        max_early_data = 0,  % No early data
+        % No early data
+        max_early_data = 0,
         received_at = erlang:system_time(second),
         cipher = aes_128_gcm,
         alpn = undefined
@@ -237,12 +243,14 @@ ticket_expiry_test() ->
     Ticket = #session_ticket{
         server_name = ServerName,
         ticket = crypto:strong_rand_bytes(32),
-        lifetime = 3600,  % 1 hour
+        % 1 hour
+        lifetime = 3600,
         age_add = 12345,
         nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>,
         resumption_secret = crypto:strong_rand_bytes(32),
         max_early_data = 16384,
-        received_at = erlang:system_time(second) - 7200,  % 2 hours ago
+        % 2 hours ago
+        received_at = erlang:system_time(second) - 7200,
         cipher = aes_128_gcm,
         alpn = <<"h3">>
     },
@@ -340,12 +348,16 @@ psk_binder_computation_test() ->
     EarlySecret = quic_crypto:derive_early_secret(aes_128_gcm, PSK),
 
     %% Then compute binder using early secret
-    Binder = quic_crypto:compute_psk_binder(aes_128_gcm, EarlySecret, TruncatedTranscript, resumption),
+    Binder = quic_crypto:compute_psk_binder(
+        aes_128_gcm, EarlySecret, TruncatedTranscript, resumption
+    ),
 
     %% Should be 32 bytes for SHA-256
     ?assertEqual(32, byte_size(Binder)),
     %% Should be deterministic
-    Binder2 = quic_crypto:compute_psk_binder(aes_128_gcm, EarlySecret, TruncatedTranscript, resumption),
+    Binder2 = quic_crypto:compute_psk_binder(
+        aes_128_gcm, EarlySecret, TruncatedTranscript, resumption
+    ),
     ?assertEqual(Binder, Binder2).
 
 %% Test early secret derivation with PSK
@@ -372,7 +384,8 @@ pre_shared_key_extension_encoding_test() ->
         nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>,
         resumption_secret = crypto:strong_rand_bytes(32),
         max_early_data = 16384,
-        received_at = erlang:system_time(second) - 100,  % 100 seconds ago
+        % 100 seconds ago
+        received_at = erlang:system_time(second) - 100,
         cipher = aes_128_gcm,
         alpn = <<"h3">>
     },
@@ -393,7 +406,8 @@ clienthello_with_psk_test() ->
         nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>,
         resumption_secret = crypto:strong_rand_bytes(32),
         max_early_data = 16384,
-        received_at = erlang:system_time(second) - 10,  % 10 seconds ago
+        % 10 seconds ago
+        received_at = erlang:system_time(second) - 10,
         cipher = aes_128_gcm,
         alpn = <<"h3">>
     },

--- a/test/quic_retry_tests.erl
+++ b/test/quic_retry_tests.erl
@@ -41,15 +41,26 @@ retry_integrity_tag_compute_test() ->
     NewSCID = <<16#f0, 16#67, 16#a5, 16#50, 16#2a, 16#42, 16#62, 16#b5>>,
     Token = <<"retry_test">>,
     RetryPacketWithoutTag = <<
-        16#FF,  % First byte (long header, fixed bit, Retry type)
-        16#00, 16#00, 16#00, 16#01,  % Version
-        0,  % DCID length
-        8, NewSCID/binary,  % SCID length + SCID
-        Token/binary  % Retry Token
+        % First byte (long header, fixed bit, Retry type)
+        16#FF,
+        % Version
+        16#00,
+        16#00,
+        16#00,
+        16#01,
+        % DCID length
+        0,
+        % SCID length + SCID
+        8,
+        NewSCID/binary,
+        % Retry Token
+        Token/binary
     >>,
 
     %% Compute the integrity tag
-    Tag = quic_crypto:compute_retry_integrity_tag(OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1),
+    Tag = quic_crypto:compute_retry_integrity_tag(
+        OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1
+    ),
 
     %% Tag should be 16 bytes
     ?assertEqual(16, byte_size(Tag)),
@@ -66,17 +77,27 @@ retry_integrity_wrong_odcid_test() ->
     NewSCID = <<16#f0, 16#67, 16#a5, 16#50, 16#2a, 16#42, 16#62, 16#b5>>,
     Token = <<"retry_test">>,
     RetryPacketWithoutTag = <<
-        16#FF, 16#00, 16#00, 16#00, 16#01,
-        0, 8, NewSCID/binary,
+        16#FF,
+        16#00,
+        16#00,
+        16#00,
+        16#01,
+        0,
+        8,
+        NewSCID/binary,
         Token/binary
     >>,
 
     %% Compute tag with correct ODCID
-    Tag = quic_crypto:compute_retry_integrity_tag(OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1),
+    Tag = quic_crypto:compute_retry_integrity_tag(
+        OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1
+    ),
     FullRetryPacket = <<RetryPacketWithoutTag/binary, Tag/binary>>,
 
     %% Verification with wrong ODCID should fail
-    ?assertNot(quic_crypto:verify_retry_integrity_tag(WrongODCID, FullRetryPacket, ?QUIC_VERSION_1)).
+    ?assertNot(
+        quic_crypto:verify_retry_integrity_tag(WrongODCID, FullRetryPacket, ?QUIC_VERSION_1)
+    ).
 
 %% Test that tampered packet fails verification
 retry_integrity_tampered_test() ->
@@ -85,29 +106,46 @@ retry_integrity_tampered_test() ->
     NewSCID = <<16#f0, 16#67, 16#a5, 16#50, 16#2a, 16#42, 16#62, 16#b5>>,
     Token = <<"retry_test">>,
     RetryPacketWithoutTag = <<
-        16#FF, 16#00, 16#00, 16#00, 16#01,
-        0, 8, NewSCID/binary,
+        16#FF,
+        16#00,
+        16#00,
+        16#00,
+        16#01,
+        0,
+        8,
+        NewSCID/binary,
         Token/binary
     >>,
 
-    Tag = quic_crypto:compute_retry_integrity_tag(OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1),
+    Tag = quic_crypto:compute_retry_integrity_tag(
+        OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1
+    ),
 
     %% Tamper with the token in the retry packet
     TamperedToken = <<"wrong_test">>,
     TamperedPacketWithoutTag = <<
-        16#FF, 16#00, 16#00, 16#00, 16#01,
-        0, 8, NewSCID/binary,
+        16#FF,
+        16#00,
+        16#00,
+        16#00,
+        16#01,
+        0,
+        8,
+        NewSCID/binary,
         TamperedToken/binary
     >>,
     TamperedFullPacket = <<TamperedPacketWithoutTag/binary, Tag/binary>>,
 
     %% Verification should fail
-    ?assertNot(quic_crypto:verify_retry_integrity_tag(OriginalDCID, TamperedFullPacket, ?QUIC_VERSION_1)).
+    ?assertNot(
+        quic_crypto:verify_retry_integrity_tag(OriginalDCID, TamperedFullPacket, ?QUIC_VERSION_1)
+    ).
 
 %% Test packet too short for integrity tag
 retry_integrity_short_packet_test() ->
     OriginalDCID = <<16#83, 16#94, 16#c8, 16#f0>>,
-    ShortPacket = <<16#FF, 16#00, 16#00, 16#00, 16#01, 0, 0>>,  % Only 7 bytes, less than 16
+    % Only 7 bytes, less than 16
+    ShortPacket = <<16#FF, 16#00, 16#00, 16#00, 16#01, 0, 0>>,
 
     %% Should return false for packet that's too short
     ?assertNot(quic_crypto:verify_retry_integrity_tag(OriginalDCID, ShortPacket, ?QUIC_VERSION_1)).
@@ -118,7 +156,8 @@ retry_integrity_short_packet_test() ->
 
 %% Test encoding and decoding a Retry packet
 retry_packet_encode_decode_test() ->
-    DCID = <<>>,  % Empty DCID is valid for Retry
+    % Empty DCID is valid for Retry
+    DCID = <<>>,
     SCID = crypto:strong_rand_bytes(8),
     Token = <<"test_token_data_12345">>,
     IntegrityTag = crypto:strong_rand_bytes(16),
@@ -164,9 +203,13 @@ retry_integrity_v2_test() ->
     %% QUIC v2 version
     V2Version = 16#6b3343cf,
     RetryPacketWithoutTag = <<
-        16#CF,  % First byte for v2 Retry
-        (V2Version):32,  % QUIC v2 version
-        0, 8, NewSCID/binary,
+        % First byte for v2 Retry
+        16#CF,
+        % QUIC v2 version
+        (V2Version):32,
+        0,
+        8,
+        NewSCID/binary,
         Token/binary
     >>,
 
@@ -175,7 +218,9 @@ retry_integrity_v2_test() ->
     ?assertEqual(16, byte_size(TagV2)),
 
     %% v1 and v2 tags should be different due to different keys
-    TagV1 = quic_crypto:compute_retry_integrity_tag(OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1),
+    TagV1 = quic_crypto:compute_retry_integrity_tag(
+        OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1
+    ),
     ?assertNotEqual(TagV1, TagV2).
 
 %%====================================================================
@@ -186,15 +231,24 @@ retry_integrity_v2_test() ->
 retry_integrity_empty_token_test() ->
     OriginalDCID = crypto:strong_rand_bytes(8),
     NewSCID = crypto:strong_rand_bytes(8),
-    Token = <<>>,  % Empty token
+    % Empty token
+    Token = <<>>,
 
     RetryPacketWithoutTag = <<
-        16#FF, 16#00, 16#00, 16#00, 16#01,
-        0, 8, NewSCID/binary,
+        16#FF,
+        16#00,
+        16#00,
+        16#00,
+        16#01,
+        0,
+        8,
+        NewSCID/binary,
         Token/binary
     >>,
 
-    Tag = quic_crypto:compute_retry_integrity_tag(OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1),
+    Tag = quic_crypto:compute_retry_integrity_tag(
+        OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1
+    ),
     FullRetryPacket = <<RetryPacketWithoutTag/binary, Tag/binary>>,
 
     ?assert(quic_crypto:verify_retry_integrity_tag(OriginalDCID, FullRetryPacket, ?QUIC_VERSION_1)).
@@ -207,13 +261,22 @@ retry_integrity_max_cid_test() ->
     Token = <<"max_cid_test">>,
 
     RetryPacketWithoutTag = <<
-        16#FF, 16#00, 16#00, 16#00, 16#01,
-        0,  % DCID len (empty in Retry response)
-        20, NewSCID/binary,  % Max SCID
+        16#FF,
+        16#00,
+        16#00,
+        16#00,
+        16#01,
+        % DCID len (empty in Retry response)
+        0,
+        % Max SCID
+        20,
+        NewSCID/binary,
         Token/binary
     >>,
 
-    Tag = quic_crypto:compute_retry_integrity_tag(OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1),
+    Tag = quic_crypto:compute_retry_integrity_tag(
+        OriginalDCID, RetryPacketWithoutTag, ?QUIC_VERSION_1
+    ),
     FullRetryPacket = <<RetryPacketWithoutTag/binary, Tag/binary>>,
 
     ?assert(quic_crypto:verify_retry_integrity_tag(OriginalDCID, FullRetryPacket, ?QUIC_VERSION_1)).

--- a/test/quic_rfc9001_crypto_tests.erl
+++ b/test/quic_rfc9001_crypto_tests.erl
@@ -27,7 +27,8 @@ client_initial_key_derivation_test() ->
     %% From RFC 9001 Appendix A.1:
     %% client_initial_secret derived from initial_secret with "client in" label
     ClientInitialSecret = hexstr_to_bin(
-        "c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"),
+        "c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"
+    ),
 
     %% Expected keys from RFC 9001 Appendix A.1
     ExpectedKey = hexstr_to_bin("1f369613dd76d5467730efcbe3b1a22d"),
@@ -48,7 +49,8 @@ server_initial_key_derivation_test() ->
     %% From RFC 9001 Appendix A.1:
     %% server_initial_secret derived from initial_secret with "server in" label
     ServerInitialSecret = hexstr_to_bin(
-        "3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"),
+        "3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"
+    ),
 
     %% Expected keys from RFC 9001 Appendix A.1
     ExpectedKey = hexstr_to_bin("cf3a5331653c364c88f0f379b6067e37"),
@@ -71,13 +73,15 @@ full_key_derivation_chain_test() ->
     %% Step 1: Initial secret from DCID
     InitialSecret = quic_keys:derive_initial_secret(DCID),
     ExpectedInitialSecret = hexstr_to_bin(
-        "7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"),
+        "7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"
+    ),
     ?assertEqual(ExpectedInitialSecret, InitialSecret),
 
     %% Step 2: Client traffic secret from initial secret
     ClientSecret = quic_hkdf:expand_label(InitialSecret, <<"client in">>, <<>>, 32),
     ExpectedClientSecret = hexstr_to_bin(
-        "c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"),
+        "c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"
+    ),
     ?assertEqual(ExpectedClientSecret, ClientSecret),
 
     %% Step 3: Keys from traffic secret (using quic_keys module)
@@ -141,7 +145,8 @@ aead_crypto_frame_test() ->
         "0018001000070005046832687400100018001604616c706e02683208"
         "687474702f312e31000d00100010040805080604050306030203050100"
         "2d00020101003300260024001d0020358072d6365880d1aeea329adf"
-        "9121383851ed21a28e3b75e965d0d2cd166254"),
+        "9121383851ed21a28e3b75e965d0d2cd166254"
+    ),
 
     %% Full plaintext: CRYPTO frame header + partial ClientHello + padding
     Plaintext = <<CryptoFrameHeader/binary, ClientHelloStart/binary>>,
@@ -223,11 +228,14 @@ header_protection_application_test() ->
     %% Unprotected first byte: 0xc3 (form=1, fixed=1, type=00, reserved=00, pn_len=11)
     %% Protected first byte: 0xc0 (first byte XOR (mask[0] AND 0x0f))
 
-    MaskByte0 = 16#43,  % From mask computation above
+    % From mask computation above
+    MaskByte0 = 16#43,
     UnprotectedFirstByte = 16#c3,
 
     %% Long header: mask lower 4 bits only
-    FirstByteMask = MaskByte0 band 16#0f,  % = 0x03
+
+    % = 0x03
+    FirstByteMask = MaskByte0 band 16#0f,
     ProtectedFirstByte = UnprotectedFirstByte bxor FirstByteMask,
 
     ?assertEqual(16#c0, ProtectedFirstByte).
@@ -245,7 +253,9 @@ packet_number_protection_test() ->
     ProtectedPN = crypto:exor(UnprotectedPN, MaskBytes),
 
     %% Expected from RFC 9001 A.2
-    ExpectedProtectedPN = hexstr_to_bin("7b9aee38"),  % Different due to PN length
+
+    % Different due to PN length
+    ExpectedProtectedPN = hexstr_to_bin("7b9aee38"),
 
     %% Actually in A.2, with 2-byte PN (pn_len=01 in byte):
     %% Let's verify 2-byte case
@@ -265,7 +275,8 @@ chacha20_header_protection_mask_test() ->
     %% From RFC 9001 Appendix A.5
     %% HP key for ChaCha20-Poly1305 (32 bytes)
     HP = hexstr_to_bin(
-        "25a282b9e82f06f21f488917a4fc8f1b73573685608597d0efcb076b0ab7a7a4"),
+        "25a282b9e82f06f21f488917a4fc8f1b73573685608597d0efcb076b0ab7a7a4"
+    ),
 
     %% Sample from A.5 (16 bytes)
     Sample = hexstr_to_bin("5e5cd55c41f69080575d7999c25a5bfb"),
@@ -277,7 +288,7 @@ chacha20_header_protection_mask_test() ->
     <<Counter:32/little, Nonce:12/binary>> = Sample,
 
     %% Generate mask using ChaCha20 with counter from sample
-    Zeros = <<0,0,0,0,0>>,
+    Zeros = <<0, 0, 0, 0, 0>>,
     Mask = crypto:crypto_one_time(chacha20, HP, <<Counter:32/little, Nonce/binary>>, Zeros, true),
 
     ?assertEqual(ExpectedMask, Mask).
@@ -322,7 +333,7 @@ full_protection_flow_test() ->
 
     %% Verify HP mask computation works
     %% Need at least 20 bytes of ciphertext for sample
-    PaddedPlaintext = <<Plaintext/binary, 0:(20*8)>>,
+    PaddedPlaintext = <<Plaintext/binary, 0:(20 * 8)>>,
     PaddedCiphertext = quic_aead:encrypt(Key, IV, PN, AAD, PaddedPlaintext, aes_128_gcm),
 
     %% Extract sample (bytes 4-19 of ciphertext)
@@ -426,27 +437,34 @@ quiche_comparison_vectors_test() ->
     %% RFC 9001 Appendix A values (these match quiche)
     Vectors = [
         %% Client Initial
-        {hexstr_to_bin("c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"),
-         hexstr_to_bin("1f369613dd76d5467730efcbe3b1a22d"),
-         hexstr_to_bin("fa044b2f42a3fd3b46fb255c"),
-         hexstr_to_bin("9f50449e04a0e810283a1e9933adedd2")},
+        {
+            hexstr_to_bin("c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea"),
+            hexstr_to_bin("1f369613dd76d5467730efcbe3b1a22d"),
+            hexstr_to_bin("fa044b2f42a3fd3b46fb255c"),
+            hexstr_to_bin("9f50449e04a0e810283a1e9933adedd2")
+        },
 
         %% Server Initial
-        {hexstr_to_bin("3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"),
-         hexstr_to_bin("cf3a5331653c364c88f0f379b6067e37"),
-         hexstr_to_bin("0ac1493ca1905853b0bba03e"),
-         hexstr_to_bin("c206b8d9b9f0f37644430b490eeaa314")}
+        {
+            hexstr_to_bin("3c199828fd139efd216c155ad844cc81fb82fa8d7446fa7d78be803acdda951b"),
+            hexstr_to_bin("cf3a5331653c364c88f0f379b6067e37"),
+            hexstr_to_bin("0ac1493ca1905853b0bba03e"),
+            hexstr_to_bin("c206b8d9b9f0f37644430b490eeaa314")
+        }
     ],
 
-    lists:foreach(fun({Secret, ExpectedKey, ExpectedIV, ExpectedHP}) ->
-        Key = quic_hkdf:expand_label(Secret, <<"quic key">>, <<>>, 16),
-        IV = quic_hkdf:expand_label(Secret, <<"quic iv">>, <<>>, 12),
-        HP = quic_hkdf:expand_label(Secret, <<"quic hp">>, <<>>, 16),
+    lists:foreach(
+        fun({Secret, ExpectedKey, ExpectedIV, ExpectedHP}) ->
+            Key = quic_hkdf:expand_label(Secret, <<"quic key">>, <<>>, 16),
+            IV = quic_hkdf:expand_label(Secret, <<"quic iv">>, <<>>, 12),
+            HP = quic_hkdf:expand_label(Secret, <<"quic hp">>, <<>>, 16),
 
-        ?assertEqual(ExpectedKey, Key),
-        ?assertEqual(ExpectedIV, IV),
-        ?assertEqual(ExpectedHP, HP)
-    end, Vectors).
+            ?assertEqual(ExpectedKey, Key),
+            ?assertEqual(ExpectedIV, IV),
+            ?assertEqual(ExpectedHP, HP)
+        end,
+        Vectors
+    ).
 
 %%====================================================================
 %% RFC 9001 Appendix A.2 - Complete Client Initial Packet
@@ -470,17 +488,22 @@ rfc9001_a2_unprotected_header_test() ->
     %% 00000002 = packet number 2 (4 bytes)
 
     ExpectedUnprotectedHeader = hexstr_to_bin(
-        "c300000001088394c8f03e5157080000449e00000002"),
+        "c300000001088394c8f03e5157080000449e00000002"
+    ),
 
     %% Verify header size
     ?assertEqual(22, byte_size(ExpectedUnprotectedHeader)),
 
     %% Verify first byte breakdown
     FirstByte = 16#c3,
-    ?assertEqual(1, (FirstByte bsr 7) band 1),   % Long header
-    ?assertEqual(1, (FirstByte bsr 6) band 1),   % Fixed bit
-    ?assertEqual(0, (FirstByte bsr 4) band 3),   % Initial type
-    ?assertEqual(3, FirstByte band 3).           % PN length = 4 bytes
+    % Long header
+    ?assertEqual(1, (FirstByte bsr 7) band 1),
+    % Fixed bit
+    ?assertEqual(1, (FirstByte bsr 6) band 1),
+    % Initial type
+    ?assertEqual(0, (FirstByte bsr 4) band 3),
+    % PN length = 4 bytes
+    ?assertEqual(3, FirstByte band 3).
 
 rfc9001_a2_sample_position_test() ->
     %% Sample position = pn_offset + 4

--- a/test/quic_rfc_vectors_tests.erl
+++ b/test/quic_rfc_vectors_tests.erl
@@ -25,7 +25,8 @@ rfc9001_initial_keys_test() ->
 
     %% Expected Initial secret (from A.1)
     ExpectedInitialSecret = hexstr_to_bin(
-        "7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"),
+        "7db5df06e7a69e432496adedb00851923595221596ae2ae9fb8115c1e9ed0a44"
+    ),
 
     InitialSecret = quic_keys:derive_initial_secret(DCID),
     ?assertEqual(ExpectedInitialSecret, InitialSecret),
@@ -59,17 +60,26 @@ long_header_format_test() ->
 
     %% Encode an Initial packet
     Payload = <<"test">>,
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                      #{token => <<>>, payload => Payload, pn => 0}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => <<>>, payload => Payload, pn => 0}
+    ),
 
     %% Verify header structure
-    <<FirstByte, Version:32, DCIDLen, EncodedDCID:DCIDLen/binary,
-      SCIDLen, EncodedSCID:SCIDLen/binary, _Rest/binary>> = Encoded,
+    <<FirstByte, Version:32, DCIDLen, EncodedDCID:DCIDLen/binary, SCIDLen,
+        EncodedSCID:SCIDLen/binary, _Rest/binary>> = Encoded,
 
     %% First byte: 1 (long header) | 1 (fixed bit) | 00 (Initial type) | XXXX (reserved + PN length)
-    ?assertEqual(1, (FirstByte bsr 7) band 1),  % Long header bit
-    ?assertEqual(1, (FirstByte bsr 6) band 1),  % Fixed bit
-    ?assertEqual(0, (FirstByte bsr 4) band 3),  % Initial packet type
+
+    % Long header bit
+    ?assertEqual(1, (FirstByte bsr 7) band 1),
+    % Fixed bit
+    ?assertEqual(1, (FirstByte bsr 6) band 1),
+    % Initial packet type
+    ?assertEqual(0, (FirstByte bsr 4) band 3),
 
     ?assertEqual(?QUIC_VERSION_1, Version),
     ?assertEqual(DCID, EncodedDCID),
@@ -81,8 +91,13 @@ zero_rtt_packet_format_test() ->
     SCID = crypto:strong_rand_bytes(8),
     Payload = <<"0-RTT data">>,
 
-    Encoded = quic_packet:encode_long(zero_rtt, ?QUIC_VERSION_1, DCID, SCID,
-                                      #{payload => Payload, pn => 0}),
+    Encoded = quic_packet:encode_long(
+        zero_rtt,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => Payload, pn => 0}
+    ),
 
     {ok, Decoded, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(zero_rtt, Decoded#quic_packet.type),
@@ -96,8 +111,13 @@ handshake_packet_format_test() ->
     SCID = crypto:strong_rand_bytes(8),
     Payload = <<"Handshake data">>,
 
-    Encoded = quic_packet:encode_long(handshake, ?QUIC_VERSION_1, DCID, SCID,
-                                      #{payload => Payload, pn => 1}),
+    Encoded = quic_packet:encode_long(
+        handshake,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => Payload, pn => 1}
+    ),
 
     {ok, Decoded, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(handshake, Decoded#quic_packet.type),
@@ -114,8 +134,13 @@ retry_packet_format_test() ->
     IntegrityTag = crypto:strong_rand_bytes(16),
     Payload = <<RetryToken/binary, IntegrityTag/binary>>,
 
-    Encoded = quic_packet:encode_long(retry, ?QUIC_VERSION_1, DCID, SCID,
-                                      #{payload => Payload}),
+    Encoded = quic_packet:encode_long(
+        retry,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => Payload}
+    ),
 
     {ok, Decoded, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(retry, Decoded#quic_packet.type),
@@ -176,18 +201,33 @@ varint_encoding_test() ->
 
     %% 8-byte encoding: larger values (prefix 11)
     ?assertEqual(<<192, 0, 0, 0, 64, 0, 0, 0>>, quic_varint:encode(1073741824)),
-    ?assertEqual(<<255, 255, 255, 255, 255, 255, 255, 255>>, quic_varint:encode(4611686018427387903)).
+    ?assertEqual(
+        <<255, 255, 255, 255, 255, 255, 255, 255>>, quic_varint:encode(4611686018427387903)
+    ).
 
 varint_decoding_test() ->
     %% Round-trip tests
-    TestValues = [0, 37, 63, 64, 15293, 16383, 16384, 1073741823,
-                  1073741824, 4611686018427387903],
+    TestValues = [
+        0,
+        37,
+        63,
+        64,
+        15293,
+        16383,
+        16384,
+        1073741823,
+        1073741824,
+        4611686018427387903
+    ],
 
-    lists:foreach(fun(V) ->
-        Encoded = quic_varint:encode(V),
-        {Decoded, <<>>} = quic_varint:decode(Encoded),
-        ?assertEqual(V, Decoded)
-    end, TestValues).
+    lists:foreach(
+        fun(V) ->
+            Encoded = quic_varint:encode(V),
+            {Decoded, <<>>} = quic_varint:decode(Encoded),
+            ?assertEqual(V, Decoded)
+        end,
+        TestValues
+    ).
 
 %%====================================================================
 %% RFC 9000 Section 12.4 - Frame Types
@@ -276,7 +316,8 @@ minimum_window_test() ->
     CCState2 = quic_cc:on_congestion_event(CCState1, erlang:monotonic_time(millisecond)),
 
     Cwnd = quic_cc:cwnd(CCState2),
-    MinWindow = 2 * 1200,  % 2 * max_datagram_size
+    % 2 * max_datagram_size
+    MinWindow = 2 * 1200,
 
     %% Window should not go below minimum
     ?assert(Cwnd >= MinWindow).
@@ -293,10 +334,12 @@ hkdf_test_case_1_test() ->
     L = 42,
 
     ExpectedPRK = hexstr_to_bin(
-        "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"),
+        "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
+    ),
     ExpectedOKM = hexstr_to_bin(
         "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
-        "34007208d5b887185865"),
+        "34007208d5b887185865"
+    ),
 
     PRK = quic_hkdf:extract(Salt, IKM),
     ?assertEqual(ExpectedPRK, PRK),
@@ -309,23 +352,28 @@ hkdf_test_case_2_test() ->
     IKM = hexstr_to_bin(
         "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
         "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
-        "404142434445464748494a4b4c4d4e4f"),
+        "404142434445464748494a4b4c4d4e4f"
+    ),
     Salt = hexstr_to_bin(
         "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
         "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
-        "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"),
+        "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+    ),
     Info = hexstr_to_bin(
         "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
         "d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef"
-        "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"),
+        "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+    ),
     L = 82,
 
     ExpectedPRK = hexstr_to_bin(
-        "06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"),
+        "06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"
+    ),
     ExpectedOKM = hexstr_to_bin(
         "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c"
         "59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71"
-        "cc30c58179ec3e87c14c01d5c1f3434f1d87"),
+        "cc30c58179ec3e87c14c01d5c1f3434f1d87"
+    ),
 
     PRK = quic_hkdf:extract(Salt, IKM),
     ?assertEqual(ExpectedPRK, PRK),

--- a/test/quic_send_data_tests.erl
+++ b/test/quic_send_data_tests.erl
@@ -43,7 +43,9 @@
 %% Verify stream is created when server receives data on client-initiated stream
 server_creates_stream_on_receive_test() ->
     %% Simulate stream state as server would see it after receiving client data
-    StreamId = 0,  % Client-initiated bidirectional
+
+    % Client-initiated bidirectional
+    StreamId = 0,
     StreamState = create_stream_state(StreamId, server),
 
     %% Verify stream is properly initialized for bidirectional communication
@@ -79,14 +81,16 @@ stream_flow_control_blocks_test() ->
         id = 0,
         state = open,
         send_offset = 1000,
-        send_max_data = 1000,  % Already at limit
+        % Already at limit
+        send_max_data = 1000,
         send_fin = false
     },
 
     %% Check if we can send more data
     DataSize = 100,
-    CanSend = StreamState#stream_state.send_offset + DataSize =<
-              StreamState#stream_state.send_max_data,
+    CanSend =
+        StreamState#stream_state.send_offset + DataSize =<
+            StreamState#stream_state.send_max_data,
     ?assertNot(CanSend).
 
 %% Test send allowed within stream flow control
@@ -100,8 +104,9 @@ stream_flow_control_allows_test() ->
     },
 
     DataSize = 100,
-    CanSend = StreamState#stream_state.send_offset + DataSize =<
-              StreamState#stream_state.send_max_data,
+    CanSend =
+        StreamState#stream_state.send_offset + DataSize =<
+            StreamState#stream_state.send_max_data,
     ?assert(CanSend).
 
 %% Test MAX_STREAM_DATA unblocks sending
@@ -122,8 +127,9 @@ max_stream_data_unblocks_test() ->
 
     %% Now can send
     DataSize = 500,
-    CanSend = StreamState1#stream_state.send_offset + DataSize =<
-              StreamState1#stream_state.send_max_data,
+    CanSend =
+        StreamState1#stream_state.send_offset + DataSize =<
+            StreamState1#stream_state.send_max_data,
     ?assert(CanSend).
 
 %%====================================================================
@@ -175,8 +181,9 @@ cc_acks_free_cwnd_test() ->
 keys_required_for_send_test() ->
     %% When app_keys is undefined, cannot send 1-RTT data
     %% This tests the precondition - keys must exist
-    Keys = {#crypto_keys{key = <<"k">>, iv = <<"iv">>, hp = <<"hp">>},
-            #crypto_keys{key = <<"k">>, iv = <<"iv">>, hp = <<"hp">>}},
+    Keys = {#crypto_keys{key = <<"k">>, iv = <<"iv">>, hp = <<"hp">>}, #crypto_keys{
+        key = <<"k">>, iv = <<"iv">>, hp = <<"hp">>
+    }},
     ?assertNotEqual(undefined, Keys).
 
 %%====================================================================
@@ -186,8 +193,16 @@ keys_required_for_send_test() ->
 %% Test data gets queued when CC blocks
 data_queued_when_blocked_test() ->
     %% Create an empty priority queue
-    PQ = {queue:new(), queue:new(), queue:new(), queue:new(),
-          queue:new(), queue:new(), queue:new(), queue:new()},
+    PQ = {
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new()
+    },
 
     %% Queue some data
     Entry = {stream_data, 0, 0, <<"hello">>, false},
@@ -202,8 +217,16 @@ data_queued_when_blocked_test() ->
 %% Test queued data can be dequeued
 queued_data_dequeue_test() ->
     %% Create a queue with one entry
-    PQ = {queue:new(), queue:new(), queue:new(), queue:new(),
-          queue:new(), queue:new(), queue:new(), queue:new()},
+    PQ = {
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new()
+    },
     Entry = {stream_data, 0, 0, <<"hello">>, false},
     Urgency = 3,
     Bucket = element(Urgency + 1, PQ),
@@ -218,8 +241,16 @@ queued_data_dequeue_test() ->
 %% Test priority ordering - lower urgency dequeues first
 priority_ordering_test() ->
     %% Create queue with entries at different priorities
-    PQ0 = {queue:new(), queue:new(), queue:new(), queue:new(),
-           queue:new(), queue:new(), queue:new(), queue:new()},
+    PQ0 = {
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new(),
+        queue:new()
+    },
 
     %% Add entry at urgency 3 (lower priority)
     Entry3 = {stream_data, 0, 0, <<"low">>, false},
@@ -259,7 +290,8 @@ full_send_flow_test() ->
 
 %% Test flow when stream not found
 send_unknown_stream_test() ->
-    Streams = #{4 => create_stream_state(4, server)},  % Different stream
+    % Different stream
+    Streams = #{4 => create_stream_state(4, server)},
 
     %% Try to send on stream 0
     Result = maps:find(0, Streams),

--- a/test/quic_stream_tests.erl
+++ b/test/quic_stream_tests.erl
@@ -138,11 +138,13 @@ receive_out_of_order_test() ->
     Stream = quic_stream:new(0, server),
     %% Receive chunk at offset 5 first
     {ok, S1} = quic_stream:receive_data(Stream, 5, <<" world">>, false),
-    ?assertEqual(0, quic_stream:bytes_available(S1)),  % Not contiguous yet
+    % Not contiguous yet
+    ?assertEqual(0, quic_stream:bytes_available(S1)),
 
     %% Now receive chunk at offset 0
     {ok, S2} = quic_stream:receive_data(S1, 0, <<"hello">>, false),
-    ?assertEqual(11, quic_stream:bytes_available(S2)),  % Now contiguous
+    % Now contiguous
+    ?assertEqual(11, quic_stream:bytes_available(S2)),
 
     {Data, _S3} = quic_stream:read(S2),
     ?assertEqual(<<"hello world">>, Data).
@@ -167,8 +169,10 @@ read_partial_test() ->
 receive_on_closed_stream_test() ->
     Stream = quic_stream:new(0, server),
     {ok, S1} = quic_stream:receive_data(Stream, 0, <<>>, true),
-    ?assertEqual({error, stream_closed},
-                 quic_stream:receive_data(S1, 0, <<"more">>, false)).
+    ?assertEqual(
+        {error, stream_closed},
+        quic_stream:receive_data(S1, 0, <<"more">>, false)
+    ).
 
 %%====================================================================
 %% Flow Control Tests
@@ -293,10 +297,13 @@ set_priority_test() ->
 set_priority_all_levels_test() ->
     Stream = quic_stream:new(0, client),
     %% Test all urgency levels 0-7
-    lists:foreach(fun(Urgency) ->
-        {ok, S} = quic_stream:set_priority(Stream, Urgency, false),
-        ?assertEqual({Urgency, false}, quic_stream:get_priority(S))
-    end, lists:seq(0, 7)).
+    lists:foreach(
+        fun(Urgency) ->
+            {ok, S} = quic_stream:set_priority(Stream, Urgency, false),
+            ?assertEqual({Urgency, false}, quic_stream:get_priority(S))
+        end,
+        lists:seq(0, 7)
+    ).
 
 set_priority_incremental_test() ->
     Stream = quic_stream:new(0, client),
@@ -307,7 +314,11 @@ set_priority_incremental_test() ->
 
 set_priority_invalid_urgency_test() ->
     Stream = quic_stream:new(0, client),
-    ?assertEqual({error, invalid_urgency},
-                 quic_stream:set_priority(Stream, 8, false)),
-    ?assertEqual({error, invalid_urgency},
-                 quic_stream:set_priority(Stream, -1, false)).
+    ?assertEqual(
+        {error, invalid_urgency},
+        quic_stream:set_priority(Stream, 8, false)
+    ),
+    ?assertEqual(
+        {error, invalid_urgency},
+        quic_stream:set_priority(Stream, -1, false)
+    ).

--- a/test/quic_ticket_tests.erl
+++ b/test/quic_ticket_tests.erl
@@ -104,14 +104,13 @@ parse_new_session_ticket_basic_test() ->
     %% Build a simple NewSessionTicket message
     Lifetime = 86400,
     AgeAdd = 12345,
-    Nonce = <<1,2,3,4,5,6,7,8>>,
+    Nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>,
     Ticket = <<"session_ticket_data">>,
     TicketLen = byte_size(Ticket),
     NonceLen = byte_size(Nonce),
 
     %% No extensions
-    Message = <<Lifetime:32, AgeAdd:32, NonceLen, Nonce/binary,
-                TicketLen:16, Ticket/binary, 0:16>>,
+    Message = <<Lifetime:32, AgeAdd:32, NonceLen, Nonce/binary, TicketLen:16, Ticket/binary, 0:16>>,
 
     {ok, Parsed} = quic_ticket:parse_new_session_ticket(Message),
     ?assertEqual(Lifetime, maps:get(lifetime, Parsed)),
@@ -123,7 +122,7 @@ parse_new_session_ticket_basic_test() ->
 parse_new_session_ticket_with_early_data_test() ->
     Lifetime = 3600,
     AgeAdd = 99999,
-    Nonce = <<1,2,3,4>>,
+    Nonce = <<1, 2, 3, 4>>,
     Ticket = <<"ticket">>,
     MaxEarlyData = 16384,
 
@@ -131,15 +130,16 @@ parse_new_session_ticket_with_early_data_test() ->
     EarlyDataExt = <<16#00, 16#2a, 4:16, MaxEarlyData:32>>,
     ExtLen = byte_size(EarlyDataExt),
 
-    Message = <<Lifetime:32, AgeAdd:32, (byte_size(Nonce)), Nonce/binary,
-                (byte_size(Ticket)):16, Ticket/binary, ExtLen:16, EarlyDataExt/binary>>,
+    Message =
+        <<Lifetime:32, AgeAdd:32, (byte_size(Nonce)), Nonce/binary, (byte_size(Ticket)):16,
+            Ticket/binary, ExtLen:16, EarlyDataExt/binary>>,
 
     {ok, Parsed} = quic_ticket:parse_new_session_ticket(Message),
     ?assertEqual(MaxEarlyData, maps:get(max_early_data, Parsed)).
 
 parse_new_session_ticket_invalid_test() ->
     %% Too short
-    ?assertEqual({error, invalid_format}, quic_ticket:parse_new_session_ticket(<<1,2,3>>)).
+    ?assertEqual({error, invalid_format}, quic_ticket:parse_new_session_ticket(<<1, 2, 3>>)).
 
 %%====================================================================
 %% Resumption Secret Tests
@@ -150,7 +150,8 @@ resumption_secret_derivation_test() ->
     TranscriptHash = crypto:strong_rand_bytes(32),
 
     ResSecret = quic_ticket:derive_resumption_secret(
-        aes_128_gcm, MasterSecret, TranscriptHash, <<>>),
+        aes_128_gcm, MasterSecret, TranscriptHash, <<>>
+    ),
 
     ?assertEqual(32, byte_size(ResSecret)).
 

--- a/test/quic_transport_params_tests.erl
+++ b/test/quic_transport_params_tests.erl
@@ -197,7 +197,8 @@ encode_zero_values_test() ->
 encode_max_values_test() ->
     %% Large values should encode correctly with 8-byte varints
     Params = #{
-        initial_max_data => 4611686018427387903  % Max varint value (2^62 - 1)
+        % Max varint value (2^62 - 1)
+        initial_max_data => 4611686018427387903
     },
     Encoded = quic_tls:encode_transport_params(Params),
     {ok, Decoded} = quic_tls:decode_transport_params(Encoded),

--- a/test/quic_v2_tests.erl
+++ b/test/quic_v2_tests.erl
@@ -47,10 +47,9 @@ version_negotiation_decoding_test() ->
     DCIDLen = byte_size(DCID),
     SCIDLen = byte_size(SCID),
     Versions = <<?QUIC_VERSION_1:32, ?QUIC_VERSION_2:32>>,
-    VNPacket = <<FirstByte:8, 0:32,  % Version = 0 indicates VN
-                 DCIDLen:8, DCID/binary,
-                 SCIDLen:8, SCID/binary,
-                 Versions/binary>>,
+    % Version = 0 indicates VN
+    VNPacket =
+        <<FirstByte:8, 0:32, DCIDLen:8, DCID/binary, SCIDLen:8, SCID/binary, Versions/binary>>,
 
     %% Decode it
     {ok, Decoded} = quic_packet:decode(VNPacket, undefined),
@@ -138,7 +137,8 @@ client_fallback_v1_test() ->
 
 %% Test version negotiation failure (no common version)
 no_common_version_test() ->
-    OfferedVersions = [16#ff000000],  % Some unsupported version
+    % Some unsupported version
+    OfferedVersions = [16#ff000000],
     SupportedVersions = [?QUIC_VERSION_1, ?QUIC_VERSION_2],
 
     Selected = select_best_version(OfferedVersions, SupportedVersions),

--- a/test/quic_varint_tests.erl
+++ b/test/quic_varint_tests.erl
@@ -41,13 +41,17 @@ encode_1073741823_test() ->
     ?assertEqual(<<16#bf, 16#ff, 16#ff, 16#ff>>, quic_varint:encode(1073741823)).
 
 encode_1073741824_test() ->
-    ?assertEqual(<<16#c0, 16#00, 16#00, 16#00, 16#40, 16#00, 16#00, 16#00>>,
-                 quic_varint:encode(1073741824)).
+    ?assertEqual(
+        <<16#c0, 16#00, 16#00, 16#00, 16#40, 16#00, 16#00, 16#00>>,
+        quic_varint:encode(1073741824)
+    ).
 
 encode_max_test() ->
     Max = 4611686018427387903,
-    ?assertEqual(<<16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff>>,
-                 quic_varint:encode(Max)).
+    ?assertEqual(
+        <<16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff>>,
+        quic_varint:encode(Max)
+    ).
 
 %%====================================================================
 %% Decode Tests (inverse of encode)
@@ -72,13 +76,17 @@ decode_1073741823_test() ->
     ?assertEqual({1073741823, <<>>}, quic_varint:decode(<<16#bf, 16#ff, 16#ff, 16#ff>>)).
 
 decode_1073741824_test() ->
-    ?assertEqual({1073741824, <<>>},
-                 quic_varint:decode(<<16#c0, 16#00, 16#00, 16#00, 16#40, 16#00, 16#00, 16#00>>)).
+    ?assertEqual(
+        {1073741824, <<>>},
+        quic_varint:decode(<<16#c0, 16#00, 16#00, 16#00, 16#40, 16#00, 16#00, 16#00>>)
+    ).
 
 decode_max_test() ->
     Max = 4611686018427387903,
-    ?assertEqual({Max, <<>>},
-                 quic_varint:decode(<<16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff>>)).
+    ?assertEqual(
+        {Max, <<>>},
+        quic_varint:decode(<<16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff>>)
+    ).
 
 %%====================================================================
 %% Decode with trailing data
@@ -123,10 +131,23 @@ max_value_test() ->
 %%====================================================================
 
 roundtrip_test_() ->
-    Values = [0, 1, 63, 64, 100, 16383, 16384, 100000, 1073741823,
-              1073741824, 4611686018427387903],
-    [?_assertEqual({V, <<>>}, quic_varint:decode(quic_varint:encode(V)))
-     || V <- Values].
+    Values = [
+        0,
+        1,
+        63,
+        64,
+        100,
+        16383,
+        16384,
+        100000,
+        1073741823,
+        1073741824,
+        4611686018427387903
+    ],
+    [
+        ?_assertEqual({V, <<>>}, quic_varint:decode(quic_varint:encode(V)))
+     || V <- Values
+    ].
 
 %%====================================================================
 %% Error cases

--- a/test/quic_version_tests.erl
+++ b/test/quic_version_tests.erl
@@ -33,8 +33,13 @@ initial_packet_version_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{token => <<>>, payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => <<>>, payload => <<"test">>}
+    ),
 
     %% Parse header to verify version
     <<_FirstByte, Version:32, _Rest/binary>> = Encoded,
@@ -45,8 +50,13 @@ handshake_packet_version_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(handshake, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        handshake,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => <<"test">>}
+    ),
 
     <<_FirstByte, Version:32, _Rest/binary>> = Encoded,
     ?assertEqual(?QUIC_VERSION_1, Version).
@@ -56,8 +66,13 @@ zero_rtt_packet_version_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(zero_rtt, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => <<"early data">>}),
+    Encoded = quic_packet:encode_long(
+        zero_rtt,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => <<"early data">>}
+    ),
 
     <<_FirstByte, Version:32, _Rest/binary>> = Encoded,
     ?assertEqual(?QUIC_VERSION_1, Version).
@@ -69,8 +84,13 @@ retry_packet_version_test() ->
     Token = <<"retry_token">>,
     Tag = crypto:strong_rand_bytes(16),
 
-    Encoded = quic_packet:encode_long(retry, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => <<Token/binary, Tag/binary>>}),
+    Encoded = quic_packet:encode_long(
+        retry,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => <<Token/binary, Tag/binary>>}
+    ),
 
     <<_FirstByte, Version:32, _Rest/binary>> = Encoded,
     ?assertEqual(?QUIC_VERSION_1, Version).
@@ -84,8 +104,13 @@ decode_initial_version_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{token => <<>>, payload => <<"test">>, pn => 0}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => <<>>, payload => <<"test">>, pn => 0}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(?QUIC_VERSION_1, Packet#quic_packet.version),
@@ -96,8 +121,13 @@ decode_handshake_version_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(handshake, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => <<"test">>, pn => 0}),
+    Encoded = quic_packet:encode_long(
+        handshake,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => <<"test">>, pn => 0}
+    ),
 
     {ok, Packet, <<>>} = quic_packet:decode(Encoded, 8),
     ?assertEqual(?QUIC_VERSION_1, Packet#quic_packet.version).
@@ -108,9 +138,9 @@ decode_handshake_version_test() ->
 
 %% QUIC v1 uses specific initial salt
 quic_v1_initial_salt_test() ->
-    ExpectedSalt = <<16#38, 16#76, 16#2c, 16#f7, 16#f5, 16#59, 16#34, 16#b3,
-                     16#4d, 16#17, 16#9a, 16#e6, 16#a4, 16#c8, 16#0c, 16#ad,
-                     16#cc, 16#bb, 16#7f, 16#0a>>,
+    ExpectedSalt =
+        <<16#38, 16#76, 16#2c, 16#f7, 16#f5, 16#59, 16#34, 16#b3, 16#4d, 16#17, 16#9a, 16#e6, 16#a4,
+            16#c8, 16#0c, 16#ad, 16#cc, 16#bb, 16#7f, 16#0a>>,
     ?assertEqual(ExpectedSalt, ?QUIC_V1_INITIAL_SALT).
 
 %% QUIC v2 uses different initial salt (RFC 9369)
@@ -174,10 +204,10 @@ rfc9001_initial_keys_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
     %% Expected Initial secret
-    ExpectedSecret = <<16#7d, 16#b5, 16#df, 16#06, 16#e7, 16#a6, 16#9e, 16#43,
-                       16#24, 16#96, 16#ad, 16#ed, 16#b0, 16#08, 16#51, 16#92,
-                       16#35, 16#95, 16#22, 16#15, 16#96, 16#ae, 16#2a, 16#e9,
-                       16#fb, 16#81, 16#15, 16#c1, 16#e9, 16#ed, 16#0a, 16#44>>,
+    ExpectedSecret =
+        <<16#7d, 16#b5, 16#df, 16#06, 16#e7, 16#a6, 16#9e, 16#43, 16#24, 16#96, 16#ad, 16#ed, 16#b0,
+            16#08, 16#51, 16#92, 16#35, 16#95, 16#22, 16#15, 16#96, 16#ae, 16#2a, 16#e9, 16#fb,
+            16#81, 16#15, 16#c1, 16#e9, 16#ed, 16#0a, 16#44>>,
 
     Secret = quic_keys:derive_initial_secret(DCID),
     ?assertEqual(ExpectedSecret, Secret).
@@ -186,8 +216,9 @@ rfc9001_initial_keys_test() ->
 rfc9001_client_key_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
-    ExpectedKey = <<16#1f, 16#36, 16#96, 16#13, 16#dd, 16#76, 16#d5, 16#46,
-                    16#77, 16#30, 16#ef, 16#cb, 16#e3, 16#b1, 16#a2, 16#2d>>,
+    ExpectedKey =
+        <<16#1f, 16#36, 16#96, 16#13, 16#dd, 16#76, 16#d5, 16#46, 16#77, 16#30, 16#ef, 16#cb, 16#e3,
+            16#b1, 16#a2, 16#2d>>,
 
     {Key, _IV, _HP} = quic_keys:derive_initial_client(DCID),
     ?assertEqual(ExpectedKey, Key).
@@ -196,8 +227,8 @@ rfc9001_client_key_test() ->
 rfc9001_client_iv_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
-    ExpectedIV = <<16#fa, 16#04, 16#4b, 16#2f, 16#42, 16#a3, 16#fd, 16#3b,
-                   16#46, 16#fb, 16#25, 16#5c>>,
+    ExpectedIV =
+        <<16#fa, 16#04, 16#4b, 16#2f, 16#42, 16#a3, 16#fd, 16#3b, 16#46, 16#fb, 16#25, 16#5c>>,
 
     {_Key, IV, _HP} = quic_keys:derive_initial_client(DCID),
     ?assertEqual(ExpectedIV, IV).
@@ -206,8 +237,9 @@ rfc9001_client_iv_test() ->
 rfc9001_client_hp_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
-    ExpectedHP = <<16#9f, 16#50, 16#44, 16#9e, 16#04, 16#a0, 16#e8, 16#10,
-                   16#28, 16#3a, 16#1e, 16#99, 16#33, 16#ad, 16#ed, 16#d2>>,
+    ExpectedHP =
+        <<16#9f, 16#50, 16#44, 16#9e, 16#04, 16#a0, 16#e8, 16#10, 16#28, 16#3a, 16#1e, 16#99, 16#33,
+            16#ad, 16#ed, 16#d2>>,
 
     {_Key, _IV, HP} = quic_keys:derive_initial_client(DCID),
     ?assertEqual(ExpectedHP, HP).
@@ -216,8 +248,9 @@ rfc9001_client_hp_test() ->
 rfc9001_server_key_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
-    ExpectedKey = <<16#cf, 16#3a, 16#53, 16#31, 16#65, 16#3c, 16#36, 16#4c,
-                    16#88, 16#f0, 16#f3, 16#79, 16#b6, 16#06, 16#7e, 16#37>>,
+    ExpectedKey =
+        <<16#cf, 16#3a, 16#53, 16#31, 16#65, 16#3c, 16#36, 16#4c, 16#88, 16#f0, 16#f3, 16#79, 16#b6,
+            16#06, 16#7e, 16#37>>,
 
     {Key, _IV, _HP} = quic_keys:derive_initial_server(DCID),
     ?assertEqual(ExpectedKey, Key).
@@ -226,8 +259,8 @@ rfc9001_server_key_test() ->
 rfc9001_server_iv_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
-    ExpectedIV = <<16#0a, 16#c1, 16#49, 16#3c, 16#a1, 16#90, 16#58, 16#53,
-                   16#b0, 16#bb, 16#a0, 16#3e>>,
+    ExpectedIV =
+        <<16#0a, 16#c1, 16#49, 16#3c, 16#a1, 16#90, 16#58, 16#53, 16#b0, 16#bb, 16#a0, 16#3e>>,
 
     {_Key, IV, _HP} = quic_keys:derive_initial_server(DCID),
     ?assertEqual(ExpectedIV, IV).
@@ -236,8 +269,9 @@ rfc9001_server_iv_test() ->
 rfc9001_server_hp_test() ->
     DCID = <<16#83, 16#94, 16#c8, 16#f0, 16#3e, 16#51, 16#57, 16#08>>,
 
-    ExpectedHP = <<16#c2, 16#06, 16#b8, 16#d9, 16#b9, 16#f0, 16#f3, 16#76,
-                   16#44, 16#43, 16#0b, 16#49, 16#0e, 16#ea, 16#a3, 16#14>>,
+    ExpectedHP =
+        <<16#c2, 16#06, 16#b8, 16#d9, 16#b9, 16#f0, 16#f3, 16#76, 16#44, 16#43, 16#0b, 16#49, 16#0e,
+            16#ea, 16#a3, 16#14>>,
 
     {_Key, _IV, HP} = quic_keys:derive_initial_server(DCID),
     ?assertEqual(ExpectedHP, HP).
@@ -251,48 +285,72 @@ initial_packet_type_bits_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{token => <<>>, payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => <<>>, payload => <<"test">>}
+    ),
 
     <<FirstByte, _/binary>> = Encoded,
     TypeBits = (FirstByte bsr 4) band 2#11,
-    ?assertEqual(0, TypeBits).  % Initial = 00
+    % Initial = 00
+    ?assertEqual(0, TypeBits).
 
 %% Verify 0-RTT packet type encoding (bits 01)
 zero_rtt_packet_type_bits_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(zero_rtt, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        zero_rtt,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => <<"test">>}
+    ),
 
     <<FirstByte, _/binary>> = Encoded,
     TypeBits = (FirstByte bsr 4) band 2#11,
-    ?assertEqual(1, TypeBits).  % 0-RTT = 01
+    % 0-RTT = 01
+    ?assertEqual(1, TypeBits).
 
 %% Verify Handshake packet type encoding (bits 10)
 handshake_packet_type_bits_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(handshake, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        handshake,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => <<"test">>}
+    ),
 
     <<FirstByte, _/binary>> = Encoded,
     TypeBits = (FirstByte bsr 4) band 2#11,
-    ?assertEqual(2, TypeBits).  % Handshake = 10
+    % Handshake = 10
+    ?assertEqual(2, TypeBits).
 
 %% Verify Retry packet type encoding (bits 11)
 retry_packet_type_bits_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(retry, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{payload => crypto:strong_rand_bytes(32)}),
+    Encoded = quic_packet:encode_long(
+        retry,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{payload => crypto:strong_rand_bytes(32)}
+    ),
 
     <<FirstByte, _/binary>> = Encoded,
     TypeBits = (FirstByte bsr 4) band 2#11,
-    ?assertEqual(3, TypeBits).  % Retry = 11
+    % Retry = 11
+    ?assertEqual(3, TypeBits).
 
 %%====================================================================
 %% Long Header Fixed Bit (RFC 9000 Section 17.2)
@@ -303,8 +361,13 @@ long_header_form_bit_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{token => <<>>, payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => <<>>, payload => <<"test">>}
+    ),
 
     <<FirstByte, _/binary>> = Encoded,
     FormBit = (FirstByte bsr 7) band 1,
@@ -315,8 +378,13 @@ long_header_fixed_bit_test() ->
     DCID = crypto:strong_rand_bytes(8),
     SCID = crypto:strong_rand_bytes(8),
 
-    Encoded = quic_packet:encode_long(initial, ?QUIC_VERSION_1, DCID, SCID,
-                                       #{token => <<>>, payload => <<"test">>}),
+    Encoded = quic_packet:encode_long(
+        initial,
+        ?QUIC_VERSION_1,
+        DCID,
+        SCID,
+        #{token => <<>>, payload => <<"test">>}
+    ),
 
     <<FirstByte, _/binary>> = Encoded,
     FixedBit = (FirstByte bsr 6) band 1,


### PR DESCRIPTION
## Summary
- Add erlfmt and rebar3_lint plugins for code formatting and linting
- Configure elvis rules with appropriate ignores for existing code patterns
- Add CI jobs for automated format checking and linting
- Add AGENTS.md and CLAUDE.md for AI coding agent instructions
- Format all Erlang source files with erlfmt

Closes #2.