### PR TITLE
Add flow control check in send queue processing

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -113,7 +113,9 @@
     add_to_ack_ranges/2,
     merge_ack_ranges/1,
     convert_ack_ranges_for_encode/1,
-    convert_rest_ranges/2
+    convert_rest_ranges/2,
+    check_send_queue_flow_control/3,
+    test_check_flow_control/5
 ]).
 -endif.
 
@@ -4338,7 +4340,64 @@ get_stream_urgency(StreamId, Streams) ->
 
 %% Process send queue when congestion window frees up
 %% Processes streams in priority order (lower urgency = higher priority)
-process_send_queue(
+%% IMPORTANT: Must check BOTH congestion control AND flow control before sending
+process_send_queue(#state{send_queue = PQ} = State) ->
+    case pqueue_peek(PQ) of
+        empty ->
+            State;
+        {value, {stream_data, StreamId, _Offset, Data, _Fin}} ->
+            %% Check flow control BEFORE dequeuing
+            DataSize = byte_size(Data),
+            case check_send_queue_flow_control(StreamId, DataSize, State) of
+                ok ->
+                    %% Flow control allows - dequeue and try to send
+                    process_send_queue_entry(State);
+                {blocked, _Reason} ->
+                    %% Flow control blocked - leave in queue, wait for MAX_DATA
+                    State
+            end
+    end.
+
+%% Check flow control limits for queued data
+%% Returns ok | {blocked, connection | {stream, StreamId}}
+%% NOTE: Only blocks if we're already OVER the limit (negative allowed).
+%% Normal flow control blocking happens in do_send_data before queueing.
+check_send_queue_flow_control(StreamId, DataSize, #state{
+    max_data_remote = MaxDataRemote,
+    data_sent = DataSent,
+    streams = Streams
+}) ->
+    %% Check connection-level flow control
+    %% Only block if we're already over limit (defensive check)
+    ConnectionAllowed = MaxDataRemote - DataSent,
+    case ConnectionAllowed >= 0 andalso DataSize =< ConnectionAllowed of
+        false when ConnectionAllowed < 0 ->
+            %% Already over limit - this shouldn't happen but guard against it
+            {blocked, connection};
+        false ->
+            %% Would exceed limit - block
+            {blocked, connection};
+        true ->
+            %% Check stream-level flow control
+            case maps:find(StreamId, Streams) of
+                {ok, #stream_state{send_max_data = SendMaxData, send_offset = Offset}} ->
+                    StreamAllowed = SendMaxData - Offset,
+                    case StreamAllowed >= 0 andalso DataSize =< StreamAllowed of
+                        false when StreamAllowed < 0 ->
+                            {blocked, {stream, StreamId}};
+                        false ->
+                            {blocked, {stream, StreamId}};
+                        true ->
+                            ok
+                    end;
+                error ->
+                    %% Stream not found - allow (will fail later)
+                    ok
+            end
+    end.
+
+%% Actually process the queue entry (called after flow control check passes)
+process_send_queue_entry(
     #state{send_queue = PQ, streams = Streams, send_queue_bytes = QueueBytes} = State
 ) ->
     case pqueue_out(PQ) of
@@ -4394,7 +4453,7 @@ process_send_queue(
                         false ->
                             %% Check if we just queued more data (cwnd full)
                             case State3#state.send_queue =:= State1#state.send_queue of
-                                % Keep processing
+                                % Keep processing (check flow control again)
                                 true -> process_send_queue(State3);
                                 % New data queued, cwnd full
                                 false -> State3
@@ -4407,8 +4466,6 @@ process_send_queue(
 %% Priority Queue - Bucket-based implementation for urgency 0-7
 %% O(1) insert, O(1) dequeue (8 buckets = constant)
 %%--------------------------------------------------------------------
-
-%% Insert entry at given urgency level (0-7)
 pqueue_in(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
     Bucket = element(Urgency + 1, PQ),
     NewBucket = queue:in(Entry, Bucket),
@@ -5155,3 +5212,33 @@ handle_retire_connection_id(SeqNum, State) ->
         Pool
     ),
     State#state{local_cid_pool = NewPool}.
+
+%%====================================================================
+%% Test Helpers
+%%====================================================================
+
+-ifdef(TEST).
+%% @doc Test helper for check_send_queue_flow_control/3
+%% Wraps the internal function to avoid exposing #state{} record.
+%% RFC 9000 Section 4.1: Connection-level flow control (max_data)
+%% RFC 9000 Section 4.2: Stream-level flow control (max_stream_data)
+%% @param StreamId - Stream ID to check
+%% @param DataSize - Size of data to send
+%% @param MaxDataRemote - Peer's connection-level max_data limit
+%% @param DataSent - Bytes already sent on connection
+%% @param StreamsMap - Map of StreamId => {SendMaxData, SendOffset}
+%% @returns ok | {blocked, connection | {stream, StreamId}}
+test_check_flow_control(StreamId, DataSize, MaxDataRemote, DataSent, StreamsMap) ->
+    Streams = maps:map(
+        fun(_K, {SendMaxData, SendOffset}) ->
+            #stream_state{send_max_data = SendMaxData, send_offset = SendOffset}
+        end,
+        StreamsMap
+    ),
+    State = #state{
+        max_data_remote = MaxDataRemote,
+        data_sent = DataSent,
+        streams = Streams
+    },
+    check_send_queue_flow_control(StreamId, DataSize, State).
+-endif.

--- a/test/quic_connection_tests.erl
+++ b/test/quic_connection_tests.erl
@@ -385,3 +385,126 @@ state_info_contains_queue_counters_test() ->
 
     quic_connection:close(Pid, normal),
     timer:sleep(100).
+
+%%====================================================================
+%% Send Queue Flow Control Tests
+%% RFC 9000 Section 4.1: Connection-level flow control
+%% RFC 9000 Section 4.2: "A sender MUST NOT send data at an offset
+%%                        beyond the limit set by its peer"
+%%====================================================================
+
+%% Test that sending within connection-level limits is allowed
+flow_control_connection_within_limit_test() ->
+    StreamId = 0,
+    DataSize = 1000,
+    MaxDataRemote = 10000,
+    DataSent = 5000,
+    Streams = #{StreamId => {10000, 0}},
+    ?assertEqual(
+        ok,
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test that exceeding connection-level limit blocks
+%% RFC 9000 Section 4.1: Sender must not exceed max_data
+flow_control_connection_exceeds_limit_test() ->
+    StreamId = 0,
+    DataSize = 6000,
+    MaxDataRemote = 10000,
+    DataSent = 5000,
+    Streams = #{StreamId => {10000, 0}},
+    ?assertEqual(
+        {blocked, connection},
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test that exactly at connection limit is allowed
+flow_control_connection_at_limit_test() ->
+    StreamId = 0,
+    DataSize = 5000,
+    MaxDataRemote = 10000,
+    DataSent = 5000,
+    Streams = #{StreamId => {10000, 0}},
+    ?assertEqual(
+        ok,
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test that already over connection limit blocks
+%% This is a defensive check - shouldn't happen but guards against it
+flow_control_connection_already_over_limit_test() ->
+    StreamId = 0,
+    DataSize = 1000,
+    MaxDataRemote = 10000,
+    DataSent = 11000,
+    Streams = #{StreamId => {10000, 0}},
+    ?assertEqual(
+        {blocked, connection},
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test that exceeding stream-level limit blocks
+%% RFC 9000 Section 4.2: max_stream_data limits per-stream
+flow_control_stream_exceeds_limit_test() ->
+    StreamId = 0,
+    DataSize = 2000,
+    MaxDataRemote = 100000,
+    DataSent = 0,
+    Streams = #{StreamId => {5000, 4000}},
+    ?assertEqual(
+        {blocked, {stream, StreamId}},
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test that stream within limit is allowed
+flow_control_stream_within_limit_test() ->
+    StreamId = 4,
+    DataSize = 500,
+    MaxDataRemote = 100000,
+    DataSent = 0,
+    Streams = #{StreamId => {5000, 4000}},
+    ?assertEqual(
+        ok,
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test that unknown stream is allowed (will fail later in processing)
+flow_control_unknown_stream_allowed_test() ->
+    StreamId = 99,
+    DataSize = 1000,
+    MaxDataRemote = 100000,
+    DataSent = 0,
+    Streams = #{0 => {5000, 0}},
+    ?assertEqual(
+        ok,
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).
+
+%% Test connection limit checked before stream limit
+%% Even if stream has capacity, connection limit blocks first
+flow_control_connection_blocks_before_stream_test() ->
+    StreamId = 0,
+    DataSize = 5000,
+    MaxDataRemote = 1000,
+    DataSent = 0,
+    Streams = #{StreamId => {10000, 0}},
+    ?assertEqual(
+        {blocked, connection},
+        quic_connection:test_check_flow_control(
+            StreamId, DataSize, MaxDataRemote, DataSent, Streams
+        )
+    ).


### PR DESCRIPTION
## Summary

- Add `check_send_queue_flow_control/3` to verify connection and stream level flow control before dequeuing data from send queue
- Fix race where `process_send_queue` could bypass flow control, causing `data_sent` to exceed `max_data_remote`
- Refactor `process_send_queue` into wrapper + `process_send_queue_entry`

This prevents a subtle bug where queued data could be sent even when flow control limits were exhausted, violating RFC 9000 flow control guarantees.