### PR TITLE
Add max_datagram_frame_size transport parameter

### DIFF
--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -1,0 +1,431 @@
+# QUIC Client Guide
+
+This guide covers connecting to QUIC servers and using client features.
+
+## Quick Start
+
+```erlang
+%% Start the QUIC application
+application:ensure_all_started(quic).
+
+%% Connect to a server
+{ok, ConnRef} = quic:connect("example.com", 443, #{
+    alpn => [<<"h3">>],
+    verify => false  % For testing only!
+}, self()).
+
+%% Wait for connection
+receive
+    {quic, ConnRef, {connected, Info}} ->
+        io:format("Connected! ALPN: ~p~n", [maps:get(alpn_protocol, Info)])
+end.
+
+%% Open a stream and send data
+{ok, StreamId} = quic:open_stream(ConnRef),
+ok = quic:send_data(ConnRef, StreamId, <<"Hello, QUIC!">>, true).
+
+%% Receive response
+receive
+    {quic, ConnRef, {stream_data, StreamId, Data, _Fin}} ->
+        io:format("Received: ~p~n", [Data])
+end.
+
+%% Close connection
+quic:close(ConnRef, normal).
+```
+
+## Connection Options
+
+### TLS Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `alpn` | [binary()] | `[<<"h3">>]` | ALPN protocols to offer |
+| `verify` | boolean | false | Verify server certificate |
+| `sni` | binary | Host | Server Name Indication |
+| `cert` | binary | - | Client certificate (for mTLS) |
+| `key` | term | - | Client private key (for mTLS) |
+
+### Connection Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `idle_timeout` | integer | 30000 | Idle timeout in ms |
+| `max_data` | integer | 10485760 | Connection-level receive limit |
+| `max_stream_data` | integer | 1048576 | Per-stream receive limit |
+| `max_streams_bidi` | integer | 100 | Max bidirectional streams |
+| `max_streams_uni` | integer | 100 | Max unidirectional streams |
+
+### Datagram Options (RFC 9221)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `max_datagram_frame_size` | integer | 0 | Max datagram size (0 = disabled) |
+
+### Advanced Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `keep_alive_interval` | integer/atom | `auto` | PING interval |
+| `socket_fd` | integer | - | Reuse existing UDP socket FD |
+| `pmtu_enabled` | boolean | true | Enable Path MTU Discovery |
+
+## Features
+
+### Stream Management
+
+```erlang
+%% Open bidirectional stream
+{ok, BidiStreamId} = quic:open_stream(ConnRef).
+
+%% Open unidirectional stream (send-only)
+{ok, UniStreamId} = quic:open_unidirectional_stream(ConnRef).
+
+%% Send data (Fin=true closes the send side)
+ok = quic:send_data(ConnRef, StreamId, <<"data">>, false),
+ok = quic:send_data(ConnRef, StreamId, <<"more">>, true).  % Final
+
+%% Send with timeout
+case quic:send_data(ConnRef, StreamId, Data, true, 5000) of
+    ok -> sent;
+    {error, timeout} -> handle_timeout()
+end.
+
+%% Reset a stream with error code
+ok = quic:reset_stream(ConnRef, StreamId, 0).
+
+%% Request peer to stop sending
+ok = quic:stop_sending(ConnRef, StreamId, 0).
+```
+
+### Stream Prioritization (RFC 9218)
+
+```erlang
+%% Set stream priority
+%% Urgency: 0-7 (0 = most urgent, default 3)
+%% Incremental: true if data can be processed incrementally
+ok = quic:set_stream_priority(ConnRef, StreamId, 0, false).
+
+%% Get current priority
+{ok, {Urgency, Incremental}} = quic:get_stream_priority(ConnRef, StreamId).
+```
+
+### Stream Deadlines
+
+```erlang
+%% Set a 5-second deadline on a stream
+ok = quic:set_stream_deadline(ConnRef, StreamId, 5000).
+
+%% Set deadline with custom action
+ok = quic:set_stream_deadline(ConnRef, StreamId, 5000, #{
+    action => notify,  % notify | reset | both
+    error_code => 16#FF
+}).
+
+%% Check remaining time
+{ok, {RemainingMs, Action}} = quic:get_stream_deadline(ConnRef, StreamId).
+
+%% Cancel deadline
+ok = quic:cancel_stream_deadline(ConnRef, StreamId).
+
+%% Handle deadline expiration
+receive
+    {quic, ConnRef, {stream_deadline, StreamId}} ->
+        handle_deadline_expired(StreamId)
+end.
+```
+
+### Unreliable Datagrams (RFC 9221)
+
+```erlang
+%% Enable datagrams (both client and server must enable)
+{ok, ConnRef} = quic:connect(Host, Port, #{
+    max_datagram_frame_size => 65535  % Accept any size
+}, self()).
+
+%% Check if datagrams are supported
+MaxSize = quic:datagram_max_size(ConnRef),
+case MaxSize of
+    0 -> io:format("Datagrams not supported~n");
+    _ -> io:format("Max datagram size: ~p~n", [MaxSize])
+end.
+
+%% Send a datagram (unreliable, not retransmitted)
+case quic:send_datagram(ConnRef, <<"game_state">>) of
+    ok -> sent;
+    {error, datagrams_not_supported} -> not_supported;
+    {error, datagram_too_large} -> too_big;
+    {error, congestion_limited} -> dropped  % Normal for datagrams
+end.
+
+%% Receive datagrams
+receive
+    {quic, ConnRef, {datagram, Data}} ->
+        handle_datagram(Data)
+end.
+```
+
+### Connection Migration
+
+```erlang
+%% Trigger migration to a new local address
+%% (e.g., when switching from WiFi to cellular)
+ok = quic:migrate(ConnRef).
+
+%% The connection will:
+%% 1. Bind to a new local socket
+%% 2. Send PATH_CHALLENGE to peer
+%% 3. Wait for PATH_RESPONSE
+%% 4. Reset congestion controller for new path
+```
+
+### 0-RTT Session Resumption
+
+```erlang
+%% First connection - receive session ticket
+receive
+    {quic, ConnRef, {session_ticket, Ticket}} ->
+        %% Store ticket for later use
+        store_ticket(Host, Ticket)
+end.
+
+%% Later connection - use stored ticket
+StoredTicket = get_ticket(Host),
+{ok, ConnRef2} = quic:connect(Host, Port, #{
+    session_ticket => StoredTicket,
+    early_data => <<"request">>  % Sent with 0-RTT
+}, self()).
+```
+
+### Connection Information
+
+```erlang
+%% Get peer address
+{ok, {IP, Port}} = quic:peername(ConnRef).
+
+%% Get local address
+{ok, {LocalIP, LocalPort}} = quic:sockname(ConnRef).
+
+%% Get peer certificate
+{ok, CertDer} = quic:peercert(ConnRef).
+
+%% Get current MTU
+{ok, MTU} = quic:get_mtu(ConnRef).
+
+%% Get connection statistics
+{ok, Stats} = quic:get_stats(ConnRef).
+%% Stats = #{
+%%     packets_sent => 150,
+%%     packets_received => 148,
+%%     data_sent => 50000,
+%%     data_received => 45000
+%% }
+```
+
+### Backpressure and Congestion
+
+```erlang
+%% Check send queue status for backpressure
+{ok, Info} = quic:get_send_queue_info(ConnRef).
+%% Info = #{
+%%     bytes => 5000,        % Bytes queued
+%%     cwnd => 14720,        % Congestion window
+%%     in_flight => 10000,   % Unacked bytes
+%%     in_recovery => false, % In loss recovery?
+%%     congested => false    % Should apply backpressure?
+%% }
+
+case maps:get(congested, Info) of
+    true -> pause_sending();
+    false -> continue_sending()
+end.
+```
+
+## Message Reference
+
+Messages sent to the owner process:
+
+| Message | Description |
+|---------|-------------|
+| `{quic, Ref, {connected, Info}}` | Connection established |
+| `{quic, Ref, {stream_opened, StreamId}}` | Peer opened a stream |
+| `{quic, Ref, {stream_data, StreamId, Data, Fin}}` | Data received |
+| `{quic, Ref, {stream_reset, StreamId, Code}}` | Stream reset by peer |
+| `{quic, Ref, {stop_sending, StreamId, Code}}` | Stop sending requested |
+| `{quic, Ref, {datagram, Data}}` | Datagram received |
+| `{quic, Ref, {session_ticket, Ticket}}` | Session ticket for 0-RTT |
+| `{quic, Ref, {stream_deadline, StreamId}}` | Stream deadline expired |
+| `{quic, Ref, {send_ready, StreamId}}` | Stream ready to write |
+| `{quic, Ref, {closed, Reason}}` | Connection closed |
+| `{quic, Ref, {transport_error, Code, Reason}}` | Transport error |
+
+## Error Handling
+
+```erlang
+%% Connection errors
+case quic:connect(Host, Port, Opts, self()) of
+    {ok, ConnRef} ->
+        wait_for_connection(ConnRef);
+    {error, Reason} ->
+        handle_connect_error(Reason)
+end.
+
+%% Stream errors
+case quic:send_data(ConnRef, StreamId, Data, true) of
+    ok -> ok;
+    {error, not_found} -> connection_gone();
+    {error, stream_closed} -> stream_gone();
+    {error, flow_control} -> apply_backpressure()
+end.
+
+%% Handle connection close
+receive
+    {quic, ConnRef, {closed, normal}} ->
+        ok;
+    {quic, ConnRef, {closed, idle_timeout}} ->
+        reconnect();
+    {quic, ConnRef, {transport_error, Code, Reason}} ->
+        log_error(Code, Reason)
+end.
+```
+
+## Best Practices
+
+### 1. Certificate Verification
+
+```erlang
+%% Production: always verify certificates
+#{
+    verify => true,
+    cacertfile => "/etc/ssl/certs/ca-certificates.crt"
+}
+
+%% Development only: disable verification
+#{verify => false}
+```
+
+### 2. Connection Pooling
+
+```erlang
+%% For multiple requests to same server, reuse connections
+%% Open multiple streams on single connection
+{ok, ConnRef} = quic:connect(Host, Port, Opts, self()),
+
+%% Concurrent requests on same connection
+{ok, Stream1} = quic:open_stream(ConnRef),
+{ok, Stream2} = quic:open_stream(ConnRef),
+{ok, Stream3} = quic:open_stream(ConnRef).
+```
+
+### 3. Graceful Shutdown
+
+```erlang
+%% Close streams before closing connection
+lists:foreach(fun(StreamId) ->
+    quic:send_data(ConnRef, StreamId, <<>>, true)
+end, OpenStreams),
+
+%% Wait for acknowledgment, then close
+timer:sleep(100),
+quic:close(ConnRef, normal).
+```
+
+### 4. Timeout Handling
+
+```erlang
+%% Set appropriate timeouts
+connect_with_timeout(Host, Port) ->
+    {ok, ConnRef} = quic:connect(Host, Port, #{
+        idle_timeout => 30000
+    }, self()),
+
+    receive
+        {quic, ConnRef, {connected, _}} ->
+            {ok, ConnRef}
+    after 10000 ->
+        quic:close(ConnRef, timeout),
+        {error, connection_timeout}
+    end.
+```
+
+### 5. Enable QLOG for Debugging
+
+```erlang
+%% Enable QLOG to debug connection issues
+quic:connect(Host, Port, #{
+    qlog => #{
+        enabled => true,
+        dir => "/tmp/qlog"
+    }
+}, self()).
+
+%% View with: qvis or Wireshark
+```
+
+## Example: HTTP/3-style Client
+
+```erlang
+-module(h3_client).
+-export([request/3]).
+
+request(Host, Port, Path) ->
+    %% Connect
+    {ok, ConnRef} = quic:connect(Host, Port, #{
+        alpn => [<<"h3">>],
+        verify => false
+    }, self()),
+
+    receive
+        {quic, ConnRef, {connected, _}} -> ok
+    after 5000 ->
+        quic:close(ConnRef, timeout),
+        exit(connection_timeout)
+    end,
+
+    %% Open request stream
+    {ok, StreamId} = quic:open_stream(ConnRef),
+
+    %% Send request (simplified, not real H3)
+    Request = <<"GET ", Path/binary, " HTTP/3\r\n\r\n">>,
+    ok = quic:send_data(ConnRef, StreamId, Request, true),
+
+    %% Receive response
+    Response = receive_response(ConnRef, StreamId, <<>>),
+
+    quic:close(ConnRef, normal),
+    Response.
+
+receive_response(ConnRef, StreamId, Acc) ->
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Data, false}} ->
+            receive_response(ConnRef, StreamId, <<Acc/binary, Data/binary>>);
+        {quic, ConnRef, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, ConnRef, {closed, _}} ->
+            Acc
+    after 10000 ->
+        Acc
+    end.
+```
+
+## Troubleshooting
+
+### Connection Fails
+
+1. Check server is reachable: `nc -u <host> <port>`
+2. Verify ALPN matches server's protocols
+3. Check certificate issues with `verify => false` first
+4. Enable QLOG to see handshake details
+
+### Slow Performance
+
+1. Check for packet loss with QLOG
+2. Verify MTU discovery is working: `quic:get_mtu(ConnRef)`
+3. Monitor congestion: `quic:get_send_queue_info(ConnRef)`
+4. Consider datagram API for latency-sensitive data
+
+### Connection Drops
+
+1. Check `idle_timeout` settings on both ends
+2. Enable keep-alive: `keep_alive_interval => 15000`
+3. Monitor for transport errors in messages

--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -42,7 +42,7 @@ quic:close(ConnRef, normal).
 |--------|------|---------|-------------|
 | `alpn` | [binary()] | `[<<"h3">>]` | ALPN protocols to offer |
 | `verify` | boolean | false | Verify server certificate |
-| `sni` | binary | Host | Server Name Indication |
+| `server_name` | binary | Host | Server Name Indication |
 | `cert` | binary | - | Client certificate (for mTLS) |
 | `key` | term | - | Client private key (for mTLS) |
 
@@ -67,7 +67,6 @@ quic:close(ConnRef, normal).
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `keep_alive_interval` | integer/atom | `auto` | PING interval |
-| `socket_fd` | integer | - | Reuse existing UDP socket FD |
 | `pmtu_enabled` | boolean | true | Enable Path MTU Discovery |
 
 ## Features

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -390,23 +390,67 @@ DATAGRAM frames provide unreliable message delivery:
 - No flow control (use connection-level limits)
 - Useful for latency-sensitive data (gaming, real-time media)
 
-### Transport Parameter
+### Transport Parameter Negotiation
 
-Negotiate via `max_datagram_frame_size` transport parameter:
-- 0 or absent: Datagrams not supported
-- Non-zero: Maximum datagram payload size
+Datagram support is negotiated via the `max_datagram_frame_size` transport parameter:
+
+| Value | Meaning |
+|-------|---------|
+| 0 or absent | Datagrams not supported (default) |
+| 1-65535 | Maximum datagram payload size accepted |
+
+Both endpoints must advertise support for datagrams to work. The effective
+maximum size is the minimum of what the peer advertises and what fits in
+a QUIC packet (path MTU minus overhead).
+
+### Configuration
+
+```erlang
+%% Enable datagram support (client)
+quic:connect(Host, Port, #{
+    max_datagram_frame_size => 65535  % Recommended: accept any size
+}, Owner).
+
+%% Enable datagram support (server)
+quic:start_server(my_server, Port, #{
+    max_datagram_frame_size => 65535,
+    cert => Cert,
+    key => Key
+}).
+```
 
 ### API
 
 ```erlang
-%% Send a datagram
-quic:send_datagram(ConnRef, Data).
+%% Check if datagrams are supported and get max size
+MaxSize = quic:datagram_max_size(ConnRef).
+%% Returns 0 if datagrams not supported, otherwise peer's max size
 
-%% Receive (owner process)
+%% Send a datagram (unreliable)
+ok = quic:send_datagram(ConnRef, Data).
+%% Returns {error, datagrams_not_supported} if peer didn't advertise
+%% Returns {error, datagram_too_large} if Data exceeds peer's limit
+%% Returns {error, congestion_limited} if cwnd is full (datagram dropped)
+
+%% Receive datagrams (owner process)
 receive
-    {quic, ConnRef, {datagram, Data}} -> ...
+    {quic, ConnRef, {datagram, Data}} -> handle_datagram(Data)
 end.
 ```
+
+### Error Handling
+
+| Error | Cause |
+|-------|-------|
+| `{error, datagrams_not_supported}` | Peer didn't advertise `max_datagram_frame_size` |
+| `{error, datagram_too_large}` | Data exceeds peer's advertised limit |
+| `{error, congestion_limited}` | Congestion window full (datagram dropped) |
+
+### Protocol Violations
+
+Per RFC 9221, the following result in `PROTOCOL_VIOLATION` connection close:
+- Receiving a DATAGRAM frame when we didn't advertise support
+- Receiving a DATAGRAM frame larger than our advertised limit
 
 ## Active Migration
 

--- a/docs/QLOG_GUIDE.md
+++ b/docs/QLOG_GUIDE.md
@@ -1,0 +1,334 @@
+# QLOG Tracing Guide
+
+QLOG is a standardized logging format for QUIC connections that enables debugging and performance analysis using tools like Wireshark and qvis.
+
+## Quick Start
+
+```erlang
+%% Enable QLOG for a client connection
+{ok, ConnRef} = quic:connect("example.com", 443, #{
+    qlog => #{
+        enabled => true,
+        dir => "/tmp/qlog"
+    }
+}, self()).
+
+%% Enable QLOG for a server
+quic:start_server(my_server, 4433, #{
+    cert => Cert,
+    key => Key,
+    qlog => #{
+        enabled => true,
+        dir => "/tmp/qlog"
+    }
+}).
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | boolean | false | Enable QLOG tracing |
+| `dir` | string | "/tmp/qlog" | Directory for QLOG files |
+| `events` | all or [atom()] | all | Events to log |
+
+### Event Types
+
+Available event types for selective logging:
+
+| Event | Description |
+|-------|-------------|
+| `packet_sent` | Outgoing packets |
+| `packet_received` | Incoming packets |
+| `frames_processed` | Frame processing details |
+| `connection_started` | Connection initiation |
+| `connection_state_updated` | State machine transitions |
+| `connection_closed` | Connection termination |
+| `packets_acked` | ACK processing |
+| `packet_lost` | Loss detection events |
+| `metrics_updated` | Congestion/RTT metrics |
+
+### Selective Logging
+
+```erlang
+%% Log only packet events
+#{
+    qlog => #{
+        enabled => true,
+        dir => "/tmp/qlog",
+        events => [packet_sent, packet_received, packet_lost]
+    }
+}
+
+%% Log everything (default)
+#{
+    qlog => #{
+        enabled => true,
+        events => all
+    }
+}
+```
+
+## Application-wide Configuration
+
+Enable QLOG globally via application environment:
+
+```erlang
+%% In sys.config
+[
+    {quic, [
+        {qlog, #{
+            enabled => true,
+            dir => "/var/log/quic/qlog"
+        }}
+    ]}
+].
+```
+
+```erlang
+%% Or programmatically
+application:set_env(quic, qlog, #{
+    enabled => true,
+    dir => "/var/log/quic/qlog"
+}).
+```
+
+Connection-level options override application-level settings.
+
+## QLOG File Format
+
+Files are written in JSON-SEQ format (one JSON object per line):
+
+```
+{"qlog_format":"JSON-SEQ","qlog_version":"0.4",...}
+{"time":0,"name":"quic:connection_started",...}
+{"time":15,"name":"quic:packet_sent",...}
+{"time":23,"name":"quic:packet_received",...}
+```
+
+### Filename Convention
+
+```
+{odcid_hex}_{vantage}_{timestamp}.qlog
+
+Example: a1b2c3d4e5f6_client_1712345678901.qlog
+```
+
+- `odcid_hex`: Original Destination Connection ID in hex
+- `vantage`: `client` or `server`
+- `timestamp`: Unix timestamp in milliseconds
+
+## Viewing QLOG Files
+
+### Using qvis (Web-based)
+
+1. Visit https://qvis.quictools.info/
+2. Upload your `.qlog` file
+3. Explore connection timeline, congestion graphs, and frame details
+
+### Using Wireshark
+
+1. Open Wireshark
+2. Go to Analyze > Follow > QUIC Stream
+3. Import QLOG for correlation with packet captures
+
+### Command Line Analysis
+
+```bash
+# View raw QLOG
+cat connection.qlog | jq .
+
+# Extract packet events
+cat connection.qlog | jq 'select(.name | startswith("quic:packet"))'
+
+# Count events by type
+cat connection.qlog | jq -r '.name' | sort | uniq -c
+```
+
+## Example QLOG Events
+
+### Packet Sent
+
+```json
+{
+  "time": 150,
+  "name": "quic:packet_sent",
+  "data": {
+    "packet_type": "1rtt",
+    "packet_number": 42,
+    "length": 1200,
+    "frames": [
+      {"frame_type": "stream", "stream_id": 0, "offset": 0, "length": 1150, "fin": false}
+    ]
+  }
+}
+```
+
+### Packet Lost
+
+```json
+{
+  "time": 500,
+  "name": "quic:packet_lost",
+  "data": {
+    "packet_number": 38,
+    "reason": "time_threshold"
+  }
+}
+```
+
+### Metrics Updated
+
+```json
+{
+  "time": 600,
+  "name": "quic:metrics_updated",
+  "data": {
+    "cwnd": 14720,
+    "bytes_in_flight": 8500,
+    "smoothed_rtt": 25,
+    "rtt_variance": 5
+  }
+}
+```
+
+### Connection State Updated
+
+```json
+{
+  "time": 50,
+  "name": "quic:connection_state_updated",
+  "data": {
+    "old": "handshaking",
+    "new": "connected"
+  }
+}
+```
+
+## Performance Considerations
+
+QLOG adds overhead due to:
+- JSON encoding for each event
+- File I/O (buffered with periodic flushes)
+- Memory for event buffering
+
+### Recommendations
+
+1. **Production**: Disable by default, enable selectively for debugging
+2. **Staging**: Enable with selective events
+3. **Development**: Enable all events
+
+```erlang
+%% Production: disabled
+#{qlog => #{enabled => false}}
+
+%% Staging: selective
+#{qlog => #{enabled => true, events => [packet_lost, connection_closed]}}
+
+%% Development: full
+#{qlog => #{enabled => true, events => all}}
+```
+
+### Buffer Settings
+
+The QLOG writer uses:
+- 64KB buffer before forced flush
+- 100ms periodic flush interval
+- Async writer process to avoid blocking connection
+
+## Debugging Common Issues
+
+### High Latency
+
+Look for in QLOG:
+1. Large gaps between `packet_sent` and `packets_acked`
+2. High `smoothed_rtt` in `metrics_updated`
+3. Frequent `packet_lost` events
+
+### Packet Loss
+
+Check QLOG for:
+1. `packet_lost` events with `reason`
+2. `metrics_updated` showing `bytes_in_flight` > `cwnd`
+3. Congestion window drops after loss
+
+### Handshake Failures
+
+Examine:
+1. `connection_started` event
+2. `frames_processed` for CRYPTO frames
+3. `connection_closed` with error code
+
+### Example Analysis Script
+
+```erlang
+-module(qlog_analyzer).
+-export([analyze/1]).
+
+analyze(Filename) ->
+    {ok, Data} = file:read_file(Filename),
+    Lines = binary:split(Data, <<"\n">>, [global, trim]),
+    Events = [jsx:decode(L, [return_maps]) || L <- Lines, L =/= <<>>],
+
+    %% Count events
+    Counts = lists:foldl(fun(#{<<"name">> := Name}, Acc) ->
+        maps:update_with(Name, fun(V) -> V + 1 end, 1, Acc)
+    end, #{}, Events),
+
+    %% Find lost packets
+    Lost = [E || #{<<"name">> := <<"quic:packet_lost">>} = E <- Events],
+
+    %% Calculate average RTT
+    RTTs = [maps:get(<<"smoothed_rtt">>, D) ||
+            #{<<"name">> := <<"quic:metrics_updated">>, <<"data">> := D} <- Events,
+            maps:is_key(<<"smoothed_rtt">>, D)],
+    AvgRTT = case RTTs of
+        [] -> undefined;
+        _ -> lists:sum(RTTs) / length(RTTs)
+    end,
+
+    #{
+        event_counts => Counts,
+        packets_lost => length(Lost),
+        average_rtt => AvgRTT
+    }.
+```
+
+## Integration with Monitoring
+
+### Export to Prometheus
+
+```erlang
+%% Parse QLOG metrics for Prometheus export
+extract_metrics(QlogFile) ->
+    %% Read final metrics_updated event
+    {ok, Data} = file:read_file(QlogFile),
+    Lines = lists:reverse(binary:split(Data, <<"\n">>, [global, trim])),
+
+    %% Find last metrics event
+    case find_metrics(Lines) of
+        {ok, Metrics} ->
+            #{
+                quic_cwnd => maps:get(<<"cwnd">>, Metrics, 0),
+                quic_rtt_ms => maps:get(<<"smoothed_rtt">>, Metrics, 0),
+                quic_bytes_in_flight => maps:get(<<"bytes_in_flight">>, Metrics, 0)
+            };
+        error ->
+            #{}
+    end.
+```
+
+### Alerting on Issues
+
+```erlang
+%% Monitor QLOG for anomalies
+monitor_qlog(Dir) ->
+    Files = filelib:wildcard(Dir ++ "/*.qlog"),
+    lists:foreach(fun(F) ->
+        #{packets_lost := Lost} = qlog_analyzer:analyze(F),
+        case Lost > 100 of
+            true -> alert("High packet loss in " ++ F);
+            false -> ok
+        end
+    end, Files).
+```

--- a/docs/SERVER_GUIDE.md
+++ b/docs/SERVER_GUIDE.md
@@ -1,0 +1,326 @@
+# QUIC Server Guide
+
+This guide covers setting up and configuring QUIC servers in Erlang applications.
+
+## Quick Start
+
+```erlang
+%% Start the QUIC application
+application:ensure_all_started(quic).
+
+%% Start a server with TLS certificates
+{ok, _Pid} = quic:start_server(my_server, 4433, #{
+    cert => CertDer,
+    key => PrivateKey,
+    alpn => [<<"h3">>, <<"myproto">>]
+}).
+
+%% Get the listening port (useful when using port 0)
+{ok, Port} = quic:get_server_port(my_server).
+```
+
+## Server Configuration Options
+
+### Required Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `cert` | binary | DER-encoded certificate |
+| `key` | term | Private key (RSA or EC) |
+
+### TLS Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `alpn` | [binary()] | `[<<"h3">>]` | ALPN protocols to advertise |
+| `cert_chain` | [binary()] | `[]` | Additional certificate chain |
+
+### Connection Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `idle_timeout` | integer | 30000 | Idle timeout in ms (0 = disabled) |
+| `max_data` | integer | 10485760 | Connection-level flow control limit |
+| `max_stream_data` | integer | 1048576 | Per-stream flow control limit |
+| `max_streams_bidi` | integer | 100 | Max bidirectional streams |
+| `max_streams_uni` | integer | 100 | Max unidirectional streams |
+| `max_datagram_frame_size` | integer | 0 | Datagram support (0 = disabled, RFC 9221) |
+
+### Server Pool Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `pool_size` | integer | 1 | Number of listener processes |
+| `connection_handler` | function | - | Callback for new connections |
+
+### Advanced Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `keep_alive_interval` | integer/atom | `auto` | PING interval (`disabled`, `auto`, or ms) |
+| `pmtu_enabled` | boolean | true | Enable Path MTU Discovery |
+| `pmtu_max_mtu` | integer | 1500 | Maximum MTU to probe |
+| `preferred_ipv4` | tuple | - | Preferred IPv4 address for migration |
+| `preferred_ipv6` | tuple | - | Preferred IPv6 address for migration |
+| `lb_config` | map | - | QUIC-LB configuration (RFC 9312) |
+
+## Loading Certificates
+
+### From PEM Files
+
+```erlang
+load_cert_and_key(CertFile, KeyFile) ->
+    {ok, CertPem} = file:read_file(CertFile),
+    {ok, KeyPem} = file:read_file(KeyFile),
+
+    %% Decode certificate
+    [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+
+    %% Decode private key
+    KeyDer = case public_key:pem_decode(KeyPem) of
+        [{'RSAPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('RSAPrivateKey', Der);
+        [{'ECPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('ECPrivateKey', Der);
+        [{'PrivateKeyInfo', Der, not_encrypted}] ->
+            public_key:der_decode('PrivateKeyInfo', Der)
+    end,
+
+    {CertDer, KeyDer}.
+```
+
+### Generating Test Certificates
+
+```bash
+# Generate self-signed certificate for testing
+openssl req -x509 -newkey rsa:2048 \
+    -keyout key.pem -out cert.pem \
+    -days 365 -nodes \
+    -subj '/CN=localhost'
+```
+
+## Connection Handling
+
+### Using connection_handler Callback
+
+```erlang
+%% Define a connection handler
+handle_connection(ConnPid, Info) ->
+    %% Info contains: peer_address, alpn_protocol, etc.
+    io:format("New connection from ~p~n", [maps:get(peer_address, Info)]),
+
+    %% Spawn a process to handle this connection
+    spawn(fun() -> connection_loop(ConnPid) end).
+
+%% Start server with handler
+quic:start_server(my_server, 4433, #{
+    cert => Cert,
+    key => Key,
+    connection_handler => fun handle_connection/2
+}).
+```
+
+### Manual Connection Handling
+
+```erlang
+%% Get all active connections
+{ok, Connections} = quic:get_server_connections(my_server).
+
+%% Each connection is a pid that can be used with quic API
+[ConnPid | _] = Connections,
+{ok, StreamId} = quic:open_stream(ConnPid),
+ok = quic:send_data(ConnPid, StreamId, <<"Hello">>, true).
+```
+
+## Message Handling
+
+The connection owner process receives these messages:
+
+```erlang
+receive
+    %% Connection established
+    {quic, ConnRef, {connected, Info}} ->
+        handle_connected(ConnRef, Info);
+
+    %% New stream opened by peer
+    {quic, ConnRef, {stream_opened, StreamId}} ->
+        handle_stream_opened(ConnRef, StreamId);
+
+    %% Data received on stream
+    {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+        handle_data(ConnRef, StreamId, Data, Fin);
+
+    %% Stream reset by peer
+    {quic, ConnRef, {stream_reset, StreamId, ErrorCode}} ->
+        handle_reset(ConnRef, StreamId, ErrorCode);
+
+    %% Datagram received (RFC 9221)
+    {quic, ConnRef, {datagram, Data}} ->
+        handle_datagram(ConnRef, Data);
+
+    %% Connection closed
+    {quic, ConnRef, {closed, Reason}} ->
+        handle_closed(ConnRef, Reason)
+end.
+```
+
+## Server Pool for High Concurrency
+
+```erlang
+%% Start a server pool with multiple listener processes
+{ok, _} = quic:start_server(high_perf_server, 4433, #{
+    cert => Cert,
+    key => Key,
+    pool_size => erlang:system_info(schedulers),  % One per scheduler
+    alpn => [<<"h3">>]
+}).
+```
+
+## Load Balancer Integration (RFC 9312)
+
+```erlang
+%% Configure QUIC-LB for load balancer routing
+LBConfig = #{
+    server_id => <<1, 2, 3, 4>>,        % Unique server identifier
+    algorithm => stream_cipher,          % plaintext | stream_cipher | block_cipher
+    key => crypto:strong_rand_bytes(16), % Encryption key (not for plaintext)
+    config_rotation => 0                 % Config rotation bits (0-7)
+},
+
+{ok, _} = quic:start_server(lb_server, 4433, #{
+    cert => Cert,
+    key => Key,
+    lb_config => LBConfig
+}).
+```
+
+## Best Practices
+
+### 1. Certificate Management
+
+- Use proper CA-signed certificates in production
+- Implement certificate rotation before expiry
+- Store private keys securely (consider HSM for production)
+
+### 2. Resource Limits
+
+```erlang
+%% Set appropriate limits to prevent resource exhaustion
+#{
+    max_streams_bidi => 100,       % Limit concurrent streams
+    max_streams_uni => 100,
+    max_data => 10 * 1024 * 1024,  % 10 MB connection limit
+    max_stream_data => 1024 * 1024, % 1 MB per stream
+    idle_timeout => 30000           % Close idle connections
+}
+```
+
+### 3. Connection Supervision
+
+```erlang
+%% Embed server in your supervision tree
+init([]) ->
+    ServerSpec = quic:server_spec(my_server, 4433, #{
+        cert => get_cert(),
+        key => get_key(),
+        alpn => [<<"myproto">>]
+    }),
+
+    {ok, {{one_for_one, 10, 60}, [ServerSpec]}}.
+```
+
+### 4. Graceful Shutdown
+
+```erlang
+%% Stop server gracefully (allows draining)
+ok = quic:stop_server(my_server).
+
+%% Close individual connections
+ok = quic:close(ConnRef, normal).
+```
+
+### 5. Monitoring
+
+```erlang
+%% Get server information
+{ok, Info} = quic:get_server_info(my_server).
+%% Info = #{pid => Pid, port => Port, opts => Opts}
+
+%% List all active servers
+Servers = quic:which_servers().
+
+%% Get connection statistics
+{ok, Stats} = quic:get_stats(ConnRef).
+%% Stats = #{packets_sent => N, packets_received => N, ...}
+```
+
+### 6. Enable QLOG for Debugging
+
+```erlang
+%% Enable QLOG tracing for debugging
+#{
+    qlog => #{
+        enabled => true,
+        dir => "/var/log/quic/qlog",
+        events => all  % or specific: [packet_sent, packet_received]
+    }
+}
+```
+
+## Example: Echo Server
+
+```erlang
+-module(echo_server).
+-export([start/1, stop/0]).
+
+start(Port) ->
+    {ok, CertPem} = file:read_file("cert.pem"),
+    {ok, KeyPem} = file:read_file("key.pem"),
+    [{'Certificate', Cert, _}] = public_key:pem_decode(CertPem),
+    [{'RSAPrivateKey', KeyDer, _}] = public_key:pem_decode(KeyPem),
+    Key = public_key:der_decode('RSAPrivateKey', KeyDer),
+
+    quic:start_server(echo, Port, #{
+        cert => Cert,
+        key => Key,
+        alpn => [<<"echo">>],
+        connection_handler => fun handle_connection/2
+    }).
+
+stop() ->
+    quic:stop_server(echo).
+
+handle_connection(ConnPid, _Info) ->
+    spawn(fun() -> echo_loop(ConnPid) end).
+
+echo_loop(ConnPid) ->
+    receive
+        {quic, _, {stream_data, StreamId, Data, Fin}} ->
+            %% Echo data back
+            quic:send_data(ConnPid, StreamId, Data, Fin),
+            echo_loop(ConnPid);
+        {quic, _, {closed, _}} ->
+            ok
+    end.
+```
+
+## Troubleshooting
+
+### Server Won't Start
+
+1. Check certificate/key format (must be DER-encoded or properly decoded)
+2. Verify port is available: `netstat -an | grep <port>`
+3. Check for proper permissions on low ports (<1024)
+
+### Connections Dropping
+
+1. Check `idle_timeout` setting
+2. Enable keep-alive: `keep_alive_interval => 15000`
+3. Review flow control limits
+
+### Performance Issues
+
+1. Increase `pool_size` for high connection counts
+2. Tune `max_streams_*` limits
+3. Consider enabling BBR congestion control (if available)
+4. Use QLOG to identify bottlenecks

--- a/docs/features.md
+++ b/docs/features.md
@@ -117,6 +117,10 @@
 - `quic:peercert/1` - Get peer certificate
 - `quic:migrate/1` - Trigger connection migration
 
+### Datagrams (RFC 9221)
+- `quic:send_datagram/2` - Send unreliable datagram
+- `quic:datagram_max_size/1` - Get max datagram size (0 if unsupported)
+
 ### Streams
 - `quic:open_stream/1` - Open bidirectional stream
 - `quic:open_unidirectional_stream/1` - Open unidirectional stream
@@ -151,6 +155,7 @@
 - `idle_timeout` - Connection idle timeout in milliseconds (0 to disable)
 - `max_data` - Connection-level flow control limit
 - `max_stream_data` - Stream-level flow control limit
+- `max_datagram_frame_size` - Max datagram size to accept (0 = disabled, default: 0)
 - `alpn` - ALPN protocols list
 - `verify` - Certificate verification mode
 - `preferred_ipv4` - Server preferred IPv4 address

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,185 @@
+# erlang_quic Examples
+
+This directory contains runnable examples demonstrating erlang_quic features.
+
+## Prerequisites
+
+1. Generate test certificates:
+   ```bash
+   cd certs
+   ./generate_certs.sh
+   ```
+
+2. Start the Erlang shell with the QUIC application:
+   ```bash
+   rebar3 shell
+   ```
+
+## Echo Server and Client
+
+Basic example showing server setup and client connection.
+
+### Start the Server
+
+```erlang
+%% Start on port 4433
+echo_server:start(4433).
+%% Output: Echo server started on port 4433
+
+%% Or use port 0 for random port
+echo_server:start(0).
+```
+
+### Run the Client
+
+```erlang
+%% Send a message and receive echo
+echo_client:run("localhost", 4433, <<"Hello, QUIC!">>).
+%% Output:
+%% Connecting to localhost:4433
+%% Connected! ALPN: <<"echo">>
+%% Opened stream 0
+%% Sent 12 bytes
+%% Received 12 bytes
+%% {ok,<<"Hello, QUIC!">>}
+```
+
+### Test Datagrams
+
+```erlang
+%% Send unreliable datagram
+echo_client:datagram("localhost", 4433, <<"Fast data!">>).
+%% Output:
+%% Sent datagram: 10 bytes
+%% Received datagram: 10 bytes
+%% {ok,<<"Fast data!">>}
+```
+
+### Benchmark
+
+```erlang
+%% Send 100 concurrent requests
+echo_client:benchmark("localhost", 4433, <<"test">>, 100).
+%% Output:
+%% Starting benchmark: 100 requests, 4 bytes each
+%% Benchmark results:
+%%   Requests: 100 successful, 0 failed
+%%   Duration: 150 ms
+%%   Throughput: 5333 bytes/sec
+```
+
+### Stop the Server
+
+```erlang
+echo_server:stop().
+```
+
+## QLOG Tracing Example
+
+Demonstrates QLOG for debugging and performance analysis.
+
+### Start Server with QLOG
+
+```erlang
+qlog_example:start_server(4433).
+%% Output:
+%% QLOG server started on port 4433
+%% QLOG files will be written to: /tmp/qlog
+```
+
+### Run Client with QLOG
+
+```erlang
+qlog_example:run_client("localhost", 4433).
+%% Output:
+%% Connecting to localhost:4433 with QLOG enabled
+%% Connected!
+%% Sent: <<"QLOG test data - Hello World!">>
+%% Received: <<"QLOG test data - Hello World!">>
+%% Connection closed. QLOG file written to: /tmp/qlog
+```
+
+### List QLOG Files
+
+```erlang
+qlog_example:list_qlogs().
+%% Output:
+%% /tmp/qlog/a1b2c3d4_client_1712345678901.qlog (4532 bytes)
+%% /tmp/qlog/a1b2c3d4_server_1712345678902.qlog (3210 bytes)
+```
+
+### Analyze QLOG
+
+```erlang
+qlog_example:analyze("/tmp/qlog/somefile.qlog").
+%% Output:
+%% QLOG Analysis: /tmp/qlog/somefile.qlog
+%% =====================================
+%% Total events: 45
+%%
+%% Event counts:
+%%   quic:connection_started: 1
+%%   quic:connection_state_updated: 2
+%%   quic:packet_received: 15
+%%   quic:packet_sent: 18
+%%   quic:packets_acked: 8
+%%   quic:metrics_updated: 1
+%%
+%% Packets lost: 0
+%% Average RTT: 12.50 ms
+```
+
+### View with External Tools
+
+QLOG files can be viewed with:
+- **qvis**: https://qvis.quictools.info/ (upload the .qlog file)
+- **Wireshark**: Correlate with packet captures
+
+## Server Options Example
+
+```erlang
+%% Start server with all options
+echo_server:start(4433, #{
+    %% Flow control
+    max_data => 10 * 1024 * 1024,           % 10 MB
+    max_stream_data => 1 * 1024 * 1024,     % 1 MB
+    max_streams_bidi => 100,
+    max_streams_uni => 100,
+
+    %% Timeouts
+    idle_timeout => 30000,                   % 30 seconds
+    keep_alive_interval => 15000,            % 15 seconds
+
+    %% Datagrams (RFC 9221)
+    max_datagram_frame_size => 65535,
+
+    %% QLOG tracing
+    qlog => #{
+        enabled => true,
+        dir => "/tmp/qlog",
+        events => all
+    },
+
+    %% Server pool
+    pool_size => 4
+}).
+```
+
+## Cleanup
+
+```erlang
+%% Stop server
+echo_server:stop().
+
+%% Or
+qlog_example:stop_server().
+
+%% Clean QLOG files
+os:cmd("rm -f /tmp/qlog/*.qlog").
+```
+
+## See Also
+
+- [Server Guide](../docs/SERVER_GUIDE.md) - Server configuration reference
+- [Client Guide](../docs/CLIENT_GUIDE.md) - Client features reference
+- [QLOG Guide](../docs/QLOG_GUIDE.md) - QLOG tracing reference

--- a/examples/echo_client.erl
+++ b/examples/echo_client.erl
@@ -1,0 +1,201 @@
+%%% -*- erlang -*-
+%%%
+%%% Example: Echo Client
+%%%
+%%% Usage:
+%%%   1. Start server: echo_server:start(4433).
+%%%   2. Run client: echo_client:run("localhost", 4433, <<"Hello!">>).
+%%%   3. Send datagram: echo_client:datagram("localhost", 4433, <<"Fast!">>).
+%%%
+
+-module(echo_client).
+
+-export([run/3, datagram/3, benchmark/4]).
+
+%% @doc Send data to echo server and receive response.
+-spec run(string() | binary(), inet:port_number(), binary()) ->
+    {ok, binary()} | {error, term()}.
+run(Host, Port, Data) ->
+    application:ensure_all_started(quic),
+
+    io:format("Connecting to ~s:~p~n", [Host, Port]),
+
+    Opts = #{
+        alpn => [<<"echo">>],
+        verify => false,
+        max_datagram_frame_size => 65535
+    },
+
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, ConnRef} ->
+            Result = do_echo(ConnRef, Data),
+            quic:close(ConnRef, normal),
+            Result;
+        {error, Reason} ->
+            {error, {connect_failed, Reason}}
+    end.
+
+%% @doc Send a datagram and wait for response.
+-spec datagram(string() | binary(), inet:port_number(), binary()) ->
+    {ok, binary()} | {error, term()}.
+datagram(Host, Port, Data) ->
+    application:ensure_all_started(quic),
+
+    Opts = #{
+        alpn => [<<"echo">>],
+        verify => false,
+        max_datagram_frame_size => 65535
+    },
+
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, ConnRef} ->
+            Result = do_datagram_echo(ConnRef, Data),
+            quic:close(ConnRef, normal),
+            Result;
+        {error, Reason} ->
+            {error, {connect_failed, Reason}}
+    end.
+
+%% @doc Simple benchmark - send N messages and measure throughput.
+-spec benchmark(string() | binary(), inet:port_number(), binary(), pos_integer()) ->
+    {ok, map()} | {error, term()}.
+benchmark(Host, Port, Data, Count) ->
+    application:ensure_all_started(quic),
+
+    Opts = #{
+        alpn => [<<"echo">>],
+        verify => false
+    },
+
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, ConnRef} ->
+            Result = run_benchmark(ConnRef, Data, Count),
+            quic:close(ConnRef, normal),
+            Result;
+        {error, Reason} ->
+            {error, {connect_failed, Reason}}
+    end.
+
+%%====================================================================
+%% Internal Functions
+%%====================================================================
+
+do_echo(ConnRef, Data) ->
+    %% Wait for connection
+    receive
+        {quic, ConnRef, {connected, Info}} ->
+            io:format("Connected! ALPN: ~p~n", [maps:get(alpn_protocol, Info, unknown)]);
+        {quic, ConnRef, {closed, Reason}} ->
+            exit({connection_closed, Reason})
+    after 5000 ->
+        exit(connection_timeout)
+    end,
+
+    %% Open stream and send data
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    io:format("Opened stream ~p~n", [StreamId]),
+
+    ok = quic:send_data(ConnRef, StreamId, Data, true),
+    io:format("Sent ~p bytes~n", [byte_size(Data)]),
+
+    %% Receive response
+    Response = receive_stream_data(ConnRef, StreamId, <<>>, 5000),
+    io:format("Received ~p bytes~n", [byte_size(Response)]),
+
+    case Response =:= Data of
+        true -> {ok, Response};
+        false -> {error, {mismatch, Data, Response}}
+    end.
+
+do_datagram_echo(ConnRef, Data) ->
+    %% Wait for connection
+    receive
+        {quic, ConnRef, {connected, _}} ->
+            ok
+    after 5000 ->
+        exit(connection_timeout)
+    end,
+
+    %% Check datagram support
+    MaxSize = quic:datagram_max_size(ConnRef),
+    case MaxSize of
+        0 ->
+            {error, datagrams_not_supported};
+        _ when byte_size(Data) > MaxSize ->
+            {error, {datagram_too_large, MaxSize}};
+        _ ->
+            %% Send datagram
+            ok = quic:send_datagram(ConnRef, Data),
+            io:format("Sent datagram: ~p bytes~n", [byte_size(Data)]),
+
+            %% Wait for response
+            receive
+                {quic, ConnRef, {datagram, Response}} ->
+                    io:format("Received datagram: ~p bytes~n", [byte_size(Response)]),
+                    {ok, Response}
+            after 5000 ->
+                {error, timeout}
+            end
+    end.
+
+receive_stream_data(ConnRef, StreamId, Acc, Timeout) ->
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, ConnRef, {stream_data, StreamId, Data, false}} ->
+            receive_stream_data(ConnRef, StreamId, <<Acc/binary, Data/binary>>, Timeout);
+        {quic, ConnRef, {closed, _}} ->
+            Acc
+    after Timeout ->
+        io:format("Timeout waiting for data, have ~p bytes~n", [byte_size(Acc)]),
+        Acc
+    end.
+
+run_benchmark(ConnRef, Data, Count) ->
+    %% Wait for connection
+    receive
+        {quic, ConnRef, {connected, _}} -> ok
+    after 5000 ->
+        exit(connection_timeout)
+    end,
+
+    DataSize = byte_size(Data),
+    io:format("Starting benchmark: ~p requests, ~p bytes each~n", [Count, DataSize]),
+
+    Start = erlang:monotonic_time(millisecond),
+
+    %% Send all requests on parallel streams
+    StreamIds = lists:map(fun(_) ->
+        {ok, StreamId} = quic:open_stream(ConnRef),
+        ok = quic:send_data(ConnRef, StreamId, Data, true),
+        StreamId
+    end, lists:seq(1, Count)),
+
+    %% Receive all responses
+    Responses = lists:map(fun(StreamId) ->
+        receive_stream_data(ConnRef, StreamId, <<>>, 30000)
+    end, StreamIds),
+
+    End = erlang:monotonic_time(millisecond),
+    Duration = End - Start,
+
+    TotalBytes = DataSize * Count * 2,  % sent + received
+    Throughput = (TotalBytes * 1000) div max(Duration, 1),
+
+    Successful = length([R || R <- Responses, R =:= Data]),
+
+    Result = #{
+        total_requests => Count,
+        successful => Successful,
+        failed => Count - Successful,
+        duration_ms => Duration,
+        bytes_transferred => TotalBytes,
+        throughput_bytes_sec => Throughput
+    },
+
+    io:format("Benchmark results:~n"),
+    io:format("  Requests: ~p successful, ~p failed~n", [Successful, Count - Successful]),
+    io:format("  Duration: ~p ms~n", [Duration]),
+    io:format("  Throughput: ~p bytes/sec~n", [Throughput]),
+
+    {ok, Result}.

--- a/examples/echo_server.erl
+++ b/examples/echo_server.erl
@@ -1,0 +1,138 @@
+%%% -*- erlang -*-
+%%%
+%%% Example: Simple Echo Server
+%%%
+%%% Usage:
+%%%   1. Generate certificates: cd certs && ./generate_certs.sh
+%%%   2. Start: echo_server:start(4433).
+%%%   3. Test with: echo_client:run("localhost", 4433, <<"Hello!">>).
+%%%   4. Stop: echo_server:stop().
+%%%
+
+-module(echo_server).
+
+-export([start/1, start/2, stop/0]).
+-export([handle_connection/2]).
+
+%% @doc Start echo server on specified port.
+-spec start(inet:port_number()) -> {ok, pid()} | {error, term()}.
+start(Port) ->
+    start(Port, #{}).
+
+%% @doc Start echo server with custom options.
+-spec start(inet:port_number(), map()) -> {ok, pid()} | {error, term()}.
+start(Port, ExtraOpts) ->
+    application:ensure_all_started(quic),
+
+    %% Load certificates
+    case load_certs() of
+        {ok, Cert, Key} ->
+            Opts = maps:merge(
+                #{
+                    cert => Cert,
+                    key => Key,
+                    alpn => [<<"echo">>],
+                    connection_handler => fun ?MODULE:handle_connection/2,
+                    %% Enable datagrams for echo
+                    max_datagram_frame_size => 65535
+                },
+                ExtraOpts
+            ),
+            case quic:start_server(echo_server, Port, Opts) of
+                {ok, Pid} ->
+                    {ok, ActualPort} = quic:get_server_port(echo_server),
+                    io:format("Echo server started on port ~p~n", [ActualPort]),
+                    {ok, Pid};
+                Error ->
+                    Error
+            end;
+        {error, Reason} ->
+            {error, {cert_load_failed, Reason}}
+    end.
+
+%% @doc Stop the echo server.
+-spec stop() -> ok.
+stop() ->
+    quic:stop_server(echo_server),
+    io:format("Echo server stopped~n"),
+    ok.
+
+%% @doc Handle new connections.
+handle_connection(ConnPid, Info) ->
+    PeerAddr = maps:get(peer_address, Info, unknown),
+    io:format("New connection from ~p~n", [PeerAddr]),
+    spawn(fun() -> echo_loop(ConnPid) end).
+
+%%====================================================================
+%% Internal Functions
+%%====================================================================
+
+echo_loop(ConnPid) ->
+    receive
+        {quic, _, {stream_data, StreamId, Data, Fin}} ->
+            %% Echo the data back
+            io:format("Echoing ~p bytes on stream ~p~n", [byte_size(Data), StreamId]),
+            quic:send_data(ConnPid, StreamId, Data, Fin),
+            echo_loop(ConnPid);
+
+        {quic, _, {datagram, Data}} ->
+            %% Echo datagrams too
+            io:format("Echoing datagram: ~p bytes~n", [byte_size(Data)]),
+            quic:send_datagram(ConnPid, Data),
+            echo_loop(ConnPid);
+
+        {quic, _, {stream_opened, StreamId}} ->
+            io:format("Stream ~p opened by peer~n", [StreamId]),
+            echo_loop(ConnPid);
+
+        {quic, _, {closed, Reason}} ->
+            io:format("Connection closed: ~p~n", [Reason]),
+            ok;
+
+        Other ->
+            io:format("Unhandled message: ~p~n", [Other]),
+            echo_loop(ConnPid)
+    end.
+
+load_certs() ->
+    %% Try multiple certificate locations
+    Locations = [
+        {"certs/cert.pem", "certs/priv.key"},
+        {"../certs/cert.pem", "../certs/priv.key"},
+        {code:priv_dir(quic) ++ "/../certs/cert.pem",
+         code:priv_dir(quic) ++ "/../certs/priv.key"}
+    ],
+    load_certs_from_locations(Locations).
+
+load_certs_from_locations([]) ->
+    {error, no_certs_found};
+load_certs_from_locations([{CertFile, KeyFile} | Rest]) ->
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            try
+                {ok, CertPem} = file:read_file(CertFile),
+                {ok, KeyPem} = file:read_file(KeyFile),
+                [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+                KeyDer = decode_key(KeyPem),
+                {ok, CertDer, KeyDer}
+            catch
+                _:Reason ->
+                    io:format("Failed to load certs from ~s: ~p~n", [CertFile, Reason]),
+                    load_certs_from_locations(Rest)
+            end;
+        _ ->
+            load_certs_from_locations(Rest)
+    end.
+
+decode_key(KeyPem) ->
+    case public_key:pem_decode(KeyPem) of
+        [{'RSAPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('RSAPrivateKey', Der);
+        [{'ECPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('ECPrivateKey', Der);
+        [{'PrivateKeyInfo', Der, not_encrypted}] ->
+            public_key:der_decode('PrivateKeyInfo', Der);
+        [{Type, Der, not_encrypted}] ->
+            io:format("Unknown key type: ~p~n", [Type]),
+            Der
+    end.

--- a/examples/qlog_example.erl
+++ b/examples/qlog_example.erl
@@ -1,0 +1,269 @@
+%%% -*- erlang -*-
+%%%
+%%% Example: QLOG Tracing
+%%%
+%%% Demonstrates enabling QLOG for debugging QUIC connections.
+%%%
+%%% Usage:
+%%%   1. Start server with QLOG: qlog_example:start_server(4433).
+%%%   2. Run client with QLOG: qlog_example:run_client("localhost", 4433).
+%%%   3. View logs: ls /tmp/qlog/*.qlog
+%%%   4. Analyze: qlog_example:analyze("/tmp/qlog/somefile.qlog").
+%%%
+
+-module(qlog_example).
+
+-export([start_server/1, stop_server/0]).
+-export([run_client/2]).
+-export([analyze/1, list_qlogs/0, list_qlogs/1]).
+
+-define(QLOG_DIR, "/tmp/qlog").
+
+%% @doc Start a server with QLOG enabled.
+-spec start_server(inet:port_number()) -> {ok, pid()} | {error, term()}.
+start_server(Port) ->
+    application:ensure_all_started(quic),
+
+    %% Ensure QLOG directory exists
+    ok = filelib:ensure_dir(?QLOG_DIR ++ "/"),
+
+    case load_certs() of
+        {ok, Cert, Key} ->
+            Opts = #{
+                cert => Cert,
+                key => Key,
+                alpn => [<<"echo">>],
+                %% Enable QLOG
+                qlog => #{
+                    enabled => true,
+                    dir => ?QLOG_DIR,
+                    events => all
+                }
+            },
+            case quic:start_server(qlog_server, Port, Opts) of
+                {ok, Pid} ->
+                    {ok, ActualPort} = quic:get_server_port(qlog_server),
+                    io:format("QLOG server started on port ~p~n", [ActualPort]),
+                    io:format("QLOG files will be written to: ~s~n", [?QLOG_DIR]),
+                    {ok, Pid};
+                Error ->
+                    Error
+            end;
+        {error, Reason} ->
+            {error, {cert_load_failed, Reason}}
+    end.
+
+%% @doc Stop the QLOG server.
+-spec stop_server() -> ok.
+stop_server() ->
+    quic:stop_server(qlog_server),
+    io:format("Server stopped. Check QLOG files in: ~s~n", [?QLOG_DIR]),
+    ok.
+
+%% @doc Connect to server with QLOG enabled.
+-spec run_client(string() | binary(), inet:port_number()) -> ok | {error, term()}.
+run_client(Host, Port) ->
+    application:ensure_all_started(quic),
+
+    %% Ensure QLOG directory exists
+    ok = filelib:ensure_dir(?QLOG_DIR ++ "/"),
+
+    Opts = #{
+        alpn => [<<"echo">>],
+        verify => false,
+        %% Enable QLOG with selective events
+        qlog => #{
+            enabled => true,
+            dir => ?QLOG_DIR,
+            events => [packet_sent, packet_received, packet_lost, metrics_updated]
+        }
+    },
+
+    io:format("Connecting to ~s:~p with QLOG enabled~n", [Host, Port]),
+
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, ConnRef} ->
+            run_client_session(ConnRef);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc List all QLOG files in the default directory.
+-spec list_qlogs() -> [string()].
+list_qlogs() ->
+    list_qlogs(?QLOG_DIR).
+
+%% @doc List all QLOG files in specified directory.
+-spec list_qlogs(string()) -> [string()].
+list_qlogs(Dir) ->
+    Pattern = filename:join(Dir, "*.qlog"),
+    Files = filelib:wildcard(Pattern),
+    lists:foreach(fun(F) ->
+        {ok, Info} = file:read_file_info(F),
+        Size = element(2, Info),
+        io:format("~s (~p bytes)~n", [F, Size])
+    end, Files),
+    Files.
+
+%% @doc Analyze a QLOG file and print summary.
+-spec analyze(string()) -> map().
+analyze(Filename) ->
+    {ok, Data} = file:read_file(Filename),
+    Lines = binary:split(Data, <<"\n">>, [global, trim]),
+
+    %% Parse each line as JSON (simple parsing)
+    Events = lists:filtermap(fun(Line) ->
+        case Line of
+            <<>> -> false;
+            _ ->
+                case parse_json_line(Line) of
+                    {ok, Map} -> {true, Map};
+                    error -> false
+                end
+        end
+    end, Lines),
+
+    %% Count events by type
+    Counts = lists:foldl(fun(Event, Acc) ->
+        Name = maps:get(<<"name">>, Event, <<"unknown">>),
+        maps:update_with(Name, fun(V) -> V + 1 end, 1, Acc)
+    end, #{}, Events),
+
+    %% Find lost packets
+    LostCount = maps:get(<<"quic:packet_lost">>, Counts, 0),
+
+    %% Extract RTT samples
+    RTTs = lists:filtermap(fun(Event) ->
+        case maps:get(<<"name">>, Event, undefined) of
+            <<"quic:metrics_updated">> ->
+                Data1 = maps:get(<<"data">>, Event, #{}),
+                case maps:get(<<"smoothed_rtt">>, Data1, undefined) of
+                    undefined -> false;
+                    RTT when is_number(RTT) -> {true, RTT};
+                    _ -> false
+                end;
+            _ ->
+                false
+        end
+    end, Events),
+
+    AvgRTT = case RTTs of
+        [] -> undefined;
+        _ -> lists:sum(RTTs) / length(RTTs)
+    end,
+
+    %% Print summary
+    io:format("~nQLOG Analysis: ~s~n", [Filename]),
+    io:format("=====================================~n"),
+    io:format("Total events: ~p~n", [length(Events)]),
+    io:format("~nEvent counts:~n"),
+    lists:foreach(fun({Name, Count}) ->
+        io:format("  ~s: ~p~n", [Name, Count])
+    end, lists:sort(maps:to_list(Counts))),
+    io:format("~nPackets lost: ~p~n", [LostCount]),
+    case AvgRTT of
+        undefined -> ok;
+        _ -> io:format("Average RTT: ~.2f ms~n", [AvgRTT])
+    end,
+
+    #{
+        total_events => length(Events),
+        event_counts => Counts,
+        packets_lost => LostCount,
+        average_rtt => AvgRTT
+    }.
+
+%%====================================================================
+%% Internal Functions
+%%====================================================================
+
+run_client_session(ConnRef) ->
+    %% Wait for connection
+    receive
+        {quic, ConnRef, {connected, _Info}} ->
+            io:format("Connected!~n")
+    after 5000 ->
+        quic:close(ConnRef, timeout),
+        exit(connection_timeout)
+    end,
+
+    %% Open stream and send some data
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    TestData = <<"QLOG test data - Hello World!">>,
+    ok = quic:send_data(ConnRef, StreamId, TestData, true),
+    io:format("Sent: ~p~n", [TestData]),
+
+    %% Wait for echo
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Response, _}} ->
+            io:format("Received: ~p~n", [Response])
+    after 5000 ->
+        io:format("Timeout waiting for response~n")
+    end,
+
+    %% Close connection
+    quic:close(ConnRef, normal),
+    io:format("~nConnection closed. QLOG file written to: ~s~n", [?QLOG_DIR]),
+    io:format("Run qlog_example:list_qlogs() to see files~n"),
+    io:format("Run qlog_example:analyze(\"<filename>\") to analyze~n"),
+    ok.
+
+parse_json_line(Line) ->
+    %% Very simple JSON object parser for QLOG events
+    %% Just extracts "name" and "data" fields
+    try
+        %% Find "name" field
+        case binary:match(Line, <<"\"name\"">>) of
+            {Pos, _} ->
+                %% Extract name value
+                Rest = binary:part(Line, Pos, byte_size(Line) - Pos),
+                case re:run(Rest, <<"\"name\":\"([^\"]+)\"">>, [{capture, [1], binary}]) of
+                    {match, [Name]} ->
+                        {ok, #{<<"name">> => Name, <<"raw">> => Line}};
+                    _ ->
+                        {ok, #{<<"raw">> => Line}}
+                end;
+            nomatch ->
+                %% Might be header
+                {ok, #{<<"header">> => true, <<"raw">> => Line}}
+        end
+    catch
+        _:_ -> error
+    end.
+
+load_certs() ->
+    Locations = [
+        {"certs/cert.pem", "certs/priv.key"},
+        {"../certs/cert.pem", "../certs/priv.key"}
+    ],
+    load_certs_from_locations(Locations).
+
+load_certs_from_locations([]) ->
+    {error, no_certs_found};
+load_certs_from_locations([{CertFile, KeyFile} | Rest]) ->
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            try
+                {ok, CertPem} = file:read_file(CertFile),
+                {ok, KeyPem} = file:read_file(KeyFile),
+                [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+                KeyDer = decode_key(KeyPem),
+                {ok, CertDer, KeyDer}
+            catch
+                _:_ -> load_certs_from_locations(Rest)
+            end;
+        _ ->
+            load_certs_from_locations(Rest)
+    end.
+
+decode_key(KeyPem) ->
+    case public_key:pem_decode(KeyPem) of
+        [{'RSAPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('RSAPrivateKey', Der);
+        [{'ECPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('ECPrivateKey', Der);
+        [{'PrivateKeyInfo', Der, not_encrypted}] ->
+            public_key:der_decode('PrivateKeyInfo', Der);
+        [{_, Der, not_encrypted}] ->
+            Der
+    end.

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -140,6 +140,9 @@
 -define(TP_INITIAL_SCID, 16#0f).
 -define(TP_RETRY_SCID, 16#10).
 
+%% RFC 9221 - QUIC Datagrams
+-define(TP_MAX_DATAGRAM_FRAME_SIZE, 16#20).
+
 %%====================================================================
 %% Crypto Constants
 %%====================================================================

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -72,6 +72,7 @@
     set_owner/2,
     set_owner_sync/2,
     send_datagram/2,
+    datagram_max_size/1,
     setopts/2,
     migrate/1,
     %% Stream prioritization (RFC 9218)
@@ -394,6 +395,21 @@ send_datagram(ConnRef, Data) when is_reference(ConnRef) ->
 send_datagram(ConnPid, Data) when is_pid(ConnPid) ->
     quic_connection:send_datagram(ConnPid, Data);
 send_datagram(_ConnRef, _Data) ->
+    {error, badarg}.
+
+%% @doc Get maximum datagram payload size.
+%% Returns 0 if peer doesn't support datagrams (RFC 9221).
+%% The returned size is the peer's advertised max_datagram_frame_size.
+-spec datagram_max_size(ConnRef) -> non_neg_integer() | {error, term()} when
+    ConnRef :: reference() | pid().
+datagram_max_size(ConnRef) when is_reference(ConnRef) ->
+    case quic_connection:lookup(ConnRef) of
+        {ok, Pid} -> quic_connection:datagram_max_size(Pid);
+        error -> {error, not_found}
+    end;
+datagram_max_size(ConnPid) when is_pid(ConnPid) ->
+    quic_connection:datagram_max_size(ConnPid);
+datagram_max_size(_ConnRef) ->
     {error, badarg}.
 
 %% @doc Set connection options.

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -148,7 +148,7 @@ get_fd(Socket) ->
 %%   <li>`socket_fd' - Use an existing UDP socket FD (see `get_fd/1')</li>
 %%   <li>`verify' - Verify server certificate (default: false)</li>
 %%   <li>`alpn' - ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
-%%   <li>`sni' - Server Name Indication (default: Host)</li>
+%%   <li>`server_name' - Server Name Indication (default: Host)</li>
 %% </ul>
 -spec connect(Host, Port, Opts, Owner) -> {ok, reference()} | {error, term()} when
     Host :: binary() | string(),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -65,6 +65,7 @@
     connect/4,
     send_data/4,
     send_datagram/2,
+    datagram_max_size/1,
     open_stream/1,
     open_unidirectional_stream/1,
     close/2,
@@ -239,6 +240,12 @@
     max_streams_bidi_remote :: non_neg_integer(),
     max_streams_uni_local :: non_neg_integer(),
     max_streams_uni_remote :: non_neg_integer(),
+
+    %% Datagram support (RFC 9221)
+    %% Local: our advertised max size (0 = disabled)
+    max_datagram_frame_size_local = 0 :: non_neg_integer(),
+    %% Remote: peer's advertised max size (0 = not supported)
+    max_datagram_frame_size_remote = 0 :: non_neg_integer(),
 
     %% Transport parameters (received from peer)
     transport_params = #{} :: map(),
@@ -543,6 +550,12 @@ set_owner_sync(Conn, NewOwner) ->
 send_datagram(Conn, Data) ->
     gen_statem:call(Conn, {send_datagram, Data}).
 
+%% @doc Get maximum datagram payload size.
+%% Returns 0 if peer doesn't support datagrams.
+-spec datagram_max_size(pid()) -> non_neg_integer().
+datagram_max_size(Conn) ->
+    gen_statem:call(Conn, datagram_max_size).
+
 %% @doc Set connection options.
 -spec setopts(pid(), [{atom(), term()}]) -> ok | {error, term()}.
 setopts(Conn, Opts) ->
@@ -745,6 +758,7 @@ init({server, Opts}) ->
         max_streams_bidi_remote = ?DEFAULT_MAX_STREAMS_BIDI,
         max_streams_uni_local = maps:get(max_streams_uni, Opts, ?DEFAULT_MAX_STREAMS_UNI),
         max_streams_uni_remote = ?DEFAULT_MAX_STREAMS_UNI,
+        max_datagram_frame_size_local = maps:get(max_datagram_frame_size, Opts, 0),
         idle_timeout = IdleTimeout,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeout),
         keep_alive_timer = undefined,
@@ -956,6 +970,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         max_streams_bidi_remote = ?DEFAULT_MAX_STREAMS_BIDI,
         max_streams_uni_local = maps:get(max_streams_uni, Opts, ?DEFAULT_MAX_STREAMS_UNI),
         max_streams_uni_remote = ?DEFAULT_MAX_STREAMS_UNI,
+        max_datagram_frame_size_local = maps:get(max_datagram_frame_size, Opts, 0),
         idle_timeout = IdleTimeoutClient,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeoutClient),
         keep_alive_timer = undefined,
@@ -1241,6 +1256,8 @@ connected({call, From}, peercert, #state{peer_cert = undefined} = State) ->
     {keep_state, State, [{reply, From, {error, no_peercert}}]};
 connected({call, From}, peercert, #state{peer_cert = Cert} = State) ->
     {keep_state, State, [{reply, From, {ok, Cert}}]};
+connected({call, From}, datagram_max_size, #state{max_datagram_frame_size_remote = Size} = State) ->
+    {keep_state, State, [{reply, From, Size}]};
 connected({call, From}, {set_owner, NewOwner}, State) ->
     {keep_state, State#state{owner = NewOwner}, [{reply, From, ok}]};
 connected(cast, {set_owner, NewOwner}, State) ->
@@ -1576,6 +1593,7 @@ send_client_hello(State) ->
         max_stream_data_uni = MaxStreamDataUni,
         max_streams_bidi_local = MaxStreamsBidi,
         max_streams_uni_local = MaxStreamsUni,
+        max_datagram_frame_size_local = MaxDatagramSize,
         ticket_store = TicketStore
     } = State,
 
@@ -1587,7 +1605,7 @@ send_client_hello(State) ->
         end,
 
     %% Build transport parameters
-    TransportParams = #{
+    TransportParams0 = #{
         initial_scid => SCID,
         initial_max_data => MaxData,
         initial_max_stream_data_bidi_local => MaxStreamDataBidiLocal,
@@ -1598,6 +1616,12 @@ send_client_hello(State) ->
         max_idle_timeout => State#state.idle_timeout,
         active_connection_id_limit => 2
     },
+    %% Add max_datagram_frame_size if datagrams are enabled (RFC 9221)
+    TransportParams =
+        case MaxDatagramSize of
+            0 -> TransportParams0;
+            _ -> TransportParams0#{max_datagram_frame_size => MaxDatagramSize}
+        end,
 
     %% Build ClientHello (with or without PSK for resumption)
     ClientHelloOpts = #{
@@ -1819,6 +1843,7 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
         max_stream_data_uni = MaxStreamDataUni,
         max_streams_bidi_local = MaxStreamsBidi,
         max_streams_uni_local = MaxStreamsUni,
+        max_datagram_frame_size_local = MaxDatagramSize,
         server_cert = Cert,
         server_cert_chain = CertChain,
         server_private_key = PrivateKey,
@@ -1841,14 +1866,20 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
         max_idle_timeout => State#state.idle_timeout,
         active_connection_id_limit => 2
     },
+    %% Add max_datagram_frame_size if datagrams are enabled (RFC 9221)
+    TransportParams1 =
+        case MaxDatagramSize of
+            0 -> TransportParams0;
+            _ -> TransportParams0#{max_datagram_frame_size => MaxDatagramSize}
+        end,
     %% Add preferred_address if configured (RFC 9000 Section 9.6)
     %% Server MUST NOT send preferred_address if disable_active_migration is set
     TransportParams =
         case State#state.server_preferred_address of
             #preferred_address{} = PA ->
-                TransportParams0#{preferred_address => PA};
+                TransportParams1#{preferred_address => PA};
             _ ->
-                TransportParams0
+                TransportParams1
         end,
 
     %% Build EncryptedExtensions
@@ -3259,6 +3290,23 @@ process_frame(
 process_frame(_Level, {data_blocked, _Limit}, State) ->
     State;
 %% DATAGRAM frames (RFC 9221)
+%% RFC 9221: MUST terminate with PROTOCOL_VIOLATION if receiving DATAGRAM
+%% without having advertised support (max_datagram_frame_size = 0)
+process_frame(app, {datagram, _Data}, #state{max_datagram_frame_size_local = 0} = State) ->
+    send_protocol_violation(<<"unexpected DATAGRAM frame">>, State);
+process_frame(
+    app, {datagram_with_length, _Data}, #state{max_datagram_frame_size_local = 0} = State
+) ->
+    send_protocol_violation(<<"unexpected DATAGRAM frame">>, State);
+%% RFC 9221: MUST terminate with PROTOCOL_VIOLATION if receiving oversized DATAGRAM
+process_frame(app, {datagram, Data}, #state{max_datagram_frame_size_local = Max} = State) when
+    byte_size(Data) > Max
+->
+    send_protocol_violation(<<"DATAGRAM frame too large">>, State);
+process_frame(
+    app, {datagram_with_length, Data}, #state{max_datagram_frame_size_local = Max} = State
+) when byte_size(Data) > Max ->
+    send_protocol_violation(<<"DATAGRAM frame too large">>, State);
 process_frame(app, {datagram, Data}, #state{owner = Owner, conn_ref = Ref} = State) ->
     Owner ! {quic, Ref, {datagram, Data}},
     State;
@@ -4882,20 +4930,33 @@ send_zero_rtt_packet(Payload, EarlyKeys, State) ->
 -define(PACKET_OVERHEAD, 50).
 
 %% Send a datagram (RFC 9221)
-do_send_datagram(Data, #state{cc_state = CCState} = State) ->
+%% RFC 9221: MUST NOT send DATAGRAM frames until receiving peer's max_datagram_frame_size
+%% and MUST NOT send frames larger than peer's advertised value
+do_send_datagram(_Data, #state{max_datagram_frame_size_remote = 0}) ->
+    %% Peer didn't advertise datagram support
+    {error, datagrams_not_supported};
+do_send_datagram(
+    Data, #state{max_datagram_frame_size_remote = MaxSize, cc_state = CCState} = State
+) ->
     DataBin = iolist_to_binary(Data),
-    PacketSize = byte_size(DataBin) + ?PACKET_OVERHEAD,
-
-    case quic_cc:can_send(CCState, PacketSize) of
+    DataSize = byte_size(DataBin),
+    case DataSize > MaxSize of
         true ->
-            %% Use datagram_with_length for better framing
-            Frame = {datagram_with_length, DataBin},
-            Payload = quic_frame:encode(Frame),
-            NewState = send_app_packet_internal(Payload, [Frame], State),
-            {ok, NewState};
+            %% Data exceeds peer's advertised max size
+            {error, datagram_too_large};
         false ->
-            %% Datagrams are unreliable - just drop if cwnd is full
-            {error, congestion_limited}
+            PacketSize = DataSize + ?PACKET_OVERHEAD,
+            case quic_cc:can_send(CCState, PacketSize) of
+                true ->
+                    %% Use datagram_with_length for better framing
+                    Frame = {datagram_with_length, DataBin},
+                    Payload = quic_frame:encode(Frame),
+                    NewState = send_app_packet_internal(Payload, [Frame], State),
+                    {ok, NewState};
+                false ->
+                    %% Datagrams are unreliable - just drop if cwnd is full
+                    {error, congestion_limited}
+            end
     end.
 
 %% Send stream data in fragments, tracking how many bytes were actually sent
@@ -5487,6 +5548,19 @@ initiate_close(Reason, State) ->
             State#state{close_reason = Reason};
         _ ->
             send_app_packet(CloseFrame, State#state{close_reason = Reason})
+    end.
+
+%% Send PROTOCOL_VIOLATION transport error (RFC 9000)
+%% Used when a peer violates the protocol (e.g., RFC 9221 datagram violations)
+send_protocol_violation(Reason, State) ->
+    CloseFrame = quic_frame:encode(
+        {connection_close, transport, ?QUIC_PROTOCOL_VIOLATION, 0, Reason}
+    ),
+    case State#state.app_keys of
+        undefined ->
+            State#state{close_reason = {protocol_violation, Reason}};
+        _ ->
+            send_app_packet(CloseFrame, State#state{close_reason = {protocol_violation, Reason}})
     end.
 
 %% Send CONNECTION_CLOSE frame during terminate (best effort)
@@ -6244,6 +6318,10 @@ apply_peer_transport_params(TransportParams, State) ->
     MaxStreamsBidi = maps:get(initial_max_streams_bidi, TransportParams, ?DEFAULT_MAX_STREAMS_BIDI),
     MaxStreamsUni = maps:get(initial_max_streams_uni, TransportParams, ?DEFAULT_MAX_STREAMS_UNI),
 
+    %% Extract max_datagram_frame_size (RFC 9221): peer's max datagram size
+    %% Default is 0 (datagrams not supported)
+    MaxDatagramFrameSize = maps:get(max_datagram_frame_size, TransportParams, 0),
+
     %% Store stream data limits in state for use when opening streams
     %% These tell us how much we can send on different stream types
     State#state{
@@ -6258,7 +6336,9 @@ apply_peer_transport_params(TransportParams, State) ->
         max_data_remote = MaxDataRemote,
         %% Stream limits (how many streams we can open)
         max_streams_bidi_remote = MaxStreamsBidi,
-        max_streams_uni_remote = MaxStreamsUni
+        max_streams_uni_remote = MaxStreamsUni,
+        %% Datagram size limit (RFC 9221)
+        max_datagram_frame_size_remote = MaxDatagramFrameSize
     }.
 
 %% @doc Handle RETIRE_CONNECTION_ID frame from peer.

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -501,6 +501,8 @@ encode_transport_param(initial_scid, Value) ->
     encode_tp(?TP_INITIAL_SCID, Value);
 encode_transport_param(preferred_address, #preferred_address{} = PA) ->
     encode_tp(?TP_PREFERRED_ADDRESS, encode_preferred_address(PA));
+encode_transport_param(max_datagram_frame_size, Value) when Value > 0 ->
+    encode_tp(?TP_MAX_DATAGRAM_FRAME_SIZE, quic_varint:encode(Value));
 encode_transport_param(_, _) ->
     <<>>.
 
@@ -545,6 +547,7 @@ tp_id_to_key(?TP_PREFERRED_ADDRESS) -> preferred_address;
 tp_id_to_key(?TP_ACTIVE_CONNECTION_ID_LIMIT) -> active_connection_id_limit;
 tp_id_to_key(?TP_INITIAL_SCID) -> initial_scid;
 tp_id_to_key(?TP_RETRY_SCID) -> retry_scid;
+tp_id_to_key(?TP_MAX_DATAGRAM_FRAME_SIZE) -> max_datagram_frame_size;
 tp_id_to_key(Id) -> {unknown, Id}.
 
 decode_tp_value(?TP_ORIGINAL_DCID, Value) ->
@@ -571,7 +574,8 @@ decode_tp_value(Id, Value) when
     Id =:= ?TP_INITIAL_MAX_STREAMS_UNI;
     Id =:= ?TP_ACK_DELAY_EXPONENT;
     Id =:= ?TP_MAX_ACK_DELAY;
-    Id =:= ?TP_ACTIVE_CONNECTION_ID_LIMIT
+    Id =:= ?TP_ACTIVE_CONNECTION_ID_LIMIT;
+    Id =:= ?TP_MAX_DATAGRAM_FRAME_SIZE
 ->
     %% Known integer parameters are varints
     {Int, _} = quic_varint:decode(Value),

--- a/test/quic_datagram_e2e_SUITE.erl
+++ b/test/quic_datagram_e2e_SUITE.erl
@@ -1,0 +1,407 @@
+%%% -*- erlang -*-
+%%%
+%%% E2E Tests for QUIC Datagram Extension (RFC 9221)
+%%%
+%%% Tests max_datagram_frame_size transport parameter negotiation
+%%% between Erlang client and server.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+
+-module(quic_datagram_e2e_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include("quic.hrl").
+
+%% CT callbacks
+-export([
+    suite/0,
+    all/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_group/2,
+    end_per_group/2,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+%% Test cases - Negotiation
+-export([
+    both_support_datagrams/1,
+    client_disabled_datagrams/1,
+    server_disabled_datagrams/1,
+    neither_supports_datagrams/1
+]).
+
+%% Test cases - Data Transfer
+-export([
+    send_small_datagram/1,
+    send_max_size_datagram/1,
+    send_oversized_datagram_fails/1,
+    receive_datagram/1,
+    bidirectional_datagrams/1
+]).
+
+%% Test cases - API
+-export([
+    datagram_max_size_api/1,
+    datagram_max_size_when_disabled/1
+]).
+
+%%====================================================================
+%% CT Callbacks
+%%====================================================================
+
+suite() ->
+    [{timetrap, {seconds, 60}}].
+
+all() ->
+    [
+        {group, negotiation},
+        {group, data_transfer},
+        {group, api}
+    ].
+
+groups() ->
+    [
+        {negotiation, [sequence], [
+            both_support_datagrams,
+            client_disabled_datagrams,
+            server_disabled_datagrams,
+            neither_supports_datagrams
+        ]},
+        {data_transfer, [sequence], [
+            send_small_datagram,
+            send_max_size_datagram,
+            send_oversized_datagram_fails,
+            receive_datagram,
+            bidirectional_datagrams
+        ]},
+        {api, [sequence], [
+            datagram_max_size_api,
+            datagram_max_size_when_disabled
+        ]}
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(crypto),
+    application:ensure_all_started(quic),
+
+    %% Generate test certificates
+    case generate_certs() of
+        {ok, TmpDir, Cert, Key} ->
+            [{tmp_dir, TmpDir}, {cert, Cert}, {key, Key} | Config];
+        {error, Reason} ->
+            ct:fail("Failed to generate certificates: ~p", [Reason])
+    end.
+
+end_per_suite(Config) ->
+    TmpDir = ?config(tmp_dir, Config),
+    os:cmd("rm -rf " ++ TmpDir),
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    ct:log("Starting test: ~p", [TestCase]),
+    %% Generate unique server name
+    ServerName = list_to_atom(
+        atom_to_list(TestCase) ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    [{server_name, ServerName} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    ServerName = ?config(server_name, Config),
+    catch quic:stop_server(ServerName),
+    timer:sleep(50),
+    ok.
+
+%%====================================================================
+%% Helper Functions
+%%====================================================================
+
+generate_certs() ->
+    TmpDir = filename:join([
+        "/tmp", "quic_datagram_test_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ]),
+    ok = filelib:ensure_dir(filename:join(TmpDir, "dummy")),
+
+    CertFile = filename:join(TmpDir, "cert.pem"),
+    KeyFile = filename:join(TmpDir, "key.pem"),
+    Cmd = io_lib:format(
+        "openssl req -x509 -newkey rsa:2048 -keyout ~s -out ~s "
+        "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+        [KeyFile, CertFile]
+    ),
+    os:cmd(lists:flatten(Cmd)),
+
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            {ok, CertPem} = file:read_file(CertFile),
+            {ok, KeyPem} = file:read_file(KeyFile),
+            [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+            KeyDer = decode_key(KeyPem),
+            {ok, TmpDir, CertDer, KeyDer};
+        _ ->
+            os:cmd("rm -rf " ++ TmpDir),
+            {error, cert_generation_failed}
+    end.
+
+decode_key(KeyPem) ->
+    case public_key:pem_decode(KeyPem) of
+        [{'RSAPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('RSAPrivateKey', Der);
+        [{'ECPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('ECPrivateKey', Der);
+        [{'PrivateKeyInfo', Der, not_encrypted}] ->
+            public_key:der_decode('PrivateKeyInfo', Der);
+        [{_Type, Der, not_encrypted}] ->
+            Der
+    end.
+
+start_server(Config, ExtraOpts) ->
+    Cert = ?config(cert, Config),
+    Key = ?config(key, Config),
+    ServerName = ?config(server_name, Config),
+
+    ServerOpts = maps:merge(
+        #{cert => Cert, key => Key, alpn => [<<"test">>]},
+        ExtraOpts
+    ),
+    {ok, _} = quic:start_server(ServerName, 0, ServerOpts),
+    {ok, Port} = quic:get_server_port(ServerName),
+    {ok, ServerName, Port}.
+
+connect_client(Port, ExtraOpts) ->
+    ClientOpts = maps:merge(
+        #{alpn => [<<"test">>], verify => false},
+        ExtraOpts
+    ),
+    {ok, ConnRef} = quic:connect("127.0.0.1", Port, ClientOpts, self()),
+    receive
+        {quic, ConnRef, {connected, _Info}} ->
+            {ok, ConnRef}
+    after 5000 ->
+        quic:close(ConnRef, timeout),
+        {error, connection_timeout}
+    end.
+
+%%====================================================================
+%% Negotiation Tests
+%%====================================================================
+
+%% Both endpoints support datagrams - negotiation succeeds
+both_support_datagrams(Config) ->
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => 65535}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Check that datagrams are enabled
+    MaxSize = quic:datagram_max_size(ConnRef),
+    ct:log("Negotiated max datagram size: ~p", [MaxSize]),
+    ?assert(MaxSize > 0),
+    ?assertEqual(65535, MaxSize),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Client doesn't advertise datagram support
+%% Server can't send to client, but client CAN send to server
+client_disabled_datagrams(Config) ->
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => 65535}),
+    %% Client doesn't set max_datagram_frame_size (defaults to 0)
+    {ok, ConnRef} = connect_client(Port, #{}),
+
+    %% Client sees server's advertised value (server CAN receive)
+    MaxSize = quic:datagram_max_size(ConnRef),
+    ct:log("Max datagram size (peer's limit): ~p", [MaxSize]),
+    ?assertEqual(65535, MaxSize),
+
+    %% Client CAN send to server (server advertised support)
+    Result = quic:send_datagram(ConnRef, <<"test">>),
+    ?assertEqual(ok, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Server doesn't advertise datagram support
+server_disabled_datagrams(Config) ->
+    %% Server doesn't set max_datagram_frame_size (defaults to 0)
+    {ok, _ServerName, Port} = start_server(Config, #{}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Datagrams should be disabled (server didn't advertise)
+    MaxSize = quic:datagram_max_size(ConnRef),
+    ct:log("Max datagram size with server disabled: ~p", [MaxSize]),
+    ?assertEqual(0, MaxSize),
+
+    %% Sending should fail
+    Result = quic:send_datagram(ConnRef, <<"test">>),
+    ?assertEqual({error, datagrams_not_supported}, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Neither endpoint supports datagrams
+neither_supports_datagrams(Config) ->
+    {ok, _ServerName, Port} = start_server(Config, #{}),
+    {ok, ConnRef} = connect_client(Port, #{}),
+
+    MaxSize = quic:datagram_max_size(ConnRef),
+    ?assertEqual(0, MaxSize),
+
+    Result = quic:send_datagram(ConnRef, <<"test">>),
+    ?assertEqual({error, datagrams_not_supported}, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%%====================================================================
+%% Data Transfer Tests
+%%====================================================================
+
+%% Send a small datagram
+send_small_datagram(Config) ->
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => 65535}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    Data = <<"Hello, datagram!">>,
+    Result = quic:send_datagram(ConnRef, Data),
+    ?assertEqual(ok, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Send a datagram at the maximum allowed size
+send_max_size_datagram(Config) ->
+    MaxSize = 1200,
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => MaxSize}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Client's max size should be the server's advertised limit
+    NegotiatedSize = quic:datagram_max_size(ConnRef),
+    ?assertEqual(MaxSize, NegotiatedSize),
+
+    %% Send exactly at the limit
+    Data = crypto:strong_rand_bytes(MaxSize),
+    Result = quic:send_datagram(ConnRef, Data),
+    ?assertEqual(ok, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Sending an oversized datagram should fail
+send_oversized_datagram_fails(Config) ->
+    MaxSize = 100,
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => MaxSize}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Verify the negotiated size
+    ?assertEqual(MaxSize, quic:datagram_max_size(ConnRef)),
+
+    %% Try to send oversized datagram
+    OversizedData = crypto:strong_rand_bytes(MaxSize + 1),
+    Result = quic:send_datagram(ConnRef, OversizedData),
+    ?assertEqual({error, datagram_too_large}, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Receive a datagram from the server
+receive_datagram(Config) ->
+    {ok, ServerName, Port} = start_server(Config, #{max_datagram_frame_size => 65535}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Get server connections to send from server side
+    {ok, ServerConns} = quic:get_server_connections(ServerName),
+
+    case ServerConns of
+        [ServerConn | _] ->
+            %% Server sends datagram to client
+            TestData = <<"Hello from server!">>,
+            ok = quic:send_datagram(ServerConn, TestData),
+
+            %% Client should receive the datagram
+            receive
+                {quic, ConnRef, {datagram, ReceivedData}} ->
+                    ct:log("Received datagram: ~p", [ReceivedData]),
+                    ?assertEqual(TestData, ReceivedData)
+            after 5000 ->
+                ct:fail("Timeout waiting for datagram")
+            end;
+        [] ->
+            %% Server connection may not be established yet, skip
+            ct:log("No server connections available, skipping receive test")
+    end,
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Bidirectional datagram exchange
+bidirectional_datagrams(Config) ->
+    {ok, ServerName, Port} = start_server(Config, #{max_datagram_frame_size => 65535}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Client sends datagram
+    ClientData = <<"Client to server">>,
+    ok = quic:send_datagram(ConnRef, ClientData),
+
+    %% Give server time to receive
+    timer:sleep(100),
+
+    %% Check server connections
+    {ok, ServerConns} = quic:get_server_connections(ServerName),
+    case ServerConns of
+        [ServerConn | _] ->
+            %% Server sends datagram back
+            ServerData = <<"Server to client">>,
+            ok = quic:send_datagram(ServerConn, ServerData),
+
+            %% Client receives server's datagram
+            receive
+                {quic, ConnRef, {datagram, ReceivedData}} ->
+                    ct:log("Client received: ~p", [ReceivedData]),
+                    ?assertEqual(ServerData, ReceivedData)
+            after 5000 ->
+                ct:fail("Timeout waiting for server datagram")
+            end;
+        [] ->
+            ct:log("No server connections available, skipping bidirectional test")
+    end,
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%%====================================================================
+%% API Tests
+%%====================================================================
+
+%% Test datagram_max_size API returns peer's value
+datagram_max_size_api(Config) ->
+    ServerMaxSize = 1200,
+    ClientMaxSize = 65535,
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => ServerMaxSize}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => ClientMaxSize}),
+
+    %% Client should see server's advertised value
+    MaxSize = quic:datagram_max_size(ConnRef),
+    ?assertEqual(ServerMaxSize, MaxSize),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% Test datagram_max_size returns 0 when disabled
+datagram_max_size_when_disabled(Config) ->
+    {ok, _ServerName, Port} = start_server(Config, #{}),
+    {ok, ConnRef} = connect_client(Port, #{}),
+
+    MaxSize = quic:datagram_max_size(ConnRef),
+    ?assertEqual(0, MaxSize),
+
+    quic:close(ConnRef, normal),
+    ok.

--- a/test/quic_datagram_tests.erl
+++ b/test/quic_datagram_tests.erl
@@ -1,0 +1,87 @@
+%%% -*- erlang -*-
+%%%
+%%% QUIC Datagram (RFC 9221) transport parameter tests
+%%%
+
+-module(quic_datagram_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+%%====================================================================
+%% Transport Parameter Encoding/Decoding Tests
+%%====================================================================
+
+%% Test transport parameter encoding roundtrip
+tp_encode_decode_test() ->
+    Params = #{max_datagram_frame_size => 65535},
+    Encoded = quic_tls:encode_transport_params(Params),
+    {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
+    ?assertEqual(65535, maps:get(max_datagram_frame_size, Decoded)).
+
+%% Test encoding with various sizes
+tp_encode_small_size_test() ->
+    Params = #{max_datagram_frame_size => 100},
+    Encoded = quic_tls:encode_transport_params(Params),
+    {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
+    ?assertEqual(100, maps:get(max_datagram_frame_size, Decoded)).
+
+tp_encode_large_size_test() ->
+    %% RFC 9221 recommends 65535 for accepting any datagram
+    Params = #{max_datagram_frame_size => 65535},
+    Encoded = quic_tls:encode_transport_params(Params),
+    {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
+    ?assertEqual(65535, maps:get(max_datagram_frame_size, Decoded)).
+
+%% Test that value 0 is not encoded (disabled)
+tp_encode_zero_not_encoded_test() ->
+    Params = #{max_datagram_frame_size => 0},
+    Encoded = quic_tls:encode_transport_params(Params),
+    {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
+    %% 0 should not be encoded, so the key should be absent
+    ?assertEqual(0, maps:get(max_datagram_frame_size, Decoded, 0)).
+
+%% Test encoding with other transport params
+tp_encode_with_other_params_test() ->
+    Params = #{
+        initial_max_data => 1000000,
+        max_datagram_frame_size => 1200,
+        initial_max_streams_bidi => 100
+    },
+    Encoded = quic_tls:encode_transport_params(Params),
+    {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
+    ?assertEqual(1000000, maps:get(initial_max_data, Decoded)),
+    ?assertEqual(1200, maps:get(max_datagram_frame_size, Decoded)),
+    ?assertEqual(100, maps:get(initial_max_streams_bidi, Decoded)).
+
+%% Test that the correct transport parameter ID (0x20) is used
+tp_id_test() ->
+    ?assertEqual(16#20, ?TP_MAX_DATAGRAM_FRAME_SIZE).
+
+%%====================================================================
+%% Validation Tests (state-based, no real connections)
+%%====================================================================
+
+%% These tests verify the validation logic in isolation.
+%% Full integration tests require connection setup which is
+%% tested in the E2E test suites.
+
+%% Validate that max size encoding works for various varint sizes
+tp_varint_encoding_test() ->
+    %% 1-byte varint (0-63)
+    Params1 = #{max_datagram_frame_size => 63},
+    Encoded1 = quic_tls:encode_transport_params(Params1),
+    {ok, Decoded1} = quic_tls:decode_transport_params(Encoded1),
+    ?assertEqual(63, maps:get(max_datagram_frame_size, Decoded1)),
+
+    %% 2-byte varint (64-16383)
+    Params2 = #{max_datagram_frame_size => 1200},
+    Encoded2 = quic_tls:encode_transport_params(Params2),
+    {ok, Decoded2} = quic_tls:decode_transport_params(Encoded2),
+    ?assertEqual(1200, maps:get(max_datagram_frame_size, Decoded2)),
+
+    %% 4-byte varint (16384-1073741823)
+    Params3 = #{max_datagram_frame_size => 100000},
+    Encoded3 = quic_tls:encode_transport_params(Params3),
+    {ok, Decoded3} = quic_tls:decode_transport_params(Encoded3),
+    ?assertEqual(100000, maps:get(max_datagram_frame_size, Decoded3)).


### PR DESCRIPTION
## Summary
- Add `max_datagram_frame_size` transport parameter negotiation (RFC 9221)
- Add `quic:datagram_max_size/1` API to query max payload size
- Add validation for send/receive (PROTOCOL_VIOLATION on violations)
- Disabled by default (set to 0)

Closes #26

## Configuration
```erlang
quic:connect(Host, Port, #{max_datagram_frame_size => 65535}, Owner).
quic:listen(Port, #{max_datagram_frame_size => 65535, ...}).
```

## API
```erlang
%% Get max datagram size (0 if peer doesn't support)
MaxSize = quic:datagram_max_size(ConnRef).

%% Send datagram
quic:send_datagram(ConnRef, Data).
%% Returns {error, datagrams_not_supported} if peer didn't advertise
%% Returns {error, datagram_too_large} if data exceeds peer's limit
```