### PR TITLE
fix(h3): discard unknown unidirectional stream payload

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -70,6 +70,7 @@
 %% Test exports - only available when compiled with TEST defined
 -ifdef(TEST).
 -export([
+    handle_stream_data/4,
     handle_stream_closed/2,
     handle_control_frame/2,
     handle_request_frame/5,
@@ -95,6 +96,9 @@
     do_send_trailers/3
 ]).
 -endif.
+
+%% Exposed for tests and introspection; not part of the public H3 API.
+-export([test_discarded_uni_streams/1]).
 
 %%====================================================================
 %% Types
@@ -152,6 +156,10 @@
     %% Pending uni stream type detection
     %% Value is binary() for regular streams, or {push_pending, binary()} for push streams
     uni_stream_buffers = #{} :: #{stream_id() => binary() | {push_pending, binary()}},
+
+    %% Uni streams classified as unknown type; subsequent bytes are
+    %% discarded per RFC 9114 §6.2.3.
+    discarded_uni_streams = sets:new([{version, 2}]) :: sets:set(stream_id()),
 
     %% QPACK instruction buffers for partial instructions (RFC 9204 Section 4.5)
     encoder_buffer = <<>> :: binary(),
@@ -941,6 +949,11 @@ stream_blocked_by_goaway(_StreamId, client, _State) ->
 
 handle_stream_data(StreamId, Data, Fin, State) ->
     case classify_stream(StreamId, State) of
+        {uni, discarded} ->
+            %% RFC 9114 §6.2.3: unknown uni-stream bytes are ignored.
+            _ = Data,
+            _ = Fin,
+            {ok, State};
         {uni, pending} ->
             handle_uni_stream_type(StreamId, Data, State);
         {uni, push_pending} ->
@@ -970,18 +983,23 @@ classify_stream(StreamId, #state{peer_encoder_stream = StreamId}) ->
 classify_stream(StreamId, #state{peer_decoder_stream = StreamId}) ->
     {uni, qpack_decoder};
 classify_stream(StreamId, #state{uni_stream_buffers = Buffers, received_pushes = Received} = State) ->
-    case maps:is_key(StreamId, Buffers) of
+    case sets:is_element(StreamId, State#state.discarded_uni_streams) of
         true ->
-            %% Check if this is a push stream pending push ID parsing
-            case maps:get(StreamId, Buffers) of
-                {push_pending, _} -> {uni, push_pending};
-                _ -> {uni, pending}
-            end;
+            {uni, discarded};
         false ->
-            %% Check if this is an active push stream (client-side)
-            case find_push_by_stream_id(StreamId, Received) of
-                {ok, PushId} -> {uni, {push, PushId}};
-                error -> classify_stream_type(StreamId, State)
+            case maps:is_key(StreamId, Buffers) of
+                true ->
+                    %% Check if this is a push stream pending push ID parsing
+                    case maps:get(StreamId, Buffers) of
+                        {push_pending, _} -> {uni, push_pending};
+                        _ -> {uni, pending}
+                    end;
+                false ->
+                    %% Check if this is an active push stream (client-side)
+                    case find_push_by_stream_id(StreamId, Received) of
+                        {ok, PushId} -> {uni, {push, PushId}};
+                        error -> classify_stream_type(StreamId, State)
+                    end
             end
     end.
 
@@ -1014,17 +1032,25 @@ handle_uni_stream_type(StreamId, Data, #state{uni_stream_buffers = Buffers} = St
             State1 = State#state{uni_stream_buffers = maps:remove(StreamId, Buffers)},
             case assign_uni_stream(StreamId, Type, State1) of
                 {ok, State2} ->
-                    %% Process remaining data if any
-                    case Rest of
-                        <<>> -> {ok, State2};
-                        _ -> handle_stream_data(StreamId, Rest, false, State2)
-                    end;
+                    dispatch_remaining_uni_data(StreamId, Type, Rest, State2);
                 {error, Reason} ->
                     {error, Reason, State1}
             end;
         {more, _} ->
             {ok, State#state{uni_stream_buffers = Buffers#{StreamId => Combined}}}
     end.
+
+%% After classifying a uni stream, either discard the rest (unknown
+%% types, RFC 9114 §6.2.3) or re-enter stream dispatch so known types
+%% process their payload.
+dispatch_remaining_uni_data(StreamId, {unknown, _Type}, _Rest, State) ->
+    {ok, State#state{
+        discarded_uni_streams = sets:add_element(StreamId, State#state.discarded_uni_streams)
+    }};
+dispatch_remaining_uni_data(_StreamId, _Type, <<>>, State) ->
+    {ok, State};
+dispatch_remaining_uni_data(StreamId, _Type, Rest, State) ->
+    handle_stream_data(StreamId, Rest, false, State).
 
 assign_uni_stream(StreamId, control, #state{peer_control_stream = undefined} = State) ->
     {ok, State#state{peer_control_stream = StreamId}};
@@ -2703,7 +2729,8 @@ handle_stream_closed(
     #state{
         streams = Streams,
         stream_buffers = Buffers,
-        uni_stream_buffers = UniBuffers
+        uni_stream_buffers = UniBuffers,
+        discarded_uni_streams = Discarded
     } = State
 ) ->
     case is_critical_stream(StreamId, State) of
@@ -2721,7 +2748,8 @@ handle_stream_closed(
             {ok, State1#state{
                 streams = maps:remove(StreamId, Streams),
                 stream_buffers = maps:remove(StreamId, Buffers),
-                uni_stream_buffers = maps:remove(StreamId, UniBuffers)
+                uni_stream_buffers = maps:remove(StreamId, UniBuffers),
+                discarded_uni_streams = sets:del_element(StreamId, Discarded)
             }}
     end.
 
@@ -2739,6 +2767,9 @@ maybe_reset_incomplete_request(StreamId, #state{role = server, quic_conn = QuicC
     end;
 maybe_reset_incomplete_request(_StreamId, _State) ->
     ok.
+
+test_discarded_uni_streams(#state{discarded_uni_streams = D}) ->
+    D.
 
 %% Check if a stream is a critical H3 stream
 is_critical_stream(StreamId, #state{peer_control_stream = StreamId}) -> {true, control};

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -474,8 +474,8 @@ goaway_clears_blocked_streams_test() ->
         local_decoder_stream => undefined
     }),
     Result = quic_h3_connection:cleanup_blocked_streams_on_goaway(State),
-    %% Blocked streams (field 26, tuple position 27) should be empty after cleanup
-    BlockedStreams = element(27, Result),
+    %% Blocked streams (tuple position 28) should be empty after cleanup
+    BlockedStreams = element(28, Result),
     ?assertEqual(#{}, BlockedStreams).
 
 goaway_empty_blocked_streams_test() ->
@@ -485,7 +485,7 @@ goaway_empty_blocked_streams_test() ->
         local_decoder_stream => undefined
     }),
     Result = quic_h3_connection:cleanup_blocked_streams_on_goaway(State),
-    BlockedStreams = element(27, Result),
+    BlockedStreams = element(28, Result),
     ?assertEqual(#{}, BlockedStreams).
 
 %%====================================================================
@@ -513,8 +513,8 @@ outbound_field_section_uses_peer_setting_test() ->
         local_max_field_section_size => 1000,
         peer_max_field_section_size => 100
     }),
-    %% peer_max_field_section_size is at tuple position 28
-    PeerMax = element(28, State),
+    %% peer_max_field_section_size is at tuple position 29
+    PeerMax = element(29, State),
     ?assertEqual(100, PeerMax).
 
 %% Blocked streams limit uses LOCAL setting (our decoder's limit)
@@ -526,9 +526,9 @@ blocked_streams_uses_local_setting_test() ->
         peer_max_blocked_streams => 10,
         blocked_streams => #{4 => {1, <<>>, false}, 8 => {2, <<>>, false}}
     }),
-    %% Tuple positions: 27=blocked_streams, 32=local_max_blocked_streams
-    BlockedStreams = element(27, State),
-    LocalMaxBlocked = element(32, State),
+    %% Tuple positions: 28=blocked_streams, 33=local_max_blocked_streams
+    BlockedStreams = element(28, State),
+    LocalMaxBlocked = element(33, State),
     BlockedCount = map_size(BlockedStreams),
     ?assertEqual(2, BlockedCount),
     ?assertEqual(2, LocalMaxBlocked),
@@ -543,12 +543,12 @@ settings_directionality_state_fields_test() ->
         peer_max_blocked_streams => 10
     }),
     %% Tuple positions:
-    %% 28=peer_max_field_section_size, 29=peer_max_blocked_streams,
-    %% 30=peer_connect_enabled, 31=local_max_field_section_size, 32=local_max_blocked_streams
-    PeerFieldSize = element(28, State),
-    PeerBlocked = element(29, State),
-    LocalFieldSize = element(31, State),
-    LocalBlocked = element(32, State),
+    %% 29=peer_max_field_section_size, 30=peer_max_blocked_streams,
+    %% 31=peer_connect_enabled, 32=local_max_field_section_size, 33=local_max_blocked_streams
+    PeerFieldSize = element(29, State),
+    PeerBlocked = element(30, State),
+    LocalFieldSize = element(32, State),
+    LocalBlocked = element(33, State),
     ?assertEqual(500, LocalFieldSize),
     ?assertEqual(1000, PeerFieldSize),
     ?assertEqual(5, LocalBlocked),
@@ -655,8 +655,8 @@ data_buffered_when_no_handler_test() ->
     {ok, _Stream2, State2} = quic_h3_connection:handle_request_frame(
         0, {data, <<"hello">>}, false, Stream, State
     ),
-    %% Check that data was buffered (tuple position 43 for stream_data_buffers)
-    StreamDataBuffers = element(43, State2),
+    %% Check that data was buffered (tuple position 44 for stream_data_buffers)
+    StreamDataBuffers = element(44, State2),
     ?assertMatch(#{0 := {[{<<"hello">>, false}], 5, false}}, StreamDataBuffers).
 
 %% Test that data is sent to handler when registered
@@ -709,7 +709,7 @@ multiple_chunks_buffered_in_order_test() ->
         0, {data, <<"chunk2">>}, true, Stream1, State1
     ),
     %% Check buffered data (stored in reverse order internally)
-    StreamDataBuffers = element(43, State2),
+    StreamDataBuffers = element(44, State2),
     {Chunks, Size, HadFin} = maps:get(0, StreamDataBuffers),
     ?assertEqual([{<<"chunk2">>, true}, {<<"chunk1">>, false}], Chunks),
     ?assertEqual(12, Size),
@@ -1473,6 +1473,73 @@ push_promise_get_accepted_client_test() ->
     ).
 
 %%====================================================================
+%% Unknown unidirectional stream discard (RFC 9114 §6.2.3)
+%%====================================================================
+
+%% Regression: an unknown uni-stream type used to be re-parsed as a new
+%% stream-type prefix, which for WebTransport's WT_STREAM (0x54)
+%% followed by a zero session-id byte meant the server classified the
+%% next byte (0x00) as a second control stream and closed the
+%% connection.
+unknown_uni_stream_wt_session_id_zero_is_discarded_test() ->
+    State0 = make_test_state(#{role => server}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    Result = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#54, 0, "GET /\n">>, false, State1
+    ),
+    ?assertMatch({ok, _}, Result),
+    {ok, State2} = Result,
+    ?assert(
+        sets:is_element(
+            StreamId, quic_h3_connection:test_discarded_uni_streams(State2)
+        )
+    ).
+
+unknown_uni_stream_subsequent_data_is_ignored_test() ->
+    State0 = make_test_state(#{role => server}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#54>>, false, State1
+    ),
+    %% Feeding more bytes on the already-discarded stream must succeed
+    %% silently and must not re-enter classification.
+    {ok, State3} = quic_h3_connection:handle_stream_data(
+        StreamId, <<0, 0, 0, "payload">>, false, State2
+    ),
+    ?assert(
+        sets:is_element(
+            StreamId, quic_h3_connection:test_discarded_uni_streams(State3)
+        )
+    ).
+
+unknown_uni_stream_closure_clears_discard_state_test() ->
+    State0 = make_test_state(#{role => server}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#54, 0>>, false, State1
+    ),
+    ?assert(
+        sets:is_element(
+            StreamId, quic_h3_connection:test_discarded_uni_streams(State2)
+        )
+    ),
+    {ok, State3} = quic_h3_connection:handle_stream_closed(StreamId, State2),
+    ?assertNot(
+        sets:is_element(
+            StreamId, quic_h3_connection:test_discarded_uni_streams(State3)
+        )
+    ).
+
+mark_uni_stream_open(StreamId, State) ->
+    {ok, State1} = quic_h3_connection:handle_new_stream(
+        StreamId, unidirectional, State
+    ),
+    State1.
+
+%%====================================================================
 %% Helper Functions
 %%====================================================================
 
@@ -1502,6 +1569,7 @@ make_test_state(Overrides) ->
         next_stream_id => 0,
         stream_buffers => #{},
         uni_stream_buffers => #{},
+        discarded_uni_streams => sets:new([{version, 2}]),
         encoder_buffer => <<>>,
         decoder_buffer => <<>>,
         blocked_streams => #{},
@@ -1541,11 +1609,11 @@ make_test_state(Overrides) ->
         maps:get(settings_sent, Merged), maps:get(settings_received, Merged),
         maps:get(goaway_id, Merged), maps:get(last_stream_id, Merged), maps:get(streams, Merged),
         maps:get(next_stream_id, Merged), maps:get(stream_buffers, Merged),
-        maps:get(uni_stream_buffers, Merged), maps:get(encoder_buffer, Merged),
-        maps:get(decoder_buffer, Merged), maps:get(blocked_streams, Merged),
-        maps:get(peer_max_field_section_size, Merged), maps:get(peer_max_blocked_streams, Merged),
-        maps:get(peer_connect_enabled, Merged), maps:get(local_max_field_section_size, Merged),
-        maps:get(local_max_blocked_streams, Merged),
+        maps:get(uni_stream_buffers, Merged), maps:get(discarded_uni_streams, Merged),
+        maps:get(encoder_buffer, Merged), maps:get(decoder_buffer, Merged),
+        maps:get(blocked_streams, Merged), maps:get(peer_max_field_section_size, Merged),
+        maps:get(peer_max_blocked_streams, Merged), maps:get(peer_connect_enabled, Merged),
+        maps:get(local_max_field_section_size, Merged), maps:get(local_max_blocked_streams, Merged),
         %% Push fields
         maps:get(max_push_id, Merged), maps:get(next_push_id, Merged),
         maps:get(push_streams, Merged), maps:get(cancelled_pushes, Merged),

--- a/test/quic_h3_push_tests.erl
+++ b/test/quic_h3_push_tests.erl
@@ -23,8 +23,8 @@ allocate_push_id_test() ->
         max_push_id => 10,
         next_push_id => 0
     }),
-    %% next_push_id is at position 34 (0-indexed: 33)
-    NextPushId = element(34, State),
+    %% next_push_id is at position 35
+    NextPushId = element(35, State),
     ?assertEqual(0, NextPushId).
 
 %%====================================================================
@@ -35,15 +35,15 @@ allocate_push_id_test() ->
 max_push_id_enables_push_test() ->
     State = make_test_state(#{role => server, settings_received => true}),
     {ok, State1} = quic_h3_connection:handle_control_frame({max_push_id, 10}, State),
-    %% max_push_id is at position 33
-    MaxPushId = element(33, State1),
+    %% max_push_id is at position 34
+    MaxPushId = element(34, State1),
     ?assertEqual(10, MaxPushId).
 
 %% MAX_PUSH_ID can increase
 max_push_id_increase_ok_test() ->
     State = make_test_state(#{role => server, max_push_id => 5, settings_received => true}),
     {ok, State1} = quic_h3_connection:handle_control_frame({max_push_id, 10}, State),
-    MaxPushId = element(33, State1),
+    MaxPushId = element(34, State1),
     ?assertEqual(10, MaxPushId).
 
 %% MAX_PUSH_ID cannot decrease
@@ -71,8 +71,8 @@ cancel_push_server_receives_test() ->
     }),
     {ok, State1} = quic_h3_connection:handle_control_frame({cancel_push, 5}, State),
     %% cancelled_pushes should contain push ID 5
-    %% cancelled_pushes is at position 36 (1-indexed, after push_streams at 35)
-    CancelledPushes = element(36, State1),
+    %% cancelled_pushes is at position 37 (1-indexed, after push_streams at 36)
+    CancelledPushes = element(37, State1),
     ?assert(sets:is_element(5, CancelledPushes)).
 
 %%====================================================================
@@ -213,8 +213,8 @@ push_allocation_cleans_cancelled_set_test() ->
         cancelled_pushes => sets:from_list([0, 1], [{version, 2}])
     }),
     {ok, 2, State1} = quic_h3_connection:allocate_push_id(State),
-    %% cancelled_pushes is at position 36
-    Cancelled = element(36, State1),
+    %% cancelled_pushes is at position 37
+    Cancelled = element(37, State1),
     %% IDs 0 and 1 should have been removed
     ?assertNot(sets:is_element(0, Cancelled)),
     ?assertNot(sets:is_element(1, Cancelled)).
@@ -234,8 +234,8 @@ push_stream_tracks_frame_state_test() ->
     }),
     %% Correlate push stream - should set state to expecting_headers
     {ok, State1} = quic_h3_connection:process_push_stream_id(100, 5, <<>>, State),
-    %% received_pushes is at position 39 and stores #h3_stream{}.
-    Received = element(39, State1),
+    %% received_pushes is at position 40 and stores #h3_stream{}.
+    Received = element(40, State1),
     PushStream = maps:get(5, Received),
     ?assertEqual(100, element(2, PushStream)),
     ?assertEqual(expecting_headers, element(15, PushStream)).
@@ -293,8 +293,8 @@ push_cleanup_removes_local_cancelled_test() ->
         stream_buffers => #{100 => <<>>}
     }),
     {ok, State1} = quic_h3_connection:cleanup_push_stream(5, 100, State),
-    %% local_cancelled_pushes is at position 40
-    LocalCancelled = element(40, State1),
+    %% local_cancelled_pushes is at position 41
+    LocalCancelled = element(41, State1),
     ?assertNot(sets:is_element(5, LocalCancelled)).
 
 %% Client-side cleanup removes from received_pushes
@@ -306,8 +306,8 @@ push_cleanup_removes_received_pushes_test() ->
         stream_buffers => #{100 => <<>>}
     }),
     {ok, State1} = quic_h3_connection:cleanup_push_stream(5, 100, State),
-    %% received_pushes is at position 39
-    Received = element(39, State1),
+    %% received_pushes is at position 40
+    Received = element(40, State1),
     ?assertNot(maps:is_key(5, Received)).
 
 %% Cleanup removes stream buffers
@@ -352,6 +352,7 @@ make_test_state(Overrides) ->
         next_stream_id => 0,
         stream_buffers => #{},
         uni_stream_buffers => #{},
+        discarded_uni_streams => sets:new([{version, 2}]),
         encoder_buffer => <<>>,
         decoder_buffer => <<>>,
         blocked_streams => #{},
@@ -387,14 +388,15 @@ make_test_state(Overrides) ->
         maps:get(settings_sent, Merged), maps:get(settings_received, Merged),
         maps:get(goaway_id, Merged), maps:get(last_stream_id, Merged), maps:get(streams, Merged),
         maps:get(next_stream_id, Merged), maps:get(stream_buffers, Merged),
-        maps:get(uni_stream_buffers, Merged), maps:get(encoder_buffer, Merged),
-        maps:get(decoder_buffer, Merged), maps:get(blocked_streams, Merged),
-        maps:get(peer_max_field_section_size, Merged), maps:get(peer_max_blocked_streams, Merged),
-        maps:get(peer_connect_enabled, Merged), maps:get(local_max_field_section_size, Merged),
-        maps:get(local_max_blocked_streams, Merged), maps:get(max_push_id, Merged),
-        maps:get(next_push_id, Merged), maps:get(push_streams, Merged),
-        maps:get(cancelled_pushes, Merged), maps:get(local_max_push_id, Merged),
-        maps:get(promised_pushes, Merged), maps:get(received_pushes, Merged),
-        maps:get(local_cancelled_pushes, Merged), maps:get(last_accepted_push_id, Merged),
-        maps:get(stream_handlers, Merged), maps:get(stream_data_buffers, Merged),
-        maps:get(stream_buffer_limit, Merged), maps:get(local_connect_enabled, Merged)}.
+        maps:get(uni_stream_buffers, Merged), maps:get(discarded_uni_streams, Merged),
+        maps:get(encoder_buffer, Merged), maps:get(decoder_buffer, Merged),
+        maps:get(blocked_streams, Merged), maps:get(peer_max_field_section_size, Merged),
+        maps:get(peer_max_blocked_streams, Merged), maps:get(peer_connect_enabled, Merged),
+        maps:get(local_max_field_section_size, Merged), maps:get(local_max_blocked_streams, Merged),
+        maps:get(max_push_id, Merged), maps:get(next_push_id, Merged),
+        maps:get(push_streams, Merged), maps:get(cancelled_pushes, Merged),
+        maps:get(local_max_push_id, Merged), maps:get(promised_pushes, Merged),
+        maps:get(received_pushes, Merged), maps:get(local_cancelled_pushes, Merged),
+        maps:get(last_accepted_push_id, Merged), maps:get(stream_handlers, Merged),
+        maps:get(stream_data_buffers, Merged), maps:get(stream_buffer_limit, Merged),
+        maps:get(local_connect_enabled, Merged)}.


### PR DESCRIPTION
## Summary

`handle_uni_stream_type/3` was re-feeding the remainder of an unknown unidirectional stream back through `classify_stream`, which happily returned `unknown` again, re-entered `handle_uni_stream_type/3`, and parsed the *next* varint as a new H3 stream-type prefix.

For a WebTransport peer opening `WT_STREAM` (varint `0x54`) followed by session-id `0`, the follow-up byte `0x00` was classified as a second `control` stream and the connection was closed with `H3_STREAM_CREATION_ERROR "duplicate control stream"`.

RFC 9114 §6.2.3 requires unknown uni-stream payload to be **ignored**, not reparsed.

## Fix

- Track unknown uni streams in a new `discarded_uni_streams :: sets:set()` field on `#state{}`.
- `classify_stream/2` returns `{uni, discarded}` for ids in the set.
- `handle_stream_data/4` drops data on `{uni, discarded}` silently.
- `handle_uni_stream_type/3` no longer recurses on the payload after classifying `{unknown, _}` — it records the id and returns.
- `handle_stream_closed/2` cleans the entry.

## Tests

New cases in `test/quic_h3_compliance_tests.erl`:

- `unknown_uni_stream_wt_session_id_zero_is_discarded_test` — drives the exact bug repro with `<<16#54, 0, "GET /\n">>` and asserts no `connection_error`.
- `unknown_uni_stream_subsequent_data_is_ignored_test` — follow-up bytes don't re-enter classification.
- `unknown_uni_stream_closure_clears_discard_state_test` — cleanup on stream close.

All pre-existing tests still pass. Full gate clean: fmt, compile, eunit (1851 tests), lint, xref, dialyzer.

## Follow-up

A separate PR will add a `stream_type_handler` option to `quic_h3:connect/3` and `quic_h3:start_server/3` that lets higher layers (WebTransport, future extensions) claim specific varint stream types on uni *and* bidi streams, receiving their bytes as owner messages instead of having the H3 module try to interpret them. That's the path to actual WT server-side receive support; this PR is strictly the correctness fix.