### PR TITLE
Replace ConnRef with Pid in QUIC API (#29)

### DIFF
--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -9,29 +9,29 @@ This guide covers connecting to QUIC servers and using client features.
 application:ensure_all_started(quic).
 
 %% Connect to a server
-{ok, ConnRef} = quic:connect("example.com", 443, #{
+{ok, Conn} = quic:connect("example.com", 443, #{
     alpn => [<<"h3">>],
     verify => false  % For testing only!
 }, self()).
 
 %% Wait for connection
 receive
-    {quic, ConnRef, {connected, Info}} ->
+    {quic, Conn, {connected, Info}} ->
         io:format("Connected! ALPN: ~p~n", [maps:get(alpn_protocol, Info)])
 end.
 
 %% Open a stream and send data
-{ok, StreamId} = quic:open_stream(ConnRef),
-ok = quic:send_data(ConnRef, StreamId, <<"Hello, QUIC!">>, true).
+{ok, StreamId} = quic:open_stream(Conn),
+ok = quic:send_data(Conn, StreamId, <<"Hello, QUIC!">>, true).
 
 %% Receive response
 receive
-    {quic, ConnRef, {stream_data, StreamId, Data, _Fin}} ->
+    {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
         io:format("Received: ~p~n", [Data])
 end.
 
 %% Close connection
-quic:close(ConnRef, normal).
+quic:close(Conn, normal).
 ```
 
 ## Connection Options
@@ -82,26 +82,26 @@ quic:close(ConnRef, normal).
 
 ```erlang
 %% Open bidirectional stream
-{ok, BidiStreamId} = quic:open_stream(ConnRef).
+{ok, BidiStreamId} = quic:open_stream(Conn).
 
 %% Open unidirectional stream (send-only)
-{ok, UniStreamId} = quic:open_unidirectional_stream(ConnRef).
+{ok, UniStreamId} = quic:open_unidirectional_stream(Conn).
 
 %% Send data (Fin=true closes the send side)
-ok = quic:send_data(ConnRef, StreamId, <<"data">>, false),
-ok = quic:send_data(ConnRef, StreamId, <<"more">>, true).  % Final
+ok = quic:send_data(Conn, StreamId, <<"data">>, false),
+ok = quic:send_data(Conn, StreamId, <<"more">>, true).  % Final
 
 %% Send with timeout
-case quic:send_data(ConnRef, StreamId, Data, true, 5000) of
+case quic:send_data(Conn, StreamId, Data, true, 5000) of
     ok -> sent;
     {error, timeout} -> handle_timeout()
 end.
 
 %% Reset a stream with error code
-ok = quic:reset_stream(ConnRef, StreamId, 0).
+ok = quic:reset_stream(Conn, StreamId, 0).
 
 %% Request peer to stop sending
-ok = quic:stop_sending(ConnRef, StreamId, 0).
+ok = quic:stop_sending(Conn, StreamId, 0).
 ```
 
 ### Stream Prioritization (RFC 9218)
@@ -110,33 +110,33 @@ ok = quic:stop_sending(ConnRef, StreamId, 0).
 %% Set stream priority
 %% Urgency: 0-7 (0 = most urgent, default 3)
 %% Incremental: true if data can be processed incrementally
-ok = quic:set_stream_priority(ConnRef, StreamId, 0, false).
+ok = quic:set_stream_priority(Conn, StreamId, 0, false).
 
 %% Get current priority
-{ok, {Urgency, Incremental}} = quic:get_stream_priority(ConnRef, StreamId).
+{ok, {Urgency, Incremental}} = quic:get_stream_priority(Conn, StreamId).
 ```
 
 ### Stream Deadlines
 
 ```erlang
 %% Set a 5-second deadline on a stream
-ok = quic:set_stream_deadline(ConnRef, StreamId, 5000).
+ok = quic:set_stream_deadline(Conn, StreamId, 5000).
 
 %% Set deadline with custom action
-ok = quic:set_stream_deadline(ConnRef, StreamId, 5000, #{
+ok = quic:set_stream_deadline(Conn, StreamId, 5000, #{
     action => notify,  % notify | reset | both
     error_code => 16#FF
 }).
 
 %% Check remaining time
-{ok, {RemainingMs, Action}} = quic:get_stream_deadline(ConnRef, StreamId).
+{ok, {RemainingMs, Action}} = quic:get_stream_deadline(Conn, StreamId).
 
 %% Cancel deadline
-ok = quic:cancel_stream_deadline(ConnRef, StreamId).
+ok = quic:cancel_stream_deadline(Conn, StreamId).
 
 %% Handle deadline expiration
 receive
-    {quic, ConnRef, {stream_deadline, StreamId}} ->
+    {quic, Conn, {stream_deadline, StreamId}} ->
         handle_deadline_expired(StreamId)
 end.
 ```
@@ -145,19 +145,19 @@ end.
 
 ```erlang
 %% Enable datagrams (both client and server must enable)
-{ok, ConnRef} = quic:connect(Host, Port, #{
+{ok, Conn} = quic:connect(Host, Port, #{
     max_datagram_frame_size => 65535  % Accept any size
 }, self()).
 
 %% Check if datagrams are supported
-MaxSize = quic:datagram_max_size(ConnRef),
+MaxSize = quic:datagram_max_size(Conn),
 case MaxSize of
     0 -> io:format("Datagrams not supported~n");
     _ -> io:format("Max datagram size: ~p~n", [MaxSize])
 end.
 
 %% Send a datagram (unreliable, not retransmitted)
-case quic:send_datagram(ConnRef, <<"game_state">>) of
+case quic:send_datagram(Conn, <<"game_state">>) of
     ok -> sent;
     {error, datagrams_not_supported} -> not_supported;
     {error, datagram_too_large} -> too_big;
@@ -166,7 +166,7 @@ end.
 
 %% Receive datagrams
 receive
-    {quic, ConnRef, {datagram, Data}} ->
+    {quic, Conn, {datagram, Data}} ->
         handle_datagram(Data)
 end.
 ```
@@ -176,7 +176,7 @@ end.
 ```erlang
 %% Trigger migration to a new local address
 %% (e.g., when switching from WiFi to cellular)
-ok = quic:migrate(ConnRef).
+ok = quic:migrate(Conn).
 
 %% The connection will:
 %% 1. Bind to a new local socket
@@ -189,13 +189,13 @@ ok = quic:migrate(ConnRef).
 
 ```erlang
 %% Bind to a specific local IP using extra_socket_opts
-{ok, ConnRef} = quic:connect(Host, Port, #{
+{ok, Conn} = quic:connect(Host, Port, #{
     extra_socket_opts => [{ip, {192,168,1,10}}]
 }, self()).
 
 %% Use a pre-opened socket for full control
 {ok, Sock} = gen_udp:open(0, [binary, inet, {ip, {192,168,1,10}}]),
-{ok, ConnRef} = quic:connect(Host, Port, #{
+{ok, Conn} = quic:connect(Host, Port, #{
     socket => Sock
 }, self()).
 
@@ -208,14 +208,14 @@ ok = quic:migrate(ConnRef).
 ```erlang
 %% First connection - receive session ticket
 receive
-    {quic, ConnRef, {session_ticket, Ticket}} ->
+    {quic, Conn, {session_ticket, Ticket}} ->
         %% Store ticket for later use
         store_ticket(Host, Ticket)
 end.
 
 %% Later connection - use stored ticket
 StoredTicket = get_ticket(Host),
-{ok, ConnRef2} = quic:connect(Host, Port, #{
+{ok, Conn2} = quic:connect(Host, Port, #{
     session_ticket => StoredTicket,
     early_data => <<"request">>  % Sent with 0-RTT
 }, self()).
@@ -225,19 +225,19 @@ StoredTicket = get_ticket(Host),
 
 ```erlang
 %% Get peer address
-{ok, {IP, Port}} = quic:peername(ConnRef).
+{ok, {IP, Port}} = quic:peername(Conn).
 
 %% Get local address
-{ok, {LocalIP, LocalPort}} = quic:sockname(ConnRef).
+{ok, {LocalIP, LocalPort}} = quic:sockname(Conn).
 
 %% Get peer certificate
-{ok, CertDer} = quic:peercert(ConnRef).
+{ok, CertDer} = quic:peercert(Conn).
 
 %% Get current MTU
-{ok, MTU} = quic:get_mtu(ConnRef).
+{ok, MTU} = quic:get_mtu(Conn).
 
 %% Get connection statistics
-{ok, Stats} = quic:get_stats(ConnRef).
+{ok, Stats} = quic:get_stats(Conn).
 %% Stats = #{
 %%     packets_sent => 150,
 %%     packets_received => 148,
@@ -250,7 +250,7 @@ StoredTicket = get_ticket(Host),
 
 ```erlang
 %% Check send queue status for backpressure
-{ok, Info} = quic:get_send_queue_info(ConnRef).
+{ok, Info} = quic:get_send_queue_info(Conn).
 %% Info = #{
 %%     bytes => 5000,        % Bytes queued
 %%     cwnd => 14720,        % Congestion window
@@ -271,31 +271,31 @@ Messages sent to the owner process:
 
 | Message | Description |
 |---------|-------------|
-| `{quic, Ref, {connected, Info}}` | Connection established |
-| `{quic, Ref, {stream_opened, StreamId}}` | Peer opened a stream |
-| `{quic, Ref, {stream_data, StreamId, Data, Fin}}` | Data received |
-| `{quic, Ref, {stream_reset, StreamId, Code}}` | Stream reset by peer |
-| `{quic, Ref, {stop_sending, StreamId, Code}}` | Stop sending requested |
-| `{quic, Ref, {datagram, Data}}` | Datagram received |
-| `{quic, Ref, {session_ticket, Ticket}}` | Session ticket for 0-RTT |
-| `{quic, Ref, {stream_deadline, StreamId}}` | Stream deadline expired |
-| `{quic, Ref, {send_ready, StreamId}}` | Stream ready to write |
-| `{quic, Ref, {closed, Reason}}` | Connection closed |
-| `{quic, Ref, {transport_error, Code, Reason}}` | Transport error |
+| `{quic, Conn, {connected, Info}}` | Connection established |
+| `{quic, Conn, {stream_opened, StreamId}}` | Peer opened a stream |
+| `{quic, Conn, {stream_data, StreamId, Data, Fin}}` | Data received |
+| `{quic, Conn, {stream_reset, StreamId, Code}}` | Stream reset by peer |
+| `{quic, Conn, {stop_sending, StreamId, Code}}` | Stop sending requested |
+| `{quic, Conn, {datagram, Data}}` | Datagram received |
+| `{quic, Conn, {session_ticket, Ticket}}` | Session ticket for 0-RTT |
+| `{quic, Conn, {stream_deadline, StreamId}}` | Stream deadline expired |
+| `{quic, Conn, {send_ready, StreamId}}` | Stream ready to write |
+| `{quic, Conn, {closed, Reason}}` | Connection closed |
+| `{quic, Conn, {transport_error, Code, Reason}}` | Transport error |
 
 ## Error Handling
 
 ```erlang
 %% Connection errors
 case quic:connect(Host, Port, Opts, self()) of
-    {ok, ConnRef} ->
-        wait_for_connection(ConnRef);
+    {ok, Conn} ->
+        wait_for_connection(Conn);
     {error, Reason} ->
         handle_connect_error(Reason)
 end.
 
 %% Stream errors
-case quic:send_data(ConnRef, StreamId, Data, true) of
+case quic:send_data(Conn, StreamId, Data, true) of
     ok -> ok;
     {error, not_found} -> connection_gone();
     {error, stream_closed} -> stream_gone();
@@ -304,11 +304,11 @@ end.
 
 %% Handle connection close
 receive
-    {quic, ConnRef, {closed, normal}} ->
+    {quic, Conn, {closed, normal}} ->
         ok;
-    {quic, ConnRef, {closed, idle_timeout}} ->
+    {quic, Conn, {closed, idle_timeout}} ->
         reconnect();
-    {quic, ConnRef, {transport_error, Code, Reason}} ->
+    {quic, Conn, {transport_error, Code, Reason}} ->
         log_error(Code, Reason)
 end.
 ```
@@ -333,12 +333,12 @@ end.
 ```erlang
 %% For multiple requests to same server, reuse connections
 %% Open multiple streams on single connection
-{ok, ConnRef} = quic:connect(Host, Port, Opts, self()),
+{ok, Conn} = quic:connect(Host, Port, Opts, self()),
 
 %% Concurrent requests on same connection
-{ok, Stream1} = quic:open_stream(ConnRef),
-{ok, Stream2} = quic:open_stream(ConnRef),
-{ok, Stream3} = quic:open_stream(ConnRef).
+{ok, Stream1} = quic:open_stream(Conn),
+{ok, Stream2} = quic:open_stream(Conn),
+{ok, Stream3} = quic:open_stream(Conn).
 ```
 
 ### 3. Graceful Shutdown
@@ -346,12 +346,12 @@ end.
 ```erlang
 %% Close streams before closing connection
 lists:foreach(fun(StreamId) ->
-    quic:send_data(ConnRef, StreamId, <<>>, true)
+    quic:send_data(Conn, StreamId, <<>>, true)
 end, OpenStreams),
 
 %% Wait for acknowledgment, then close
 timer:sleep(100),
-quic:close(ConnRef, normal).
+quic:close(Conn, normal).
 ```
 
 ### 4. Timeout Handling
@@ -359,15 +359,15 @@ quic:close(ConnRef, normal).
 ```erlang
 %% Set appropriate timeouts
 connect_with_timeout(Host, Port) ->
-    {ok, ConnRef} = quic:connect(Host, Port, #{
+    {ok, Conn} = quic:connect(Host, Port, #{
         idle_timeout => 30000
     }, self()),
 
     receive
-        {quic, ConnRef, {connected, _}} ->
-            {ok, ConnRef}
+        {quic, Conn, {connected, _}} ->
+            {ok, Conn}
     after 10000 ->
-        quic:close(ConnRef, timeout),
+        quic:close(Conn, timeout),
         {error, connection_timeout}
     end.
 ```
@@ -394,38 +394,38 @@ quic:connect(Host, Port, #{
 
 request(Host, Port, Path) ->
     %% Connect
-    {ok, ConnRef} = quic:connect(Host, Port, #{
+    {ok, Conn} = quic:connect(Host, Port, #{
         alpn => [<<"h3">>],
         verify => false
     }, self()),
 
     receive
-        {quic, ConnRef, {connected, _}} -> ok
+        {quic, Conn, {connected, _}} -> ok
     after 5000 ->
-        quic:close(ConnRef, timeout),
+        quic:close(Conn, timeout),
         exit(connection_timeout)
     end,
 
     %% Open request stream
-    {ok, StreamId} = quic:open_stream(ConnRef),
+    {ok, StreamId} = quic:open_stream(Conn),
 
     %% Send request (simplified, not real H3)
     Request = <<"GET ", Path/binary, " HTTP/3\r\n\r\n">>,
-    ok = quic:send_data(ConnRef, StreamId, Request, true),
+    ok = quic:send_data(Conn, StreamId, Request, true),
 
     %% Receive response
-    Response = receive_response(ConnRef, StreamId, <<>>),
+    Response = receive_response(Conn, StreamId, <<>>),
 
-    quic:close(ConnRef, normal),
+    quic:close(Conn, normal),
     Response.
 
-receive_response(ConnRef, StreamId, Acc) ->
+receive_response(Conn, StreamId, Acc) ->
     receive
-        {quic, ConnRef, {stream_data, StreamId, Data, false}} ->
-            receive_response(ConnRef, StreamId, <<Acc/binary, Data/binary>>);
-        {quic, ConnRef, {stream_data, StreamId, Data, true}} ->
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            receive_response(Conn, StreamId, <<Acc/binary, Data/binary>>);
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
             <<Acc/binary, Data/binary>>;
-        {quic, ConnRef, {closed, _}} ->
+        {quic, Conn, {closed, _}} ->
             Acc
     after 10000 ->
         Acc
@@ -444,8 +444,8 @@ receive_response(ConnRef, StreamId, Acc) ->
 ### Slow Performance
 
 1. Check for packet loss with QLOG
-2. Verify MTU discovery is working: `quic:get_mtu(ConnRef)`
-3. Monitor congestion: `quic:get_send_queue_info(ConnRef)`
+2. Verify MTU discovery is working: `quic:get_mtu(Conn)`
+3. Monitor congestion: `quic:get_send_queue_info(Conn)`
 4. Consider datagram API for latency-sensitive data
 
 ### Connection Drops

--- a/include/quic_dist.hrl
+++ b/include/quic_dist.hrl
@@ -128,9 +128,8 @@
 
 %% Connection controller state
 -record(quic_dist_conn, {
-    %% Connection identity
-    conn_ref :: reference(),
-    conn_pid :: pid(),
+    %% Connection identity (Conn is the connection pid, receives {quic, Conn, Event} messages)
+    conn :: pid(),
     node :: node() | undefined,
     role :: client | server,
 

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -548,14 +548,14 @@ load_credentials(_) ->
 %% @private
 %% Handle a new incoming QUIC connection.
 handle_new_connection(Conn) ->
-    error_logger:info_msg(
+    logger:info(
         "quic_dist: handle_new_connection called, Conn=~p~n",
         [Conn]
     ),
     %% Start distribution controller for this connection
     case quic_dist_controller:start_link(Conn, server) of
         {ok, ControllerPid} ->
-            error_logger:info_msg("quic_dist: server controller started: ~p~n", [ControllerPid]),
+            logger:info("quic_dist: server controller started: ~p~n", [ControllerPid]),
             %% Notify the acceptor about the new connection
             %% The server name is based on the short node name (before @)
             NodeName = node(),
@@ -582,7 +582,7 @@ handle_new_connection(Conn) ->
             end,
             {ok, ControllerPid};
         Error ->
-            error_logger:error_msg("quic_dist: Failed to start controller: ~p~n", [Error]),
+            logger:error("quic_dist: Failed to start controller: ~p~n", [Error]),
             Error
     end.
 
@@ -662,35 +662,35 @@ acceptor_loop(Kernel, #quic_dist_listener{} = Listener, Pending) ->
 do_accept_connection(AcceptPid, DistCtrl, MyNode, Allowed, SetupTime, Kernel) ->
     %% Trap exits so we can handle the setup timer timeout properly
     process_flag(trap_exit, true),
-    error_logger:info_msg("do_accept_connection: waiting for controller message from ~p~n", [
+    logger:info("do_accept_connection: waiting for controller message from ~p~n", [
         AcceptPid
     ]),
     receive
         {AcceptPid, controller} ->
-            error_logger:info_msg(
+            logger:info(
                 "do_accept_connection: got controller, starting handshake. MyNode=~p, Kernel=~p~n",
                 [MyNode, Kernel]
             ),
             Timer = dist_util:start_timer(SetupTime),
             HSData = create_hs_data(DistCtrl, MyNode, Timer, Allowed, Kernel),
-            error_logger:info_msg(
+            logger:info(
                 "do_accept_connection: HSData created, kernel_pid=~p~n",
                 [HSData#hs_data.kernel_pid]
             ),
             try
                 Result = dist_util:handshake_other_started(HSData),
-                error_logger:info_msg("do_accept_connection: handshake result: ~p~n", [Result]),
+                logger:info("do_accept_connection: handshake result: ~p~n", [Result]),
                 Result
             catch
                 Class:Reason:Stack ->
-                    error_logger:error_msg(
+                    logger:error(
                         "do_accept_connection: handshake crashed: ~p:~p~n~p~n",
                         [Class, Reason, Stack]
                     ),
                     erlang:raise(Class, Reason, Stack)
             end
     after 5000 ->
-        error_logger:error_msg("do_accept_connection: TIMEOUT waiting for controller from ~p~n", [
+        logger:error("do_accept_connection: TIMEOUT waiting for controller from ~p~n", [
             AcceptPid
         ]),
         exit(controller_timeout)
@@ -902,7 +902,7 @@ wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer) ->
 create_hs_data(DistCtrl, MyNode, Timer, Allowed, Kernel) ->
     %% Capture SetupPid (self) for dist_ctrlr message
     SetupPid = self(),
-    error_logger:info_msg(
+    logger:info(
         "create_hs_data: Kernel=~p, DistCtrl=~p, SetupPid=~p~n",
         [Kernel, DistCtrl, SetupPid]
     ),
@@ -930,7 +930,7 @@ create_hs_data(DistCtrl, MyNode, Timer, Allowed, Kernel) ->
         f_setopts_pre_nodeup = fun(Ctrl) ->
             %% Just log and return ok - inet_tcp_dist doesn't do anything special here
             StoredNode = get_stored_node(Ctrl),
-            error_logger:info_msg(
+            logger:info(
                 "f_setopts_pre_nodeup (accept): Ctrl=~p, Node=~p, SetupPid=~p, linked=~p~n",
                 [
                     Ctrl,
@@ -953,7 +953,7 @@ create_hs_data(DistCtrl, MyNode, Timer, Allowed, Kernel) ->
         mf_getopts = fun(_Ctrl, Opts) -> {ok, [{O, 0} || O <- Opts]} end,
         allowed = Allowed,
         f_handshake_complete = fun(Ctrl, HsNode, DHandle) ->
-            error_logger:info_msg(
+            logger:info(
                 "f_handshake_complete (accept): Ctrl=~p, Node=~p, DHandle=~p~n",
                 [Ctrl, HsNode, DHandle]
             ),
@@ -1007,7 +1007,7 @@ get_stored_node(Ctrl) ->
 create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer) ->
     %% Capture SetupPid (self) for dist_ctrlr message
     SetupPid = self(),
-    error_logger:info_msg(
+    logger:info(
         "create_hs_data_setup: Kernel=~p, DistCtrl=~p, Node=~p, SetupPid=~p~n",
         [Kernel, DistCtrl, Node, SetupPid]
     ),
@@ -1023,7 +1023,7 @@ create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer) ->
         f_recv = fun(Ctrl, Len, Timeout) -> quic_dist_controller:recv(Ctrl, Len, Timeout) end,
         f_setopts_pre_nodeup = fun(Ctrl) ->
             %% Just log and return ok - inet_tcp_dist doesn't do anything special here
-            error_logger:info_msg(
+            logger:info(
                 "f_setopts_pre_nodeup (setup): Ctrl=~p, Node=~p, SetupPid=~p, linked=~p~n",
                 [Ctrl, Node, SetupPid, lists:member(Ctrl, element(2, process_info(self(), links)))]
             ),
@@ -1040,7 +1040,7 @@ create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer) ->
         mf_setopts = fun(_Ctrl, _Opts) -> ok end,
         mf_getopts = fun(_Ctrl, Opts) -> {ok, [{O, 0} || O <- Opts]} end,
         f_handshake_complete = fun(Ctrl, HsNode, DHandle) ->
-            error_logger:info_msg(
+            logger:info(
                 "f_handshake_complete (setup): Ctrl=~p, Node=~p, DHandle=~p~n",
                 [Ctrl, HsNode, DHandle]
             ),

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -419,8 +419,8 @@ start_quic_server(Name, Port, Config, _ExtraOpts) ->
                 %% instead of PMTU probing which adds overhead
                 max_udp_payload_size => ?DIST_MAX_UDP_PAYLOAD_SIZE,
                 pmtu_enabled => false,
-                connection_handler => fun(ConnPid, ConnRef) ->
-                    handle_new_connection(ConnPid, ConnRef)
+                connection_handler => fun(Conn) ->
+                    handle_new_connection(Conn)
                 end
             },
 
@@ -547,13 +547,13 @@ load_credentials(_) ->
 
 %% @private
 %% Handle a new incoming QUIC connection.
-handle_new_connection(ConnPid, ConnRef) ->
+handle_new_connection(Conn) ->
     error_logger:info_msg(
-        "quic_dist: handle_new_connection called, ConnPid=~p, ConnRef=~p~n",
-        [ConnPid, ConnRef]
+        "quic_dist: handle_new_connection called, Conn=~p~n",
+        [Conn]
     ),
     %% Start distribution controller for this connection
-    case quic_dist_controller:start_link(ConnPid, ConnRef, server) of
+    case quic_dist_controller:start_link(Conn, server) of
         {ok, ControllerPid} ->
             error_logger:info_msg("quic_dist: server controller started: ~p~n", [ControllerPid]),
             %% Notify the acceptor about the new connection
@@ -857,9 +857,9 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
 
             %% Attempt connection
             case quic:connect(Host, Port, Opts, self()) of
-                {ok, ConnRef} ->
+                {ok, Conn} ->
                     %% Wait for connection to be established
-                    wait_for_connection(Kernel, Node, ConnRef, MyNode, Type, Timer);
+                    wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer);
                 {error, Reason} ->
                     ?shutdown2(Node, {connect_failed, Reason})
             end;
@@ -868,11 +868,11 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
     end.
 
 %% @private
-wait_for_connection(Kernel, Node, ConnRef, MyNode, Type, Timer) ->
+wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer) ->
     receive
-        {quic, ConnRef, {connected, _Info}} ->
+        {quic, Conn, {connected, _Info}} ->
             %% Start distribution controller
-            case quic_dist_controller:start_link(ConnRef, client) of
+            case quic_dist_controller:start_link(Conn, client) of
                 {ok, DistCtrl} ->
                     %% Set kernel on controller and store node
                     quic_dist_controller:set_supervisor(DistCtrl, Kernel),
@@ -881,15 +881,15 @@ wait_for_connection(Kernel, Node, ConnRef, MyNode, Type, Timer) ->
                     HSData = create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer),
                     dist_util:handshake_we_started(HSData);
                 {error, Reason} ->
-                    quic:close(ConnRef, normal),
+                    quic:close(Conn, normal),
                     ?shutdown2(Node, {controller_failed, Reason})
             end;
-        {quic, ConnRef, {closed, Reason}} ->
+        {quic, Conn, {closed, Reason}} ->
             ?shutdown2(Node, {closed, Reason});
-        {quic, ConnRef, {transport_error, Code, Reason}} ->
+        {quic, Conn, {transport_error, Code, Reason}} ->
             ?shutdown2(Node, {transport_error, Code, Reason});
         {'EXIT', Timer, setup_timer_timeout} ->
-            quic:close(ConnRef, timeout),
+            quic:close(Conn, timeout),
             ?shutdown2(Node, connect_timeout)
     end.
 

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -53,7 +53,6 @@
 %% API
 -export([
     start_link/2,
-    start_link/3,
     send/2,
     recv/3,
     tick/1,
@@ -83,9 +82,8 @@
 
 %% Internal state
 -record(state, {
-    %% Connection
-    conn_ref :: reference(),
-    conn_pid :: pid() | undefined,
+    %% Connection (pid, receives {quic, Conn, Event} messages)
+    conn :: pid(),
     role :: client | server,
 
     %% Streams
@@ -148,17 +146,11 @@
 %% API
 %%====================================================================
 
-%% @doc Start a controller for a client connection.
--spec start_link(ConnRef :: reference(), Role :: client) ->
+%% @doc Start a controller for a QUIC distribution connection.
+-spec start_link(Conn :: pid(), Role :: client | server) ->
     {ok, pid()} | {error, term()}.
-start_link(ConnRef, client = Role) ->
-    gen_statem:start_link(?MODULE, {ConnRef, Role}, []).
-
-%% @doc Start a controller for a server connection.
--spec start_link(ConnPid :: pid(), ConnRef :: reference(), Role :: server) ->
-    {ok, pid()} | {error, term()}.
-start_link(ConnPid, ConnRef, server = Role) ->
-    gen_statem:start_link(?MODULE, {ConnPid, ConnRef, Role}, []).
+start_link(Conn, Role) when Role =:= client; Role =:= server ->
+    gen_statem:start_link(?MODULE, {Conn, Role}, []).
 
 %% @doc Send data on the control stream.
 -spec send(Controller :: pid(), Data :: iodata()) -> ok | {error, term()}.
@@ -226,24 +218,16 @@ callback_mode() ->
     [state_functions, state_enter].
 
 %% Initialize for client role
-init({ConnRef, client}) ->
-    %% Lookup connection PID
-    case quic_connection:lookup(ConnRef) of
-        {ok, ConnPid} ->
-            State = init_backpressure_config(#state{
-                conn_ref = ConnRef,
-                conn_pid = ConnPid,
-                role = client
-            }),
-            {ok, init_state, State};
-        error ->
-            {stop, connection_not_found}
-    end;
-%% Initialize for server role
-init({ConnPid, ConnRef, server}) ->
+init({Conn, client}) ->
     State = init_backpressure_config(#state{
-        conn_ref = ConnRef,
-        conn_pid = ConnPid,
+        conn = Conn,
+        role = client
+    }),
+    {ok, init_state, State};
+%% Initialize for server role
+init({Conn, server}) ->
+    State = init_backpressure_config(#state{
+        conn = Conn,
         role = server
     }),
     {ok, init_state, State}.
@@ -267,14 +251,14 @@ get_dist_opt(Key, Opts, Default) when is_list(Opts) ->
 get_dist_opt(Key, Opts, Default) when is_map(Opts) ->
     maps:get(Key, Opts, Default).
 
-terminate(_Reason, _StateName, #state{conn_ref = ConnRef, pending_tick_timer = Timer}) ->
+terminate(_Reason, _StateName, #state{conn = Conn, pending_tick_timer = Timer}) ->
     %% Cancel pending tick retry timer if running
     case Timer of
         undefined -> ok;
         TimerRef -> erlang:cancel_timer(TimerRef)
     end,
     try
-        quic:close(ConnRef, normal)
+        quic:close(Conn, normal)
     catch
         _:_ -> ok
     end,
@@ -287,10 +271,10 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %% State: init_state
 %%====================================================================
 
-init_state(enter, _OldState, #state{role = client, conn_ref = ConnRef} = State) ->
+init_state(enter, _OldState, #state{role = client, conn = Conn} = State) ->
     %% Client: connection is already established (we received connected message)
     %% Take over ownership synchronously to ensure we receive stream_data messages
-    ok = quic:set_owner_sync(ConnRef, self()),
+    ok = quic:set_owner_sync(Conn, self()),
     %% Can proceed to open streams immediately
     case setup_streams(State) of
         {ok, State1} ->
@@ -298,38 +282,32 @@ init_state(enter, _OldState, #state{role = client, conn_ref = ConnRef} = State) 
         {error, Reason} ->
             {stop, {stream_setup_failed, Reason}}
     end;
-init_state(enter, _OldState, #state{role = server, conn_ref = ConnRef} = State) ->
+init_state(enter, _OldState, #state{role = server, conn = Conn} = State) ->
     %% Server: take ownership synchronously and proceed immediately
     %% The connection_handler callback is called during QUIC handshake,
     %% and the listener transfers ownership to us. We don't need to wait
     %% for {connected, _} since we use stream 0 (client-initiated).
-    case quic_connection:lookup(ConnRef) of
-        {ok, ConnPid} ->
-            %% Take over as owner synchronously to ensure we receive stream_data
-            ok = quic:set_owner_sync(ConnRef, self()),
-            State1 = State#state{conn_pid = ConnPid},
-            %% Setup streams - transition via timeout since enter can't change state
-            case setup_streams(State1) of
-                {ok, State2} ->
-                    {keep_state, State2, [{state_timeout, 0, proceed_to_handshaking}]};
-                {error, Reason} ->
-                    {stop, {stream_setup_failed, Reason}}
-            end;
-        error ->
-            {stop, connection_not_found}
+    %% Take over as owner synchronously to ensure we receive stream_data
+    ok = quic:set_owner_sync(Conn, self()),
+    %% Setup streams - transition via timeout since enter can't change state
+    case setup_streams(State) of
+        {ok, State1} ->
+            {keep_state, State1, [{state_timeout, 0, proceed_to_handshaking}]};
+        {error, Reason} ->
+            {stop, {stream_setup_failed, Reason}}
     end;
 %% Server proceeds to handshaking after setup
 init_state(state_timeout, proceed_to_handshaking, State) ->
     {next_state, handshaking, State};
 %% Server receives connected message - just ignore, we already transitioned
-init_state(info, {quic, ConnRef, {connected, _Info}}, #state{conn_ref = ConnRef} = State) ->
+init_state(info, {quic, Conn, {connected, _Info}}, #state{conn = Conn} = State) ->
     {keep_state, State};
 init_state(state_timeout, start_handshake, State) ->
     {next_state, handshaking, State};
 %% Handle QUIC errors during init
-init_state(info, {quic, ConnRef, {closed, Reason}}, #state{conn_ref = ConnRef}) ->
+init_state(info, {quic, Conn, {closed, Reason}}, #state{conn = Conn}) ->
     {stop, {connection_closed, Reason}};
-init_state(info, {quic, ConnRef, {transport_error, Code, Reason}}, #state{conn_ref = ConnRef}) ->
+init_state(info, {quic, Conn, {transport_error, Code, Reason}}, #state{conn = Conn}) ->
     {stop, {transport_error, Code, Reason}};
 init_state(EventType, Event, State) ->
     handle_common_event(EventType, Event, init_state, State).
@@ -400,11 +378,11 @@ handshaking(info, {handshake_complete, Node, DHandle}, State) ->
 
     %% Spawn input handler to receive QUIC data and deliver to VM
     Self = self(),
-    ConnRef = State#state.conn_ref,
+    Conn = State#state.conn,
     ControlStream = State#state.control_stream,
     InputHandler = spawn_link(
         fun() ->
-            input_handler_loop(DHandle, Self, ConnRef, ControlStream)
+            input_handler_loop(DHandle, Self, Conn, ControlStream)
         end
     ),
 
@@ -481,7 +459,7 @@ connected({call, From}, {recv, Length}, State) ->
 %% The tick frame uses the control stream (urgency 0, separate flow control)
 %% to ensure it gets through even when data streams are congested.
 %% Then optionally flush limited data (best effort, not blocking).
-connected(cast, tick, #state{dhandle = DHandle, conn_ref = ConnRef} = State) when
+connected(cast, tick, #state{dhandle = DHandle, conn = Conn} = State) when
     DHandle =/= undefined
 ->
     %% Try to drain any pending send queue first
@@ -490,7 +468,7 @@ connected(cast, tick, #state{dhandle = DHandle, conn_ref = ConnRef} = State) whe
     State2 = do_send_tick_frame(State1),
     %% Then try to flush some data if not congested (best effort)
     State3 =
-        case quic:get_send_queue_info(ConnRef) of
+        case quic:get_send_queue_info(Conn) of
             {ok, #{congested := false}} ->
                 send_dist_data_with_tick(State2);
             _ ->
@@ -507,7 +485,7 @@ connected(cast, tick, State) ->
 connected(
     info,
     dist_data,
-    #state{dhandle = DHandle, conn_ref = ConnRef, backpressure_retry = RetryMs} = State
+    #state{dhandle = DHandle, conn = Conn, backpressure_retry = RetryMs} = State
 ) when
     DHandle =/= undefined
 ->
@@ -515,7 +493,7 @@ connected(
     State1 = drain_send_queue(State),
     %% Also retry pending tick if any
     State2 = maybe_retry_pending_tick(State1),
-    case quic:get_send_queue_info(ConnRef) of
+    case quic:get_send_queue_info(Conn) of
         {ok, #{congested := true}} ->
             %% Queue is congested - don't pull more data
             %% Re-check after a delay
@@ -537,7 +515,7 @@ connected(
 connected(
     info,
     check_queue,
-    #state{dhandle = DHandle, conn_ref = ConnRef, backpressure_retry = RetryMs} = State
+    #state{dhandle = DHandle, conn = Conn, backpressure_retry = RetryMs} = State
 ) when
     DHandle =/= undefined
 ->
@@ -545,7 +523,7 @@ connected(
     State1 = drain_send_queue(State),
     %% Also retry pending tick if any
     State2 = maybe_retry_pending_tick(State1),
-    case quic:get_send_queue_info(ConnRef) of
+    case quic:get_send_queue_info(Conn) of
         {ok, #{congested := false}} ->
             %% Queue has room - pull and send data
             State3 = send_dist_data_limited(State2),
@@ -563,12 +541,12 @@ connected(EventType, Event, State) ->
 %% Common Event Handling
 %%====================================================================
 
-handle_common_event({call, From}, getstat, _StateName, #state{conn_ref = ConnRef} = State) ->
+handle_common_event({call, From}, getstat, _StateName, #state{conn = Conn} = State) ->
     %% Use QUIC-level packet counts for liveness detection
     %% This ensures any QUIC activity (ACKs, PINGs) counts as proof of liveness,
     %% even when application-level data is blocked by flow control.
     {RecvCnt, SendCnt} =
-        case quic:get_stats(ConnRef) of
+        case quic:get_stats(Conn) of
             {ok, #{packets_received := PR, packets_sent := PS}} ->
                 {PR, PS};
             _ ->
@@ -581,10 +559,10 @@ handle_common_event(
     {call, From},
     {get_address, Node},
     _StateName,
-    #state{conn_ref = ConnRef} = State
+    #state{conn = Conn} = State
 ) ->
     Address =
-        case quic:peername(ConnRef) of
+        case quic:peername(Conn) of
             {ok, {IP, Port}} ->
                 #net_address{
                     address = {IP, Port},
@@ -637,10 +615,10 @@ handle_common_event(
 %% Handle incoming QUIC messages
 handle_common_event(
     info,
-    {quic, ConnRef, {stream_data, StreamId, Data, _Fin}},
+    {quic, Conn, {stream_data, StreamId, Data, _Fin}},
     StateName,
     #state{
-        conn_ref = ConnRef,
+        conn = Conn,
         control_stream = CtrlStream
     } = State
 ) ->
@@ -654,42 +632,42 @@ handle_common_event(
     end;
 handle_common_event(
     info,
-    {quic, ConnRef, {session_ticket, Ticket}},
+    {quic, Conn, {session_ticket, Ticket}},
     _StateName,
-    #state{conn_ref = ConnRef} = State
+    #state{conn = Conn} = State
 ) ->
     %% Store session ticket for 0-RTT
     {keep_state, State#state{session_ticket = Ticket}};
 handle_common_event(
     info,
-    {quic, ConnRef, {connected, _Info}},
+    {quic, Conn, {connected, _Info}},
     _StateName,
-    #state{conn_ref = ConnRef} = State
+    #state{conn = Conn} = State
 ) ->
     %% Connection fully established - we may receive this after transitioning
     %% to handshaking state, just acknowledge and continue
     {keep_state, State};
 handle_common_event(
     info,
-    {quic, ConnRef, {stream_opened, _StreamId}},
+    {quic, Conn, {stream_opened, _StreamId}},
     _StateName,
-    #state{conn_ref = ConnRef} = State
+    #state{conn = Conn} = State
 ) ->
     %% New stream opened by peer - for distribution, we primarily use stream 0
     {keep_state, State};
 handle_common_event(
     info,
-    {quic, ConnRef, {closed, Reason}},
+    {quic, Conn, {closed, Reason}},
     _StateName,
-    #state{conn_ref = ConnRef} = State
+    #state{conn = Conn} = State
 ) ->
     %% Connection closed
     {stop, {connection_closed, Reason}, State};
 handle_common_event(
     info,
-    {quic, ConnRef, {transport_error, Code, Reason}},
+    {quic, Conn, {transport_error, Code, Reason}},
     _StateName,
-    #state{conn_ref = ConnRef} = State
+    #state{conn = Conn} = State
 ) ->
     {stop, {transport_error, Code, Reason}, State};
 handle_common_event(
@@ -698,7 +676,7 @@ handle_common_event(
     _StateName,
     State
 ) ->
-    %% Stream data with non-matching ConnRef (should not happen)
+    %% Stream data with non-matching Conn (should not happen)
     ?LOG_WARNING(
         #{
             what => stream_data_conn_mismatch,
@@ -726,8 +704,8 @@ handle_common_event(_EventType, _Event, _StateName, State) ->
 
 %% @private
 %% Open the control stream (client only - server uses stream 0 from client).
-open_control_stream(#state{conn_ref = ConnRef} = State) ->
-    case quic:open_stream(ConnRef) of
+open_control_stream(#state{conn = Conn} = State) ->
+    case quic:open_stream(Conn) of
         {ok, StreamId} ->
             {ok, StreamId, State};
         Error ->
@@ -738,8 +716,8 @@ open_control_stream(#state{conn_ref = ConnRef} = State) ->
 %% Open data streams for message passing.
 open_data_streams(State, 0) ->
     {ok, State};
-open_data_streams(#state{conn_ref = ConnRef, data_streams = Streams} = State, N) ->
-    case quic:open_stream(ConnRef) of
+open_data_streams(#state{conn = Conn, data_streams = Streams} = State, N) ->
+    case quic:open_stream(Conn) of
         {ok, StreamId} ->
             %% Set priority (lower than control, but reasonable)
             ok = set_stream_priority(State, StreamId, ?QUIC_DIST_URGENCY_DATA_NORMAL),
@@ -751,8 +729,8 @@ open_data_streams(#state{conn_ref = ConnRef, data_streams = Streams} = State, N)
     end.
 
 %% @private
-set_stream_priority(#state{conn_ref = ConnRef}, StreamId, Urgency) ->
-    quic:set_stream_priority(ConnRef, StreamId, Urgency, false).
+set_stream_priority(#state{conn = Conn}, StreamId, Urgency) ->
+    quic:set_stream_priority(Conn, StreamId, Urgency, false).
 
 %% @private
 %% Open server-initiated data streams after handshake.
@@ -812,7 +790,7 @@ forward_pending_data(State) ->
 do_send_control(
     Data,
     #state{
-        conn_ref = ConnRef,
+        conn = Conn,
         control_stream = StreamId,
         send_cnt = SendCnt,
         send_oct = SendOct
@@ -821,7 +799,7 @@ do_send_control(
     DataBin = iolist_to_binary(Data),
     Len = byte_size(DataBin),
 
-    case quic:send_data(ConnRef, StreamId, DataBin, false) of
+    case quic:send_data(Conn, StreamId, DataBin, false) of
         ok ->
             Now = erlang:monotonic_time(millisecond),
             {ok, State#state{
@@ -839,7 +817,7 @@ do_send_control(
 do_send_data(
     Data,
     #state{
-        conn_ref = ConnRef,
+        conn = Conn,
         data_streams = Streams,
         data_stream_idx = Idx,
         send_cnt = SendCnt,
@@ -852,7 +830,7 @@ do_send_data(
     DataBin = iolist_to_binary(Data),
     Len = byte_size(DataBin),
 
-    case quic:send_data(ConnRef, StreamId, DataBin, false) of
+    case quic:send_data(Conn, StreamId, DataBin, false) of
         ok ->
             Now = erlang:monotonic_time(millisecond),
             {ok, State#state{
@@ -875,13 +853,13 @@ do_send_data(Data, State) ->
 %% 2. Stream tick - needed for Erlang distribution response mechanism
 %% Returns updated state with pending_tick flag set if stream send failed.
 %% Starts a retry timer when tick is blocked to ensure retry during idle periods.
-do_send_tick_frame(#state{conn_ref = ConnRef, control_stream = CtrlStream} = State) when
+do_send_tick_frame(#state{conn = Conn, control_stream = CtrlStream} = State) when
     CtrlStream =/= undefined
 ->
     %% Send QUIC PING to keep transport alive (bypasses congestion)
-    _ = quic:send_ping(ConnRef),
+    _ = quic:send_ping(Conn),
     %% Also send stream-based tick for Erlang distribution protocol
-    case quic:send_data(ConnRef, CtrlStream, <<0:32/big-unsigned>>, false) of
+    case quic:send_data(Conn, CtrlStream, <<0:32/big-unsigned>>, false) of
         ok ->
             Now = erlang:monotonic_time(millisecond),
             cancel_pending_tick_timer(State#state{pending_tick = false, last_send_time = Now});
@@ -895,10 +873,10 @@ do_send_tick_frame(#state{conn_ref = ConnRef, control_stream = CtrlStream} = Sta
             %% Other error - clear pending
             cancel_pending_tick_timer(State#state{pending_tick = false})
     end;
-do_send_tick_frame(#state{conn_ref = ConnRef, data_streams = [FirstStream | _]} = State) ->
+do_send_tick_frame(#state{conn = Conn, data_streams = [FirstStream | _]} = State) ->
     %% Fallback to data stream if no control stream
-    _ = quic:send_ping(ConnRef),
-    case quic:send_data(ConnRef, FirstStream, <<0:32/big-unsigned>>, false) of
+    _ = quic:send_ping(Conn),
+    case quic:send_data(Conn, FirstStream, <<0:32/big-unsigned>>, false) of
         ok ->
             Now = erlang:monotonic_time(millisecond),
             cancel_pending_tick_timer(State#state{pending_tick = false, last_send_time = Now});
@@ -951,38 +929,38 @@ maybe_retry_pending_tick(#state{pending_tick = true} = State) ->
 send_dist_data_limited(
     #state{
         dhandle = DHandle,
-        conn_ref = ConnRef,
+        conn = Conn,
         data_streams = [FirstStream | _],
         max_pull = MaxPull
     } = State
 ) ->
     %% Use first data stream for all distribution data to maintain ordering
-    send_dist_data_limited_loop(DHandle, ConnRef, FirstStream, MaxPull, State);
+    send_dist_data_limited_loop(DHandle, Conn, FirstStream, MaxPull, State);
 send_dist_data_limited(
     #state{
         dhandle = DHandle,
-        conn_ref = ConnRef,
+        conn = Conn,
         control_stream = CtrlStream,
         max_pull = MaxPull
     } = State
 ) ->
     %% Fallback: no data streams, use control stream
-    send_dist_data_limited_loop(DHandle, ConnRef, CtrlStream, MaxPull, State).
+    send_dist_data_limited_loop(DHandle, Conn, CtrlStream, MaxPull, State).
 
 %% @private
 %% Send distribution data with limited pulls per notification.
 %% Buffers unsent data in send_queue instead of dropping it.
-send_dist_data_limited_loop(_DHandle, _ConnRef, _StreamId, 0, State) ->
+send_dist_data_limited_loop(_DHandle, _Conn, _StreamId, 0, State) ->
     %% Pulled enough for now
     State;
-send_dist_data_limited_loop(DHandle, ConnRef, StreamId, Remaining, State) ->
+send_dist_data_limited_loop(DHandle, Conn, StreamId, Remaining, State) ->
     case erlang:dist_ctrl_get_data(DHandle) of
         none ->
             State;
         Data ->
-            case send_one_frame(ConnRef, StreamId, Data) of
+            case send_one_frame(Conn, StreamId, Data) of
                 ok ->
-                    send_dist_data_limited_loop(DHandle, ConnRef, StreamId, Remaining - 1, State);
+                    send_dist_data_limited_loop(DHandle, Conn, StreamId, Remaining - 1, State);
                 {error, send_queue_full} ->
                     %% Queue full - buffer the data we already pulled
                     enqueue_send_data(Data, State);
@@ -991,7 +969,7 @@ send_dist_data_limited_loop(DHandle, ConnRef, StreamId, Remaining, State) ->
                     enqueue_send_data(Data, State);
                 {error, _} ->
                     %% Other error - continue trying (don't lose the data)
-                    send_dist_data_limited_loop(DHandle, ConnRef, StreamId, Remaining - 1, State)
+                    send_dist_data_limited_loop(DHandle, Conn, StreamId, Remaining - 1, State)
             end
     end.
 
@@ -1003,36 +981,36 @@ send_dist_data_limited_loop(DHandle, ConnRef, StreamId, Remaining, State) ->
 send_dist_data_with_tick(
     #state{
         dhandle = DHandle,
-        conn_ref = ConnRef,
+        conn = Conn,
         data_streams = [FirstStream | _],
         max_pull = MaxPull
     } = State
 ) ->
-    send_dist_data_loop_tick(DHandle, ConnRef, FirstStream, MaxPull, State);
+    send_dist_data_loop_tick(DHandle, Conn, FirstStream, MaxPull, State);
 send_dist_data_with_tick(
     #state{
         dhandle = DHandle,
-        conn_ref = ConnRef,
+        conn = Conn,
         control_stream = CtrlStream,
         max_pull = MaxPull
     } = State
 ) ->
-    send_dist_data_loop_tick(DHandle, ConnRef, CtrlStream, MaxPull, State).
+    send_dist_data_loop_tick(DHandle, Conn, CtrlStream, MaxPull, State).
 
 %% @private
 %% Send distribution data with pull limit to prevent tick callback blocking.
 %% Buffers unsent data in send_queue instead of dropping it.
-send_dist_data_loop_tick(_DHandle, _ConnRef, _StreamId, 0, State) ->
+send_dist_data_loop_tick(_DHandle, _Conn, _StreamId, 0, State) ->
     %% Reached pull limit - stop to avoid blocking tick callback
     State;
-send_dist_data_loop_tick(DHandle, ConnRef, StreamId, Remaining, State) ->
+send_dist_data_loop_tick(DHandle, Conn, StreamId, Remaining, State) ->
     case erlang:dist_ctrl_get_data(DHandle) of
         none ->
             State;
         Data ->
-            case send_one_frame(ConnRef, StreamId, Data) of
+            case send_one_frame(Conn, StreamId, Data) of
                 ok ->
-                    send_dist_data_loop_tick(DHandle, ConnRef, StreamId, Remaining - 1, State);
+                    send_dist_data_loop_tick(DHandle, Conn, StreamId, Remaining - 1, State);
                 {error, send_queue_full} ->
                     %% Queue full - buffer the data we already pulled
                     enqueue_send_data(Data, State);
@@ -1054,27 +1032,27 @@ enqueue_send_data(Data, #state{send_queue = Queue} = State) ->
 %% Drain the send queue - try to send any buffered data.
 %% Returns updated state with remaining unsent data in queue.
 drain_send_queue(
-    #state{send_queue = Queue, conn_ref = ConnRef, data_streams = [FirstStream | _]} = State
+    #state{send_queue = Queue, conn = Conn, data_streams = [FirstStream | _]} = State
 ) ->
-    drain_send_queue_loop(Queue, ConnRef, FirstStream, State);
+    drain_send_queue_loop(Queue, Conn, FirstStream, State);
 drain_send_queue(
-    #state{send_queue = Queue, conn_ref = ConnRef, control_stream = CtrlStream} = State
+    #state{send_queue = Queue, conn = Conn, control_stream = CtrlStream} = State
 ) when
     CtrlStream =/= undefined
 ->
-    drain_send_queue_loop(Queue, ConnRef, CtrlStream, State);
+    drain_send_queue_loop(Queue, Conn, CtrlStream, State);
 drain_send_queue(State) ->
     State.
 
-drain_send_queue_loop(Queue, ConnRef, StreamId, State) ->
+drain_send_queue_loop(Queue, Conn, StreamId, State) ->
     case queue:out(Queue) of
         {empty, _} ->
             State#state{send_queue = Queue};
         {{value, Data}, RestQueue} ->
-            case send_one_frame(ConnRef, StreamId, Data) of
+            case send_one_frame(Conn, StreamId, Data) of
                 ok ->
                     %% Sent successfully, continue draining
-                    drain_send_queue_loop(RestQueue, ConnRef, StreamId, State);
+                    drain_send_queue_loop(RestQueue, Conn, StreamId, State);
                 {error, _} ->
                     %% Failed to send - put data back and stop
                     %% (data is already at front since we just dequeued it)
@@ -1086,13 +1064,13 @@ drain_send_queue_loop(Queue, ConnRef, StreamId, State) ->
 %% Send a single framed message.
 %% Adds 4-byte big-endian length prefix for message framing over QUIC.
 %% Returns ok on success or {error, Reason} on failure.
-send_one_frame(ConnRef, StreamId, Data) ->
+send_one_frame(Conn, StreamId, Data) ->
     %% dist_ctrl_get_data returns raw message data (no length prefix)
     %% We add 4-byte length prefix for framing over QUIC
     DataBin = iolist_to_binary(Data),
     Length = byte_size(DataBin),
     FramedData = <<Length:32/big-unsigned, DataBin/binary>>,
-    case quic:send_data(ConnRef, StreamId, FramedData, false) of
+    case quic:send_data(Conn, StreamId, FramedData, false) of
         ok -> ok;
         {error, Reason} -> {error, Reason}
     end.
@@ -1111,18 +1089,18 @@ send_one_frame(ConnRef, StreamId, Data) ->
 %% QUIC delivers data in arbitrary chunks (typically ~1100 bytes due to MTU).
 %% We MUST buffer incoming data and only pass complete messages to the VM.
 %% Passing partial messages causes "corrupted distribution header" errors.
-input_handler_loop(DHandle, Controller, ConnRef, ControlStream) ->
+input_handler_loop(DHandle, Controller, Conn, ControlStream) ->
     %% Start with empty buffer
-    input_handler_loop(DHandle, Controller, ConnRef, ControlStream, <<>>).
+    input_handler_loop(DHandle, Controller, Conn, ControlStream, <<>>).
 
-input_handler_loop(DHandle, Controller, ConnRef, ControlStream, Buffer) ->
+input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer) ->
     receive
         {continue_delivery, PendingBuffer} ->
             %% Continue processing after batch yield
             case deliver_complete_messages(DHandle, PendingBuffer) of
                 {ok, RemainingBuffer} ->
                     input_handler_loop(
-                        DHandle, Controller, ConnRef, ControlStream, RemainingBuffer
+                        DHandle, Controller, Conn, ControlStream, RemainingBuffer
                     );
                 {error, _Reason} ->
                     exit(normal)
@@ -1133,7 +1111,7 @@ input_handler_loop(DHandle, Controller, ConnRef, ControlStream, Buffer) ->
             case deliver_complete_messages(DHandle, NewBuffer) of
                 {ok, RemainingBuffer} ->
                     input_handler_loop(
-                        DHandle, Controller, ConnRef, ControlStream, RemainingBuffer
+                        DHandle, Controller, Conn, ControlStream, RemainingBuffer
                     );
                 {error, _Reason} ->
                     %% Error delivering to VM, connection is broken
@@ -1142,25 +1120,25 @@ input_handler_loop(DHandle, Controller, ConnRef, ControlStream, Buffer) ->
         {'EXIT', Controller, Reason} ->
             %% Controller died, exit
             exit(Reason);
-        {quic, ConnRef, {stream_data, _StreamId, Data, _Fin}} ->
+        {quic, Conn, {stream_data, _StreamId, Data, _Fin}} ->
             %% Direct QUIC data (if we're receiving messages directly)
             NewBuffer = <<Buffer/binary, Data/binary>>,
             case deliver_complete_messages(DHandle, NewBuffer) of
                 {ok, RemainingBuffer} ->
                     input_handler_loop(
-                        DHandle, Controller, ConnRef, ControlStream, RemainingBuffer
+                        DHandle, Controller, Conn, ControlStream, RemainingBuffer
                     );
                 {error, _Reason} ->
                     exit(normal)
             end;
-        {quic, ConnRef, {closed, _Reason}} ->
+        {quic, Conn, {closed, _Reason}} ->
             exit(normal);
         Other ->
             logger:warning(
                 #{what => input_handler_unexpected_msg, msg => Other},
                 ?QUIC_LOG_META
             ),
-            input_handler_loop(DHandle, Controller, ConnRef, ControlStream, Buffer)
+            input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer)
     end.
 
 %% @private

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -114,11 +114,11 @@ download_file(TestCase, Url, DownloadsDir) ->
 
             %% Connect
             case quic:connect(Host, Port, Opts, self()) of
-                {ok, ConnRef} ->
+                {ok, Conn} ->
                     Result = wait_for_connection_and_download(
-                        ConnRef, Path, DownloadsDir, TestCase
+                        Conn, Path, DownloadsDir, TestCase
                     ),
-                    quic:close(ConnRef, normal),
+                    quic:close(Conn, normal),
                     Result;
                 {error, Reason} ->
                     io:format("Connection failed: ~p~n", [Reason]),
@@ -158,38 +158,35 @@ build_opts(_) ->
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
 
-wait_for_connection_and_download(ConnRef, Path, DownloadsDir, TestCase) ->
+wait_for_connection_and_download(Conn, Path, DownloadsDir, TestCase) ->
     receive
-        {quic, ConnRef, {connected, _Info}} ->
+        {quic, Conn, {connected, _Info}} ->
             io:format("Connected~n"),
 
             %% Handle key update test case
             case TestCase of
                 "keyupdate" ->
                     %% Initiate key update before request
-                    case quic_connection:lookup(ConnRef) of
-                        {ok, Pid} -> quic_connection:key_update(Pid);
-                        _ -> ok
-                    end;
+                    quic_connection:key_update(Conn);
                 _ ->
                     ok
             end,
 
             %% Open stream and send request
-            case quic:open_stream(ConnRef) of
+            case quic:open_stream(Conn) of
                 {ok, StreamId} ->
                     %% Send HTTP/0.9 style request (for hq-interop)
                     Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(ConnRef, StreamId, Request, true),
-                    receive_and_save(ConnRef, StreamId, Path, DownloadsDir);
+                    ok = quic:send_data(Conn, StreamId, Request, true),
+                    receive_and_save(Conn, StreamId, Path, DownloadsDir);
                 {error, StreamErr} ->
                     io:format("Failed to open stream: ~p~n", [StreamErr]),
                     error
             end;
-        {quic, ConnRef, {closed, Reason}} ->
+        {quic, Conn, {closed, Reason}} ->
             io:format("Connection closed: ~p~n", [Reason]),
             error;
-        {quic, ConnRef, {transport_error, Code, Msg}} ->
+        {quic, Conn, {transport_error, Code, Msg}} ->
             io:format("Transport error: ~p ~p~n", [Code, Msg]),
             error
     after 30000 ->
@@ -197,14 +194,14 @@ wait_for_connection_and_download(ConnRef, Path, DownloadsDir, TestCase) ->
         error
     end.
 
-receive_and_save(ConnRef, StreamId, Path, DownloadsDir) ->
+receive_and_save(Conn, StreamId, Path, DownloadsDir) ->
     %% Extract filename and open file for streaming writes
     Filename = filename:basename(Path),
     FilePath = filename:join(DownloadsDir, Filename),
 
     case file:open(FilePath, [write, binary, raw]) of
         {ok, FileHandle} ->
-            Result = receive_stream_data_streaming(ConnRef, StreamId, FileHandle, 0, 60000),
+            Result = receive_stream_data_streaming(Conn, StreamId, FileHandle, 0, 60000),
             file:close(FileHandle),
             case Result of
                 {ok, BytesWritten} ->
@@ -221,9 +218,9 @@ receive_and_save(ConnRef, StreamId, Path, DownloadsDir) ->
     end.
 
 %% Streaming version: write chunks to disk as they arrive (memory efficient for large files)
-receive_stream_data_streaming(ConnRef, StreamId, FileHandle, BytesWritten, Timeout) ->
+receive_stream_data_streaming(Conn, StreamId, FileHandle, BytesWritten, Timeout) ->
     receive
-        {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             case file:write(FileHandle, Data) of
                 ok ->
                     NewBytesWritten = BytesWritten + byte_size(Data),
@@ -232,17 +229,17 @@ receive_stream_data_streaming(ConnRef, StreamId, FileHandle, BytesWritten, Timeo
                             {ok, NewBytesWritten};
                         false ->
                             receive_stream_data_streaming(
-                                ConnRef, StreamId, FileHandle, NewBytesWritten, Timeout
+                                Conn, StreamId, FileHandle, NewBytesWritten, Timeout
                             )
                     end;
                 {error, WriteErr} ->
                     io:format("Write error: ~p~n", [WriteErr]),
                     error
             end;
-        {quic, ConnRef, {stream_reset, StreamId, _Code}} ->
+        {quic, Conn, {stream_reset, StreamId, _Code}} ->
             io:format("Stream reset~n"),
             error;
-        {quic, ConnRef, {closed, _Reason}} ->
+        {quic, Conn, {closed, _Reason}} ->
             %% Connection closed, return what we have
             case BytesWritten of
                 0 -> error;
@@ -325,9 +322,9 @@ resumption_phase1(Host, Port, Path, DownloadsDir) ->
         alpn => [<<"hq-interop">>, <<"h3">>]
     },
     case quic:connect(Host, Port, Opts, self()) of
-        {ok, ConnRef} ->
-            Result = wait_for_ticket_and_download(ConnRef, Path, DownloadsDir),
-            quic:close(ConnRef, normal),
+        {ok, Conn} ->
+            Result = wait_for_ticket_and_download(Conn, Path, DownloadsDir),
+            quic:close(Conn, normal),
             Result;
         {error, Reason} ->
             io:format("Phase 1 connection failed: ~p~n", [Reason]),
@@ -335,21 +332,21 @@ resumption_phase1(Host, Port, Path, DownloadsDir) ->
     end.
 
 %% Wait for connection, download, and capture session ticket
-wait_for_ticket_and_download(ConnRef, Path, DownloadsDir) ->
+wait_for_ticket_and_download(Conn, Path, DownloadsDir) ->
     receive
-        {quic, ConnRef, {connected, _Info}} ->
+        {quic, Conn, {connected, _Info}} ->
             io:format("Phase 1: Connected~n"),
-            case quic:open_stream(ConnRef) of
+            case quic:open_stream(Conn) of
                 {ok, StreamId} ->
                     Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(ConnRef, StreamId, Request, true),
+                    ok = quic:send_data(Conn, StreamId, Request, true),
                     %% Download and wait for ticket
-                    download_and_wait_for_ticket(ConnRef, StreamId, Path, DownloadsDir, undefined);
+                    download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, undefined);
                 {error, Err} ->
                     io:format("Failed to open stream: ~p~n", [Err]),
                     error
             end;
-        {quic, ConnRef, {closed, Reason}} ->
+        {quic, Conn, {closed, Reason}} ->
             io:format("Phase 1: Connection closed: ~p~n", [Reason]),
             error
     after 30000 ->
@@ -358,9 +355,9 @@ wait_for_ticket_and_download(ConnRef, Path, DownloadsDir) ->
     end.
 
 %% Download file and wait for session ticket
-download_and_wait_for_ticket(ConnRef, StreamId, Path, DownloadsDir, Ticket) ->
+download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket) ->
     receive
-        {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             %% Accumulate data (could use streaming, but for resumption test this is fine)
             case Fin of
                 true ->
@@ -371,16 +368,16 @@ download_and_wait_for_ticket(ConnRef, StreamId, Path, DownloadsDir, Ticket) ->
                     io:format("Phase 1: Downloaded ~s~n", [FilePath]),
                     %% Continue waiting for ticket if we don't have one yet
                     case Ticket of
-                        undefined -> wait_for_ticket_only(ConnRef, 5000);
+                        undefined -> wait_for_ticket_only(Conn, 5000);
                         _ -> {ok, Ticket}
                     end;
                 false ->
-                    download_and_wait_for_ticket(ConnRef, StreamId, Path, DownloadsDir, Ticket)
+                    download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket)
             end;
-        {quic, ConnRef, {session_ticket, NewTicket}} ->
+        {quic, Conn, {session_ticket, NewTicket}} ->
             io:format("Phase 1: Received session ticket~n"),
-            download_and_wait_for_ticket(ConnRef, StreamId, Path, DownloadsDir, NewTicket);
-        {quic, ConnRef, {closed, _Reason}} ->
+            download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, NewTicket);
+        {quic, Conn, {closed, _Reason}} ->
             case Ticket of
                 undefined -> error;
                 _ -> {ok, Ticket}
@@ -394,12 +391,12 @@ download_and_wait_for_ticket(ConnRef, StreamId, Path, DownloadsDir, Ticket) ->
     end.
 
 %% Wait only for a session ticket (after download is complete)
-wait_for_ticket_only(ConnRef, Timeout) ->
+wait_for_ticket_only(Conn, Timeout) ->
     receive
-        {quic, ConnRef, {session_ticket, Ticket}} ->
+        {quic, Conn, {session_ticket, Ticket}} ->
             io:format("Received session ticket~n"),
             {ok, Ticket};
-        {quic, ConnRef, {closed, _Reason}} ->
+        {quic, Conn, {closed, _Reason}} ->
             io:format("Connection closed before ticket received~n"),
             error
     after Timeout ->
@@ -415,9 +412,9 @@ resumption_phase2(Host, Port, Path, DownloadsDir, Ticket) ->
         session_ticket => Ticket
     },
     case quic:connect(Host, Port, Opts, self()) of
-        {ok, ConnRef} ->
-            Result = wait_for_connection_and_download(ConnRef, Path, DownloadsDir, "resumption"),
-            quic:close(ConnRef, normal),
+        {ok, Conn} ->
+            Result = wait_for_connection_and_download(Conn, Path, DownloadsDir, "resumption"),
+            quic:close(Conn, normal),
             Result;
         {error, Reason} ->
             io:format("Phase 2 connection failed: ~p~n", [Reason]),
@@ -504,25 +501,25 @@ zerortt_with_ticket(Host, Port, Path, DownloadsDir, Ticket) ->
         enable_early_data => true
     },
     case quic:connect(Host, Port, Opts, self()) of
-        {ok, ConnRef} ->
+        {ok, Conn} ->
             %% Open stream and send request immediately (uses 0-RTT if available)
-            case quic:open_stream(ConnRef) of
+            case quic:open_stream(Conn) of
                 {ok, StreamId} ->
                     Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
                     io:format("Sending 0-RTT request~n"),
-                    ok = quic:send_data(ConnRef, StreamId, Request, true),
-                    Result = wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir),
-                    quic:close(ConnRef, normal),
+                    ok = quic:send_data(Conn, StreamId, Request, true),
+                    Result = wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir),
+                    quic:close(Conn, normal),
                     Result;
                 {error, not_connected} ->
                     %% Early keys not available, fall back to waiting for connection
                     io:format("0-RTT: Early keys not available, waiting for connection~n"),
-                    Result = wait_for_connection_then_request(ConnRef, Path, DownloadsDir),
-                    quic:close(ConnRef, normal),
+                    Result = wait_for_connection_then_request(Conn, Path, DownloadsDir),
+                    quic:close(Conn, normal),
                     Result;
                 {error, Err} ->
                     io:format("Failed to open stream: ~p~n", [Err]),
-                    quic:close(ConnRef, normal),
+                    quic:close(Conn, normal),
                     error
             end;
         {error, Reason} ->
@@ -531,20 +528,20 @@ zerortt_with_ticket(Host, Port, Path, DownloadsDir, Ticket) ->
     end.
 
 %% Fallback: wait for connection then send request
-wait_for_connection_then_request(ConnRef, Path, DownloadsDir) ->
+wait_for_connection_then_request(Conn, Path, DownloadsDir) ->
     receive
-        {quic, ConnRef, {connected, _Info}} ->
+        {quic, Conn, {connected, _Info}} ->
             io:format("0-RTT: Connected (fallback to 1-RTT)~n"),
-            case quic:open_stream(ConnRef) of
+            case quic:open_stream(Conn) of
                 {ok, StreamId} ->
                     Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(ConnRef, StreamId, Request, true),
-                    wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir);
+                    ok = quic:send_data(Conn, StreamId, Request, true),
+                    wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir);
                 {error, Err} ->
                     io:format("Failed to open stream: ~p~n", [Err]),
                     error
             end;
-        {quic, ConnRef, {closed, Reason}} ->
+        {quic, Conn, {closed, Reason}} ->
             io:format("0-RTT: Connection closed: ~p~n", [Reason]),
             error
     after 30000 ->
@@ -553,10 +550,10 @@ wait_for_connection_then_request(ConnRef, Path, DownloadsDir) ->
     end.
 
 %% Wait for 0-RTT response (may receive before or after connected event)
-wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir) ->
-    wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, false, false, <<>>).
+wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir) ->
+    wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir, false, false, <<>>).
 
-wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, Connected, Retried, Acc) ->
+wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir, Connected, Retried, Acc) ->
     %% Use shorter timeout after handshake to detect rejected 0-RTT
     Timeout =
         case Connected andalso Acc =:= <<>> andalso not Retried of
@@ -565,10 +562,10 @@ wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, Connected, Retr
             false -> 60000
         end,
     receive
-        {quic, ConnRef, {connected, _Info}} ->
+        {quic, Conn, {connected, _Info}} ->
             io:format("0-RTT: Handshake completed~n"),
-            wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, true, Retried, Acc);
-        {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+            wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir, true, Retried, Acc);
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             NewAcc = <<Acc/binary, Data/binary>>,
             case Fin of
                 true ->
@@ -579,14 +576,14 @@ wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, Connected, Retr
                     ok;
                 false ->
                     wait_for_zerortt_response(
-                        ConnRef, StreamId, Path, DownloadsDir, Connected, Retried, NewAcc
+                        Conn, StreamId, Path, DownloadsDir, Connected, Retried, NewAcc
                     )
             end;
-        {quic, ConnRef, {early_data_rejected, _}} ->
+        {quic, Conn, {early_data_rejected, _}} ->
             io:format("0-RTT: Early data rejected, resending as 1-RTT~n"),
             %% Resend request on new stream
-            resend_request_1rtt(ConnRef, Path, DownloadsDir);
-        {quic, ConnRef, {closed, Reason}} ->
+            resend_request_1rtt(Conn, Path, DownloadsDir);
+        {quic, Conn, {closed, Reason}} ->
             io:format("0-RTT: Connection closed: ~p~n", [Reason]),
             case Acc of
                 <<>> ->
@@ -602,7 +599,7 @@ wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, Connected, Retr
             true ->
                 %% 0-RTT likely rejected (server couldn't decrypt), retry as 1-RTT
                 io:format("0-RTT: No response, resending as 1-RTT~n"),
-                resend_request_1rtt(ConnRef, Path, DownloadsDir);
+                resend_request_1rtt(Conn, Path, DownloadsDir);
             false ->
                 io:format("0-RTT: Timeout~n"),
                 error
@@ -610,21 +607,21 @@ wait_for_zerortt_response(ConnRef, StreamId, Path, DownloadsDir, Connected, Retr
     end.
 
 %% Resend the request using 1-RTT (after 0-RTT was rejected)
-resend_request_1rtt(ConnRef, Path, DownloadsDir) ->
-    case quic:open_stream(ConnRef) of
+resend_request_1rtt(Conn, Path, DownloadsDir) ->
+    case quic:open_stream(Conn) of
         {ok, NewStreamId} ->
             Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-            ok = quic:send_data(ConnRef, NewStreamId, Request, true),
-            wait_for_1rtt_response(ConnRef, NewStreamId, Path, DownloadsDir, <<>>);
+            ok = quic:send_data(Conn, NewStreamId, Request, true),
+            wait_for_1rtt_response(Conn, NewStreamId, Path, DownloadsDir, <<>>);
         {error, Err} ->
             io:format("0-RTT: Failed to open 1-RTT stream: ~p~n", [Err]),
             error
     end.
 
 %% Wait for 1-RTT response
-wait_for_1rtt_response(ConnRef, StreamId, Path, DownloadsDir, Acc) ->
+wait_for_1rtt_response(Conn, StreamId, Path, DownloadsDir, Acc) ->
     receive
-        {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             NewAcc = <<Acc/binary, Data/binary>>,
             case Fin of
                 true ->
@@ -636,9 +633,9 @@ wait_for_1rtt_response(ConnRef, StreamId, Path, DownloadsDir, Acc) ->
                     ]),
                     ok;
                 false ->
-                    wait_for_1rtt_response(ConnRef, StreamId, Path, DownloadsDir, NewAcc)
+                    wait_for_1rtt_response(Conn, StreamId, Path, DownloadsDir, NewAcc)
             end;
-        {quic, ConnRef, {closed, Reason}} ->
+        {quic, Conn, {closed, Reason}} ->
             io:format("0-RTT: Connection closed during 1-RTT: ~p~n", [Reason]),
             error
     after 60000 ->
@@ -681,9 +678,9 @@ run_migration_download(Host, Port, Path, DownloadsDir) ->
         alpn => [<<"hq-interop">>, <<"h3">>]
     },
     case quic:connect(Host, Port, Opts, self()) of
-        {ok, ConnRef} ->
-            Result = wait_and_migrate_download(ConnRef, Path, DownloadsDir),
-            quic:close(ConnRef, normal),
+        {ok, Conn} ->
+            Result = wait_and_migrate_download(Conn, Path, DownloadsDir),
+            quic:close(Conn, normal),
             Result;
         {error, Reason} ->
             io:format("Migration test connection failed: ~p~n", [Reason]),
@@ -691,20 +688,20 @@ run_migration_download(Host, Port, Path, DownloadsDir) ->
     end.
 
 %% Wait for connection, start download, trigger migration mid-transfer
-wait_and_migrate_download(ConnRef, Path, DownloadsDir) ->
+wait_and_migrate_download(Conn, Path, DownloadsDir) ->
     receive
-        {quic, ConnRef, {connected, _Info}} ->
+        {quic, Conn, {connected, _Info}} ->
             io:format("Migration test: Connected~n"),
-            case quic:open_stream(ConnRef) of
+            case quic:open_stream(Conn) of
                 {ok, StreamId} ->
                     Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(ConnRef, StreamId, Request, true),
-                    receive_with_migration(ConnRef, StreamId, Path, DownloadsDir, false, <<>>);
+                    ok = quic:send_data(Conn, StreamId, Request, true),
+                    receive_with_migration(Conn, StreamId, Path, DownloadsDir, false, <<>>);
                 {error, Err} ->
                     io:format("Failed to open stream: ~p~n", [Err]),
                     error
             end;
-        {quic, ConnRef, {closed, Reason}} ->
+        {quic, Conn, {closed, Reason}} ->
             io:format("Migration test: Connection closed: ~p~n", [Reason]),
             error
     after 30000 ->
@@ -713,9 +710,9 @@ wait_and_migrate_download(ConnRef, Path, DownloadsDir) ->
     end.
 
 %% Receive data and trigger migration after first chunk
-receive_with_migration(ConnRef, StreamId, Path, DownloadsDir, Migrated, Acc) ->
+receive_with_migration(Conn, StreamId, Path, DownloadsDir, Migrated, Acc) ->
     receive
-        {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             NewAcc = <<Acc/binary, Data/binary>>,
 
             %% Trigger migration after receiving some data (but before FIN)
@@ -726,7 +723,7 @@ receive_with_migration(ConnRef, StreamId, Path, DownloadsDir, Migrated, Acc) ->
                     false when byte_size(NewAcc) > 0 ->
                         io:format("Migration test: Triggering path migration~n"),
                         %% The migrate call initiates path validation
-                        case quic:migrate(ConnRef) of
+                        case quic:migrate(Conn) of
                             ok ->
                                 io:format("Migration test: Migration initiated~n"),
                                 true;
@@ -749,12 +746,12 @@ receive_with_migration(ConnRef, StreamId, Path, DownloadsDir, Migrated, Acc) ->
                     ]),
                     ok;
                 false ->
-                    receive_with_migration(ConnRef, StreamId, Path, DownloadsDir, Migrated1, NewAcc)
+                    receive_with_migration(Conn, StreamId, Path, DownloadsDir, Migrated1, NewAcc)
             end;
-        {quic, ConnRef, {path_validated, _PathInfo}} ->
+        {quic, Conn, {path_validated, _PathInfo}} ->
             io:format("Migration test: New path validated~n"),
-            receive_with_migration(ConnRef, StreamId, Path, DownloadsDir, Migrated, Acc);
-        {quic, ConnRef, {closed, Reason}} ->
+            receive_with_migration(Conn, StreamId, Path, DownloadsDir, Migrated, Acc);
+        {quic, Conn, {closed, Reason}} ->
             io:format("Migration test: Connection closed: ~p~n", [Reason]),
             case Acc of
                 <<>> ->

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -105,8 +105,8 @@ build_server_opts(TestCase, Cert, Key, WwwDir) ->
         cert => Cert,
         key => Key,
         alpn => [<<"hq-interop">>, <<"h3">>],
-        connection_handler => fun(ConnPid, ConnRef) ->
-            spawn_handler(ConnPid, ConnRef, WwwDir, TestCase)
+        connection_handler => fun(ConnPid, Conn) ->
+            spawn_handler(ConnPid, Conn, WwwDir, TestCase)
         end
     },
 
@@ -144,50 +144,50 @@ decode_key_entry('PrivateKeyInfo', Der) ->
 decode_key_entry(Type, _Der) ->
     error({unsupported_key_type, Type}).
 
-spawn_handler(ConnPid, ConnRef, WwwDir, TestCase) ->
+spawn_handler(ConnPid, Conn, WwwDir, TestCase) ->
     HandlerPid = spawn(fun() ->
-        connection_handler(ConnPid, ConnRef, WwwDir, TestCase)
+        connection_handler(ConnPid, Conn, WwwDir, TestCase)
     end),
     {ok, HandlerPid}.
 
-connection_handler(ConnPid, ConnRef, WwwDir, TestCase) ->
+connection_handler(ConnPid, Conn, WwwDir, TestCase) ->
     io:format("Handler started, waiting for messages...~n"),
     %% Wait for stream data
     receive
-        {quic, ConnRef, {connected, Info}} ->
+        {quic, Conn, {connected, Info}} ->
             io:format("Handler got connected: ~p~n", [Info]),
-            connection_handler(ConnPid, ConnRef, WwwDir, TestCase);
-        {quic, ConnRef, {stream_opened, StreamId}} ->
+            connection_handler(ConnPid, Conn, WwwDir, TestCase);
+        {quic, Conn, {stream_opened, StreamId}} ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
-            handle_stream(ConnPid, ConnRef, StreamId, WwwDir, TestCase);
-        {quic, ConnRef, {stream_data, StreamId, Data, Fin}} ->
+            handle_stream(ConnPid, Conn, StreamId, WwwDir, TestCase);
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             io:format(
                 "Handler got stream_data: stream=~p size=~p fin=~p~n",
                 [StreamId, byte_size(Data), Fin]
             ),
             %% Handle request
-            handle_request(ConnPid, ConnRef, StreamId, Data, WwwDir, TestCase);
-        {quic, ConnRef, {closed, Reason}} ->
+            handle_request(ConnPid, Conn, StreamId, Data, WwwDir, TestCase);
+        {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
         Other ->
             io:format("Handler got unexpected: ~p~n", [Other]),
-            connection_handler(ConnPid, ConnRef, WwwDir, TestCase)
+            connection_handler(ConnPid, Conn, WwwDir, TestCase)
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
     end.
 
-handle_stream(_ConnPid, ConnRef, StreamId, WwwDir, TestCase) ->
+handle_stream(_ConnPid, Conn, StreamId, WwwDir, TestCase) ->
     %% Wait for request on this stream
     receive
-        {quic, ConnRef, {stream_data, StreamId, Data, _Fin}} ->
-            handle_request(undefined, ConnRef, StreamId, Data, WwwDir, TestCase)
+        {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
+            handle_request(undefined, Conn, StreamId, Data, WwwDir, TestCase)
     after 30000 ->
         ok
     end.
 
-handle_request(_ConnPid, ConnRef, StreamId, Data, WwwDir, TestCase) ->
+handle_request(_ConnPid, Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),
     %% Parse simple HTTP/0.9 request: "GET /path\r\n"
     case parse_request(Data) of
@@ -196,10 +196,7 @@ handle_request(_ConnPid, ConnRef, StreamId, Data, WwwDir, TestCase) ->
             %% Handle key update test
             case TestCase of
                 "keyupdate" ->
-                    case quic_connection:lookup(ConnRef) of
-                        {ok, Pid} -> quic_connection:key_update(Pid);
-                        _ -> ok
-                    end;
+                    quic_connection:key_update(Conn);
                 _ ->
                     ok
             end,
@@ -210,16 +207,16 @@ handle_request(_ConnPid, ConnRef, StreamId, Data, WwwDir, TestCase) ->
             case file:read_file(FilePath) of
                 {ok, Content} ->
                     io:format("Sending ~p bytes on stream ~p~n", [byte_size(Content), StreamId]),
-                    Result = quic:send_data(ConnRef, StreamId, Content, true),
+                    Result = quic:send_data(Conn, StreamId, Content, true),
                     io:format("send_data result: ~p~n", [Result]),
                     Result;
                 {error, ReadErr} ->
                     io:format("File read error: ~p, sending 404~n", [ReadErr]),
-                    quic:send_data(ConnRef, StreamId, <<"404 Not Found">>, true)
+                    quic:send_data(Conn, StreamId, <<"404 Not Found">>, true)
             end;
         error ->
             io:format("Parse error, sending 400~n"),
-            quic:send_data(ConnRef, StreamId, <<"400 Bad Request">>, true)
+            quic:send_data(Conn, StreamId, <<"400 Bad Request">>, true)
     end.
 
 parse_request(Data) ->

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -13,21 +13,21 @@
 %%%
 %%% == Messages ==
 %%%
-%%% Messages sent to owner process:
+%%% Messages sent to owner process (Conn is the connection pid):
 %%% <ul>
-%%%   <li>`{quic, ConnRef, {connected, Info}}' - Connection established</li>
-%%%   <li>`{quic, ConnRef, {stream_opened, StreamId}}' - Stream opened</li>
-%%%   <li>`{quic, ConnRef, {closed, Reason}}' - Connection closed</li>
-%%%   <li>`{quic, ConnRef, {transport_error, Code, Reason}}' - Transport error</li>
-%%%   <li>`{quic, ConnRef, {stream_data, StreamId, Bin, Fin}}' - Data received</li>
-%%%   <li>`{quic, ConnRef, {stream_reset, StreamId, ErrorCode}}' - Stream reset</li>
-%%%   <li>`{quic, ConnRef, {stop_sending, StreamId, ErrorCode}}' - Stop sending</li>
-%%%   <li>`{quic, ConnRef, {goaway, LastStreamId, ErrorCode, Debug}}' - GoAway received</li>
-%%%   <li>`{quic, ConnRef, {session_ticket, Ticket}}' - Session ticket for 0-RTT</li>
-%%%   <li>`{quic, ConnRef, {send_ready, StreamId}}' - Stream ready to write</li>
-%%%   <li>`{quic, ConnRef, {timer, NextTimeoutMs}}' - Timer notification</li>
-%%%   <li>`{quic, ConnRef, {datagram, Data}}' - Datagram received (RFC 9221)</li>
-%%%   <li>`{quic, ConnRef, {stream_deadline, StreamId}}' - Stream deadline expired</li>
+%%%   <li>`{quic, Conn, {connected, Info}}' - Connection established</li>
+%%%   <li>`{quic, Conn, {stream_opened, StreamId}}' - Stream opened</li>
+%%%   <li>`{quic, Conn, {closed, Reason}}' - Connection closed</li>
+%%%   <li>`{quic, Conn, {transport_error, Code, Reason}}' - Transport error</li>
+%%%   <li>`{quic, Conn, {stream_data, StreamId, Bin, Fin}}' - Data received</li>
+%%%   <li>`{quic, Conn, {stream_reset, StreamId, ErrorCode}}' - Stream reset</li>
+%%%   <li>`{quic, Conn, {stop_sending, StreamId, ErrorCode}}' - Stop sending</li>
+%%%   <li>`{quic, Conn, {goaway, LastStreamId, ErrorCode, Debug}}' - GoAway received</li>
+%%%   <li>`{quic, Conn, {session_ticket, Ticket}}' - Session ticket for 0-RTT</li>
+%%%   <li>`{quic, Conn, {send_ready, StreamId}}' - Stream ready to write</li>
+%%%   <li>`{quic, Conn, {timer, NextTimeoutMs}}' - Timer notification</li>
+%%%   <li>`{quic, Conn, {datagram, Data}}' - Datagram received (RFC 9221)</li>
+%%%   <li>`{quic, Conn, {stream_deadline, StreamId}}' - Stream deadline expired</li>
 %%% </ul>
 %%%
 
@@ -139,8 +139,8 @@ get_fd(Socket) ->
     end.
 
 %% @doc Connect to a QUIC server.
-%% Returns {ok, ConnRef} on success where ConnRef is a reference().
-%% The owner process will receive {quic, ConnRef, {connected, Info}}
+%% Returns {ok, Conn} on success where Conn is a pid().
+%% The owner process will receive {quic, Conn, {connected, Info}}
 %% when the connection is established.
 %%
 %% Options:
@@ -151,7 +151,7 @@ get_fd(Socket) ->
 %%   <li>`alpn' - ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
 %%   <li>`server_name' - Server Name Indication (default: Host)</li>
 %% </ul>
--spec connect(Host, Port, Opts, Owner) -> {ok, reference()} | {error, term()} when
+-spec connect(Host, Port, Opts, Owner) -> {ok, pid()} | {error, term()} when
     Host :: binary() | string(),
     Port :: inet:port_number(),
     Opts :: map(),
@@ -170,8 +170,7 @@ connect(Host, Port, Opts, Owner) when
     Socket = maps:get(socket, Opts, undefined),
     case quic_connection:start_link(Host, Port, Opts, Owner, Socket) of
         {ok, Pid} ->
-            ConnRef = gen_statem:call(Pid, get_ref),
-            {ok, ConnRef};
+            {ok, Pid};
         Error ->
             Error
     end;
@@ -179,374 +178,218 @@ connect(_Host, _Port, _Opts, _Owner) ->
     {error, badarg}.
 
 %% @doc Close a QUIC connection.
--spec close(ConnRef, Reason) -> ok when
-    ConnRef :: reference() | pid(),
+-spec close(Conn, Reason) -> ok when
+    Conn :: pid(),
     Reason :: term().
-close(ConnRef, Reason) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:close(Pid, Reason);
-        error -> ok
-    end;
-close(ConnPid, Reason) when is_pid(ConnPid) ->
-    quic_connection:close(ConnPid, Reason).
+close(Conn, Reason) when is_pid(Conn) ->
+    quic_connection:close(Conn, Reason).
 
 %% @doc Open a new bidirectional stream.
 %% Returns {ok, StreamId} on success.
--spec open_stream(ConnRef) -> {ok, non_neg_integer()} | {error, term()} when
-    ConnRef :: reference() | pid().
-open_stream(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:open_stream(Pid);
-        error -> {error, not_found}
-    end;
-open_stream(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:open_stream(ConnPid).
+-spec open_stream(Conn) -> {ok, non_neg_integer()} | {error, term()} when
+    Conn :: pid().
+open_stream(Conn) when is_pid(Conn) ->
+    quic_connection:open_stream(Conn).
 
 %% @doc Open a new unidirectional stream.
 %% Returns {ok, StreamId} on success.
 %% Unidirectional streams are send-only for the initiator.
--spec open_unidirectional_stream(ConnRef) -> {ok, non_neg_integer()} | {error, term()} when
-    ConnRef :: reference() | pid().
-open_unidirectional_stream(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:open_unidirectional_stream(Pid);
-        error -> {error, not_found}
-    end;
-open_unidirectional_stream(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:open_unidirectional_stream(ConnPid).
+-spec open_unidirectional_stream(Conn) -> {ok, non_neg_integer()} | {error, term()} when
+    Conn :: pid().
+open_unidirectional_stream(Conn) when is_pid(Conn) ->
+    quic_connection:open_unidirectional_stream(Conn).
 
 %% @doc Send data on a stream.
 %% Fin indicates if this is the final frame on the stream.
--spec send_data(ConnRef, StreamId, Data, Fin) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec send_data(Conn, StreamId, Data, Fin) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     Data :: iodata(),
     Fin :: boolean().
-send_data(ConnRef, StreamId, Data, Fin) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:send_data(Pid, StreamId, Data, Fin);
-        error -> {error, not_found}
-    end;
-send_data(ConnPid, StreamId, Data, Fin) when is_pid(ConnPid) ->
-    quic_connection:send_data(ConnPid, StreamId, Data, Fin);
-send_data(_ConnRef, _StreamId, _Data, _Fin) ->
-    {error, badarg}.
+send_data(Conn, StreamId, Data, Fin) when is_pid(Conn) ->
+    quic_connection:send_data(Conn, StreamId, Data, Fin).
 
 %% @doc Send data on a stream with a timeout.
 %% Fin indicates if this is the final frame on the stream.
 %% Timeout is in milliseconds; if the operation takes longer, returns {error, timeout}.
--spec send_data(ConnRef, StreamId, Data, Fin, Timeout) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec send_data(Conn, StreamId, Data, Fin, Timeout) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     Data :: iodata(),
     Fin :: boolean(),
     Timeout :: timeout().
-send_data(ConnRef, StreamId, Data, Fin, Timeout) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} ->
-            try
-                gen_statem:call(Pid, {send_data, StreamId, Data, Fin}, Timeout)
-            catch
-                exit:{timeout, _} -> {error, timeout}
-            end;
-        error ->
-            {error, not_found}
-    end;
-send_data(ConnPid, StreamId, Data, Fin, Timeout) when is_pid(ConnPid) ->
+send_data(Conn, StreamId, Data, Fin, Timeout) when is_pid(Conn) ->
     try
-        gen_statem:call(ConnPid, {send_data, StreamId, Data, Fin}, Timeout)
+        gen_statem:call(Conn, {send_data, StreamId, Data, Fin}, Timeout)
     catch
         exit:{timeout, _} -> {error, timeout}
-    end;
-send_data(_ConnRef, _StreamId, _Data, _Fin, _Timeout) ->
-    {error, badarg}.
+    end.
 
 %% @doc Reset a stream with an error code.
--spec reset_stream(ConnRef, StreamId, ErrorCode) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec reset_stream(Conn, StreamId, ErrorCode) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     ErrorCode :: non_neg_integer().
-reset_stream(ConnRef, StreamId, ErrorCode) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:reset_stream(Pid, StreamId, ErrorCode);
-        error -> {error, not_found}
-    end;
-reset_stream(ConnPid, StreamId, ErrorCode) when is_pid(ConnPid) ->
-    quic_connection:reset_stream(ConnPid, StreamId, ErrorCode);
-reset_stream(_ConnRef, _StreamId, _ErrorCode) ->
-    {error, badarg}.
+reset_stream(Conn, StreamId, ErrorCode) when is_pid(Conn) ->
+    quic_connection:reset_stream(Conn, StreamId, ErrorCode).
 
 %% @doc Request peer to stop sending on a stream.
 %% Sends a STOP_SENDING frame (RFC 9000 Section 19.5).
--spec stop_sending(ConnRef, StreamId, ErrorCode) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec stop_sending(Conn, StreamId, ErrorCode) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     ErrorCode :: non_neg_integer().
-stop_sending(ConnRef, StreamId, ErrorCode) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:stop_sending(Pid, StreamId, ErrorCode);
-        error -> {error, not_found}
-    end;
-stop_sending(ConnPid, StreamId, ErrorCode) when is_pid(ConnPid) ->
-    quic_connection:stop_sending(ConnPid, StreamId, ErrorCode);
-stop_sending(_ConnRef, _StreamId, _ErrorCode) ->
-    {error, badarg}.
+stop_sending(Conn, StreamId, ErrorCode) when is_pid(Conn) ->
+    quic_connection:stop_sending(Conn, StreamId, ErrorCode).
 
 %% @doc Handle connection timeout.
 %% Should be called when timer expires.
 %% Returns next timeout in ms or 'infinity'.
--spec handle_timeout(ConnRef, NowMs) -> non_neg_integer() | infinity when
-    ConnRef :: reference() | pid(),
+-spec handle_timeout(Conn, NowMs) -> non_neg_integer() | infinity when
+    Conn :: pid(),
     NowMs :: non_neg_integer().
-handle_timeout(ConnRef, NowMs) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:handle_timeout(Pid, NowMs);
-        error -> infinity
-    end;
-handle_timeout(ConnPid, NowMs) when is_pid(ConnPid) ->
-    quic_connection:handle_timeout(ConnPid, NowMs);
-handle_timeout(_ConnRef, _NowMs) ->
-    infinity.
+handle_timeout(Conn, NowMs) when is_pid(Conn) ->
+    quic_connection:handle_timeout(Conn, NowMs).
 
 %% @doc Process pending QUIC events.
 %% This is called automatically by the connection process.
-%% Returns the next timeout in milliseconds, or 'infinity'.
--spec process(ConnRef) -> non_neg_integer() | infinity when
-    ConnRef :: reference() | pid().
-process(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:process(Pid);
-        error -> infinity
-    end;
-process(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:process(ConnPid).
+-spec process(Conn) -> ok when
+    Conn :: pid().
+process(Conn) when is_pid(Conn) ->
+    quic_connection:process(Conn).
 
 %% @doc Get the remote address of the connection.
--spec peername(ConnRef) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()} when
-    ConnRef :: reference() | pid().
-peername(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:peername(Pid);
-        error -> {error, not_found}
-    end;
-peername(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:peername(ConnPid).
+-spec peername(Conn) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()} when
+    Conn :: pid().
+peername(Conn) when is_pid(Conn) ->
+    quic_connection:peername(Conn).
 
 %% @doc Get the local address of the connection.
--spec sockname(ConnRef) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()} when
-    ConnRef :: reference() | pid().
-sockname(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:sockname(Pid);
-        error -> {error, not_found}
-    end;
-sockname(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:sockname(ConnPid).
+-spec sockname(Conn) -> {ok, {inet:ip_address(), inet:port_number()}} | {error, term()} when
+    Conn :: pid().
+sockname(Conn) when is_pid(Conn) ->
+    quic_connection:sockname(Conn).
 
 %% @doc Get the peer certificate.
 %% Returns the DER-encoded certificate of the peer if available.
--spec peercert(ConnRef) -> {ok, binary()} | {error, term()} when
-    ConnRef :: reference() | pid().
-peercert(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:peercert(Pid);
-        error -> {error, not_found}
-    end;
-peercert(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:peercert(ConnPid).
+-spec peercert(Conn) -> {ok, binary()} | {error, term()} when
+    Conn :: pid().
+peercert(Conn) when is_pid(Conn) ->
+    quic_connection:peercert(Conn).
 
 %% @doc Set the owner process for a connection.
 %% Similar to gen_tcp:controlling_process/2.
--spec set_owner(ConnRef, NewOwner) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec set_owner(Conn, NewOwner) -> ok | {error, term()} when
+    Conn :: pid(),
     NewOwner :: pid().
-set_owner(ConnRef, NewOwner) when is_reference(ConnRef), is_pid(NewOwner) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:set_owner(Pid, NewOwner);
-        error -> {error, not_found}
-    end;
-set_owner(ConnPid, NewOwner) when is_pid(ConnPid), is_pid(NewOwner) ->
-    quic_connection:set_owner(ConnPid, NewOwner);
-set_owner(_ConnRef, _NewOwner) ->
-    {error, badarg}.
+set_owner(Conn, NewOwner) when is_pid(Conn), is_pid(NewOwner) ->
+    quic_connection:set_owner(Conn, NewOwner).
 
 %% @doc Set the owner process for a connection (synchronous).
 %% Use this when you need to ensure ownership is transferred before continuing.
--spec set_owner_sync(ConnRef, NewOwner) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec set_owner_sync(Conn, NewOwner) -> ok | {error, term()} when
+    Conn :: pid(),
     NewOwner :: pid().
-set_owner_sync(ConnRef, NewOwner) when is_reference(ConnRef), is_pid(NewOwner) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:set_owner_sync(Pid, NewOwner);
-        error -> {error, not_found}
-    end;
-set_owner_sync(ConnPid, NewOwner) when is_pid(ConnPid), is_pid(NewOwner) ->
-    quic_connection:set_owner_sync(ConnPid, NewOwner);
-set_owner_sync(_ConnRef, _NewOwner) ->
-    {error, badarg}.
+set_owner_sync(Conn, NewOwner) when is_pid(Conn), is_pid(NewOwner) ->
+    quic_connection:set_owner_sync(Conn, NewOwner).
 
 %% @doc Send a datagram on the connection.
 %% Datagrams are unreliable and may be lost.
--spec send_datagram(ConnRef, Data) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec send_datagram(Conn, Data) -> ok | {error, term()} when
+    Conn :: pid(),
     Data :: iodata().
-send_datagram(ConnRef, Data) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:send_datagram(Pid, Data);
-        error -> {error, not_found}
-    end;
-send_datagram(ConnPid, Data) when is_pid(ConnPid) ->
-    quic_connection:send_datagram(ConnPid, Data);
-send_datagram(_ConnRef, _Data) ->
-    {error, badarg}.
+send_datagram(Conn, Data) when is_pid(Conn) ->
+    quic_connection:send_datagram(Conn, Data).
 
 %% @doc Get maximum datagram payload size.
 %% Returns 0 if peer doesn't support datagrams (RFC 9221).
 %% The returned size is the peer's advertised max_datagram_frame_size.
--spec datagram_max_size(ConnRef) -> non_neg_integer() | {error, term()} when
-    ConnRef :: reference() | pid().
-datagram_max_size(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:datagram_max_size(Pid);
-        error -> {error, not_found}
-    end;
-datagram_max_size(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:datagram_max_size(ConnPid);
-datagram_max_size(_ConnRef) ->
-    {error, badarg}.
+-spec datagram_max_size(Conn) -> non_neg_integer() | {error, term()} when
+    Conn :: pid().
+datagram_max_size(Conn) when is_pid(Conn) ->
+    quic_connection:datagram_max_size(Conn).
 
 %% @doc Set connection options.
--spec setopts(ConnRef, Opts) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec setopts(Conn, Opts) -> ok | {error, term()} when
+    Conn :: pid(),
     Opts :: [{atom(), term()}].
-setopts(ConnRef, Opts) when is_reference(ConnRef), is_list(Opts) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:setopts(Pid, Opts);
-        error -> {error, not_found}
-    end;
-setopts(ConnPid, Opts) when is_pid(ConnPid), is_list(Opts) ->
-    quic_connection:setopts(ConnPid, Opts);
-setopts(_ConnRef, _Opts) ->
-    {error, badarg}.
+setopts(Conn, Opts) when is_pid(Conn), is_list(Opts) ->
+    quic_connection:setopts(Conn, Opts).
 
 %% @doc Trigger connection migration to a new local address.
 %% This initiates path validation on a new network path.
 %% The connection will send PATH_CHALLENGE and wait for PATH_RESPONSE.
--spec migrate(ConnRef) -> ok | {error, term()} when
-    ConnRef :: reference() | pid().
-migrate(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:migrate(Pid);
-        error -> {error, not_found}
-    end;
-migrate(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:migrate(ConnPid);
-migrate(_ConnRef) ->
-    {error, badarg}.
+-spec migrate(Conn) -> ok | {error, term()} when
+    Conn :: pid().
+migrate(Conn) when is_pid(Conn) ->
+    quic_connection:migrate(Conn).
 
 %% @doc Set the priority for a stream.
 %% Urgency: 0-7 (lower = more urgent, default 3)
 %% Incremental: boolean (data can be processed incrementally, default false)
 %% Per RFC 9218 (Extensible Priorities for HTTP).
--spec set_stream_priority(ConnRef, StreamId, Urgency, Incremental) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec set_stream_priority(Conn, StreamId, Urgency, Incremental) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     Urgency :: 0..7,
     Incremental :: boolean().
-set_stream_priority(ConnRef, StreamId, Urgency, Incremental) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:set_stream_priority(Pid, StreamId, Urgency, Incremental);
-        error -> {error, not_found}
-    end;
-set_stream_priority(ConnPid, StreamId, Urgency, Incremental) when is_pid(ConnPid) ->
-    quic_connection:set_stream_priority(ConnPid, StreamId, Urgency, Incremental);
-set_stream_priority(_ConnRef, _StreamId, _Urgency, _Incremental) ->
-    {error, badarg}.
+set_stream_priority(Conn, StreamId, Urgency, Incremental) when is_pid(Conn) ->
+    quic_connection:set_stream_priority(Conn, StreamId, Urgency, Incremental).
 
 %% @doc Get the priority for a stream.
 %% Returns {ok, {Urgency, Incremental}} or {error, not_found}.
--spec get_stream_priority(ConnRef, StreamId) -> {ok, {0..7, boolean()}} | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec get_stream_priority(Conn, StreamId) -> {ok, {0..7, boolean()}} | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer().
-get_stream_priority(ConnRef, StreamId) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:get_stream_priority(Pid, StreamId);
-        error -> {error, not_found}
-    end;
-get_stream_priority(ConnPid, StreamId) when is_pid(ConnPid) ->
-    quic_connection:get_stream_priority(ConnPid, StreamId);
-get_stream_priority(_ConnRef, _StreamId) ->
-    {error, badarg}.
+get_stream_priority(Conn, StreamId) when is_pid(Conn) ->
+    quic_connection:get_stream_priority(Conn, StreamId).
 
 %% @doc Set a deadline for a stream.
 %% TimeoutMs is the number of milliseconds from now until the deadline expires.
 %% When the deadline expires, the stream will be reset and/or the owner will be notified.
 %% Default action is 'both' (notify + reset).
--spec set_stream_deadline(ConnRef, StreamId, TimeoutMs) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec set_stream_deadline(Conn, StreamId, TimeoutMs) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     TimeoutMs :: pos_integer().
-set_stream_deadline(ConnRef, StreamId, TimeoutMs) ->
-    set_stream_deadline(ConnRef, StreamId, TimeoutMs, #{}).
+set_stream_deadline(Conn, StreamId, TimeoutMs) ->
+    set_stream_deadline(Conn, StreamId, TimeoutMs, #{}).
 
 %% @doc Set a deadline for a stream with options.
 %% TimeoutMs is the number of milliseconds from now until the deadline expires.
 %%
 %% Options:
 %% - `action': What to do when deadline expires:
-%%   - `notify': Send `{quic, ConnRef, {stream_deadline, StreamId}}' to owner
+%%   - `notify': Send `{quic, Conn, {stream_deadline, StreamId}}' to owner
 %%   - `reset': Send RESET_STREAM and clean up
 %%   - `both' (default): Notify AND reset
 %% - `error_code': Error code for RESET_STREAM (default: 16#FF)
--spec set_stream_deadline(ConnRef, StreamId, TimeoutMs, Opts) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec set_stream_deadline(Conn, StreamId, TimeoutMs, Opts) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer(),
     TimeoutMs :: pos_integer(),
     Opts :: #{action => reset | notify | both, error_code => non_neg_integer()}.
-set_stream_deadline(ConnRef, StreamId, TimeoutMs, Opts) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} ->
-            quic_connection:set_stream_deadline(Pid, StreamId, TimeoutMs, Opts);
-        error ->
-            {error, not_found}
-    end;
-set_stream_deadline(ConnPid, StreamId, TimeoutMs, Opts) when is_pid(ConnPid) ->
-    quic_connection:set_stream_deadline(ConnPid, StreamId, TimeoutMs, Opts);
-set_stream_deadline(_ConnRef, _StreamId, _TimeoutMs, _Opts) ->
-    {error, badarg}.
+set_stream_deadline(Conn, StreamId, TimeoutMs, Opts) when is_pid(Conn) ->
+    quic_connection:set_stream_deadline(Conn, StreamId, TimeoutMs, Opts).
 
 %% @doc Cancel a stream deadline.
 %% Returns ok if the deadline was cancelled, or {error, not_found} if no deadline exists.
--spec cancel_stream_deadline(ConnRef, StreamId) -> ok | {error, term()} when
-    ConnRef :: reference() | pid(),
+-spec cancel_stream_deadline(Conn, StreamId) -> ok | {error, term()} when
+    Conn :: pid(),
     StreamId :: non_neg_integer().
-cancel_stream_deadline(ConnRef, StreamId) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:cancel_stream_deadline(Pid, StreamId);
-        error -> {error, not_found}
-    end;
-cancel_stream_deadline(ConnPid, StreamId) when is_pid(ConnPid) ->
-    quic_connection:cancel_stream_deadline(ConnPid, StreamId);
-cancel_stream_deadline(_ConnRef, _StreamId) ->
-    {error, badarg}.
+cancel_stream_deadline(Conn, StreamId) when is_pid(Conn) ->
+    quic_connection:cancel_stream_deadline(Conn, StreamId).
 
 %% @doc Get the remaining time for a stream deadline.
 %% Returns {ok, {RemainingMs, Action}} where RemainingMs is milliseconds until expiry.
 %% Returns {error, no_deadline} if no deadline is set.
--spec get_stream_deadline(ConnRef, StreamId) ->
+-spec get_stream_deadline(Conn, StreamId) ->
     {ok, {non_neg_integer() | infinity, reset | notify | both}} | {error, term()}
 when
-    ConnRef :: reference() | pid(),
+    Conn :: pid(),
     StreamId :: non_neg_integer().
-get_stream_deadline(ConnRef, StreamId) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:get_stream_deadline(Pid, StreamId);
-        error -> {error, not_found}
-    end;
-get_stream_deadline(ConnPid, StreamId) when is_pid(ConnPid) ->
-    quic_connection:get_stream_deadline(ConnPid, StreamId);
-get_stream_deadline(_ConnRef, _StreamId) ->
-    {error, badarg}.
+get_stream_deadline(Conn, StreamId) when is_pid(Conn) ->
+    quic_connection:get_stream_deadline(Conn, StreamId).
 
 %% @doc Get send queue information for a connection.
 %% This can be used by distribution controllers or other high-level
@@ -560,17 +403,10 @@ get_stream_deadline(_ConnRef, _StreamId) ->
 %% - `congested': Whether backpressure should be applied
 %%
 %% @see quic_dist_controller for usage example
--spec get_send_queue_info(ConnRef) -> {ok, send_queue_info()} | {error, term()} when
-    ConnRef :: reference() | pid().
-get_send_queue_info(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:get_send_queue_info(Pid);
-        error -> {error, not_found}
-    end;
-get_send_queue_info(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:get_send_queue_info(ConnPid);
-get_send_queue_info(_ConnRef) ->
-    {error, badarg}.
+-spec get_send_queue_info(Conn) -> {ok, send_queue_info()} | {error, term()} when
+    Conn :: pid().
+get_send_queue_info(Conn) when is_pid(Conn) ->
+    quic_connection:get_send_queue_info(Conn).
 
 %% @doc Get connection statistics for liveness detection.
 %%
@@ -584,17 +420,10 @@ get_send_queue_info(_ConnRef) ->
 %% - `data_sent': Total bytes of application data sent
 %%
 %% @see quic_dist_controller for usage in distribution tick checking
--spec get_stats(ConnRef) -> {ok, map()} | {error, term()} when
-    ConnRef :: reference() | pid().
-get_stats(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:get_stats(Pid);
-        error -> {error, not_found}
-    end;
-get_stats(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:get_stats(ConnPid);
-get_stats(_ConnRef) ->
-    {error, badarg}.
+-spec get_stats(Conn) -> {ok, map()} | {error, term()} when
+    Conn :: pid().
+get_stats(Conn) when is_pid(Conn) ->
+    quic_connection:get_stats(Conn).
 
 %% @doc Send a PING frame on the connection.
 %%
@@ -604,17 +433,10 @@ get_stats(_ConnRef) ->
 %% even when the connection is congested.
 %%
 %% Returns `ok' if the PING was sent, or `{error, Reason}' if it failed.
--spec send_ping(ConnRef) -> ok | {error, term()} when
-    ConnRef :: reference() | pid().
-send_ping(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:send_ping(Pid);
-        error -> {error, not_found}
-    end;
-send_ping(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:send_ping(ConnPid);
-send_ping(_ConnRef) ->
-    {error, badarg}.
+-spec send_ping(Conn) -> ok | {error, term()} when
+    Conn :: pid().
+send_ping(Conn) when is_pid(Conn) ->
+    quic_connection:send_ping(Conn).
 
 %% @doc Get the current MTU for a connection.
 %%
@@ -624,17 +446,10 @@ send_ping(_ConnRef) ->
 %%
 %% Returns `{ok, MTU}' where MTU is the current maximum packet size,
 %% or `{error, not_found}' if the connection doesn't exist.
--spec get_mtu(ConnRef) -> {ok, pos_integer()} | {error, term()} when
-    ConnRef :: reference() | pid().
-get_mtu(ConnRef) when is_reference(ConnRef) ->
-    case quic_connection:lookup(ConnRef) of
-        {ok, Pid} -> quic_connection:get_mtu(Pid);
-        error -> {error, not_found}
-    end;
-get_mtu(ConnPid) when is_pid(ConnPid) ->
-    quic_connection:get_mtu(ConnPid);
-get_mtu(_ConnRef) ->
-    {error, badarg}.
+-spec get_mtu(Conn) -> {ok, pos_integer()} | {error, term()} when
+    Conn :: pid().
+get_mtu(Conn) when is_pid(Conn) ->
+    quic_connection:get_mtu(Conn).
 
 %%====================================================================
 %% Server Management API
@@ -651,7 +466,7 @@ get_mtu(_ConnRef) ->
 %%   <li>`key' - Private key term (required)</li>
 %%   <li>`alpn' - List of ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
 %%   <li>`pool_size' - Number of listener processes (default: 1)</li>
-%%   <li>`connection_handler' - Fun(ConnPid, ConnRef) -> {ok, HandlerPid}</li>
+%%   <li>`connection_handler' - Fun(Conn) -> {ok, HandlerPid} where Conn is the pid</li>
 %% </ul>
 %%
 %% Example:

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -21,10 +21,10 @@
 %%%
 %%% == Messages to Owner ==
 %%%
-%%% {quic, ConnRef, {connected, Info}}
-%%% {quic, ConnRef, {stream_data, StreamId, Data, Fin}}
-%%% {quic, ConnRef, {stream_opened, StreamId}}
-%%% {quic, ConnRef, {closed, Reason}}
+%%% {quic, Conn, {connected, Info}}         where Conn is the connection pid
+%%% {quic, Conn, {stream_data, StreamId, Data, Fin}}
+%%% {quic, Conn, {stream_opened, StreamId}}
+%%% {quic, Conn, {closed, Reason}}
 %%%
 
 -module(quic_connection).
@@ -50,13 +50,6 @@
     ]}
 ).
 -dialyzer([no_match]).
-
-%% Registry API
--export([
-    register_conn/2,
-    unregister_conn/1,
-    lookup/1
-]).
 
 %% API
 -export([
@@ -133,9 +126,6 @@
 ]).
 -endif.
 
-%% Registry table name
--define(REGISTRY, quic_connection_registry).
-
 %% TLS handshake states (client)
 -define(TLS_AWAITING_SERVER_HELLO, awaiting_server_hello).
 -define(TLS_AWAITING_ENCRYPTED_EXT, awaiting_encrypted_extensions).
@@ -177,7 +167,7 @@
     remote_addr :: {inet:ip_address(), inet:port_number()},
     local_addr :: {inet:ip_address(), inet:port_number()} | undefined,
 
-    %% Owner process (receives {quic, Ref, Event} messages)
+    %% Owner process (receives {quic, Conn, Event} messages where Conn is pid())
     owner :: pid(),
     conn_ref :: reference(),
 
@@ -364,49 +354,6 @@
     %% QLOG Tracing (draft-ietf-quic-qlog-quic-events)
     qlog_ctx :: #qlog_ctx{} | undefined
 }).
-
-%%====================================================================
-%% Registry API
-%%====================================================================
-
-%% @doc Register a connection reference to a pid.
--spec register_conn(reference(), pid()) -> ok.
-register_conn(ConnRef, Pid) ->
-    ensure_registry(),
-    ets:insert(?REGISTRY, {ConnRef, Pid}),
-    ok.
-
-%% @doc Unregister a connection reference.
--spec unregister_conn(reference()) -> ok.
-unregister_conn(ConnRef) ->
-    (try
-        ets:delete(?REGISTRY, ConnRef)
-    catch
-        _:_ -> ok
-    end),
-    ok.
-
-%% @doc Lookup a connection pid by reference.
--spec lookup(reference()) -> {ok, pid()} | error.
-lookup(ConnRef) ->
-    ensure_registry(),
-    case ets:lookup(?REGISTRY, ConnRef) of
-        [{_, Pid}] -> {ok, Pid};
-        [] -> error
-    end.
-
-ensure_registry() ->
-    case ets:whereis(?REGISTRY) of
-        undefined ->
-            try
-                ets:new(?REGISTRY, [named_table, public, set, {read_concurrency, true}])
-            catch
-                % Already exists (race condition)
-                error:badarg -> ok
-            end;
-        _ ->
-            ok
-    end.
 
 %%====================================================================
 %% API
@@ -705,9 +652,8 @@ init({server, Opts}) ->
         sent_packets = #{}
     },
 
-    %% Create connection reference and register
+    %% Create connection reference (for internal use only)
     ConnRef = make_ref(),
-    register_conn(ConnRef, self()),
 
     %% Initialize congestion control and loss detection
     %% Support configurable initial cwnd for distribution workloads
@@ -915,9 +861,8 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         sent_packets = #{}
     },
 
-    %% Create connection reference and register
+    %% Create connection reference (for internal use only)
     ConnRef = make_ref(),
-    register_conn(ConnRef, self()),
 
     %% Get server name for SNI
     ServerName =
@@ -1011,7 +956,6 @@ terminate(
     StateName,
     #state{
         socket = Socket,
-        conn_ref = ConnRef,
         pto_timer = PtoTimer,
         idle_timer = IdleTimer,
         keep_alive_timer = KeepAliveTimer,
@@ -1034,7 +978,6 @@ terminate(
                 _:_ -> ok
             end
     end,
-    unregister_conn(ConnRef),
     %% Cancel any active timers
     cancel_timer(PtoTimer),
     cancel_timer(IdleTimer),
@@ -1211,7 +1154,6 @@ connected(
     OldState,
     #state{
         owner = Owner,
-        conn_ref = Ref,
         alpn = Alpn,
         socket = Socket,
         role = Role,
@@ -1226,7 +1168,7 @@ connected(
         alpn => Alpn,
         alpn_protocol => Alpn
     },
-    Owner ! {quic, Ref, {connected, Info}},
+    Owner ! {quic, self(), {connected, Info}},
     %% For client connections, ensure socket is active for receiving
     %% Server connections receive via listener (quic_packet messages)
     case Role of
@@ -1490,7 +1432,6 @@ draining(
     _OldState,
     #state{
         owner = Owner,
-        conn_ref = Ref,
         close_reason = Reason,
         loss_state = LossState,
         qlog_ctx = QlogCtx
@@ -1499,7 +1440,7 @@ draining(
     %% Emit qlog connection_closed event
     quic_qlog:connection_closed(QlogCtx, close_reason_to_code(Reason), undefined),
 
-    Owner ! {quic, Ref, {closed, Reason}},
+    Owner ! {quic, self(), {closed, Reason}},
     %% Start drain timer (3 * PTO per RFC 9000 Section 10.2)
     DrainTimeout =
         case LossState of
@@ -3204,7 +3145,7 @@ process_frame(_Level, {connection_close, _Type, _Code, _FrameType, _Reason}, Sta
 process_frame(
     app,
     {reset_stream, StreamId, ErrorCode, FinalSize},
-    #state{owner = Owner, conn_ref = Ref, streams = Streams} = State
+    #state{owner = Owner, streams = Streams} = State
 ) ->
     %% Update stream state to reset
     NewStreams =
@@ -3221,7 +3162,7 @@ process_frame(
                 );
             error ->
                 %% Unknown stream - notify owner and create minimal state to track reset
-                Owner ! {quic, Ref, {stream_opened, StreamId}},
+                Owner ! {quic, self(), {stream_opened, StreamId}},
                 maps:put(
                     StreamId,
                     #stream_state{
@@ -3233,14 +3174,14 @@ process_frame(
                 )
         end,
     %% Notify owner of stream reset
-    Owner ! {quic, Ref, {stream_reset, StreamId, ErrorCode}},
+    Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
     State#state{streams = NewStreams};
 %% STOP_SENDING: Peer wants us to stop sending on a stream
 %% RFC 9000 Section 19.5
 process_frame(
     app,
     {stop_sending, StreamId, ErrorCode},
-    #state{owner = Owner, conn_ref = Ref, streams = Streams} = State
+    #state{owner = Owner, streams = Streams} = State
 ) ->
     %% Clear any queued data for this stream and mark as stopped
     NewStreams =
@@ -3257,7 +3198,7 @@ process_frame(
                 );
             error ->
                 %% Unknown stream - notify owner and create minimal state
-                Owner ! {quic, Ref, {stream_opened, StreamId}},
+                Owner ! {quic, self(), {stream_opened, StreamId}},
                 maps:put(
                     StreamId,
                     #stream_state{
@@ -3268,7 +3209,7 @@ process_frame(
                 )
         end,
     %% Notify owner - they should stop sending and may send RESET_STREAM
-    Owner ! {quic, Ref, {stop_sending, StreamId, ErrorCode}},
+    Owner ! {quic, self(), {stop_sending, StreamId, ErrorCode}},
     %% Also remove from send queue and adjust byte count
     {NewSendQueue, RemovedBytes} = remove_stream_from_queue(StreamId, State#state.send_queue),
     NewQueueBytes = State#state.send_queue_bytes - RemovedBytes,
@@ -3278,7 +3219,7 @@ process_frame(
 process_frame(
     app,
     {stream_data_blocked, StreamId, _Limit},
-    #state{owner = Owner, conn_ref = Ref, streams = Streams} = State
+    #state{owner = Owner, streams = Streams} = State
 ) ->
     case maps:is_key(StreamId, Streams) of
         true ->
@@ -3286,7 +3227,7 @@ process_frame(
             State;
         false ->
             %% New stream from peer - notify owner
-            Owner ! {quic, Ref, {stream_opened, StreamId}},
+            Owner ! {quic, self(), {stream_opened, StreamId}},
             %% Create minimal stream state
             InitSendMaxData = get_peer_stream_limit(bidi_peer_initiated, State),
             InitRecvMaxData = get_local_recv_limit(bidi_peer_initiated, State),
@@ -3319,11 +3260,11 @@ process_frame(
     app, {datagram_with_length, Data}, #state{max_datagram_frame_size_local = Max} = State
 ) when byte_size(Data) > Max ->
     send_protocol_violation(<<"DATAGRAM frame too large">>, State);
-process_frame(app, {datagram, Data}, #state{owner = Owner, conn_ref = Ref} = State) ->
-    Owner ! {quic, Ref, {datagram, Data}},
+process_frame(app, {datagram, Data}, #state{owner = Owner} = State) ->
+    Owner ! {quic, self(), {datagram, Data}},
     State;
-process_frame(app, {datagram_with_length, Data}, #state{owner = Owner, conn_ref = Ref} = State) ->
-    Owner ! {quic, Ref, {datagram, Data}},
+process_frame(app, {datagram_with_length, Data}, #state{owner = Owner} = State) ->
+    Owner ! {quic, self(), {datagram, Data}},
     State;
 process_frame(_Level, _Frame, State) ->
     %% Ignore unknown frames
@@ -3887,8 +3828,8 @@ process_tls_message(
             ),
 
             %% Notify owner about the new ticket
-            #state{owner = Owner, conn_ref = Ref} = State,
-            Owner ! {quic, Ref, {session_ticket, Ticket}},
+            #state{owner = Owner} = State,
+            Owner ! {quic, self(), {session_ticket, Ticket}},
 
             State#state{
                 ticket_store = TicketStore,
@@ -3940,7 +3881,6 @@ validate_receive_stream(StreamId, Role) ->
 process_stream_data_validated(StreamId, Offset, Data, Fin, State) ->
     #state{
         owner = Owner,
-        conn_ref = Ref,
         streams = Streams,
         max_data_local = MaxDataLocal,
         data_received = DataReceived,
@@ -3956,7 +3896,7 @@ process_stream_data_validated(StreamId, Offset, Data, Fin, State) ->
                 S;
             error ->
                 %% New stream from peer - notify owner
-                Owner ! {quic, Ref, {stream_opened, StreamId}},
+                Owner ! {quic, self(), {stream_opened, StreamId}},
                 %% Use peer's limits for streams they initiate
                 InitSendMaxData = get_peer_stream_limit(bidi_peer_initiated, State),
                 InitRecvMaxData = get_local_recv_limit(bidi_peer_initiated, State),
@@ -4068,9 +4008,9 @@ process_stream_data_validated(StreamId, Offset, Data, Fin, State) ->
                     ok;
                 {<<>>, true, _} ->
                     %% FIN-only delivery (all data already delivered)
-                    Owner ! {quic, Ref, {stream_data, StreamId, <<>>, true}};
+                    Owner ! {quic, self(), {stream_data, StreamId, <<>>, true}};
                 {_, _, _} ->
-                    Owner ! {quic, Ref, {stream_data, StreamId, DeliverData, DeliverFin}}
+                    Owner ! {quic, self(), {stream_data, StreamId, DeliverData, DeliverFin}}
             end,
 
             NewStream = Stream#stream_state{
@@ -5486,8 +5426,7 @@ handle_stream_deadline_expired(
     StreamId,
     #state{
         streams = Streams,
-        owner = Owner,
-        conn_ref = Ref
+        owner = Owner
     } = State
 ) ->
     case maps:find(StreamId, Streams) of
@@ -5507,12 +5446,12 @@ handle_stream_deadline_expired(
             %% Notify owner if requested
             case Action of
                 notify ->
-                    Owner ! {quic, Ref, {stream_deadline, StreamId}},
+                    Owner ! {quic, self(), {stream_deadline, StreamId}},
                     {ok, State1};
                 reset ->
                     do_close_stream_deadline(StreamId, ErrorCode, State1);
                 both ->
-                    Owner ! {quic, Ref, {stream_deadline, StreamId}},
+                    Owner ! {quic, self(), {stream_deadline, StreamId}},
                     do_close_stream_deadline(StreamId, ErrorCode, State1)
             end;
         {ok, _ClosedStream} ->

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -21,9 +21,10 @@
 %%% Opts = #{
 %%%     cert => Cert,
 %%%     key => Key,
-%%%     connection_handler => fun(ConnPid, ConnRef) ->
+%%%     connection_handler => fun(Conn) ->
+%%%         %% Conn is the connection pid
 %%%         %% Spawn your handler and return its pid
-%%%         HandlerPid = spawn(fun() -> my_handler(ConnPid, ConnRef) end),
+%%%         HandlerPid = spawn(fun() -> my_handler(Conn) end),
 %%%         %% Ownership will be transferred to HandlerPid
 %%%         {ok, HandlerPid}
 %%%     end
@@ -75,8 +76,8 @@
     owns_tables = true :: boolean(),
     %% Stateless reset secret (RFC 9000 Section 10.3)
     reset_secret :: binary(),
-    %% Connection handler callback: fun(ConnPid, ConnRef) -> {ok, HandlerPid}
-    connection_handler :: fun((pid(), reference()) -> {ok, pid()}) | undefined,
+    %% Connection handler callback: fun(Conn) -> {ok, HandlerPid} where Conn is pid()
+    connection_handler :: fun((pid()) -> {ok, pid()}) | undefined,
     %% QUIC-LB CID configuration (RFC 9312)
     cid_config :: #cid_config{} | undefined,
     %% Expected DCID length for short header packets
@@ -497,9 +498,6 @@ create_connection(
     case quic_connection:start_server(maps:merge(Opts, ConnOpts)) of
         {ok, ConnPid} ->
             ?LOG_INFO(#{what => connection_created, conn_pid => ConnPid}, ?QUIC_LOG_META),
-            %% Get connection reference
-            %% Note: ConnPid is already linked via start_link in start_server/1
-            ConnRef = gen_statem:call(ConnPid, get_ref),
 
             %% Register connection ID
             ets:insert(Conns, {DCID, ConnPid}),
@@ -510,19 +508,19 @@ create_connection(
             case ConnHandler of
                 undefined ->
                     ok;
-                Fun when is_function(Fun, 2) ->
-                    case Fun(ConnPid, ConnRef) of
+                Fun when is_function(Fun, 1) ->
+                    case Fun(ConnPid) of
                         {ok, HandlerPid} when is_pid(HandlerPid) ->
                             %% Transfer ownership to handler (sync to ensure it completes
                             %% before any packets trigger handshake completion)
-                            case quic:set_owner_sync(ConnRef, HandlerPid) of
+                            case quic:set_owner_sync(ConnPid, HandlerPid) of
                                 ok ->
                                     ok;
                                 {error, Reason} ->
                                     ?LOG_WARNING(
                                         #{
                                             what => set_owner_failed,
-                                            conn_ref => ConnRef,
+                                            conn => ConnPid,
                                             reason => Reason
                                         },
                                         ?QUIC_LOG_META

--- a/test/quic_dist_controller_tests.erl
+++ b/test/quic_dist_controller_tests.erl
@@ -36,7 +36,6 @@ exports_test() ->
     Exports = quic_dist_controller:module_info(exports),
     %% Check key API functions are exported
     ?assert(lists:member({start_link, 2}, Exports)),
-    ?assert(lists:member({start_link, 3}, Exports)),
     ?assert(lists:member({send, 2}, Exports)),
     ?assert(lists:member({recv, 3}, Exports)),
     ?assert(lists:member({tick, 1}, Exports)),

--- a/test/quic_stop_sending_tests.erl
+++ b/test/quic_stop_sending_tests.erl
@@ -13,16 +13,6 @@
 %% API Tests
 %%====================================================================
 
-%% Test that stop_sending returns badarg for invalid ConnRef
-stop_sending_badarg_test() ->
-    ?assertEqual({error, badarg}, quic:stop_sending(invalid, 0, 0)),
-    ?assertEqual({error, badarg}, quic:stop_sending("not_a_ref", 0, 0)).
-
-%% Test that stop_sending returns not_found for unknown reference
-stop_sending_not_found_test() ->
-    UnknownRef = make_ref(),
-    ?assertEqual({error, not_found}, quic:stop_sending(UnknownRef, 0, 0)).
-
 %% Test that stop_sending in idle state returns invalid_state error
 stop_sending_idle_state_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
@@ -38,20 +28,7 @@ stop_sending_idle_state_test() ->
     quic_connection:close(Pid, normal),
     timer:sleep(100).
 
-%% Test that stop_sending API accepts reference and delegates correctly
-stop_sending_with_ref_test() ->
-    {ok, Ref, Pid} = quic_connection:connect("127.0.0.1", 4433, #{}, self()),
-    ?assert(is_reference(Ref)),
-
-    %% Connection is in idle state (not connected yet)
-    %% stop_sending should fail because we're not in connected state
-    Result = quic:stop_sending(Ref, 0, 0),
-    ?assertEqual({error, {invalid_state, idle}}, Result),
-
-    quic_connection:close(Pid, normal),
-    timer:sleep(100).
-
-%% Test that stop_sending API accepts pid directly
+%% Test that stop_sending API accepts pid
 stop_sending_with_pid_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
 


### PR DESCRIPTION
## Summary

- Remove ETS registry indirection from quic_connection (register_conn, unregister_conn, lookup)
- Change quic:connect/4 to return `{ok, pid()}` instead of `{ok, reference()}`
- Simplify all quic.erl API functions to only accept pid (removes ~300 lines)
- Change owner messages from `{quic, Ref, Event}` to `{quic, Conn, Event}`
- Update connection_handler callback signature
- Update quic_dist_controller to use single `conn` field

Closes #29