### PR TITLE
feat(h3): stream_type_handler option for extensions (WebTransport uni)

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -350,6 +350,53 @@ Cancel a push (client only).
 
 Sends CANCEL_PUSH to tell the server we don't want this push. Can be called after receiving a `push_promise` notification.
 
+### Extension Streams (stream_type_handler)
+
+HTTP/3 layers extensions on top of unidirectional streams by assigning
+them new type codepoints — WebTransport's `WT_STREAM` (varint `0x54`) is
+the canonical example. By default, RFC 9114 §6.2.3 says the server MUST
+ignore unknown types: the bytes are discarded and the stream is left
+alone. Set `stream_type_handler` to take them over instead.
+
+The handler is a function the connection calls whenever it sees a new
+uni stream with a type it doesn't recognise:
+
+```erlang
+stream_type_handler => fun((uni, StreamId, VarintType) -> claim | ignore)
+```
+
+Return `claim` to take ownership of the stream, or `ignore` to fall back
+to the default discard. The option can be passed to either
+`quic_h3:connect/3` or `quic_h3:start_server/3`.
+
+```erlang
+Claim = fun
+    (uni, _StreamId, 16#54) -> claim;   %% WebTransport WT_STREAM
+    (_, _, _)               -> ignore
+end,
+{ok, _} = quic_h3:start_server(my_server, 4433, #{
+    cert => Cert, key => Key,
+    handler => fun my_http_handler/5,
+    stream_type_handler => Claim
+}).
+```
+
+Once a stream is claimed, the connection owner receives these events:
+
+| Event | Description |
+|-------|-------------|
+| `{stream_type_open, uni, StreamId, VarintType}` | Claim accepted; no payload yet |
+| `{stream_type_data, uni, StreamId, Data, Fin}` | Raw bytes received on the claimed stream |
+| `{stream_type_closed, uni, StreamId}` | Peer closed the stream |
+
+To send on a claimed stream, retrieve the QUIC connection with
+`quic_h3:get_quic_conn/1` and call `quic:send_data/4` directly; H3 does
+not frame or encode the payload.
+
+Bidirectional streams are always handled as HTTP/3 request streams
+today — WebTransport's `WT_BIDI_SIGNAL` (varint `0x41`) is not yet
+claimable through this hook.
+
 ### Messages to Owner
 
 The connection owner process receives messages in the form `{quic_h3, Conn, Event}`.
@@ -381,6 +428,17 @@ The connection owner process receives messages in the form `{quic_h3, Conn, Even
 | `{push_data, PushId, Data, Fin}` | Push response data (client) |
 | `{push_complete, PushId}` | Push stream completed (client) |
 | `{push_cancelled, PushId}` | Push was cancelled (client) |
+
+#### Extension Stream Events
+
+Emitted only when a `stream_type_handler` has claimed the stream — see
+[Extension Streams](#extension-streams-stream_type_handler) above.
+
+| Event | Description |
+|-------|-------------|
+| `{stream_type_open, uni, StreamId, VarintType}` | Extension claimed a new uni stream |
+| `{stream_type_data, uni, StreamId, Data, Fin}` | Raw bytes on a claimed stream |
+| `{stream_type_closed, uni, StreamId}` | Peer closed a claimed stream |
 
 #### Error Events
 

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -138,7 +138,7 @@
 
 %% Internal callbacks
 -export([
-    h3_connection_handler/4
+    h3_connection_handler/5
 ]).
 
 %% Query API
@@ -174,6 +174,9 @@
 -type status() :: 100..599.
 -type error_code() :: non_neg_integer().
 
+-type stream_type_handler() ::
+    fun((uni, stream_id(), non_neg_integer()) -> claim | ignore).
+
 -type connect_opts() :: #{
     %% TLS options
     cert => binary(),
@@ -183,7 +186,9 @@
     %% HTTP/3 settings
     settings => map(),
     %% QUIC options
-    quic_opts => map()
+    quic_opts => map(),
+    %% Extension hook for unknown uni-stream types (e.g. WebTransport).
+    stream_type_handler => stream_type_handler()
 }.
 
 -type server_opts() :: #{
@@ -195,7 +200,9 @@
     %% HTTP/3 settings
     settings => map(),
     %% QUIC options
-    quic_opts => map()
+    quic_opts => map(),
+    %% Extension hook for unknown uni-stream types (e.g. WebTransport).
+    stream_type_handler => stream_type_handler()
 }.
 
 %%====================================================================
@@ -240,7 +247,7 @@ connect(Host, Port, Opts) ->
     end.
 
 start_h3_connection(QuicConn, HostBin, Port, Opts) ->
-    H3Opts = maps:with([settings], Opts),
+    H3Opts = maps:with([settings, stream_type_handler], Opts),
     case quic_h3_connection:start_link(QuicConn, HostBin, Port, H3Opts) of
         {ok, H3Conn} ->
             %% Transfer ownership to H3 process so it receives QUIC events
@@ -429,11 +436,15 @@ unset_stream_handler(Conn, StreamId) ->
 start_server(Name, Port, Opts) ->
     Handler = maps:get(handler, Opts, fun default_handler/5),
     H3Settings = maps:get(settings, Opts, #{}),
+    StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
     QuicOpts0 = build_server_quic_opts(Opts),
     %% Set up connection handler that starts H3 connection for each QUIC connection
+    Owner = self(),
     QuicOpts = QuicOpts0#{
         connection_handler => fun(ConnPid, _ConnRef) ->
-            h3_connection_handler(ConnPid, Handler, H3Settings, self())
+            h3_connection_handler(
+                ConnPid, Handler, H3Settings, StreamTypeHandler, Owner
+            )
         end
     },
     quic:start_server(Name, Port, QuicOpts).
@@ -597,15 +608,23 @@ build_server_quic_opts(Opts) ->
     maps:merge(maps:merge(BaseOpts, TlsOpts), QuicOpts).
 
 %% @private
-%% Connection handler callback for QUIC server
-%% Called when a new QUIC connection is established (before handshake completes)
-h3_connection_handler(QuicConnPid, Handler, Settings, _Owner) ->
+%% Connection handler callback for QUIC server.
+%% Called when a new QUIC connection is established (before handshake completes).
+%% When `StreamTypeHandler' is set, the claimed stream events are
+%% delivered to `Owner' (the process that called `start_server/3').
+h3_connection_handler(QuicConnPid, Handler, Settings, StreamTypeHandler, Owner) ->
     %% Start HTTP/3 connection handler for the server side
-    H3Opts = #{
-        settings => Settings,
-        handler => Handler
-    },
-    case gen_statem:start_link(quic_h3_connection, {server, QuicConnPid, H3Opts, self()}, []) of
+    H3Opts = base_server_h3_opts(Settings, Handler, StreamTypeHandler),
+    OwnerForH3 =
+        case StreamTypeHandler of
+            undefined -> self();
+            _ -> Owner
+        end,
+    case
+        gen_statem:start_link(
+            quic_h3_connection, {server, QuicConnPid, H3Opts, OwnerForH3}, []
+        )
+    of
         {ok, H3Conn} ->
             %% Transfer ownership to H3 process so it receives QUIC events
             %% including the {connected, Info} notification after handshake completes
@@ -614,6 +633,15 @@ h3_connection_handler(QuicConnPid, Handler, Settings, _Owner) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+base_server_h3_opts(Settings, Handler, undefined) ->
+    #{settings => Settings, handler => Handler};
+base_server_h3_opts(Settings, Handler, StreamTypeHandler) ->
+    #{
+        settings => Settings,
+        handler => Handler,
+        stream_type_handler => StreamTypeHandler
+    }.
 
 default_handler(Conn, StreamId, _Method, _Path, _Headers) ->
     send_response(Conn, StreamId, 404, [{<<"content-type">>, <<"text/plain">>}]),

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -216,7 +216,19 @@
     %% RFC 9220: extended CONNECT enabled locally (advertised in our SETTINGS).
     %% Used on the server side to validate inbound :protocol pseudo-headers.
     %% Placed at the end so prior tuple positions stay stable for tests.
-    local_connect_enabled = false :: boolean()
+    local_connect_enabled = false :: boolean(),
+
+    %% Extension hook. When set, `handle_uni_stream_type/3` consults
+    %% this function for unknown stream types and, on `claim`, routes
+    %% subsequent bytes to the owner as `{stream_type_*, ...}` events
+    %% instead of discarding them.
+    stream_type_handler ::
+        fun((uni, stream_id(), non_neg_integer()) -> claim | ignore) | undefined,
+
+    %% Uni streams that the stream_type_handler claimed; maps StreamId
+    %% to the advertised varint stream type so owner messages can
+    %% include it.
+    claimed_uni_streams = #{} :: #{stream_id() => non_neg_integer()}
 }).
 
 %%====================================================================
@@ -386,6 +398,7 @@ init({client, QuicConn, _Host, _Port, Opts, Owner}) ->
     ),
     LocalMaxBlocked = maps:get(qpack_blocked_streams, LocalSettings, 0),
     LocalConnectEnabled = maps:get(enable_connect_protocol, LocalSettings, 0) =:= 1,
+    StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
 
     State = #state{
         quic_conn = QuicConn,
@@ -400,7 +413,8 @@ init({client, QuicConn, _Host, _Port, Opts, Owner}) ->
         next_stream_id = 0,
         local_max_field_section_size = LocalMaxFieldSize,
         local_max_blocked_streams = LocalMaxBlocked,
-        local_connect_enabled = LocalConnectEnabled
+        local_connect_enabled = LocalConnectEnabled,
+        stream_type_handler = StreamTypeHandler
     },
 
     %% Start in awaiting_quic - wait for QUIC connected notification
@@ -419,6 +433,7 @@ init({server, QuicConn, Opts, Owner}) ->
     LocalMaxBlocked = maps:get(qpack_blocked_streams, LocalSettings, 0),
     LocalConnectEnabled = maps:get(enable_connect_protocol, LocalSettings, 0) =:= 1,
     Handler = maps:get(handler, Opts, undefined),
+    StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
 
     State = #state{
         quic_conn = QuicConn,
@@ -433,7 +448,8 @@ init({server, QuicConn, Opts, Owner}) ->
         next_stream_id = 1,
         local_max_field_section_size = LocalMaxFieldSize,
         local_max_blocked_streams = LocalMaxBlocked,
-        local_connect_enabled = LocalConnectEnabled
+        local_connect_enabled = LocalConnectEnabled,
+        stream_type_handler = StreamTypeHandler
     },
 
     %% Store handler in process dictionary for server
@@ -954,6 +970,9 @@ handle_stream_data(StreamId, Data, Fin, State) ->
             _ = Data,
             _ = Fin,
             {ok, State};
+        {uni, {claimed, _Type}} ->
+            forward_claimed_uni_data(StreamId, Data, Fin, State),
+            {ok, State};
         {uni, pending} ->
             handle_uni_stream_type(StreamId, Data, State);
         {uni, push_pending} ->
@@ -987,19 +1006,27 @@ classify_stream(StreamId, #state{uni_stream_buffers = Buffers, received_pushes =
         true ->
             {uni, discarded};
         false ->
-            case maps:is_key(StreamId, Buffers) of
-                true ->
-                    %% Check if this is a push stream pending push ID parsing
-                    case maps:get(StreamId, Buffers) of
-                        {push_pending, _} -> {uni, push_pending};
-                        _ -> {uni, pending}
-                    end;
-                false ->
-                    %% Check if this is an active push stream (client-side)
-                    case find_push_by_stream_id(StreamId, Received) of
-                        {ok, PushId} -> {uni, {push, PushId}};
-                        error -> classify_stream_type(StreamId, State)
-                    end
+            case maps:find(StreamId, State#state.claimed_uni_streams) of
+                {ok, Type} ->
+                    {uni, {claimed, Type}};
+                error ->
+                    classify_fresh_uni_stream(StreamId, Buffers, Received, State)
+            end
+    end.
+
+classify_fresh_uni_stream(StreamId, Buffers, Received, State) ->
+    case maps:is_key(StreamId, Buffers) of
+        true ->
+            %% Check if this is a push stream pending push ID parsing
+            case maps:get(StreamId, Buffers) of
+                {push_pending, _} -> {uni, push_pending};
+                _ -> {uni, pending}
+            end;
+        false ->
+            %% Check if this is an active push stream (client-side)
+            case find_push_by_stream_id(StreamId, Received) of
+                {ok, PushId} -> {uni, {push, PushId}};
+                error -> classify_stream_type(StreamId, State)
             end
     end.
 
@@ -1040,17 +1067,51 @@ handle_uni_stream_type(StreamId, Data, #state{uni_stream_buffers = Buffers} = St
             {ok, State#state{uni_stream_buffers = Buffers#{StreamId => Combined}}}
     end.
 
-%% After classifying a uni stream, either discard the rest (unknown
-%% types, RFC 9114 §6.2.3) or re-enter stream dispatch so known types
-%% process their payload.
-dispatch_remaining_uni_data(StreamId, {unknown, _Type}, _Rest, State) ->
-    {ok, State#state{
-        discarded_uni_streams = sets:add_element(StreamId, State#state.discarded_uni_streams)
-    }};
+%% After classifying a uni stream, either hand off to an extension
+%% handler (when one claims the type), discard the rest (unknown types
+%% with no handler, RFC 9114 §6.2.3), or re-enter stream dispatch so
+%% known types process their payload.
+dispatch_remaining_uni_data(StreamId, {unknown, Type}, Rest, State) ->
+    case consult_stream_type_handler(uni, StreamId, Type, State) of
+        claim ->
+            State1 = claim_uni_stream(StreamId, Type, State),
+            forward_claimed_uni_data(StreamId, Rest, false, State1),
+            {ok, State1};
+        ignore ->
+            {ok, State#state{
+                discarded_uni_streams = sets:add_element(
+                    StreamId, State#state.discarded_uni_streams
+                )
+            }}
+    end;
 dispatch_remaining_uni_data(_StreamId, _Type, <<>>, State) ->
     {ok, State};
 dispatch_remaining_uni_data(StreamId, _Type, Rest, State) ->
     handle_stream_data(StreamId, Rest, false, State).
+
+consult_stream_type_handler(_Direction, _StreamId, _Type, #state{
+    stream_type_handler = undefined
+}) ->
+    ignore;
+consult_stream_type_handler(Direction, StreamId, Type, #state{
+    stream_type_handler = Fun
+}) ->
+    case Fun(Direction, StreamId, Type) of
+        claim -> claim;
+        _ -> ignore
+    end.
+
+claim_uni_stream(StreamId, Type, #state{owner = Owner} = State) ->
+    Owner ! {quic_h3, self(), {stream_type_open, uni, StreamId, Type}},
+    State#state{
+        claimed_uni_streams = maps:put(StreamId, Type, State#state.claimed_uni_streams)
+    }.
+
+forward_claimed_uni_data(_StreamId, <<>>, false, _State) ->
+    ok;
+forward_claimed_uni_data(StreamId, Data, Fin, #state{owner = Owner}) ->
+    Owner ! {quic_h3, self(), {stream_type_data, uni, StreamId, Data, Fin}},
+    ok.
 
 assign_uni_stream(StreamId, control, #state{peer_control_stream = undefined} = State) ->
     {ok, State#state{peer_control_stream = StreamId}};
@@ -2730,7 +2791,9 @@ handle_stream_closed(
         streams = Streams,
         stream_buffers = Buffers,
         uni_stream_buffers = UniBuffers,
-        discarded_uni_streams = Discarded
+        discarded_uni_streams = Discarded,
+        claimed_uni_streams = Claimed,
+        owner = Owner
     } = State
 ) ->
     case is_critical_stream(StreamId, State) of
@@ -2740,6 +2803,12 @@ handle_stream_closed(
                 {connection_error, ?H3_CLOSED_CRITICAL_STREAM,
                     iolist_to_binary(io_lib:format("~p stream closed", [Type]))}};
         false ->
+            case maps:is_key(StreamId, Claimed) of
+                true ->
+                    Owner ! {quic_h3, self(), {stream_type_closed, uni, StreamId}};
+                false ->
+                    ok
+            end,
             %% RFC 9114 Section 4.1.1: server-side request stream that ends
             %% before a complete request is received MUST be reset with
             %% H3_REQUEST_INCOMPLETE.
@@ -2749,7 +2818,8 @@ handle_stream_closed(
                 streams = maps:remove(StreamId, Streams),
                 stream_buffers = maps:remove(StreamId, Buffers),
                 uni_stream_buffers = maps:remove(StreamId, UniBuffers),
-                discarded_uni_streams = sets:del_element(StreamId, Discarded)
+                discarded_uni_streams = sets:del_element(StreamId, Discarded),
+                claimed_uni_streams = maps:remove(StreamId, Claimed)
             }}
     end.
 

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1501,7 +1501,7 @@ unknown_uni_stream_subsequent_data_is_ignored_test() ->
     StreamId = 3,
     State1 = mark_uni_stream_open(StreamId, State0),
     {ok, State2} = quic_h3_connection:handle_stream_data(
-        StreamId, <<16#54>>, false, State1
+        StreamId, <<16#40, 16#54>>, false, State1
     ),
     %% Feeding more bytes on the already-discarded stream must succeed
     %% silently and must not re-enter classification.
@@ -1519,7 +1519,7 @@ unknown_uni_stream_closure_clears_discard_state_test() ->
     StreamId = 3,
     State1 = mark_uni_stream_open(StreamId, State0),
     {ok, State2} = quic_h3_connection:handle_stream_data(
-        StreamId, <<16#54, 0>>, false, State1
+        StreamId, <<16#40, 16#54, 0>>, false, State1
     ),
     ?assert(
         sets:is_element(
@@ -1538,6 +1538,83 @@ mark_uni_stream_open(StreamId, State) ->
         StreamId, unidirectional, State
     ),
     State1.
+
+%%====================================================================
+%% stream_type_handler extension hook
+%%====================================================================
+
+stream_type_handler_claims_uni_stream_test() ->
+    Claim = fun(uni, _StreamId, 16#54) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    flush_mailbox(),
+    {ok, _State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54, 0, "hello">>, false, State1
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, uni, StreamId, 16#54}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, uni, StreamId, <<0, "hello">>, false}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+stream_type_handler_follow_up_data_forwarded_test() ->
+    Claim = fun(uni, _StreamId, _Type) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54>>, false, State1
+    ),
+    flush_mailbox(),
+    {ok, _State3} = quic_h3_connection:handle_stream_data(
+        StreamId, <<0, "body">>, true, State2
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_data, uni, StreamId, <<0, "body">>, true}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+stream_type_handler_ignore_falls_back_to_discard_test() ->
+    Ignore = fun(uni, _StreamId, _Type) -> ignore end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Ignore}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54, 0, "payload">>, false, State1
+    ),
+    ?assert(
+        sets:is_element(
+            StreamId, quic_h3_connection:test_discarded_uni_streams(State2)
+        )
+    ).
+
+stream_type_handler_closure_notifies_owner_test() ->
+    Claim = fun(uni, _StreamId, _Type) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54, 0>>, false, State1
+    ),
+    flush_mailbox(),
+    {ok, _State3} = quic_h3_connection:handle_stream_closed(StreamId, State2),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_closed, uni, StreamId}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+flush_mailbox() ->
+    receive
+        _ -> flush_mailbox()
+    after 0 -> ok
+    end.
 
 %%====================================================================
 %% Helper Functions
@@ -1595,7 +1672,9 @@ make_test_state(Overrides) ->
         %% Per-stream handler registration
         stream_handlers => #{},
         stream_data_buffers => #{},
-        stream_buffer_limit => 65536
+        stream_buffer_limit => 65536,
+        stream_type_handler => undefined,
+        claimed_uni_streams => #{}
     },
     Merged = maps:merge(Default, Overrides),
     %% Build the state tuple in the same order as the record definition
@@ -1622,4 +1701,5 @@ make_test_state(Overrides) ->
         maps:get(last_accepted_push_id, Merged),
         %% Per-stream handler registration
         maps:get(stream_handlers, Merged), maps:get(stream_data_buffers, Merged),
-        maps:get(stream_buffer_limit, Merged), maps:get(local_connect_enabled, Merged)}.
+        maps:get(stream_buffer_limit, Merged), maps:get(local_connect_enabled, Merged),
+        maps:get(stream_type_handler, Merged), maps:get(claimed_uni_streams, Merged)}.

--- a/test/quic_h3_push_tests.erl
+++ b/test/quic_h3_push_tests.erl
@@ -375,7 +375,9 @@ make_test_state(Overrides) ->
         %% Per-stream handler registration
         stream_handlers => #{},
         stream_data_buffers => #{},
-        stream_buffer_limit => 65536
+        stream_buffer_limit => 65536,
+        stream_type_handler => undefined,
+        claimed_uni_streams => #{}
     },
     Merged = maps:merge(Default, Overrides),
     {state, maps:get(quic_conn, Merged), maps:get(quic_ref, Merged), maps:get(role, Merged),
@@ -399,4 +401,5 @@ make_test_state(Overrides) ->
         maps:get(received_pushes, Merged), maps:get(local_cancelled_pushes, Merged),
         maps:get(last_accepted_push_id, Merged), maps:get(stream_handlers, Merged),
         maps:get(stream_data_buffers, Merged), maps:get(stream_buffer_limit, Merged),
-        maps:get(local_connect_enabled, Merged)}.
+        maps:get(local_connect_enabled, Merged), maps:get(stream_type_handler, Merged),
+        maps:get(claimed_uni_streams, Merged)}.


### PR DESCRIPTION
Adds a `stream_type_handler` option to `quic_h3:connect/3` and `quic_h3:start_server/3`. It's a function the H3 connection consults whenever it sees a unidirectional stream whose type it doesn't recognise. If the function returns `claim`, the H3 module hands the stream off to your code: you'll get `{quic_h3, Conn, {stream_type_open, uni, StreamId, VarintType}}` when it arrives, `{stream_type_data, uni, StreamId, Data, Fin}` for each chunk, and `{stream_type_closed, uni, StreamId}` on close. If it returns `ignore` (or you don't set the option), the bytes are discarded per RFC 9114 §6.2.3, same as #47.

This is enough to receive WebTransport `WT_STREAM` streams (varint type `0x54`). To send back on a claimed stream, use `quic_h3:get_quic_conn/1` and write directly against the QUIC connection.

Typical use:

```erlang
Claim = fun(uni, _StreamId, 16#54) -> claim; (_, _, _) -> ignore end,
{ok, _} = quic_h3:start_server(my_server, 4433, #{
    cert => Cert, key => Key,
    handler => fun my_http_handler/5,
    stream_type_handler => Claim
}).
```

Bidirectional streams still go straight to the HTTP/3 request path; deferring bidi classification to enable `WT_BIDI_SIGNAL` is tracked as a follow-up.

Four new eunit cases in `quic_h3_compliance_tests`; full gate green (1855 tests).

Base: `fix/h3-unknown-uni-stream-discard` (#47).