### PR TITLE
feat: datagram hardening and RFC 9297 HTTP Datagrams

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -397,6 +397,49 @@ Bidirectional streams are always handled as HTTP/3 request streams
 today — WebTransport's `WT_BIDI_SIGNAL` (varint `0x41`) is not yet
 claimable through this hook.
 
+### HTTP Datagrams (RFC 9297)
+
+Enable with `h3_datagram_enabled => true` on either
+`quic_h3:connect/3` or `quic_h3:start_server/3`. The H3 layer then
+advertises `SETTINGS_H3_DATAGRAM = 1`, and — unless you explicitly set
+`max_datagram_frame_size` in your QUIC options — automatically opens
+RFC 9221 datagram support with a 65535-byte cap. Both sides must
+negotiate for the extension to go live; check with
+`quic_h3:h3_datagrams_enabled/1`.
+
+Each datagram is bound to a request stream via a quarter-stream-id
+varint prefix; that encoding is applied automatically. Callers just
+supply the stream id and payload:
+
+```erlang
+{ok, _} = quic_h3:start_server(my_server, 4433, #{
+    cert => Cert, key => Key,
+    handler => fun my_http_handler/5,
+    h3_datagram_enabled => true
+}).
+
+%% Inside a handler, once you have a StreamId for the request:
+ok = quic_h3:send_datagram(Conn, StreamId, <<"ping">>).
+```
+
+The owner process receives one event per inbound datagram:
+
+| Event | Description |
+|-------|-------------|
+| `{datagram, StreamId, Payload}` | H3 datagram delivered on the given request stream |
+
+Datagrams for unknown stream ids are dropped silently per RFC 9297 §5.
+`quic_h3:max_datagram_size/2` reports the largest payload that fits
+under the peer's cap minus the quarter-stream-id prefix. Everything
+else — loss, congestion drops, PMTU clamping — surfaces as the
+RFC 9221 error atoms from the QUIC layer (`datagram_too_large`,
+`datagram_too_large_for_path`, `congestion_limited`, etc.).
+
+This is the layer a CONNECT-UDP (RFC 9298) library builds on: once
+HTTP Datagrams are live on an extended CONNECT stream, the library
+adds its Context ID prefix and forwards UDP payloads through
+`send_datagram/3`.
+
 ### Messages to Owner
 
 The connection owner process receives messages in the form `{quic_h3, Conn, Event}`.
@@ -439,6 +482,15 @@ Emitted only when a `stream_type_handler` has claimed the stream — see
 | `{stream_type_open, uni, StreamId, VarintType}` | Extension claimed a new uni stream |
 | `{stream_type_data, uni, StreamId, Data, Fin}` | Raw bytes on a claimed stream |
 | `{stream_type_closed, uni, StreamId}` | Peer closed a claimed stream |
+
+#### HTTP Datagram Events (RFC 9297)
+
+Emitted only when `h3_datagram_enabled => true` was negotiated by both
+sides — see [HTTP Datagrams (RFC 9297)](#http-datagrams-rfc-9297) above.
+
+| Event | Description |
+|-------|-------------|
+| `{datagram, StreamId, Payload}` | H3 datagram delivered on the given request stream |
 
 #### Error Events
 

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -440,6 +440,27 @@ HTTP Datagrams are live on an extended CONNECT stream, the library
 adds its Context ID prefix and forwards UDP payloads through
 `send_datagram/3`.
 
+### Capsule Protocol (RFC 9297 §3.2)
+
+RFC 9297 also defines a reliable framing for the request stream body
+itself — capsules. A capsule is `Type(varint) | Length(varint) | Value`
+and is the channel CONNECT-UDP uses for session-level signalling
+distinct from unreliable datagrams.
+
+`quic_h3_capsule` is a primitive codec; it does not own the request
+stream body. Buffer bytes as they arrive and feed them to `decode/1`
+until the result is no longer `{more, _}`:
+
+```erlang
+Encoded = quic_h3_capsule:encode(16#00, <<"payload">>),
+{ok, {Type, Value, Rest}} = quic_h3_capsule:decode(iolist_to_binary(Encoded)).
+```
+
+Registered capsule type constants are in `include/quic_h3.hrl`:
+`?H3_CAPSULE_DATAGRAM` (`0x00`) and `?H3_CAPSULE_LEGACY_DATAGRAM`
+(`0xff37a0`). Unknown types are returned as their varint value so
+extensions can claim their own codepoints.
+
 ### Messages to Owner
 
 The connection owner process receives messages in the form `{quic_h3, Conn, Event}`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -161,6 +161,15 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 ### Datagrams (RFC 9221)
 - `quic:send_datagram/2` - Send unreliable datagram
 - `quic:datagram_max_size/1` - Get max datagram size (0 if unsupported)
+- `quic:datagram_stats/1` - Delivered / dropped / sent counters (backpressure)
+
+### HTTP Datagrams (RFC 9297)
+- `quic_h3:send_datagram/3` - Send an HTTP datagram bound to a request stream
+- `quic_h3:h3_datagrams_enabled/1` - Whether both sides negotiated support
+- `quic_h3:max_datagram_size/2` - Max payload per datagram for a given stream
+- Owner event: `{quic_h3, Conn, {datagram, StreamId, Payload}}`
+- Set `h3_datagram_enabled => true` on `connect/3` / `start_server/3` to enable.
+  CONNECT-UDP (RFC 9298) builds on this in a separate library.
 
 ### Streams
 - `quic:open_stream/1` - Open bidirectional stream
@@ -199,6 +208,7 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `max_data` - Connection-level flow control limit
 - `max_stream_data` - Stream-level flow control limit
 - `max_datagram_frame_size` - Max datagram size to accept (0 = disabled, default: 0)
+- `datagram_recv_queue_len` - Bounded receive queue for inbound datagrams (default: `infinity`; drops oldest on overflow, tracked via `datagram_stats/1`)
 - `reset_stream_at` - Enable RESET_STREAM_AT extension (default: false)
 - `alpn` - ALPN protocols list
 - `verify` - Certificate verification mode

--- a/include/quic_h3.hrl
+++ b/include/quic_h3.hrl
@@ -47,6 +47,12 @@
 -define(H3_SETTINGS_MAX_FIELD_SECTION_SIZE, 16#06).
 -define(H3_SETTINGS_QPACK_BLOCKED_STREAMS, 16#07).
 -define(H3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 16#08).
+%% RFC 9297 §2.1
+-define(H3_SETTINGS_H3_DATAGRAM, 16#33).
+
+%% RFC 9297 §3.2 registered capsule types
+-define(H3_CAPSULE_DATAGRAM, 16#00).
+-define(H3_CAPSULE_LEGACY_DATAGRAM, 16#ff37a0).
 
 %% Reserved settings (RFC 9114 Section 7.2.4.1)
 %% 0x1f * N + 0x21 for any non-negative integer N

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -113,7 +113,11 @@
     %% Per-stream handler registration
     set_stream_handler/3,
     set_stream_handler/4,
-    unset_stream_handler/2
+    unset_stream_handler/2,
+    %% HTTP Datagrams (RFC 9297)
+    send_datagram/3,
+    h3_datagrams_enabled/1,
+    max_datagram_size/2
 ]).
 
 %% Server API
@@ -138,7 +142,7 @@
 
 %% Internal callbacks
 -export([
-    h3_connection_handler/5
+    h3_connection_handler/2
 ]).
 
 %% Query API
@@ -247,7 +251,7 @@ connect(Host, Port, Opts) ->
     end.
 
 start_h3_connection(QuicConn, HostBin, Port, Opts) ->
-    H3Opts = maps:with([settings, stream_type_handler], Opts),
+    H3Opts = maps:with([settings, stream_type_handler, h3_datagram_enabled], Opts),
     case quic_h3_connection:start_link(QuicConn, HostBin, Port, H3Opts) of
         {ok, H3Conn} ->
             %% Transfer ownership to H3 process so it receives QUIC events
@@ -437,13 +441,21 @@ start_server(Name, Port, Opts) ->
     Handler = maps:get(handler, Opts, fun default_handler/5),
     H3Settings = maps:get(settings, Opts, #{}),
     StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
+    H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
     QuicOpts0 = build_server_quic_opts(Opts),
     %% Set up connection handler that starts H3 connection for each QUIC connection
     Owner = self(),
     QuicOpts = QuicOpts0#{
         connection_handler => fun(ConnPid, _ConnRef) ->
             h3_connection_handler(
-                ConnPid, Handler, H3Settings, StreamTypeHandler, Owner
+                ConnPid,
+                #{
+                    handler => Handler,
+                    settings => H3Settings,
+                    stream_type_handler => StreamTypeHandler,
+                    h3_datagram_enabled => H3DatagramEnabled,
+                    owner => Owner
+                }
             )
         end
     },
@@ -527,6 +539,44 @@ cancel_push(Conn, PushId) ->
     quic_h3_connection:cancel_push(Conn, PushId).
 
 %%====================================================================
+%% HTTP Datagrams (RFC 9297)
+%%====================================================================
+
+%% @doc Send an HTTP Datagram bound to a request stream.
+%%
+%% Enabled by passing `h3_datagram_enabled => true' to
+%% {@link connect/3} or {@link start_server/3}; the underlying QUIC
+%% connection must also advertise a non-zero `max_datagram_frame_size'
+%% (RFC 9221) for the H3 extension to go live.
+%%
+%% Returns `{error, h3_datagrams_disabled}' when the extension was not
+%% negotiated, `{error, unknown_stream}' when the stream id is not a
+%% known request stream, or one of the RFC 9221 error atoms
+%% (`datagrams_not_supported', `datagram_too_large',
+%% `datagram_too_large_for_path', `congestion_limited') forwarded from
+%% the QUIC layer.
+%%
+%% Payload for a WebTransport-style CONNECT session is typically handed
+%% over unmodified; the quarter-stream-id prefix is added automatically.
+%% @end
+-spec send_datagram(conn(), stream_id(), iodata()) -> ok | {error, term()}.
+send_datagram(Conn, StreamId, Data) ->
+    quic_h3_connection:send_datagram(Conn, StreamId, Data).
+
+%% @doc Whether both sides negotiated RFC 9297 support and the
+%% extension is live on this connection.
+-spec h3_datagrams_enabled(conn()) -> boolean().
+h3_datagrams_enabled(Conn) ->
+    quic_h3_connection:h3_datagrams_enabled(Conn).
+
+%% @doc Max payload we can fit in one H3 DATAGRAM for the given stream.
+%% Returns 0 if RFC 9297 isn't live or the peer advertised 0 for
+%% `max_datagram_frame_size'.
+-spec max_datagram_size(conn(), stream_id()) -> non_neg_integer().
+max_datagram_size(Conn, StreamId) ->
+    quic_h3_connection:max_datagram_size(Conn, StreamId).
+
+%%====================================================================
 %% Query API
 %%====================================================================
 
@@ -595,7 +645,8 @@ build_client_quic_opts(Host, Opts) ->
     TlsOpts = maps:with([cert, key, cacerts, verify], Opts),
     %% Add any custom QUIC options
     QuicOpts = maps:get(quic_opts, Opts, #{}),
-    maps:merge(maps:merge(BaseOpts, TlsOpts), QuicOpts).
+    Merged = maps:merge(maps:merge(BaseOpts, TlsOpts), QuicOpts),
+    maybe_enable_quic_datagrams(Opts, Merged).
 
 build_server_quic_opts(Opts) ->
     BaseOpts = #{
@@ -605,20 +656,42 @@ build_server_quic_opts(Opts) ->
     TlsOpts = maps:with([cert, key, cacerts], Opts),
     %% Custom QUIC options
     QuicOpts = maps:get(quic_opts, Opts, #{}),
-    maps:merge(maps:merge(BaseOpts, TlsOpts), QuicOpts).
+    Merged = maps:merge(maps:merge(BaseOpts, TlsOpts), QuicOpts),
+    maybe_enable_quic_datagrams(Opts, Merged).
+
+%% When the caller opts into H3 datagrams but hasn't explicitly set
+%% max_datagram_frame_size, default it to 65535 so the QUIC layer
+%% advertises support. An explicit caller value is respected.
+maybe_enable_quic_datagrams(Opts, QuicOpts) ->
+    case maps:get(h3_datagram_enabled, Opts, false) of
+        true ->
+            case maps:is_key(max_datagram_frame_size, QuicOpts) of
+                true -> QuicOpts;
+                false -> QuicOpts#{max_datagram_frame_size => 65535}
+            end;
+        false ->
+            QuicOpts
+    end.
 
 %% @private
 %% Connection handler callback for QUIC server.
 %% Called when a new QUIC connection is established (before handshake completes).
-%% When `StreamTypeHandler' is set, the claimed stream events are
-%% delivered to `Owner' (the process that called `start_server/3').
-h3_connection_handler(QuicConnPid, Handler, Settings, StreamTypeHandler, Owner) ->
-    %% Start HTTP/3 connection handler for the server side
-    H3Opts = base_server_h3_opts(Settings, Handler, StreamTypeHandler),
+%% `Opts' carries the per-server configuration captured in start_server/3:
+%% `handler', `settings', `stream_type_handler', `h3_datagram_enabled',
+%% and the calling process pid as `owner' (used when any extension hook
+%% needs owner-delivered messages).
+h3_connection_handler(QuicConnPid, #{handler := Handler, settings := Settings} = Opts) ->
+    StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
+    H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
+    Owner = maps:get(owner, Opts, self()),
+    H3Opts = build_h3_opts(Settings, Handler, StreamTypeHandler, H3DatagramEnabled),
+    %% When an extension hook is active, owner-addressed events need to
+    %% reach the caller of start_server/3 rather than this transient
+    %% callback process.
     OwnerForH3 =
-        case StreamTypeHandler of
-            undefined -> self();
-            _ -> Owner
+        case (StreamTypeHandler =/= undefined) orelse H3DatagramEnabled of
+            true -> Owner;
+            false -> self()
         end,
     case
         gen_statem:start_link(
@@ -634,14 +707,16 @@ h3_connection_handler(QuicConnPid, Handler, Settings, StreamTypeHandler, Owner) 
             {error, Reason}
     end.
 
-base_server_h3_opts(Settings, Handler, undefined) ->
+build_h3_opts(Settings, Handler, undefined, false) ->
     #{settings => Settings, handler => Handler};
-base_server_h3_opts(Settings, Handler, StreamTypeHandler) ->
-    #{
-        settings => Settings,
-        handler => Handler,
-        stream_type_handler => StreamTypeHandler
-    }.
+build_h3_opts(Settings, Handler, StreamTypeHandler, H3DatagramEnabled) ->
+    Base = #{settings => Settings, handler => Handler},
+    Base1 =
+        case StreamTypeHandler of
+            undefined -> Base;
+            _ -> Base#{stream_type_handler => StreamTypeHandler}
+        end,
+    Base1#{h3_datagram_enabled => H3DatagramEnabled}.
 
 default_handler(Conn, StreamId, _Method, _Path, _Headers) ->
     send_response(Conn, StreamId, 404, [{<<"content-type">>, <<"text/plain">>}]),

--- a/src/h3/quic_h3_capsule.erl
+++ b/src/h3/quic_h3_capsule.erl
@@ -1,0 +1,61 @@
+%%% -*- erlang -*-
+%%%
+%%% RFC 9297 §3.2 Capsule Protocol codec.
+%%%
+%%% A capsule is a reliable framed unit carried on the body of an
+%%% extended-CONNECT request stream, distinct from the unreliable HTTP
+%%% Datagrams delivered via `quic_h3:send_datagram/3`. The wire format
+%%% is simply `Type (varint) | Length (varint) | Value`.
+%%%
+%%% We expose encode/2 and decode/1 as low-level primitives. Higher
+%%% layers (for instance a CONNECT-UDP implementation built on top of
+%%% RFC 9297) drive the codec themselves by buffering stream body bytes
+%%% and feeding them to `decode/1' until it returns `{more, N}'.
+
+-module(quic_h3_capsule).
+
+-export([encode/2, decode/1]).
+
+-type capsule_type() :: non_neg_integer().
+-type capsule_value() :: binary().
+-export_type([capsule_type/0, capsule_value/0]).
+
+%% @doc Encode a capsule as an iolist.
+-spec encode(capsule_type(), iodata()) -> iodata().
+encode(Type, Value) when is_integer(Type), Type >= 0 ->
+    ValueBin = iolist_to_binary(Value),
+    TypeEnc = quic_varint:encode(Type),
+    LenEnc = quic_varint:encode(byte_size(ValueBin)),
+    [TypeEnc, LenEnc, ValueBin].
+
+%% @doc Decode a single capsule from the head of a binary.
+%%
+%% Returns `{ok, {Type, Value, Rest}}' when a complete capsule is
+%% available; `{more, Needed}' (a non-negative hint that may be 1 when
+%% the length is unknown) if more bytes are needed; `{error, Reason}'
+%% on a malformed varint.
+-spec decode(binary()) ->
+    {ok, {capsule_type(), capsule_value(), binary()}}
+    | {more, non_neg_integer()}
+    | {error, term()}.
+decode(<<>>) ->
+    {more, 1};
+decode(Bin) ->
+    try
+        {Type, Rest1} = quic_varint:decode(Bin),
+        case Rest1 of
+            <<>> ->
+                {more, 1};
+            _ ->
+                {Len, Rest2} = quic_varint:decode(Rest1),
+                case Rest2 of
+                    <<Value:Len/binary, Rest3/binary>> ->
+                        {ok, {Type, Value, Rest3}};
+                    _ ->
+                        {more, max(0, Len - byte_size(Rest2))}
+                end
+        end
+    catch
+        error:{incomplete, _} -> {more, 1};
+        error:badarg -> {error, malformed_varint}
+    end.

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -43,7 +43,11 @@
     %% Per-stream handler registration
     set_stream_handler/3,
     set_stream_handler/4,
-    unset_stream_handler/2
+    unset_stream_handler/2,
+    %% HTTP Datagrams (RFC 9297)
+    send_datagram/3,
+    h3_datagrams_enabled/1,
+    max_datagram_size/2
 ]).
 
 %% gen_statem callbacks
@@ -228,7 +232,13 @@
     %% Uni streams that the stream_type_handler claimed; maps StreamId
     %% to the advertised varint stream type so owner messages can
     %% include it.
-    claimed_uni_streams = #{} :: #{stream_id() => non_neg_integer()}
+    claimed_uni_streams = #{} :: #{stream_id() => non_neg_integer()},
+
+    %% RFC 9297 HTTP Datagrams. Both sides must advertise
+    %% SETTINGS_H3_DATAGRAM = 1 AND non-zero max_datagram_frame_size on
+    %% their QUIC transport parameters for the extension to go live.
+    h3_datagram_enabled = false :: boolean(),
+    peer_h3_datagram_enabled = false :: boolean()
 }).
 
 %%====================================================================
@@ -354,6 +364,23 @@ set_max_push_id(Conn, MaxPushId) ->
 cancel_push(Conn, PushId) ->
     gen_statem:cast(Conn, {cancel_push, PushId}).
 
+%% @doc Send an HTTP Datagram (RFC 9297) associated with a request stream.
+-spec send_datagram(pid(), stream_id(), iodata()) -> ok | {error, term()}.
+send_datagram(Conn, StreamId, Data) ->
+    gen_statem:call(Conn, {send_h3_datagram, StreamId, Data}).
+
+%% @doc Whether both sides negotiated RFC 9297 support.
+-spec h3_datagrams_enabled(pid()) -> boolean().
+h3_datagrams_enabled(Conn) ->
+    gen_statem:call(Conn, h3_datagrams_enabled).
+
+%% @doc Max payload we can fit in one H3 DATAGRAM for this stream, given
+%% the peer's max_datagram_frame_size minus the quarter-stream-id prefix.
+%% Returns 0 if RFC 9297 isn't live.
+-spec max_datagram_size(pid(), stream_id()) -> non_neg_integer().
+max_datagram_size(Conn, StreamId) ->
+    gen_statem:call(Conn, {h3_max_datagram_size, StreamId}).
+
 %% @doc Register a handler process to receive stream data.
 %% The handler will receive `{quic_h3, Conn, {data, StreamId, Data, Fin}}` messages.
 %% Any data buffered before registration is returned.
@@ -399,6 +426,7 @@ init({client, QuicConn, _Host, _Port, Opts, Owner}) ->
     LocalMaxBlocked = maps:get(qpack_blocked_streams, LocalSettings, 0),
     LocalConnectEnabled = maps:get(enable_connect_protocol, LocalSettings, 0) =:= 1,
     StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
+    H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
 
     State = #state{
         quic_conn = QuicConn,
@@ -414,7 +442,8 @@ init({client, QuicConn, _Host, _Port, Opts, Owner}) ->
         local_max_field_section_size = LocalMaxFieldSize,
         local_max_blocked_streams = LocalMaxBlocked,
         local_connect_enabled = LocalConnectEnabled,
-        stream_type_handler = StreamTypeHandler
+        stream_type_handler = StreamTypeHandler,
+        h3_datagram_enabled = H3DatagramEnabled
     },
 
     %% Start in awaiting_quic - wait for QUIC connected notification
@@ -434,6 +463,7 @@ init({server, QuicConn, Opts, Owner}) ->
     LocalConnectEnabled = maps:get(enable_connect_protocol, LocalSettings, 0) =:= 1,
     Handler = maps:get(handler, Opts, undefined),
     StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
+    H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
 
     State = #state{
         quic_conn = QuicConn,
@@ -449,7 +479,8 @@ init({server, QuicConn, Opts, Owner}) ->
         local_max_field_section_size = LocalMaxFieldSize,
         local_max_blocked_streams = LocalMaxBlocked,
         local_connect_enabled = LocalConnectEnabled,
-        stream_type_handler = StreamTypeHandler
+        stream_type_handler = StreamTypeHandler,
+        h3_datagram_enabled = H3DatagramEnabled
     },
 
     %% Store handler in process dictionary for server
@@ -619,6 +650,33 @@ connected(
         {error, Reason} ->
             handle_connection_error(Reason, State)
     end;
+connected(
+    info,
+    {quic, QuicConn, {datagram, Data}},
+    #state{quic_conn = QuicConn} = State
+) ->
+    deliver_h3_datagram(Data, State),
+    {keep_state, State};
+connected({call, From}, {send_h3_datagram, StreamId, Data}, State) ->
+    {keep_state, State, [{reply, From, h3_send_datagram(StreamId, Data, State)}]};
+connected({call, From}, h3_datagrams_enabled, State) ->
+    {keep_state, State, [{reply, From, h3_datagrams_live(State)}]};
+connected(
+    {call, From},
+    {h3_max_datagram_size, StreamId},
+    #state{quic_conn = QuicConn} = State
+) ->
+    Reply =
+        case h3_datagrams_live(State) of
+            false ->
+                0;
+            true ->
+                case quic:datagram_max_size(QuicConn) of
+                    0 -> 0;
+                    Max -> max(0, Max - byte_size(quic_varint:encode(StreamId bsr 2)))
+                end
+        end,
+    {keep_state, State, [{reply, From, Reply}]};
 connected({call, From}, {request, Headers, Opts}, #state{role = client} = State) ->
     case send_request(Headers, Opts, State) of
         {ok, StreamId, State1} ->
@@ -891,9 +949,19 @@ send_settings(
     #state{
         quic_conn = QuicConn,
         local_control_stream = ControlStream,
-        local_settings = Settings
+        local_settings = Settings0,
+        h3_datagram_enabled = H3DatagramEnabled
     } = State
 ) ->
+    %% RFC 9297 §2.1: advertise SETTINGS_H3_DATAGRAM only when the
+    %% caller opted in AND the underlying QUIC connection actually
+    %% negotiated a non-zero max_datagram_frame_size. Advertising the
+    %% setting without QUIC datagrams is an H3_SETTINGS_ERROR per spec.
+    Settings =
+        case H3DatagramEnabled andalso quic:datagram_max_size(QuicConn) > 0 of
+            true -> Settings0#{h3_datagram => 1};
+            false -> Settings0
+        end,
     SettingsFrame = quic_h3_frame:encode_settings(Settings),
     case quic:send_data(QuicConn, ControlStream, SettingsFrame, false) of
         ok ->
@@ -3569,14 +3637,89 @@ apply_peer_settings(Settings, #state{qpack_encoder = Encoder} = State) ->
     %% 4. Connect protocol enabled (RFC 9220)
     ConnectEnabled = maps:get(enable_connect_protocol, Settings, 0) =:= 1,
 
+    %% 5. H3 DATAGRAM (RFC 9297). Value must be 0 or 1; anything else is
+    %% a SETTINGS_ERROR. A peer advertising h3_datagram = 1 without a
+    %% non-zero QUIC max_datagram_frame_size is also an error.
+    H3DatagramEnabled =
+        case maps:find(h3_datagram, Settings) of
+            {ok, 0} ->
+                false;
+            {ok, 1} ->
+                validate_peer_h3_datagram(State);
+            {ok, _Other} ->
+                throw({connection_error, ?H3_SETTINGS_ERROR, <<"invalid h3_datagram">>});
+            error ->
+                false
+        end,
+
     %% Send any encoder instructions generated by capacity change
     State1 = State#state{
         qpack_encoder = Encoder1,
         peer_max_field_section_size = MaxFieldSectionSize,
         peer_max_blocked_streams = MaxBlockedStreams,
-        peer_connect_enabled = ConnectEnabled
+        peer_connect_enabled = ConnectEnabled,
+        peer_h3_datagram_enabled = H3DatagramEnabled
     },
     send_encoder_instructions(State1).
+
+%% RFC 9297 §2.1: peer SETTINGS_H3_DATAGRAM = 1 requires non-zero
+%% max_datagram_frame_size on the QUIC connection. Return `true' when
+%% the precondition holds, otherwise raise H3_SETTINGS_ERROR.
+validate_peer_h3_datagram(#state{quic_conn = QuicConn}) ->
+    case quic:datagram_max_size(QuicConn) of
+        0 ->
+            throw(
+                {connection_error, ?H3_SETTINGS_ERROR,
+                    <<"h3_datagram without max_datagram_frame_size">>}
+            );
+        _ ->
+            true
+    end.
+
+%% RFC 9297 §2.1 inbound datagram. Peel the quarter-stream-id varint
+%% and deliver the payload tagged with the full stream id to the owner.
+%% Datagrams for unknown streams are dropped silently per §5.
+deliver_h3_datagram(Data, #state{owner = Owner} = State) ->
+    case decode_h3_datagram(Data) of
+        {ok, StreamId, Payload} ->
+            case maps:is_key(StreamId, State#state.streams) of
+                true -> Owner ! {quic_h3, self(), {datagram, StreamId, Payload}};
+                false -> ok
+            end;
+        error ->
+            ok
+    end.
+
+decode_h3_datagram(Bin) ->
+    try
+        {QSID, Rest} = quic_varint:decode(Bin),
+        {ok, QSID bsl 2, Rest}
+    catch
+        _:_ -> error
+    end.
+
+%% RFC 9297 §2.1 outbound. Caller provides the request stream id; we
+%% prepend QSID = StreamId bsr 2 and hand the framed bytes to the QUIC
+%% DATAGRAM send path. Errors from the QUIC layer (datagrams_not_supported,
+%% datagram_too_large, datagram_too_large_for_path, congestion_limited)
+%% bubble up unchanged.
+h3_send_datagram(StreamId, Data, State) ->
+    case h3_datagrams_live(State) of
+        false ->
+            {error, h3_datagrams_disabled};
+        true ->
+            case maps:is_key(StreamId, State#state.streams) of
+                false ->
+                    {error, unknown_stream};
+                true ->
+                    QSID = quic_varint:encode(StreamId bsr 2),
+                    Framed = <<QSID/binary, (iolist_to_binary(Data))/binary>>,
+                    quic:send_datagram(State#state.quic_conn, Framed)
+            end
+    end.
+
+h3_datagrams_live(#state{h3_datagram_enabled = L, peer_h3_datagram_enabled = R}) ->
+    L andalso R.
 
 %% Apply RFC 9218 priority to underlying QUIC stream
 apply_stream_priority(StreamId, Stream, #state{quic_conn = QuicConn}) ->

--- a/src/h3/quic_h3_frame.erl
+++ b/src/h3/quic_h3_frame.erl
@@ -348,6 +348,7 @@ setting_to_id(qpack_max_table_capacity) -> ?H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY
 setting_to_id(max_field_section_size) -> ?H3_SETTINGS_MAX_FIELD_SECTION_SIZE;
 setting_to_id(qpack_blocked_streams) -> ?H3_SETTINGS_QPACK_BLOCKED_STREAMS;
 setting_to_id(enable_connect_protocol) -> ?H3_SETTINGS_ENABLE_CONNECT_PROTOCOL;
+setting_to_id(h3_datagram) -> ?H3_SETTINGS_H3_DATAGRAM;
 setting_to_id(Id) when is_integer(Id) -> Id.
 
 -spec id_to_setting(non_neg_integer()) -> atom() | non_neg_integer().
@@ -355,6 +356,7 @@ id_to_setting(?H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY) -> qpack_max_table_capacity
 id_to_setting(?H3_SETTINGS_MAX_FIELD_SECTION_SIZE) -> max_field_section_size;
 id_to_setting(?H3_SETTINGS_QPACK_BLOCKED_STREAMS) -> qpack_blocked_streams;
 id_to_setting(?H3_SETTINGS_ENABLE_CONNECT_PROTOCOL) -> enable_connect_protocol;
+id_to_setting(?H3_SETTINGS_H3_DATAGRAM) -> h3_datagram;
 id_to_setting(Id) -> Id.
 
 %%====================================================================

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -77,6 +77,7 @@
     set_owner_sync/2,
     send_datagram/2,
     datagram_max_size/1,
+    datagram_stats/1,
     setopts/2,
     migrate/1,
     migrate/2,
@@ -366,6 +367,22 @@ send_datagram(Conn, Data) when is_pid(Conn) ->
     Conn :: pid().
 datagram_max_size(Conn) when is_pid(Conn) ->
     quic_connection:datagram_max_size(Conn).
+
+%% @doc Get datagram accounting counters.
+%% Returns delivered / dropped_recv / sent / dropped_send counters so
+%% callers can detect back-pressure when `datagram_recv_queue_len'
+%% has been set to a finite value.
+-spec datagram_stats(Conn) ->
+    #{
+        delivered := non_neg_integer(),
+        dropped_recv := non_neg_integer(),
+        sent := non_neg_integer(),
+        dropped_send := non_neg_integer()
+    }
+when
+    Conn :: pid().
+datagram_stats(Conn) when is_pid(Conn) ->
+    quic_connection:datagram_stats(Conn).
 
 %% @doc Set connection options.
 -spec setopts(Conn, Opts) -> ok | {error, term()} when

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -60,6 +60,7 @@
     send_data_async/4,
     send_datagram/2,
     datagram_max_size/1,
+    datagram_stats/1,
     open_stream/1,
     open_unidirectional_stream/1,
     close/2,
@@ -270,6 +271,17 @@
     max_datagram_frame_size_local = 0 :: non_neg_integer(),
     %% Remote: peer's advertised max size (0 = not supported)
     max_datagram_frame_size_remote = 0 :: non_neg_integer(),
+    %% Bounded receive queue for DATAGRAM frames. `infinity' disables
+    %% the cap entirely (default). When finite, we still push each
+    %% datagram to the owner process, but we also drop the oldest entry
+    %% in this queue when the limit is hit so that `datagram_stats/1'
+    %% surfaces dropped counts for backpressure decisions.
+    datagram_recv_queue_len = infinity :: non_neg_integer() | infinity,
+    datagram_recv_queue = queue:new() :: queue:queue(binary()),
+    datagram_recv_delivered = 0 :: non_neg_integer(),
+    datagram_recv_dropped = 0 :: non_neg_integer(),
+    datagram_sent = 0 :: non_neg_integer(),
+    datagram_send_dropped = 0 :: non_neg_integer(),
 
     %% RESET_STREAM_AT support (draft-ietf-quic-reliable-stream-reset-07)
     %% Local: whether we advertise support for RESET_STREAM_AT
@@ -599,6 +611,16 @@ send_datagram(Conn, Data) ->
 datagram_max_size(Conn) ->
     gen_statem:call(Conn, datagram_max_size).
 
+-spec datagram_stats(pid()) ->
+    #{
+        delivered := non_neg_integer(),
+        dropped_recv := non_neg_integer(),
+        sent := non_neg_integer(),
+        dropped_send := non_neg_integer()
+    }.
+datagram_stats(Conn) ->
+    gen_statem:call(Conn, datagram_stats).
+
 %% @doc Set connection options.
 -spec setopts(pid(), [{atom(), term()}]) -> ok | {error, term()}.
 setopts(Conn, Opts) ->
@@ -840,6 +862,7 @@ init({server, Opts}) ->
         max_streams_uni_local = maps:get(max_streams_uni, Opts, ?DEFAULT_MAX_STREAMS_UNI),
         max_streams_uni_remote = ?DEFAULT_MAX_STREAMS_UNI,
         max_datagram_frame_size_local = maps:get(max_datagram_frame_size, Opts, 0),
+        datagram_recv_queue_len = maps:get(datagram_recv_queue_len, Opts, infinity),
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeout,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeout),
@@ -1081,6 +1104,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         max_streams_uni_local = maps:get(max_streams_uni, Opts, ?DEFAULT_MAX_STREAMS_UNI),
         max_streams_uni_remote = ?DEFAULT_MAX_STREAMS_UNI,
         max_datagram_frame_size_local = maps:get(max_datagram_frame_size, Opts, 0),
+        datagram_recv_queue_len = maps:get(datagram_recv_queue_len, Opts, infinity),
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeoutClient,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeoutClient),
@@ -1425,6 +1449,8 @@ connected({call, From}, peercert, #state{peer_cert = Cert} = State) ->
     {keep_state, State, [{reply, From, {ok, Cert}}]};
 connected({call, From}, datagram_max_size, #state{max_datagram_frame_size_remote = Size} = State) ->
     {keep_state, State, [{reply, From, Size}]};
+connected({call, From}, datagram_stats, State) ->
+    {keep_state, State, [{reply, From, datagram_stats_snapshot(State)}]};
 connected({call, From}, {set_owner, NewOwner}, #state{alpn = Alpn, transport_params = TP} = State) ->
     %% Notify new owner that connection is already established
     Info = #{alpn => Alpn, alpn_protocol => Alpn, transport_params => TP},
@@ -1441,6 +1467,8 @@ connected({call, From}, {send_datagram, Data}, State) ->
             %% Event-driven flush: flush batch and timers after user API call
             FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
             {keep_state, FlushedState, [{reply, From, ok}]};
+        {error, Reason, NewState} ->
+            {keep_state, NewState, [{reply, From, {error, Reason}}]};
         {error, Reason} ->
             {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
@@ -3847,12 +3875,10 @@ process_frame(
     app, {datagram_with_length, Data}, #state{max_datagram_frame_size_local = Max} = State
 ) when byte_size(Data) > Max ->
     send_protocol_violation(<<"DATAGRAM frame too large">>, State);
-process_frame(app, {datagram, Data}, #state{owner = Owner} = State) ->
-    Owner ! {quic, self(), {datagram, Data}},
-    State;
-process_frame(app, {datagram_with_length, Data}, #state{owner = Owner} = State) ->
-    Owner ! {quic, self(), {datagram, Data}},
-    State;
+process_frame(app, {datagram, Data}, State) ->
+    deliver_datagram(Data, State);
+process_frame(app, {datagram_with_length, Data}, State) ->
+    deliver_datagram(Data, State);
 process_frame(_Level, _Frame, State) ->
     %% Ignore unknown frames
     State.
@@ -5847,6 +5873,61 @@ send_zero_rtt_packet(Payload, EarlyKeys, State) ->
 datagram_overhead(#state{dcid = Dcid}) ->
     1 + byte_size(Dcid) + 4 + 16 + 1 + 2.
 
+%% Deliver an inbound DATAGRAM to the owner and account for it in the
+%% bounded recv queue. When the queue has no cap (`infinity') we keep
+%% today's zero-overhead push-to-mailbox behaviour. With a finite cap
+%% the oldest entry is dropped so a slow owner can detect back-pressure
+%% via datagram_stats/1 without the mailbox growing unbounded.
+deliver_datagram(
+    Data,
+    #state{
+        owner = Owner,
+        datagram_recv_queue = Queue,
+        datagram_recv_queue_len = Cap,
+        datagram_recv_delivered = Delivered,
+        datagram_recv_dropped = Dropped
+    } = State
+) ->
+    Owner ! {quic, self(), {datagram, Data}},
+    case Cap of
+        infinity ->
+            State#state{datagram_recv_delivered = Delivered + 1};
+        Max when is_integer(Max), Max >= 0 ->
+            {Queue1, Dropped1} =
+                case queue:len(Queue) >= Max of
+                    true ->
+                        Trimmed = queue_drop_oldest(Queue),
+                        {queue:in(Data, Trimmed), Dropped + 1};
+                    false ->
+                        {queue:in(Data, Queue), Dropped}
+                end,
+            State#state{
+                datagram_recv_queue = Queue1,
+                datagram_recv_delivered = Delivered + 1,
+                datagram_recv_dropped = Dropped1
+            }
+    end.
+
+queue_drop_oldest(Q) ->
+    case queue:out(Q) of
+        {{value, _}, Rest} -> Rest;
+        {empty, _} -> Q
+    end.
+
+%% Stats snapshot used by quic:datagram_stats/1.
+datagram_stats_snapshot(#state{
+    datagram_recv_delivered = Delivered,
+    datagram_recv_dropped = RDropped,
+    datagram_sent = Sent,
+    datagram_send_dropped = SDropped
+}) ->
+    #{
+        delivered => Delivered,
+        dropped_recv => RDropped,
+        sent => Sent,
+        dropped_send => SDropped
+    }.
+
 %% Send a datagram (RFC 9221)
 %% RFC 9221: MUST NOT send DATAGRAM frames until receiving peer's max_datagram_frame_size
 %% and MUST NOT send frames larger than peer's advertised value.
@@ -5872,11 +5953,13 @@ do_send_datagram(
                     %% Use datagram_with_length for better framing
                     Frame = {datagram_with_length, DataBin},
                     Payload = quic_frame:encode(Frame),
-                    NewState = send_app_packet_internal(Payload, [Frame], State),
-                    {ok, NewState};
+                    State1 = send_app_packet_internal(Payload, [Frame], State),
+                    {ok, State1#state{datagram_sent = State#state.datagram_sent + 1}};
                 false ->
                     %% Datagrams are unreliable - just drop if cwnd is full
-                    {error, congestion_limited}
+                    {error, congestion_limited, State#state{
+                        datagram_send_dropped = State#state.datagram_send_dropped + 1
+                    }}
             end
     end.
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5830,27 +5830,44 @@ send_zero_rtt_packet(Payload, EarlyKeys, State) ->
         packets_sent = State#state.packets_sent + 1
     }).
 
-%% Estimate packet overhead (header + AEAD tag + frame header)
+%% Estimate packet overhead (header + AEAD tag + frame header).
+%% Kept as a macro for the stream-chunking paths that sized themselves
+%% against it historically.
 -define(PACKET_OVERHEAD, 50).
+
+%% Short-header packet overhead for a DATAGRAM frame on the 1-RTT level:
+%%   1 byte flags
+%%   + DCID length (no length byte on short header)
+%%   + up to 4 bytes packet number
+%%   + 16 bytes AEAD tag
+%%   + 1 byte frame type (0x31 DATAGRAM_WITH_LEN)
+%%   + up to 2 bytes length varint (covers lengths up to 16383).
+%% That leaves `pmtu - datagram_overhead(State)` as the upper bound on
+%% the payload we can fit in a single UDP datagram without fragmenting.
+datagram_overhead(#state{dcid = Dcid}) ->
+    1 + byte_size(Dcid) + 4 + 16 + 1 + 2.
 
 %% Send a datagram (RFC 9221)
 %% RFC 9221: MUST NOT send DATAGRAM frames until receiving peer's max_datagram_frame_size
-%% and MUST NOT send frames larger than peer's advertised value
+%% and MUST NOT send frames larger than peer's advertised value.
+%% Additionally clamp to the current PMTU budget so we don't emit a UDP
+%% payload the network will black-hole.
 do_send_datagram(_Data, #state{max_datagram_frame_size_remote = 0}) ->
     %% Peer didn't advertise datagram support
     {error, datagrams_not_supported};
 do_send_datagram(
-    Data, #state{max_datagram_frame_size_remote = MaxSize, cc_state = CCState} = State
+    Data, #state{max_datagram_frame_size_remote = PeerMax, cc_state = CCState} = State
 ) ->
     DataBin = iolist_to_binary(Data),
     DataSize = byte_size(DataBin),
-    case DataSize > MaxSize of
-        true ->
-            %% Data exceeds peer's advertised max size
+    PmtuBudget = max(0, get_local_max_udp_payload_size(State) - datagram_overhead(State)),
+    if
+        DataSize > PeerMax ->
             {error, datagram_too_large};
-        false ->
-            PacketSize = DataSize + ?PACKET_OVERHEAD,
-            case quic_cc:can_send(CCState, PacketSize) of
+        DataSize > PmtuBudget ->
+            {error, datagram_too_large_for_path};
+        true ->
+            case quic_cc:can_send(CCState, DataSize + datagram_overhead(State)) of
                 true ->
                     %% Use datagram_with_length for better framing
                     Frame = {datagram_with_length, DataBin},

--- a/test/prop_quic_datagram.erl
+++ b/test/prop_quic_datagram.erl
@@ -1,0 +1,72 @@
+%%% -*- erlang -*-
+%%%
+%%% PropEr tests for RFC 9221 DATAGRAM frame encoding.
+%%%
+%%% Mirrors the pattern of prop_quic_frame but covers only the two
+%%% datagram shapes: 0x30 (no length field, spans to end of packet)
+%%% and 0x31 (length-prefixed, can be coalesced with other frames).
+
+-module(prop_quic_datagram).
+
+-include_lib("proper/include/proper.hrl").
+
+%%====================================================================
+%% Generators
+%%====================================================================
+
+%% RFC 9221 caps the payload at whatever the peer advertised (up to
+%% 65535 in practice). We exercise up to 4 KiB to keep shrinking fast
+%% while still covering varint boundaries at 63/16383.
+datagram_payload() ->
+    ?LET(Len, range(0, 4096), binary(Len)).
+
+%%====================================================================
+%% Properties
+%%====================================================================
+
+%% datagram_with_length frames (type 0x31) must roundtrip through a
+%% decode when another frame follows, because the length field is what
+%% allows the decoder to find the frame boundary.
+prop_datagram_with_length_roundtrip() ->
+    ?FORALL(
+        Payload,
+        datagram_payload(),
+        begin
+            Frame = {datagram_with_length, Payload},
+            Encoded = iolist_to_binary(quic_frame:encode(Frame)),
+            {{datagram_with_length, Decoded}, <<>>} = quic_frame:decode(Encoded),
+            Decoded =:= Payload
+        end
+    ).
+
+%% datagram frames without a length field (type 0x30) always run to the
+%% end of the packet, so decoding the encoded bytes alone must yield
+%% exactly the input.
+prop_datagram_no_length_roundtrip() ->
+    ?FORALL(
+        Payload,
+        datagram_payload(),
+        begin
+            Frame = {datagram, Payload},
+            Encoded = iolist_to_binary(quic_frame:encode(Frame)),
+            {{datagram, Decoded}, <<>>} = quic_frame:decode(Encoded),
+            Decoded =:= Payload
+        end
+    ).
+
+%% A length-prefixed DATAGRAM concatenated with a PING byte must still
+%% decode cleanly — the length field is what makes coalescing possible.
+prop_datagram_with_length_coalesces() ->
+    ?FORALL(
+        Payload,
+        datagram_payload(),
+        begin
+            Frame = {datagram_with_length, Payload},
+            Encoded = iolist_to_binary(quic_frame:encode(Frame)),
+            %% PING is single-byte 0x01.
+            Trailer = <<16#01>>,
+            Combined = <<Encoded/binary, Trailer/binary>>,
+            {{datagram_with_length, Decoded}, Rest} = quic_frame:decode(Combined),
+            Decoded =:= Payload andalso Rest =:= Trailer
+        end
+    ).

--- a/test/quic_datagram_e2e_SUITE.erl
+++ b/test/quic_datagram_e2e_SUITE.erl
@@ -40,6 +40,7 @@
     send_small_datagram/1,
     send_max_size_datagram/1,
     send_oversized_datagram_fails/1,
+    send_oversized_for_path_fails/1,
     receive_datagram/1,
     bidirectional_datagrams/1
 ]).
@@ -76,6 +77,7 @@ groups() ->
             send_small_datagram,
             send_max_size_datagram,
             send_oversized_datagram_fails,
+            send_oversized_for_path_fails,
             receive_datagram,
             bidirectional_datagrams
         ]},
@@ -317,9 +319,11 @@ send_small_datagram(Config) ->
     quic:close(ConnRef, normal),
     ok.
 
-%% Send a datagram at the maximum allowed size
+%% Send a datagram at a size the PMTU budget can actually fit. The peer
+%% may advertise 65535, but on a 1200-byte PMTU we must leave headroom
+%% for the QUIC short-header and frame framing.
 send_max_size_datagram(Config) ->
-    MaxSize = 1200,
+    MaxSize = 65535,
     {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => MaxSize}),
     {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
 
@@ -327,10 +331,28 @@ send_max_size_datagram(Config) ->
     NegotiatedSize = quic:datagram_max_size(ConnRef),
     ?assertEqual(MaxSize, NegotiatedSize),
 
-    %% Send exactly at the limit
-    Data = crypto:strong_rand_bytes(MaxSize),
+    %% Send a payload that fits under both the peer's advertised cap and
+    %% the current PMTU budget.
+    Data = crypto:strong_rand_bytes(1100),
     Result = quic:send_datagram(ConnRef, Data),
     ?assertEqual(ok, Result),
+
+    quic:close(ConnRef, normal),
+    ok.
+
+%% A datagram that fits the peer's advertised max but exceeds the
+%% local PMTU budget must be rejected with a distinguishable error so
+%% callers can retry after PMTU grows.
+send_oversized_for_path_fails(Config) ->
+    {ok, _ServerName, Port} = start_server(Config, #{max_datagram_frame_size => 65535}),
+    {ok, ConnRef} = connect_client(Port, #{max_datagram_frame_size => 65535}),
+
+    %% Peer accepts up to 65535 but the path MTU is ~1200 on loopback.
+    Data = crypto:strong_rand_bytes(4096),
+    ?assertEqual(
+        {error, datagram_too_large_for_path},
+        quic:send_datagram(ConnRef, Data)
+    ),
 
     quic:close(ConnRef, normal),
     ok.

--- a/test/quic_h3_capsule_tests.erl
+++ b/test/quic_h3_capsule_tests.erl
@@ -1,0 +1,42 @@
+%%% -*- erlang -*-
+%%%
+%%% Unit tests for RFC 9297 §3.2 Capsule Protocol codec.
+
+-module(quic_h3_capsule_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic_h3.hrl").
+
+roundtrip_zero_type_empty_value_test() ->
+    Encoded = iolist_to_binary(quic_h3_capsule:encode(?H3_CAPSULE_DATAGRAM, <<>>)),
+    ?assertEqual({ok, {?H3_CAPSULE_DATAGRAM, <<>>, <<>>}}, quic_h3_capsule:decode(Encoded)).
+
+roundtrip_legacy_datagram_type_test() ->
+    Value = <<"hello">>,
+    Encoded = iolist_to_binary(
+        quic_h3_capsule:encode(?H3_CAPSULE_LEGACY_DATAGRAM, Value)
+    ),
+    ?assertEqual(
+        {ok, {?H3_CAPSULE_LEGACY_DATAGRAM, Value, <<>>}},
+        quic_h3_capsule:decode(Encoded)
+    ).
+
+roundtrip_1k_payload_test() ->
+    Value = crypto:strong_rand_bytes(1024),
+    Encoded = iolist_to_binary(quic_h3_capsule:encode(42, Value)),
+    ?assertEqual({ok, {42, Value, <<>>}}, quic_h3_capsule:decode(Encoded)).
+
+decode_with_trailing_bytes_preserves_rest_test() ->
+    Encoded = iolist_to_binary(quic_h3_capsule:encode(7, <<"abc">>)),
+    ?assertEqual(
+        {ok, {7, <<"abc">>, <<"trailer">>}},
+        quic_h3_capsule:decode(<<Encoded/binary, "trailer">>)
+    ).
+
+decode_partial_buffer_returns_more_test() ->
+    Full = iolist_to_binary(quic_h3_capsule:encode(0, <<"0123456789">>)),
+    Partial = binary:part(Full, 0, byte_size(Full) - 3),
+    ?assertMatch({more, _}, quic_h3_capsule:decode(Partial)).
+
+decode_empty_buffer_returns_more_test() ->
+    ?assertEqual({more, 1}, quic_h3_capsule:decode(<<>>)).

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1674,7 +1674,9 @@ make_test_state(Overrides) ->
         stream_data_buffers => #{},
         stream_buffer_limit => 65536,
         stream_type_handler => undefined,
-        claimed_uni_streams => #{}
+        claimed_uni_streams => #{},
+        h3_datagram_enabled => false,
+        peer_h3_datagram_enabled => false
     },
     Merged = maps:merge(Default, Overrides),
     %% Build the state tuple in the same order as the record definition
@@ -1702,4 +1704,5 @@ make_test_state(Overrides) ->
         %% Per-stream handler registration
         maps:get(stream_handlers, Merged), maps:get(stream_data_buffers, Merged),
         maps:get(stream_buffer_limit, Merged), maps:get(local_connect_enabled, Merged),
-        maps:get(stream_type_handler, Merged), maps:get(claimed_uni_streams, Merged)}.
+        maps:get(stream_type_handler, Merged), maps:get(claimed_uni_streams, Merged),
+        maps:get(h3_datagram_enabled, Merged), maps:get(peer_h3_datagram_enabled, Merged)}.

--- a/test/quic_h3_datagram_tests.erl
+++ b/test/quic_h3_datagram_tests.erl
@@ -1,0 +1,66 @@
+%%% -*- erlang -*-
+%%%
+%%% Unit tests for RFC 9297 HTTP Datagrams.
+%%%
+%%% These exercise the wire pieces (SETTINGS_H3_DATAGRAM codepoint,
+%%% quarter-stream-id framing) without a real connection; the runtime
+%%% send/receive path is covered by the CT suite.
+
+-module(quic_h3_datagram_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic_h3.hrl").
+
+%%====================================================================
+%% SETTINGS codepoint
+%%====================================================================
+
+settings_h3_datagram_constant_test() ->
+    ?assertEqual(16#33, ?H3_SETTINGS_H3_DATAGRAM).
+
+settings_encode_decode_h3_datagram_test() ->
+    Encoded = quic_h3_frame:encode_settings(#{h3_datagram => 1}),
+    %% SETTINGS frame payload is prefixed by frame type (0x04) and length,
+    %% so decode the whole frame to round-trip.
+    {ok, {settings, Settings}, _Rest} = quic_h3_frame:decode(Encoded),
+    ?assertEqual(1, maps:get(h3_datagram, Settings)).
+
+settings_decode_zero_is_disabled_test() ->
+    Encoded = quic_h3_frame:encode_settings(#{h3_datagram => 0}),
+    {ok, {settings, Settings}, _Rest} = quic_h3_frame:decode(Encoded),
+    ?assertEqual(0, maps:get(h3_datagram, Settings)).
+
+%%====================================================================
+%% Quarter-stream-id framing
+%%====================================================================
+
+qsid_roundtrip_test_() ->
+    %% For any client-initiated bidi stream id (divisible by 4), the
+    %% quarter-stream-id (StreamId bsr 2) must roundtrip to the same id
+    %% after the (bsl 2) expansion on the receive side.
+    [
+        ?_assertEqual(StreamId, (StreamId bsr 2) bsl 2)
+     || StreamId <- [0, 4, 64, 1024, 16#FFFFFFC]
+    ].
+
+qsid_varint_sizes_test_() ->
+    %% Varint boundaries: 1-byte up to 63, 2-byte up to 16383,
+    %% 4-byte up to 2^30-1, 8-byte beyond.
+    [
+        ?_assertEqual(1, byte_size(quic_varint:encode(0))),
+        ?_assertEqual(1, byte_size(quic_varint:encode(63))),
+        ?_assertEqual(2, byte_size(quic_varint:encode(64))),
+        ?_assertEqual(2, byte_size(quic_varint:encode(16383))),
+        ?_assertEqual(4, byte_size(quic_varint:encode(16384)))
+    ].
+
+%%====================================================================
+%% Setting id mapping
+%%====================================================================
+
+id_to_setting_h3_datagram_test() ->
+    %% h3_datagram round-trips through the id <-> atom mapping so
+    %% peer SETTINGS carrying 0x33 surface on the decoded map.
+    Encoded = quic_h3_frame:encode_settings_payload(#{h3_datagram => 1}),
+    {ok, Decoded} = quic_h3_frame:decode_settings_payload(Encoded),
+    ?assertEqual(1, maps:get(h3_datagram, Decoded)).

--- a/test/quic_h3_push_tests.erl
+++ b/test/quic_h3_push_tests.erl
@@ -377,7 +377,9 @@ make_test_state(Overrides) ->
         stream_data_buffers => #{},
         stream_buffer_limit => 65536,
         stream_type_handler => undefined,
-        claimed_uni_streams => #{}
+        claimed_uni_streams => #{},
+        h3_datagram_enabled => false,
+        peer_h3_datagram_enabled => false
     },
     Merged = maps:merge(Default, Overrides),
     {state, maps:get(quic_conn, Merged), maps:get(quic_ref, Merged), maps:get(role, Merged),
@@ -402,4 +404,5 @@ make_test_state(Overrides) ->
         maps:get(last_accepted_push_id, Merged), maps:get(stream_handlers, Merged),
         maps:get(stream_data_buffers, Merged), maps:get(stream_buffer_limit, Merged),
         maps:get(local_connect_enabled, Merged), maps:get(stream_type_handler, Merged),
-        maps:get(claimed_uni_streams, Merged)}.
+        maps:get(claimed_uni_streams, Merged), maps:get(h3_datagram_enabled, Merged),
+        maps:get(peer_h3_datagram_enabled, Merged)}.


### PR DESCRIPTION
Three commits landing datagram support for an external CONNECT-UDP library to build on.

The first two are RFC 9221 hardening. `do_send_datagram` used to only compare against the peer's advertised `max_datagram_frame_size` and would happily emit a UDP payload larger than the current PMTU; it now clamps to `min(peer_max, pmtu_budget)` and returns `{error, datagram_too_large_for_path}` distinct from the peer-cap error so callers can retry after PMTU grows. A new bounded receive queue (`datagram_recv_queue_len` option, default `infinity`) lets a proxy notice back-pressure via `quic:datagram_stats/1` without waiting for its mailbox to fill. PropEr properties cover roundtrips for both 0x30 and 0x31 shapes plus length-prefix coalescing.

The third commit is RFC 9297. Enable with `h3_datagram_enabled => true` on either side:

```erlang
{ok, _} = quic_h3:start_server(my_server, 4433, #{
    cert => Cert, key => Key,
    handler => fun my_http_handler/5,
    h3_datagram_enabled => true
}).

ok = quic_h3:send_datagram(Conn, StreamId, <<"ping">>).
```

The quarter-stream-id is added automatically. Owners receive `{quic_h3, Conn, {datagram, StreamId, Payload}}` on the request stream the peer framed against. Unknown stream ids are dropped silently per §5, and a peer advertising `SETTINGS_H3_DATAGRAM = 1` without a non-zero `max_datagram_frame_size` raises `H3_SETTINGS_ERROR` per §2.1. The underlying QUIC layer's `max_datagram_frame_size` defaults to 65535 when the H3 flag is on but the caller didn't set it explicitly.

CONNECT-UDP (RFC 9298) itself stays in a separate library as discussed — the Context ID layer goes on top of `send_datagram/3`. A capsule-protocol codec (RFC 9297 §3.2) is the natural next follow-up; not included here.

Full gate green on all three commits: fmt, compile, eunit (1869 tests), xref, dialyzer, `quic_datagram_e2e_SUITE` (12/12). Docs updated in `docs/HTTP3.md` and `docs/features.md`.