### PR TITLE
Add STOP_SENDING API (issue #18)

### DIFF
--- a/src/quic.erl
+++ b/src/quic.erl
@@ -61,6 +61,7 @@
     open_unidirectional_stream/1,
     send_data/4,
     reset_stream/3,
+    stop_sending/3,
     handle_timeout/2,
     process/1,
     peername/1,
@@ -231,6 +232,22 @@ reset_stream(ConnRef, StreamId, ErrorCode) when is_reference(ConnRef) ->
 reset_stream(ConnPid, StreamId, ErrorCode) when is_pid(ConnPid) ->
     quic_connection:reset_stream(ConnPid, StreamId, ErrorCode);
 reset_stream(_ConnRef, _StreamId, _ErrorCode) ->
+    {error, badarg}.
+
+%% @doc Request peer to stop sending on a stream.
+%% Sends a STOP_SENDING frame (RFC 9000 Section 19.5).
+-spec stop_sending(ConnRef, StreamId, ErrorCode) -> ok | {error, term()} when
+    ConnRef :: reference() | pid(),
+    StreamId :: non_neg_integer(),
+    ErrorCode :: non_neg_integer().
+stop_sending(ConnRef, StreamId, ErrorCode) when is_reference(ConnRef) ->
+    case quic_connection:lookup(ConnRef) of
+        {ok, Pid} -> quic_connection:stop_sending(Pid, StreamId, ErrorCode);
+        error -> {error, not_found}
+    end;
+stop_sending(ConnPid, StreamId, ErrorCode) when is_pid(ConnPid) ->
+    quic_connection:stop_sending(ConnPid, StreamId, ErrorCode);
+stop_sending(_ConnRef, _StreamId, _ErrorCode) ->
     {error, badarg}.
 
 %% @doc Handle connection timeout.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -69,6 +69,7 @@
     close/2,
     close_stream/3,
     reset_stream/3,
+    stop_sending/3,
     handle_timeout/1,
     handle_timeout/2,
     process/1,
@@ -465,6 +466,13 @@ close_stream(Conn, StreamId, ErrorCode) ->
     ok | {error, term()}.
 reset_stream(Conn, StreamId, ErrorCode) ->
     gen_statem:call(Conn, {close_stream, StreamId, ErrorCode}).
+
+%% @doc Request peer to stop sending on a stream.
+%% Sends a STOP_SENDING frame (RFC 9000 Section 19.5).
+-spec stop_sending(pid(), non_neg_integer(), non_neg_integer()) ->
+    ok | {error, term()}.
+stop_sending(Conn, StreamId, ErrorCode) ->
+    gen_statem:call(Conn, {stop_sending, StreamId, ErrorCode}).
 
 %% @doc Handle a timeout event.
 -spec handle_timeout(pid()) -> ok.
@@ -1187,6 +1195,14 @@ connected({call, From}, open_unidirectional_stream, State) ->
     end;
 connected({call, From}, {close_stream, StreamId, ErrorCode}, State) ->
     case do_close_stream(StreamId, ErrorCode, State) of
+        {ok, NewState} ->
+            {keep_state, NewState, [{reply, From, ok}]};
+        {error, Reason} ->
+            {keep_state, State, [{reply, From, {error, Reason}}]}
+    end;
+%% STOP_SENDING: Request peer to stop sending on a stream (RFC 9000 Section 19.5)
+connected({call, From}, {stop_sending, StreamId, ErrorCode}, State) ->
+    case do_stop_sending(StreamId, ErrorCode, State) of
         {ok, NewState} ->
             {keep_state, NewState, [{reply, From, ok}]};
         {error, Reason} ->
@@ -5017,6 +5033,18 @@ do_close_stream(StreamId, ErrorCode, #state{streams = Streams} = State) ->
             {ok, NewState#state{
                 streams = maps:remove(StreamId, Streams)
             }};
+        error ->
+            {error, unknown_stream}
+    end.
+
+%% Request peer to stop sending on a stream (RFC 9000 Section 19.5)
+do_stop_sending(StreamId, ErrorCode, #state{streams = Streams} = State) ->
+    case maps:find(StreamId, Streams) of
+        {ok, _StreamState} ->
+            %% Send STOP_SENDING frame
+            Frame = quic_frame:encode({stop_sending, StreamId, ErrorCode}),
+            NewState = send_app_packet(Frame, State),
+            {ok, NewState};
         error ->
             {error, unknown_stream}
     end.

--- a/test/quic_stop_sending_tests.erl
+++ b/test/quic_stop_sending_tests.erl
@@ -1,0 +1,166 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for QUIC STOP_SENDING API
+%%% RFC 9000 Section 19.5
+%%%
+
+-module(quic_stop_sending_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+%%====================================================================
+%% API Tests
+%%====================================================================
+
+%% Test that stop_sending returns badarg for invalid ConnRef
+stop_sending_badarg_test() ->
+    ?assertEqual({error, badarg}, quic:stop_sending(invalid, 0, 0)),
+    ?assertEqual({error, badarg}, quic:stop_sending("not_a_ref", 0, 0)).
+
+%% Test that stop_sending returns not_found for unknown reference
+stop_sending_not_found_test() ->
+    UnknownRef = make_ref(),
+    ?assertEqual({error, not_found}, quic:stop_sending(UnknownRef, 0, 0)).
+
+%% Test that stop_sending in idle state returns invalid_state error
+stop_sending_idle_state_test() ->
+    {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
+
+    %% Connection is in idle state (not connected yet)
+    {State, _} = quic_connection:get_state(Pid),
+    ?assertEqual(idle, State),
+
+    %% stop_sending should fail because we're not in connected state
+    Result = quic_connection:stop_sending(Pid, 0, 0),
+    ?assertEqual({error, {invalid_state, idle}}, Result),
+
+    quic_connection:close(Pid, normal),
+    timer:sleep(100).
+
+%% Test that stop_sending API accepts reference and delegates correctly
+stop_sending_with_ref_test() ->
+    {ok, Ref, Pid} = quic_connection:connect("127.0.0.1", 4433, #{}, self()),
+    ?assert(is_reference(Ref)),
+
+    %% Connection is in idle state (not connected yet)
+    %% stop_sending should fail because we're not in connected state
+    Result = quic:stop_sending(Ref, 0, 0),
+    ?assertEqual({error, {invalid_state, idle}}, Result),
+
+    quic_connection:close(Pid, normal),
+    timer:sleep(100).
+
+%% Test that stop_sending API accepts pid directly
+stop_sending_with_pid_test() ->
+    {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
+
+    %% Connection is in idle state
+    Result = quic:stop_sending(Pid, 0, 0),
+    ?assertEqual({error, {invalid_state, idle}}, Result),
+
+    quic_connection:close(Pid, normal),
+    timer:sleep(100).
+
+%%====================================================================
+%% Frame Encoding Tests
+%%====================================================================
+
+%% Verify STOP_SENDING frame encoding
+stop_sending_frame_encode_test() ->
+    StreamId = 4,
+    ErrorCode = 256,
+
+    Frame = {stop_sending, StreamId, ErrorCode},
+    Encoded = quic_frame:encode(Frame),
+
+    %% Frame type should be 0x05
+    ?assertMatch(<<5, _/binary>>, Encoded),
+
+    %% Should roundtrip correctly
+    {Decoded, <<>>} = quic_frame:decode(Encoded),
+    ?assertEqual(Frame, Decoded).
+
+%% Test various stream IDs and error codes
+stop_sending_frame_values_test() ->
+    TestCases = [
+        {0, 0},
+        {1, 1},
+        {100, 500},
+        % Large varint values
+        {16#3FFFFFFF, 16#3FFFFFFF}
+    ],
+
+    lists:foreach(
+        fun({StreamId, ErrorCode}) ->
+            Frame = {stop_sending, StreamId, ErrorCode},
+            Encoded = quic_frame:encode(Frame),
+            {Decoded, <<>>} = quic_frame:decode(Encoded),
+            ?assertEqual(Frame, Decoded)
+        end,
+        TestCases
+    ).
+
+%%====================================================================
+%% quic_stream Module Integration Tests
+%%====================================================================
+
+%% Test that quic_stream:stop_sending clears send buffer
+stream_stop_sending_clears_buffer_test() ->
+    Stream = quic_stream:new(0, client),
+    {ok, S1} = quic_stream:send(Stream, <<"pending data">>),
+    ?assert(quic_stream:bytes_to_send(S1) > 0),
+
+    %% stop_sending should clear send buffer
+    S2 = quic_stream:stop_sending(S1, 0),
+    ?assertEqual(0, quic_stream:bytes_to_send(S2)).
+
+%% Test stop_sending on empty stream
+stream_stop_sending_empty_test() ->
+    Stream = quic_stream:new(0, client),
+    S1 = quic_stream:stop_sending(Stream, 42),
+    ?assertEqual(0, quic_stream:bytes_to_send(S1)).
+
+%% Test stop_sending with different error codes
+stream_stop_sending_error_codes_test() ->
+    Stream = quic_stream:new(4, server),
+    {ok, S1} = quic_stream:send(Stream, <<"data">>),
+
+    %% Various error codes should all clear the buffer
+    lists:foreach(
+        fun(ErrorCode) ->
+            S2 = quic_stream:stop_sending(S1, ErrorCode),
+            ?assertEqual(0, quic_stream:bytes_to_send(S2))
+        end,
+        [0, 1, 256, 16#FFFFFFFF]
+    ).
+
+%%====================================================================
+%% Protocol Compliance Tests (RFC 9000 Section 19.5)
+%%====================================================================
+
+%% Verify STOP_SENDING frame type is 0x05
+stop_sending_frame_type_test() ->
+    Frame = {stop_sending, 0, 0},
+    <<Type, _/binary>> = quic_frame:encode(Frame),
+    ?assertEqual(5, Type).
+
+%% Test that STOP_SENDING uses varint encoding for StreamId and ErrorCode
+stop_sending_varint_encoding_test() ->
+    %% Small values (1-byte varint, values 0-63)
+    Frame1 = {stop_sending, 0, 0},
+    Encoded1 = quic_frame:encode(Frame1),
+    % 1 type + 1 stream_id + 1 error_code
+    ?assertEqual(3, byte_size(Encoded1)),
+
+    %% Values 0-63 fit in 1 byte
+    Frame2 = {stop_sending, 63, 63},
+    Encoded2 = quic_frame:encode(Frame2),
+    % 1 type + 1 stream_id + 1 error_code
+    ?assertEqual(3, byte_size(Encoded2)),
+
+    %% Values 64-16383 require 2-byte varint
+    Frame3 = {stop_sending, 1000, 2000},
+    Encoded3 = quic_frame:encode(Frame3),
+    % 1 type + 2 stream_id + 2 error_code
+    ?assertEqual(5, byte_size(Encoded3)).


### PR DESCRIPTION
## Summary

- Add `quic:stop_sending/3` to allow applications to send STOP_SENDING frames
- Sends RFC 9000 Section 19.5 STOP_SENDING frame to request peer stop sending on a stream
- Previously only receiving STOP_SENDING was implemented

Closes #18