### PR TITLE
feat(dist): add user-accessible streams API

### DIFF
--- a/docker/dist/src/quic_dist_test_server.erl
+++ b/docker/dist/src/quic_dist_test_server.erl
@@ -18,7 +18,8 @@
     broadcast_test/0,
     get_stats/0,
     echo/1,
-    echo_data/1
+    echo_data/1,
+    start_stream_acceptor/1
 ]).
 
 %% gen_server callbacks
@@ -236,13 +237,80 @@ get_cluster_nodes() ->
 
 run_all_tests() ->
     Results1 = test_basic_rpc(),
+    Results3 = test_throughput_benchmark(),
     Results2 = test_large_messages(),
+    Results4 = test_user_streams(),
 
     %% Log individual results
     log_test_results(basic, Results1),
     log_test_results(large_msg, Results2),
+    log_test_results(user_stream, Results4),
 
-    [{basic, Results1}, {large_msg, Results2}].
+    [{basic, Results1}, {throughput, Results3}, {large_msg, Results2}, {user_stream, Results4}].
+
+%% Test 3: Throughput benchmark
+test_throughput_benchmark() ->
+    Nodes = nodes(),
+    case Nodes of
+        [] -> [];
+        [TargetNode | _] ->
+            log_event(throughput_start, #{target => TargetNode}),
+            Results = run_throughput_bench(TargetNode),
+            log_event(throughput_complete, Results),
+            [{TargetNode, {ok, Results}}]
+    end.
+
+run_throughput_bench(TargetNode) ->
+    %% Spawn echo server on target
+    ServerPid = spawn(TargetNode, fun() -> bench_echo_loop() end),
+
+    Sizes = [64, 256, 1024, 4096, 16384, 65536],
+    Iterations = 2000,
+
+    Results = lists:map(fun(Size) ->
+        Data = crypto:strong_rand_bytes(Size),
+
+        %% Warmup
+        lists:foreach(fun(_) ->
+            Ref = make_ref(),
+            ServerPid ! {echo, self(), Ref, Data},
+            receive {echo_reply, Ref, _} -> ok after 5000 -> ok end
+        end, lists:seq(1, 50)),
+
+        %% Benchmark
+        Start = erlang:monotonic_time(microsecond),
+        lists:foreach(fun(_) ->
+            Ref = make_ref(),
+            ServerPid ! {echo, self(), Ref, Data},
+            receive {echo_reply, Ref, _} -> ok after 5000 -> ok end
+        end, lists:seq(1, Iterations)),
+        Elapsed = erlang:monotonic_time(microsecond) - Start,
+
+        Throughput = Iterations / (Elapsed / 1000000),
+        Bandwidth = Throughput * Size / 1048576,
+        AvgLatency = Elapsed / Iterations,
+
+        log_event(throughput_result, #{
+            size => Size,
+            throughput => round(Throughput),
+            bandwidth_mbps => round(Bandwidth * 100) / 100,
+            latency_us => round(AvgLatency * 10) / 10
+        }),
+
+        {Size, Throughput, Bandwidth, AvgLatency}
+    end, Sizes),
+
+    ServerPid ! stop,
+    Results.
+
+bench_echo_loop() ->
+    receive
+        {echo, From, Ref, Data} ->
+            From ! {echo_reply, Ref, Data},
+            bench_echo_loop();
+        stop ->
+            ok
+    end.
 
 %% Test 1: Basic RPC to all connected nodes
 test_basic_rpc() ->
@@ -301,6 +369,86 @@ count_results(AllResults) ->
             end
         end, {S, F}, Results)
     end, {0, 0}, AllResults).
+
+%% Test 4: User streams over QUIC distribution
+test_user_streams() ->
+    Nodes = nodes(),
+    [{Node, user_stream_test(Node)} || Node <- Nodes].
+
+user_stream_test(Node) ->
+    %% Start acceptor on remote node (pass our node name)
+    case rpc:call(Node, ?MODULE, start_stream_acceptor, [node()], 5000) of
+        {ok, _AcceptorPid} ->
+            %% Wait for acceptor to be ready
+            timer:sleep(100),
+            run_user_stream_test(Node);
+        {badrpc, Reason} ->
+            {error, {acceptor_start_failed, Reason}};
+        Error ->
+            {error, {acceptor_start_failed, Error}}
+    end.
+
+run_user_stream_test(Node) ->
+    Start = erlang:monotonic_time(millisecond),
+    case quic_dist:open_stream(Node) of
+        {ok, Stream} ->
+            TestData = <<"user_stream_test_", (crypto:strong_rand_bytes(32))/binary>>,
+            case quic_dist:send(Stream, TestData, true) of
+                ok ->
+                    %% Wait for echo response
+                    receive
+                        {quic_dist_stream, Stream, {data, Response, true}} ->
+                            quic_dist:close_stream(Stream),
+                            case Response of
+                                TestData ->
+                                    Latency = erlang:monotonic_time(millisecond) - Start,
+                                    {ok, Latency};
+                                _ ->
+                                    {error, data_mismatch}
+                            end;
+                        {quic_dist_stream, Stream, {reset, Code}} ->
+                            {error, {stream_reset, Code}}
+                    after 10000 ->
+                        quic_dist:close_stream(Stream),
+                        {error, timeout}
+                    end;
+                {error, Reason} ->
+                    quic_dist:close_stream(Stream),
+                    {error, {send_failed, Reason}}
+            end;
+        {error, Reason} ->
+            {error, {open_failed, Reason}}
+    end.
+
+%% Start a stream acceptor on this node (called via RPC)
+start_stream_acceptor(CallerNode) ->
+    Pid = spawn(fun() -> stream_acceptor_loop(CallerNode) end),
+    {ok, Pid}.
+
+stream_acceptor_loop(CallerNode) ->
+    ok = quic_dist:accept_streams(CallerNode),
+    stream_acceptor_receive().
+
+stream_acceptor_receive() ->
+    receive
+        {quic_dist_stream, Stream, {data, Data, true}} ->
+            %% Echo data back
+            quic_dist:send(Stream, Data, true),
+            stream_acceptor_receive();
+        {quic_dist_stream, Stream, {data, Data, false}} ->
+            %% Accumulate partial data (simplified: just echo immediately)
+            quic_dist:send(Stream, Data, false),
+            stream_acceptor_receive();
+        {quic_dist_stream, _Stream, closed} ->
+            stream_acceptor_receive();
+        {quic_dist_stream, _Stream, {reset, _Code}} ->
+            stream_acceptor_receive();
+        stop ->
+            ok
+    after 60000 ->
+        %% Timeout after 1 minute of inactivity
+        ok
+    end.
 
 log_event(Event, Data) ->
     Timestamp = calendar:system_time_to_rfc3339(erlang:system_time(millisecond), [{unit, millisecond}]),

--- a/docs/QUIC_DIST.md
+++ b/docs/QUIC_DIST.md
@@ -105,6 +105,156 @@ The control stream (stream 0) has the highest priority (urgency 0), ensuring tha
 - Tick frames for liveness detection bypass congestion
 - Critical signals are not blocked by bulk data transfers
 
+### User Streams API
+
+QUIC distribution supports user-accessible streams, allowing applications to open bidirectional streams over existing distribution connections. This leverages QUIC's multiplexing while keeping distribution traffic separate.
+
+#### Stream ID Allocation
+
+QUIC stream IDs encode the initiator in bit 0:
+- Even IDs (0, 4, 8...): Client-initiated bidirectional
+- Odd IDs (1, 5, 9...): Server-initiated bidirectional
+
+Distribution reserves low stream IDs:
+- Stream 0: Control (handshake, ticks)
+- Streams 4, 8, 12, 16: Client data (4 streams)
+- Streams 1, 5, 9, 13: Server data (4 streams)
+
+User streams start at:
+- Client-initiated: StreamId >= 20 (first available: 20, 24, 28...)
+- Server-initiated: StreamId >= 17 (first available: 17, 21, 25...)
+
+#### API Reference
+
+**Opening and Closing Streams**
+
+```erlang
+%% Open a bidirectional stream to a connected node
+{ok, StreamRef} = quic_dist:open_stream(Node).
+
+%% Open with priority (16-255, lower = higher priority)
+{ok, StreamRef} = quic_dist:open_stream(Node, [{priority, 64}]).
+
+%% Close a stream gracefully (sends FIN)
+ok = quic_dist:close_stream(StreamRef).
+
+%% Reset a stream immediately (notifies peer)
+ok = quic_dist:reset_stream(StreamRef).
+ok = quic_dist:reset_stream(StreamRef, ErrorCode).
+```
+
+**Sending Data**
+
+```erlang
+%% Send data on a user stream
+ok = quic_dist:send(StreamRef, <<"Hello">>).
+
+%% Send data with FIN flag (marks end of stream)
+ok = quic_dist:send(StreamRef, <<"World">>, true).
+```
+
+**Receiving Streams**
+
+Register as an acceptor to receive incoming streams. Incoming streams are assigned to acceptors via round-robin:
+
+```erlang
+%% Join acceptor pool for a node
+ok = quic_dist:accept_streams(Node).
+
+%% Leave acceptor pool
+ok = quic_dist:stop_accepting(Node).
+
+%% Transfer stream ownership to another process
+ok = quic_dist:controlling_process(StreamRef, NewOwner).
+```
+
+**Listing Streams**
+
+```erlang
+%% List all user streams
+Streams = quic_dist:list_streams().
+
+%% List user streams for a specific node
+Streams = quic_dist:list_streams(Node).
+```
+
+Returns a list of maps:
+```erlang
+#{ref => StreamRef,
+  node => 'node@host',
+  stream_id => 20,
+  owner => <0.123.0>,
+  priority => 128,
+  recv_fin => false,
+  send_fin => false}
+```
+
+#### Messages to Owner
+
+Stream owners receive the following messages:
+
+```erlang
+%% Data received (Fin=true means end of stream from peer)
+{quic_dist_stream, StreamRef, {data, Data :: binary(), Fin :: boolean()}}
+
+%% Stream was reset by peer
+{quic_dist_stream, StreamRef, {reset, ErrorCode :: non_neg_integer()}}
+
+%% Stream fully closed (both sides sent FIN)
+{quic_dist_stream, StreamRef, closed}
+```
+
+#### Priority
+
+User streams have priority range 16-255 (lower = higher priority). Distribution reserves priority 0-15 for internal use:
+- Priority 0: Control stream (highest)
+- Priority 1-15: Distribution data streams
+- Priority 16-255: User streams (default: 128)
+
+#### Example: Request/Response
+
+```erlang
+%% Node A: Send request
+{ok, Stream} = quic_dist:open_stream('nodeB@host'),
+ok = quic_dist:send(Stream, <<"GET /data">>, true),
+receive
+    {quic_dist_stream, Stream, {data, Response, true}} ->
+        io:format("Response: ~p~n", [Response])
+end.
+
+%% Node B: Accept and respond
+ok = quic_dist:accept_streams('nodeA@host'),
+receive
+    {quic_dist_stream, Stream, {data, Request, true}} ->
+        Response = handle_request(Request),
+        quic_dist:send(Stream, Response, true)
+end.
+```
+
+#### Example: Acceptor Pool
+
+```erlang
+%% Start multiple acceptors for load distribution
+start_acceptor_pool(Node, N) ->
+    [spawn(fun() -> acceptor_loop(Node) end) || _ <- lists:seq(1, N)].
+
+acceptor_loop(Node) ->
+    ok = quic_dist:accept_streams(Node),
+    receive
+        {quic_dist_stream, Stream, {data, Data, Fin}} ->
+            handle_request(Stream, Data, Fin),
+            acceptor_loop(Node)
+    end.
+```
+
+#### Error Handling
+
+When no acceptor is available for an incoming stream, the stream is immediately reset with error code `0x100` (`STREAM_REFUSED`). The peer's owner receives:
+
+```erlang
+{quic_dist_stream, StreamRef, {reset, 16#100}}
+```
+
 ### Message Framing
 
 During handshake (stream 0):

--- a/elvis.config
+++ b/elvis.config
@@ -56,11 +56,13 @@
                 %% TODO: Per-module ignores; to be fixed later
                 {elvis_style, dont_repeat_yourself, #{
                     ignore => [
+                        quic_ack,
                         quic_connection,
                         quic_cc,
                         quic_cc_bbr,
                         quic_cc_cubic,
                         quic_cc_newreno,
+                        quic_discovery_dns,
                         quic_listener,
                         quic_loss,
                         quic_aead,

--- a/elvis.config
+++ b/elvis.config
@@ -95,7 +95,7 @@
                     ]
                 }},
                 {elvis_style, no_god_modules, #{
-                    ignore => [quic, quic_cc, quic_connection, quic_crypto, quic_stream]
+                    ignore => [quic, quic_cc, quic_connection, quic_crypto, quic_stream, quic_dist_controller]
                 }},
                 {elvis_style, max_function_clause_length, #{
                     ignore => [

--- a/include/quic_dist.hrl
+++ b/include/quic_dist.hrl
@@ -187,5 +187,37 @@
     fin = false :: boolean()
 }).
 
+%%====================================================================
+%% User Stream Support
+%%====================================================================
+
+%% User stream thresholds
+%% Distribution uses streams 0 (control) and 4,8,12,16 (client data) or 1,5,9,13 (server data)
+%% User streams start above these reserved ranges
+
+% Client-initiated user streams start at 20 (above 0,4,8,12,16)
+-define(USER_STREAM_THRESHOLD_CLIENT, 20).
+% Server-initiated user streams start at 17 (above 1,5,9,13)
+-define(USER_STREAM_THRESHOLD_SERVER, 17).
+
+%% Application error code for refused streams (no acceptor available)
+-define(STREAM_REFUSED, 16#100).
+
+%% User stream priority constraints
+%% User streams CANNOT have priority < 16 (reserved for distribution)
+-define(USER_STREAM_MIN_PRIORITY, 16).
+-define(USER_STREAM_DEFAULT_PRIORITY, 128).
+
+%% User stream state record
+-record(user_stream, {
+    id :: non_neg_integer(),
+    owner :: pid(),
+    monitor :: reference(),
+    %% Stream priority (16=highest user, 255=lowest)
+    priority = ?USER_STREAM_DEFAULT_PRIORITY :: 16..255,
+    recv_fin = false :: boolean(),
+    send_fin = false :: boolean()
+}).
+
 % QUIC_DIST_HRL
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -170,11 +170,13 @@
                 %% TODO: Per-module ignores; to be fixed later
                 {elvis_style, dont_repeat_yourself, #{
                     ignore => [
+                        quic_ack,
                         quic_connection,
                         quic_cc,
                         quic_cc_bbr,
                         quic_cc_cubic,
                         quic_cc_newreno,
+                        quic_discovery_dns,
                         quic_loss,
                         quic_aead,
                         quic_dist_controller,

--- a/rebar.config
+++ b/rebar.config
@@ -209,7 +209,14 @@
                     ]
                 }},
                 {elvis_style, no_god_modules, #{
-                    ignore => [quic, quic_cc, quic_connection, quic_crypto, quic_stream, quic_dist_controller]
+                    ignore => [
+                        quic,
+                        quic_cc,
+                        quic_connection,
+                        quic_crypto,
+                        quic_stream,
+                        quic_dist_controller
+                    ]
                 }},
                 {elvis_style, max_function_clause_length, #{
                     ignore => [

--- a/rebar.config
+++ b/rebar.config
@@ -209,7 +209,7 @@
                     ]
                 }},
                 {elvis_style, no_god_modules, #{
-                    ignore => [quic, quic_cc, quic_connection, quic_crypto, quic_stream]
+                    ignore => [quic, quic_cc, quic_connection, quic_crypto, quic_stream, quic_dist_controller]
                 }},
                 {elvis_style, max_function_clause_length, #{
                     ignore => [

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -69,6 +69,38 @@
     is_node_name/1
 ]).
 
+%% User stream API
+-export([
+    open_stream/1,
+    open_stream/2,
+    send/2,
+    send/3,
+    close_stream/1,
+    reset_stream/1,
+    reset_stream/2,
+    accept_streams/1,
+    stop_accepting/1,
+    controlling_process/2,
+    list_streams/0,
+    list_streams/1,
+    get_controller/1
+]).
+
+%% Types
+-export_type([stream_ref/0, stream_info/0, stream_opt/0]).
+
+-type stream_ref() :: {quic_dist_stream, node(), non_neg_integer()}.
+-type stream_opt() :: {priority, 16..255}.
+-type stream_info() :: #{
+    ref => stream_ref(),
+    node => node(),
+    stream_id => non_neg_integer(),
+    owner => pid(),
+    priority => 16..255,
+    recv_fin => boolean(),
+    send_fin => boolean()
+}.
+
 %% Internal exports
 -export([
     acceptor_loop/2,
@@ -1050,3 +1082,173 @@ create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer) ->
             ok
         end
     }.
+
+%%====================================================================
+%% User Stream API
+%%====================================================================
+
+%% @doc Open a bidirectional user stream to a connected node.
+%% Returns {ok, StreamRef} on success where StreamRef can be used with send/2,3 and close_stream/1.
+%% The caller becomes the stream owner.
+-spec open_stream(Node :: node()) -> {ok, stream_ref()} | {error, term()}.
+open_stream(Node) ->
+    open_stream(Node, []).
+
+%% @doc Open a bidirectional user stream with options.
+%% Options:
+%%   {priority, 16..255} - Stream priority (default: 128, lower = higher priority)
+%%                         Note: priorities 0-15 are reserved for distribution
+-spec open_stream(Node :: node(), Options :: [stream_opt()]) ->
+    {ok, stream_ref()} | {error, term()}.
+open_stream(Node, Options) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            case quic_dist_controller:open_user_stream(Ctrl, self(), Options) of
+                {ok, StreamId} ->
+                    {ok, {quic_dist_stream, Node, StreamId}};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Send data on a user stream.
+%% Equivalent to send(StreamRef, Data, false).
+-spec send(StreamRef :: stream_ref(), Data :: iodata()) -> ok | {error, term()}.
+send(StreamRef, Data) ->
+    send(StreamRef, Data, false).
+
+%% @doc Send data on a user stream.
+%% When Fin is true, this marks the end of data on this stream (half-close).
+-spec send(StreamRef :: stream_ref(), Data :: iodata(), Fin :: boolean()) -> ok | {error, term()}.
+send({quic_dist_stream, Node, StreamId}, Data, Fin) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:send_user_data(Ctrl, StreamId, Data, Fin);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Close a user stream gracefully.
+%% This sends a FIN to the peer. When both sides have sent FIN, the owner
+%% receives {quic_dist_stream, StreamRef, closed}.
+-spec close_stream(StreamRef :: stream_ref()) -> ok | {error, term()}.
+close_stream({quic_dist_stream, Node, StreamId}) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:close_user_stream(Ctrl, StreamId);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Reset/cancel a user stream immediately (notifies peer).
+%% Uses default error code 0.
+-spec reset_stream(StreamRef :: stream_ref()) -> ok | {error, term()}.
+reset_stream(StreamRef) ->
+    reset_stream(StreamRef, 0).
+
+%% @doc Reset/cancel a user stream with a specific error code.
+%% The peer receives the reset notification immediately.
+-spec reset_stream(StreamRef :: stream_ref(), ErrorCode :: non_neg_integer()) ->
+    ok | {error, term()}.
+reset_stream({quic_dist_stream, Node, StreamId}, ErrorCode) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:reset_user_stream(Ctrl, StreamId, ErrorCode);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Register to accept incoming user streams from a node.
+%% Joins the acceptor pool for the node. Multiple processes can register as acceptors.
+%% Incoming streams are assigned to acceptors using round-robin selection.
+%%
+%% When a new stream arrives, one acceptor receives:
+%%   {quic_dist_stream, StreamRef, {data, Data, Fin}}
+%%
+%% The acceptor automatically becomes the stream owner (implicit ownership).
+%% Use controlling_process/2 to transfer ownership to a worker process.
+%%
+%% If no acceptors are registered, incoming streams are refused with RESET.
+-spec accept_streams(Node :: node()) -> ok | {error, term()}.
+accept_streams(Node) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:accept_user_streams(Ctrl, self());
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Stop accepting incoming user streams from a node.
+%% Removes the calling process from the acceptor pool.
+-spec stop_accepting(Node :: node()) -> ok | {error, term()}.
+stop_accepting(Node) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:stop_accepting_streams(Ctrl);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Transfer stream ownership to another process.
+%% The new owner will receive all subsequent messages for this stream.
+-spec controlling_process(StreamRef :: stream_ref(), NewOwner :: pid()) -> ok | {error, term()}.
+controlling_process({quic_dist_stream, Node, StreamId}, NewOwner) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:controlling_process(Ctrl, StreamId, NewOwner);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc List all user streams across all connected nodes.
+-spec list_streams() -> [stream_info()].
+list_streams() ->
+    try
+        DistCtrls = erlang:system_info(dist_ctrl),
+        lists:flatmap(
+            fun
+                ({_Node, Ctrl}) when is_pid(Ctrl) ->
+                    quic_dist_controller:list_user_streams(Ctrl);
+                ({_Node, _Port}) ->
+                    []
+            end,
+            DistCtrls
+        )
+    catch
+        _:_ ->
+            []
+    end.
+
+%% @doc List user streams for a specific connected node.
+-spec list_streams(Node :: node()) -> [stream_info()].
+list_streams(Node) ->
+    case get_controller(Node) of
+        {ok, Ctrl} ->
+            quic_dist_controller:list_user_streams(Ctrl);
+        {error, _} ->
+            []
+    end.
+
+%% @doc Get the distribution controller for a connected node.
+%% Returns {ok, ControllerPid} if the node is connected, {error, not_connected} otherwise.
+-spec get_controller(Node :: node()) -> {ok, pid()} | {error, not_connected | not_quic_connection}.
+get_controller(Node) ->
+    %% Use erlang:system_info(dist_ctrl) to get the list of distribution controllers
+    %% This returns [{Node, CtrlPid}] for all connected nodes
+    try
+        DistCtrls = erlang:system_info(dist_ctrl),
+        case lists:keyfind(Node, 1, DistCtrls) of
+            {Node, Ctrl} when is_pid(Ctrl) ->
+                {ok, Ctrl};
+            {Node, Port} when is_port(Port) ->
+                %% TCP distribution uses ports, not pids - not supported
+                {error, not_quic_connection};
+            _ ->
+                {error, not_connected}
+        end
+    catch
+        _:_ ->
+            {error, not_connected}
+    end.

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -65,6 +65,20 @@
     pre_nodeup/1
 ]).
 
+%% User stream API
+-export([
+    open_user_stream/2,
+    open_user_stream/3,
+    send_user_data/4,
+    close_user_stream/2,
+    reset_user_stream/2,
+    reset_user_stream/3,
+    accept_user_streams/2,
+    stop_accepting_streams/1,
+    controlling_process/3,
+    list_user_streams/1
+]).
+
 %% gen_statem callbacks
 -export([
     init/1,
@@ -139,7 +153,15 @@
     %% Last time we sent data (for tick response rate limiting)
     last_send_time = 0 :: integer(),
     %% Last time we sent a tick response (to prevent feedback loops)
-    last_tick_response = 0 :: integer()
+    last_tick_response = 0 :: integer(),
+
+    %% User stream support
+    %% Map of StreamId -> #user_stream{} for user-accessible streams
+    user_streams = #{} :: #{non_neg_integer() => #user_stream{}},
+    %% Acceptor pool: list of {Pid, MonitorRef} for processes accepting incoming streams
+    acceptor_pool = [] :: [{pid(), reference()}],
+    %% Round-robin index for acceptor selection
+    acceptor_idx = 0 :: non_neg_integer()
 }).
 
 %%====================================================================
@@ -211,6 +233,81 @@ pre_nodeup(Controller) ->
     gen_statem:call(Controller, {pre_nodeup, self()}).
 
 %%====================================================================
+%% User Stream API
+%%====================================================================
+
+%% @doc Open a user stream for application use.
+%% Returns {ok, StreamId} on success.
+-spec open_user_stream(Controller :: pid(), Owner :: pid()) ->
+    {ok, non_neg_integer()} | {error, term()}.
+open_user_stream(Controller, Owner) ->
+    open_user_stream(Controller, Owner, []).
+
+%% @doc Open a user stream with options.
+%% Options:
+%%   {priority, 16..255} - Stream priority (default: 128, lower = higher priority)
+-spec open_user_stream(Controller :: pid(), Owner :: pid(), Opts :: list()) ->
+    {ok, non_neg_integer()} | {error, term()}.
+open_user_stream(Controller, Owner, Opts) ->
+    gen_statem:call(Controller, {open_user_stream, Owner, Opts}).
+
+%% @doc Send data on a user stream.
+%% Fin=true marks the end of data on this stream.
+-spec send_user_data(
+    Controller :: pid(),
+    StreamId :: non_neg_integer(),
+    Data :: iodata(),
+    Fin :: boolean()
+) -> ok | {error, term()}.
+send_user_data(Controller, StreamId, Data, Fin) ->
+    gen_statem:call(Controller, {send_user_data, StreamId, Data, Fin}).
+
+%% @doc Close a user stream.
+-spec close_user_stream(Controller :: pid(), StreamId :: non_neg_integer()) ->
+    ok | {error, term()}.
+close_user_stream(Controller, StreamId) ->
+    gen_statem:call(Controller, {close_user_stream, StreamId}).
+
+%% @doc Reset/cancel a user stream (notifies peer immediately).
+%% Uses default error code 0.
+-spec reset_user_stream(Controller :: pid(), StreamId :: non_neg_integer()) ->
+    ok | {error, term()}.
+reset_user_stream(Controller, StreamId) ->
+    reset_user_stream(Controller, StreamId, 0).
+
+%% @doc Reset/cancel a user stream with a specific error code.
+-spec reset_user_stream(
+    Controller :: pid(), StreamId :: non_neg_integer(), ErrorCode :: non_neg_integer()
+) ->
+    ok | {error, term()}.
+reset_user_stream(Controller, StreamId, ErrorCode) ->
+    gen_statem:call(Controller, {reset_user_stream, StreamId, ErrorCode}).
+
+%% @doc Register to accept incoming user streams.
+%% The acceptor will receive {quic_dist_stream, Node, {incoming, StreamId}} messages.
+-spec accept_user_streams(Controller :: pid(), Acceptor :: pid()) ->
+    ok | {error, term()}.
+accept_user_streams(Controller, Acceptor) ->
+    gen_statem:call(Controller, {accept_user_streams, Acceptor}).
+
+%% @doc Stop accepting incoming user streams.
+-spec stop_accepting_streams(Controller :: pid()) -> ok.
+stop_accepting_streams(Controller) ->
+    gen_statem:call(Controller, stop_accepting_streams).
+
+%% @doc Transfer stream ownership to another process.
+-spec controlling_process(Controller :: pid(), StreamId :: non_neg_integer(), NewOwner :: pid()) ->
+    ok | {error, term()}.
+controlling_process(Controller, StreamId, NewOwner) ->
+    gen_statem:call(Controller, {controlling_process, StreamId, NewOwner}).
+
+%% @doc List all user streams.
+%% Returns a list of stream info maps.
+-spec list_user_streams(Controller :: pid()) -> [map()].
+list_user_streams(Controller) ->
+    gen_statem:call(Controller, list_user_streams).
+
+%%====================================================================
 %% gen_statem callbacks
 %%====================================================================
 
@@ -251,12 +348,28 @@ get_dist_opt(Key, Opts, Default) when is_list(Opts) ->
 get_dist_opt(Key, Opts, Default) when is_map(Opts) ->
     maps:get(Key, Opts, Default).
 
-terminate(_Reason, _StateName, #state{conn = Conn, pending_tick_timer = Timer}) ->
+terminate(_Reason, _StateName, #state{
+    conn = Conn, pending_tick_timer = Timer, user_streams = Streams, acceptor_pool = Pool
+}) ->
     %% Cancel pending tick retry timer if running
     case Timer of
         undefined -> ok;
         TimerRef -> erlang:cancel_timer(TimerRef)
     end,
+    %% Demonitor all user stream owners
+    maps:foreach(
+        fun(_StreamId, #user_stream{monitor = MonRef}) ->
+            erlang:demonitor(MonRef, [flush])
+        end,
+        Streams
+    ),
+    %% Demonitor all acceptors in pool
+    lists:foreach(
+        fun({_Pid, MonRef}) ->
+            erlang:demonitor(MonRef, [flush])
+        end,
+        Pool
+    ),
     try
         quic:close(Conn, normal)
     catch
@@ -546,6 +659,28 @@ connected(info, {quic, _Conn, {path_changed, OldPath, NewPath}}, State) ->
         ?QUIC_LOG_META
     ),
     {keep_state, State};
+%% Handle user stream operations
+connected({call, From}, {open_user_stream, Owner}, State) ->
+    handle_open_user_stream(From, Owner, [], State);
+connected({call, From}, {open_user_stream, Owner, Opts}, State) ->
+    handle_open_user_stream(From, Owner, Opts, State);
+connected({call, From}, {send_user_data, StreamId, Data, Fin}, State) ->
+    handle_send_user_data(From, StreamId, Data, Fin, State);
+connected({call, From}, {close_user_stream, StreamId}, State) ->
+    handle_close_user_stream(From, StreamId, State);
+connected({call, From}, {reset_user_stream, StreamId, ErrorCode}, State) ->
+    handle_reset_user_stream(From, StreamId, ErrorCode, State);
+connected({call, From}, {accept_user_streams, Acceptor}, State) ->
+    handle_accept_user_streams(From, Acceptor, State);
+connected({call, From}, stop_accepting_streams, State) ->
+    handle_stop_accepting_streams(From, State);
+connected({call, From}, {controlling_process, StreamId, NewOwner}, State) ->
+    handle_controlling_process(From, StreamId, NewOwner, State);
+connected({call, From}, list_user_streams, State) ->
+    handle_list_user_streams(From, State);
+%% Handle user stream owner DOWN
+connected(info, {'DOWN', MonRef, process, Pid, _Reason}, State) ->
+    handle_user_stream_owner_down(MonRef, Pid, State);
 connected(EventType, Event, State) ->
     handle_common_event(EventType, Event, connected, State).
 
@@ -627,7 +762,7 @@ handle_common_event(
 %% Handle incoming QUIC messages
 handle_common_event(
     info,
-    {quic, Conn, {stream_data, StreamId, Data, _Fin}},
+    {quic, Conn, {stream_data, StreamId, Data, Fin}},
     StateName,
     #state{
         conn = Conn,
@@ -639,8 +774,38 @@ handle_common_event(
             %% Data on control stream
             handle_control_data(Data, StateName, State);
         _ ->
-            %% Data on data stream
-            handle_stream_data(StreamId, Data, StateName, State)
+            %% Data on data stream - check if user stream and pass Fin
+            case StateName of
+                connected ->
+                    case is_user_stream(StreamId, State) of
+                        true ->
+                            handle_user_stream_data(StreamId, Data, Fin, State);
+                        false ->
+                            handle_stream_data(StreamId, Data, StateName, State)
+                    end;
+                _ ->
+                    handle_stream_data(StreamId, Data, StateName, State)
+            end
+    end;
+%% Handle stream reset for user streams
+handle_common_event(
+    info,
+    {quic, Conn, {stream_reset, StreamId, ErrorCode}},
+    _StateName,
+    #state{conn = Conn, node = Node, user_streams = Streams} = State
+) ->
+    case maps:find(StreamId, Streams) of
+        {ok, #user_stream{owner = Owner, monitor = MonRef}} ->
+            %% Notify owner of reset
+            StreamRef = {quic_dist_stream, Node, StreamId},
+            Owner ! {quic_dist_stream, StreamRef, {reset, ErrorCode}},
+            %% Demonitor and remove from map
+            erlang:demonitor(MonRef, [flush]),
+            NewStreams = maps:remove(StreamId, Streams),
+            {keep_state, State#state{user_streams = NewStreams}};
+        error ->
+            %% Not a user stream or not known - ignore
+            {keep_state, State}
     end;
 handle_common_event(
     info,
@@ -1327,10 +1492,10 @@ handle_control_data(
 
 %% @private
 %% Handle data received on data streams.
-%% In connected state, forward to input handler for VM delivery.
+%% In connected state, forward to input handler for VM delivery or user stream owner.
 %% During handshake, buffer data (shouldn't happen for data streams).
 handle_stream_data(
-    _StreamId,
+    StreamId,
     Data,
     connected,
     #state{
@@ -1339,12 +1504,19 @@ handle_stream_data(
         recv_oct = RecvOct
     } = State
 ) when is_pid(InputHandler) ->
-    %% Forward data stream content to input handler
-    InputHandler ! {dist_data, Data},
-    {keep_state, State#state{
-        recv_cnt = RecvCnt + 1,
-        recv_oct = RecvOct + byte_size(Data)
-    }};
+    %% Check if this is a user stream
+    case is_user_stream(StreamId, State) of
+        true ->
+            %% User stream - route to owner or acceptor
+            handle_user_stream_data(StreamId, Data, false, State);
+        false ->
+            %% Distribution data stream - forward to input handler
+            InputHandler ! {dist_data, Data},
+            {keep_state, State#state{
+                recv_cnt = RecvCnt + 1,
+                recv_oct = RecvOct + byte_size(Data)
+            }}
+    end;
 handle_stream_data(
     _StreamId,
     Data,
@@ -1389,3 +1561,403 @@ satisfy_waiters([{From, _Ref, Length} | Rest], State, Actions) ->
             %% Put waiter back
             {State1#state{recv_waiters = [{From, _Ref, Length} | Rest]}, lists:reverse(Actions)}
     end.
+
+%%====================================================================
+%% User Stream Support
+%%====================================================================
+
+%% @private
+%% Check if a stream ID is a user stream (above distribution reserved streams).
+%% IMPORTANT: Check based on stream ID's initiator bit, NOT connection role.
+%% QUIC stream IDs encode the initiator: even=client-initiated, odd=server-initiated.
+is_user_stream(StreamId, _State) ->
+    case StreamId band 1 of
+        0 ->
+            %% Client-initiated stream (even IDs: 0, 4, 8, 12, 16, 20...)
+            StreamId >= ?USER_STREAM_THRESHOLD_CLIENT;
+        1 ->
+            %% Server-initiated stream (odd IDs: 1, 5, 9, 13, 17...)
+            StreamId >= ?USER_STREAM_THRESHOLD_SERVER
+    end.
+
+%% @private
+%% Handle open_user_stream call with options.
+handle_open_user_stream(From, Owner, Opts, #state{conn = Conn, user_streams = Streams} = State) ->
+    case quic:open_stream(Conn) of
+        {ok, StreamId} ->
+            %% Verify it's above the threshold
+            case is_user_stream(StreamId, State) of
+                true ->
+                    %% Extract and validate priority
+                    Priority = validate_priority(
+                        proplists:get_value(priority, Opts, ?USER_STREAM_DEFAULT_PRIORITY)
+                    ),
+                    %% Set stream priority (user streams always lower than distribution)
+                    _ = quic:set_stream_priority(Conn, StreamId, Priority, false),
+                    %% Monitor the owner
+                    MonRef = erlang:monitor(process, Owner),
+                    UserStream = #user_stream{
+                        id = StreamId,
+                        owner = Owner,
+                        monitor = MonRef,
+                        priority = Priority
+                    },
+                    NewStreams = maps:put(StreamId, UserStream, Streams),
+                    {keep_state, State#state{user_streams = NewStreams}, [
+                        {reply, From, {ok, StreamId}}
+                    ]};
+                false ->
+                    %% Shouldn't happen but handle gracefully
+                    ?LOG_WARNING(
+                        #{what => user_stream_below_threshold, stream_id => StreamId},
+                        ?QUIC_LOG_META
+                    ),
+                    quic:reset_stream(Conn, StreamId, 0),
+                    {keep_state, State, [{reply, From, {error, stream_below_threshold}}]}
+            end;
+        {error, Reason} ->
+            {keep_state, State, [{reply, From, {error, Reason}}]}
+    end.
+
+%% @private
+%% Validate and clamp user priority to allowed range.
+validate_priority(P) when P < ?USER_STREAM_MIN_PRIORITY -> ?USER_STREAM_MIN_PRIORITY;
+validate_priority(P) when P > 255 -> 255;
+validate_priority(P) -> P.
+
+%% @private
+%% Handle send_user_data call.
+handle_send_user_data(
+    From, StreamId, Data, Fin, #state{conn = Conn, user_streams = Streams} = State
+) ->
+    case maps:find(StreamId, Streams) of
+        {ok, #user_stream{owner = Owner} = US} ->
+            %% Verify caller is the owner
+            {CallerPid, _} = From,
+            case CallerPid =:= Owner of
+                true ->
+                    DataBin = iolist_to_binary(Data),
+                    case quic:send_data(Conn, StreamId, DataBin, Fin) of
+                        ok ->
+                            NewUS = US#user_stream{send_fin = Fin},
+                            NewStreams = maps:put(StreamId, NewUS, Streams),
+                            {keep_state, State#state{user_streams = NewStreams}, [
+                                {reply, From, ok}
+                            ]};
+                        {error, Reason} ->
+                            {keep_state, State, [{reply, From, {error, Reason}}]}
+                    end;
+                false ->
+                    {keep_state, State, [{reply, From, {error, not_owner}}]}
+            end;
+        error ->
+            {keep_state, State, [{reply, From, {error, unknown_stream}}]}
+    end.
+
+%% @private
+%% Handle close_user_stream call.
+handle_close_user_stream(
+    From, StreamId, #state{conn = Conn, node = Node, user_streams = Streams} = State
+) ->
+    case maps:find(StreamId, Streams) of
+        {ok, #user_stream{owner = Owner, monitor = MonRef, recv_fin = RecvFin} = US} ->
+            %% Verify caller is the owner
+            {CallerPid, _} = From,
+            case CallerPid =:= Owner of
+                true ->
+                    %% Send FIN on the stream
+                    _ = quic:send_data(Conn, StreamId, <<>>, true),
+                    %% Check if stream is now fully closed
+                    case RecvFin of
+                        true ->
+                            %% Both sides closed - cleanup
+                            erlang:demonitor(MonRef, [flush]),
+                            StreamRef = {quic_dist_stream, Node, StreamId},
+                            Owner ! {quic_dist_stream, StreamRef, closed},
+                            NewStreams = maps:remove(StreamId, Streams),
+                            {keep_state, State#state{user_streams = NewStreams}, [
+                                {reply, From, ok}
+                            ]};
+                        false ->
+                            %% Only send side closed - update state
+                            NewUS = US#user_stream{send_fin = true},
+                            NewStreams = maps:put(StreamId, NewUS, Streams),
+                            {keep_state, State#state{user_streams = NewStreams}, [
+                                {reply, From, ok}
+                            ]}
+                    end;
+                false ->
+                    {keep_state, State, [{reply, From, {error, not_owner}}]}
+            end;
+        error ->
+            {keep_state, State, [{reply, From, {error, unknown_stream}}]}
+    end.
+
+%% @private
+%% Handle reset_user_stream call.
+handle_reset_user_stream(
+    From, StreamId, ErrorCode, #state{conn = Conn, node = Node, user_streams = Streams} = State
+) ->
+    case maps:find(StreamId, Streams) of
+        {ok, #user_stream{owner = Owner, monitor = MonRef}} ->
+            %% Verify caller is the owner
+            {CallerPid, _} = From,
+            case CallerPid =:= Owner of
+                true ->
+                    %% Reset the stream
+                    _ = quic:reset_stream(Conn, StreamId, ErrorCode),
+                    %% Notify owner and cleanup
+                    erlang:demonitor(MonRef, [flush]),
+                    StreamRef = {quic_dist_stream, Node, StreamId},
+                    Owner ! {quic_dist_stream, StreamRef, {reset, ErrorCode}},
+                    NewStreams = maps:remove(StreamId, Streams),
+                    {keep_state, State#state{user_streams = NewStreams}, [
+                        {reply, From, ok}
+                    ]};
+                false ->
+                    {keep_state, State, [{reply, From, {error, not_owner}}]}
+            end;
+        error ->
+            {keep_state, State, [{reply, From, {error, unknown_stream}}]}
+    end.
+
+%% @private
+%% Handle accept_user_streams call.
+%% Adds the caller to the acceptor pool (multiple processes can accept streams).
+handle_accept_user_streams(From, Acceptor, #state{acceptor_pool = Pool} = State) ->
+    %% Check if already in pool
+    case lists:keyfind(Acceptor, 1, Pool) of
+        {Acceptor, _} ->
+            %% Already registered
+            {keep_state, State, [{reply, From, ok}]};
+        false ->
+            %% Add to pool with monitor
+            MonRef = erlang:monitor(process, Acceptor),
+            NewPool = [{Acceptor, MonRef} | Pool],
+            {keep_state, State#state{acceptor_pool = NewPool}, [{reply, From, ok}]}
+    end.
+
+%% @private
+%% Handle stop_accepting_streams call.
+%% Removes the caller from the acceptor pool.
+handle_stop_accepting_streams(From, #state{acceptor_pool = Pool} = State) ->
+    {CallerPid, _} = From,
+    case lists:keyfind(CallerPid, 1, Pool) of
+        {CallerPid, MonRef} ->
+            erlang:demonitor(MonRef, [flush]),
+            NewPool = lists:keydelete(CallerPid, 1, Pool),
+            {keep_state, State#state{acceptor_pool = NewPool}, [{reply, From, ok}]};
+        false ->
+            %% Not in pool - ok
+            {keep_state, State, [{reply, From, ok}]}
+    end.
+
+%% @private
+%% Handle controlling_process call - transfer stream ownership to another process.
+handle_controlling_process(From, StreamId, NewOwner, #state{user_streams = Streams} = State) ->
+    case maps:find(StreamId, Streams) of
+        {ok, #user_stream{owner = Owner, monitor = MonRef} = US} ->
+            %% Verify caller is the current owner
+            {CallerPid, _} = From,
+            case CallerPid =:= Owner of
+                true ->
+                    %% Transfer ownership
+                    erlang:demonitor(MonRef, [flush]),
+                    NewMonRef = erlang:monitor(process, NewOwner),
+                    NewUS = US#user_stream{owner = NewOwner, monitor = NewMonRef},
+                    NewStreams = maps:put(StreamId, NewUS, Streams),
+                    {keep_state, State#state{user_streams = NewStreams}, [
+                        {reply, From, ok}
+                    ]};
+                false ->
+                    {keep_state, State, [{reply, From, {error, not_owner}}]}
+            end;
+        error ->
+            {keep_state, State, [{reply, From, {error, unknown_stream}}]}
+    end.
+
+%% @private
+%% Handle list_user_streams call.
+handle_list_user_streams(From, #state{node = Node, user_streams = Streams} = State) ->
+    StreamList = maps:fold(
+        fun(
+            StreamId,
+            #user_stream{
+                owner = Owner, priority = Priority, recv_fin = RecvFin, send_fin = SendFin
+            },
+            Acc
+        ) ->
+            [
+                #{
+                    ref => {quic_dist_stream, Node, StreamId},
+                    node => Node,
+                    stream_id => StreamId,
+                    owner => Owner,
+                    priority => Priority,
+                    recv_fin => RecvFin,
+                    send_fin => SendFin
+                }
+                | Acc
+            ]
+        end,
+        [],
+        Streams
+    ),
+    {keep_state, State, [{reply, From, StreamList}]}.
+
+%% @private
+%% Handle user stream owner process going down.
+handle_user_stream_owner_down(
+    MonRef, Pid, #state{conn = Conn, user_streams = Streams, acceptor_pool = Pool} = State
+) ->
+    %% Check if this is an acceptor from the pool
+    case lists:keyfind(Pid, 1, Pool) of
+        {Pid, MonRef} ->
+            %% Acceptor died - remove from pool
+            %% Also reset any streams owned by this acceptor
+            {StreamsToReset, RemainingStreams} = maps:fold(
+                fun(StreamId, #user_stream{owner = O, monitor = M} = US, {ToReset, Keep}) ->
+                    case O =:= Pid of
+                        true ->
+                            erlang:demonitor(M, [flush]),
+                            {[StreamId | ToReset], Keep};
+                        false ->
+                            {ToReset, maps:put(StreamId, US, Keep)}
+                    end
+                end,
+                {[], #{}},
+                Streams
+            ),
+            %% Reset streams owned by dead acceptor
+            lists:foreach(
+                fun(StreamId) -> _ = quic:reset_stream(Conn, StreamId, 0) end,
+                StreamsToReset
+            ),
+            NewPool = lists:keydelete(Pid, 1, Pool),
+            {keep_state, State#state{acceptor_pool = NewPool, user_streams = RemainingStreams}};
+        false ->
+            %% Check if this is a stream owner
+            case find_stream_by_monitor(MonRef, Streams) of
+                {ok, StreamId, _UserStream} ->
+                    %% Reset the stream since owner died
+                    _ = quic:reset_stream(Conn, StreamId, 0),
+                    NewStreams = maps:remove(StreamId, Streams),
+                    {keep_state, State#state{user_streams = NewStreams}};
+                error ->
+                    %% Unknown monitor - ignore
+                    {keep_state, State}
+            end
+    end.
+
+%% @private
+%% Find a stream by its monitor reference.
+find_stream_by_monitor(MonRef, Streams) ->
+    maps:fold(
+        fun(StreamId, #user_stream{monitor = MRef} = US, Acc) ->
+            case MRef =:= MonRef of
+                true -> {ok, StreamId, US};
+                false -> Acc
+            end
+        end,
+        error,
+        Streams
+    ).
+
+%% @private
+%% Handle data received on a user stream.
+%% For existing streams: forward data to owner.
+%% For new streams: select acceptor from pool (round-robin), auto-assign ownership, deliver data.
+%% If no acceptor available: RESET stream immediately.
+handle_user_stream_data(
+    StreamId,
+    Data,
+    Fin,
+    #state{
+        conn = Conn,
+        node = Node,
+        user_streams = Streams,
+        acceptor_pool = Pool,
+        acceptor_idx = Idx,
+        recv_cnt = RecvCnt,
+        recv_oct = RecvOct
+    } = State
+) ->
+    StreamRef = {quic_dist_stream, Node, StreamId},
+    case maps:find(StreamId, Streams) of
+        {ok, #user_stream{owner = Owner, monitor = MonRef, send_fin = SendFin} = US} ->
+            %% Known stream - forward data to owner
+            Owner ! {quic_dist_stream, StreamRef, {data, Data, Fin}},
+            %% Update recv_fin if FIN received
+            case Fin of
+                true ->
+                    %% Check if stream is now fully closed
+                    case SendFin of
+                        true ->
+                            %% Both sides closed - send closed notification and cleanup
+                            Owner ! {quic_dist_stream, StreamRef, closed},
+                            erlang:demonitor(MonRef, [flush]),
+                            NewStreams = maps:remove(StreamId, Streams),
+                            {keep_state, State#state{
+                                user_streams = NewStreams,
+                                recv_cnt = RecvCnt + 1,
+                                recv_oct = RecvOct + byte_size(Data)
+                            }};
+                        false ->
+                            %% Only recv side closed
+                            NewUS = US#user_stream{recv_fin = true},
+                            NewStreams = maps:put(StreamId, NewUS, Streams),
+                            {keep_state, State#state{
+                                user_streams = NewStreams,
+                                recv_cnt = RecvCnt + 1,
+                                recv_oct = RecvOct + byte_size(Data)
+                            }}
+                    end;
+                false ->
+                    {keep_state, State#state{
+                        recv_cnt = RecvCnt + 1,
+                        recv_oct = RecvOct + byte_size(Data)
+                    }}
+            end;
+        error ->
+            %% New incoming stream - select acceptor from pool (round-robin)
+            case select_acceptor(Pool, Idx) of
+                {ok, AcceptorPid, NewIdx} ->
+                    %% Auto-assign ownership to selected acceptor
+                    OwnerMonRef = erlang:monitor(process, AcceptorPid),
+                    UserStream = #user_stream{
+                        id = StreamId,
+                        owner = AcceptorPid,
+                        monitor = OwnerMonRef,
+                        recv_fin = Fin
+                    },
+                    NewStreams = maps:put(StreamId, UserStream, Streams),
+                    %% Deliver data directly to acceptor (implicit ownership)
+                    AcceptorPid ! {quic_dist_stream, StreamRef, {data, Data, Fin}},
+                    {keep_state, State#state{
+                        user_streams = NewStreams,
+                        acceptor_idx = NewIdx,
+                        recv_cnt = RecvCnt + 1,
+                        recv_oct = RecvOct + byte_size(Data)
+                    }};
+                {error, no_acceptor} ->
+                    %% No acceptor available - RESET stream immediately
+                    ?LOG_WARNING(
+                        #{what => user_stream_no_acceptor, stream_id => StreamId, action => reset},
+                        ?QUIC_LOG_META
+                    ),
+                    _ = quic:reset_stream(Conn, StreamId, ?STREAM_REFUSED),
+                    {keep_state, State#state{
+                        recv_cnt = RecvCnt + 1,
+                        recv_oct = RecvOct + byte_size(Data)
+                    }}
+            end
+    end.
+
+%% @private
+%% Select an acceptor from the pool using round-robin.
+select_acceptor([], _Idx) ->
+    {error, no_acceptor};
+select_acceptor(Pool, Idx) ->
+    Len = length(Pool),
+    {Acceptor, _MonRef} = lists:nth((Idx rem Len) + 1, Pool),
+    {ok, Acceptor, Idx + 1}.

--- a/test/quic_dist_user_stream_tests.erl
+++ b/test/quic_dist_user_stream_tests.erl
@@ -1,0 +1,237 @@
+%%% -*- erlang -*-
+%%%
+%%% QUIC Distribution User Stream Unit Tests
+%%% Tests basic user stream types, records, and helper functions
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+
+-module(quic_dist_user_stream_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic_dist.hrl").
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+%% Test user stream thresholds
+user_stream_threshold_test_() ->
+    [
+        {"Client threshold is 20", fun() ->
+            ?assertEqual(20, ?USER_STREAM_THRESHOLD_CLIENT)
+        end},
+        {"Server threshold is 17", fun() ->
+            ?assertEqual(17, ?USER_STREAM_THRESHOLD_SERVER)
+        end},
+        {"Client threshold above highest dist stream (16)", fun() ->
+            %% Client dist streams: 0, 4, 8, 12, 16
+            ?assert(?USER_STREAM_THRESHOLD_CLIENT > 16)
+        end},
+        {"Server threshold above highest dist stream (13)", fun() ->
+            %% Server dist streams: 1, 5, 9, 13
+            ?assert(?USER_STREAM_THRESHOLD_SERVER > 13)
+        end}
+    ].
+
+%% Test user stream constants
+user_stream_constants_test_() ->
+    [
+        {"STREAM_REFUSED error code is defined", fun() ->
+            ?assertEqual(16#100, ?STREAM_REFUSED)
+        end},
+        {"USER_STREAM_MIN_PRIORITY is 16", fun() ->
+            ?assertEqual(16, ?USER_STREAM_MIN_PRIORITY)
+        end},
+        {"USER_STREAM_DEFAULT_PRIORITY is 128", fun() ->
+            ?assertEqual(128, ?USER_STREAM_DEFAULT_PRIORITY)
+        end},
+        {"Min priority is less than default", fun() ->
+            ?assert(?USER_STREAM_MIN_PRIORITY < ?USER_STREAM_DEFAULT_PRIORITY)
+        end},
+        {"Default priority is in valid range", fun() ->
+            ?assert(?USER_STREAM_DEFAULT_PRIORITY >= ?USER_STREAM_MIN_PRIORITY),
+            ?assert(?USER_STREAM_DEFAULT_PRIORITY =< 255)
+        end}
+    ].
+
+%% Test stream_ref type construction
+stream_ref_test_() ->
+    [
+        {"Stream ref is a tuple", fun() ->
+            Ref = {quic_dist_stream, 'node@host', 20},
+            ?assertMatch({quic_dist_stream, _, _}, Ref)
+        end},
+        {"Stream ref contains node", fun() ->
+            Node = 'test@localhost',
+            Ref = {quic_dist_stream, Node, 20},
+            {quic_dist_stream, RefNode, _} = Ref,
+            ?assertEqual(Node, RefNode)
+        end},
+        {"Stream ref contains stream id", fun() ->
+            StreamId = 24,
+            Ref = {quic_dist_stream, 'node@host', StreamId},
+            {quic_dist_stream, _, RefStreamId} = Ref,
+            ?assertEqual(StreamId, RefStreamId)
+        end}
+    ].
+
+%% Test user_stream record
+user_stream_record_test_() ->
+    [
+        {"Default recv_fin is false", fun() ->
+            US = #user_stream{id = 20, owner = self(), monitor = make_ref()},
+            ?assertEqual(false, US#user_stream.recv_fin)
+        end},
+        {"Default send_fin is false", fun() ->
+            US = #user_stream{id = 20, owner = self(), monitor = make_ref()},
+            ?assertEqual(false, US#user_stream.send_fin)
+        end},
+        {"Default priority is USER_STREAM_DEFAULT_PRIORITY", fun() ->
+            US = #user_stream{id = 20, owner = self(), monitor = make_ref()},
+            ?assertEqual(?USER_STREAM_DEFAULT_PRIORITY, US#user_stream.priority)
+        end},
+        {"Can set recv_fin to true", fun() ->
+            US = #user_stream{id = 20, owner = self(), monitor = make_ref(), recv_fin = true},
+            ?assertEqual(true, US#user_stream.recv_fin)
+        end},
+        {"Can set send_fin to true", fun() ->
+            US = #user_stream{id = 20, owner = self(), monitor = make_ref(), send_fin = true},
+            ?assertEqual(true, US#user_stream.send_fin)
+        end},
+        {"Can set custom priority", fun() ->
+            US = #user_stream{id = 20, owner = self(), monitor = make_ref(), priority = 64},
+            ?assertEqual(64, US#user_stream.priority)
+        end},
+        {"Record stores owner pid", fun() ->
+            Owner = self(),
+            US = #user_stream{id = 20, owner = Owner, monitor = make_ref()},
+            ?assertEqual(Owner, US#user_stream.owner)
+        end},
+        {"Record stores stream id", fun() ->
+            US = #user_stream{id = 42, owner = self(), monitor = make_ref()},
+            ?assertEqual(42, US#user_stream.id)
+        end}
+    ].
+
+%% Test message formats
+message_format_test_() ->
+    [
+        {"Data message format", fun() ->
+            StreamRef = {quic_dist_stream, 'node@host', 20},
+            Data = <<"test data">>,
+            Msg = {quic_dist_stream, StreamRef, {data, Data, false}},
+            ?assertMatch({quic_dist_stream, {quic_dist_stream, _, _}, {data, _, false}}, Msg)
+        end},
+        {"Data message with FIN", fun() ->
+            StreamRef = {quic_dist_stream, 'node@host', 20},
+            Msg = {quic_dist_stream, StreamRef, {data, <<"last">>, true}},
+            ?assertMatch({quic_dist_stream, _, {data, _, true}}, Msg)
+        end},
+        {"Reset message format", fun() ->
+            StreamRef = {quic_dist_stream, 'node@host', 20},
+            Msg = {quic_dist_stream, StreamRef, {reset, 0}},
+            ?assertMatch({quic_dist_stream, _, {reset, _}}, Msg)
+        end},
+        {"Reset message with STREAM_REFUSED code", fun() ->
+            StreamRef = {quic_dist_stream, 'node@host', 20},
+            Msg = {quic_dist_stream, StreamRef, {reset, ?STREAM_REFUSED}},
+            ?assertMatch({quic_dist_stream, _, {reset, 16#100}}, Msg)
+        end},
+        {"Closed message format", fun() ->
+            StreamRef = {quic_dist_stream, 'node@host', 20},
+            Msg = {quic_dist_stream, StreamRef, closed},
+            ?assertMatch({quic_dist_stream, _, closed}, Msg)
+        end}
+    ].
+
+%% Test stream ID classification
+%% Note: is_user_stream checks based on stream ID bits, NOT connection role
+%% Even IDs (bit 0 = 0): client-initiated, use CLIENT threshold
+%% Odd IDs (bit 0 = 1): server-initiated, use SERVER threshold
+stream_id_classification_test_() ->
+    [
+        {"Control stream (0) is client-initiated (even), not user stream", fun() ->
+            % bit 0 = 0, client-initiated
+            ?assertEqual(0, 0 band 1),
+            ?assert(0 < ?USER_STREAM_THRESHOLD_CLIENT)
+        end},
+        {"Stream 1 is server-initiated (odd), not user stream", fun() ->
+            % bit 0 = 1, server-initiated
+            ?assertEqual(1, 1 band 1),
+            ?assert(1 < ?USER_STREAM_THRESHOLD_SERVER)
+        end},
+        {"Client data stream 4 (even) is not user stream", fun() ->
+            ?assertEqual(0, 4 band 1),
+            ?assert(4 < ?USER_STREAM_THRESHOLD_CLIENT)
+        end},
+        {"Client data stream 16 (even) is not user stream", fun() ->
+            ?assertEqual(0, 16 band 1),
+            ?assert(16 < ?USER_STREAM_THRESHOLD_CLIENT)
+        end},
+        {"Server data stream 13 (odd) is not user stream", fun() ->
+            ?assertEqual(1, 13 band 1),
+            ?assert(13 < ?USER_STREAM_THRESHOLD_SERVER)
+        end},
+        {"Stream 20 (even, client-initiated) is user stream", fun() ->
+            ?assertEqual(0, 20 band 1),
+            ?assert(20 >= ?USER_STREAM_THRESHOLD_CLIENT)
+        end},
+        {"Stream 17 (odd, server-initiated) is user stream", fun() ->
+            ?assertEqual(1, 17 band 1),
+            ?assert(17 >= ?USER_STREAM_THRESHOLD_SERVER)
+        end},
+        {"Stream 100 (even) uses client threshold", fun() ->
+            ?assertEqual(0, 100 band 1),
+            ?assert(100 >= ?USER_STREAM_THRESHOLD_CLIENT)
+        end},
+        {"Stream 101 (odd) uses server threshold", fun() ->
+            ?assertEqual(1, 101 band 1),
+            ?assert(101 >= ?USER_STREAM_THRESHOLD_SERVER)
+        end}
+    ].
+
+%% Test is_user_stream helper function logic
+%% This tests the correct implementation based on stream ID bit, not role
+is_user_stream_logic_test_() ->
+    IsUserStream = fun(StreamId) ->
+        case StreamId band 1 of
+            % Client-initiated
+            0 -> StreamId >= ?USER_STREAM_THRESHOLD_CLIENT;
+            % Server-initiated
+            1 -> StreamId >= ?USER_STREAM_THRESHOLD_SERVER
+        end
+    end,
+    [
+        {"Stream 0 (control, client-initiated) is not user stream", fun() ->
+            ?assertNot(IsUserStream(0))
+        end},
+        {"Stream 1 (server-initiated) is not user stream", fun() ->
+            ?assertNot(IsUserStream(1))
+        end},
+        {"Stream 4 (client data) is not user stream", fun() ->
+            ?assertNot(IsUserStream(4))
+        end},
+        {"Stream 5 (server data) is not user stream", fun() ->
+            ?assertNot(IsUserStream(5))
+        end},
+        {"Stream 16 (client data) is not user stream", fun() ->
+            ?assertNot(IsUserStream(16))
+        end},
+        {"Stream 13 (server data) is not user stream", fun() ->
+            ?assertNot(IsUserStream(13))
+        end},
+        {"Stream 17 (server-initiated) IS user stream", fun() ->
+            ?assert(IsUserStream(17))
+        end},
+        {"Stream 20 (client-initiated) IS user stream", fun() ->
+            ?assert(IsUserStream(20))
+        end},
+        {"Stream 21 (server-initiated) IS user stream", fun() ->
+            ?assert(IsUserStream(21))
+        end},
+        {"Stream 24 (client-initiated) IS user stream", fun() ->
+            ?assert(IsUserStream(24))
+        end}
+    ].


### PR DESCRIPTION
## Summary

- Add API for opening, sending, receiving, and closing streams over existing distribution connections
- Support acceptor pool with round-robin selection for incoming streams
- Add stream priority support (16-255, distribution reserves 0-15)
- Fix `is_user_stream` bug to check stream ID bits instead of connection role

## API

```erlang
%% Open/close streams
quic_dist:open_stream(Node) -> {ok, StreamRef} | {error, term()}
quic_dist:open_stream(Node, [{priority, 16..255}]) -> {ok, StreamRef}
quic_dist:close_stream(StreamRef) -> ok
quic_dist:reset_stream(StreamRef) -> ok

%% Send data
quic_dist:send(StreamRef, Data) -> ok
quic_dist:send(StreamRef, Data, Fin) -> ok

%% Accept incoming streams
quic_dist:accept_streams(Node) -> ok
quic_dist:stop_accepting(Node) -> ok
quic_dist:controlling_process(StreamRef, NewOwner) -> ok

%% List streams
quic_dist:list_streams() -> [stream_info()]
quic_dist:list_streams(Node) -> [stream_info()]
```

## Changes

- `include/quic_dist.hrl`: Add constants and `user_stream` record
- `src/dist/quic_dist_controller.erl`: Add acceptor pool, stream handlers, fix `is_user_stream`
- `src/dist/quic_dist.erl`: Add public API functions
- `docs/QUIC_DIST.md`: Add User Streams API documentation
- `test/quic_dist_user_stream_tests.erl`: Unit tests