### PR TITLE
feat(h3): bidi stream-type hook, per-connection owner, reset events

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -393,9 +393,87 @@ To send on a claimed stream, retrieve the QUIC connection with
 `quic_h3:get_quic_conn/1` and call `quic:send_data/4` directly; H3 does
 not frame or encode the payload.
 
-Bidirectional streams are always handled as HTTP/3 request streams
-today — WebTransport's `WT_BIDI_SIGNAL` (varint `0x41`) is not yet
-claimable through this hook.
+Bidirectional streams go through the same claim hook. The handler is
+consulted on the first varint of every peer-initiated bidi stream,
+before HTTP/3 request parsing kicks in. WebTransport's
+`WT_BIDI_SIGNAL` (varint `0x41`) is the canonical use:
+
+```erlang
+Claim = fun
+    (uni,  _StreamId, 16#54) -> claim;   %% WT_STREAM
+    (bidi, _StreamId, 16#41) -> claim;   %% WT_BIDI_SIGNAL
+    (_, _, _)                -> ignore
+end,
+```
+
+On claim, the owner sees bidi versions of the same events:
+
+| Event | Description |
+|-------|-------------|
+| `{stream_type_open, bidi, StreamId, VarintType}` | Claim accepted; no payload yet |
+| `{stream_type_data, bidi, StreamId, Data, Fin}` | Raw bytes on the claimed stream |
+| `{stream_type_closed, bidi, StreamId}` | Peer closed the stream |
+| `{stream_type_reset, bidi, StreamId, ErrorCode}` | Peer reset the stream with a non-zero code |
+| `{stream_type_stop_sending, bidi, StreamId, ErrorCode}` | Peer sent STOP_SENDING |
+
+On `ignore`, the bidi stream falls back to the HTTP/3 request path
+exactly as if the hook had never fired — every buffered byte
+(including the varint that was peeked) is replayed through the
+request parser, so legitimate `HEADERS`-starting peers are
+unaffected.
+
+The same claimed-stream reset/stop_sending events fire on uni
+streams too.
+
+### Per-connection owner
+
+By default every H3 connection spawned by `start_server/3` delivers
+extension-stream events (claimed streams, H3 datagrams) to the single
+process that called `start_server/3`. Extension libraries that host
+many concurrent sessions on one listener can pick a dedicated owner
+pid per H3 connection via the `connection_handler` option:
+
+```erlang
+{ok, _} = quic_h3:start_server(my_server, 4433, #{
+    cert => Cert, key => Key,
+    stream_type_handler => Claim,
+    h3_datagram_enabled => true,
+    connection_handler => fun(_QuicConnPid) ->
+        #{owner => spawn(fun my_router:loop/0)}
+    end
+}).
+```
+
+The returned map's `owner`, `handler`, `stream_type_handler`,
+`h3_datagram_enabled`, and `settings` keys replace the listener
+defaults for that single connection; absent keys inherit.
+
+#### `connection_handler` vs `set_stream_handler/3`
+
+These solve different problems and compose rather than overlap.
+
+- `set_stream_handler/3,4` reroutes the body `{data, StreamId, Data,
+  Fin}` events of an *already-classified HTTP/3 request stream* to a
+  chosen pid, returning any bytes buffered before registration. It
+  only works on streams already present in the connection's request
+  map; extension-claimed streams (WT uni `0x54`, WT bidi `0x41`)
+  aren't request streams and can't be registered this way. Other
+  events on the same request stream (`{request, ...}`,
+  `{trailers, ...}`, `{stream_reset, ...}`) still reach the
+  connection owner.
+- `connection_handler` picks the *connection's* owner pid at
+  construction, before any stream exists. Every connection-level
+  event — `{connected, ...}`, `{request, ...}`,
+  `{stream_type_*, ...}`, `{datagram, StreamId, ...}` — is routed to
+  it. Use this to spawn one router process per H3 connection when
+  hosting many concurrent extension sessions on a single listener.
+
+A WebTransport or CONNECT-UDP server uses `connection_handler` to
+create a per-connection router and then simply consumes
+`{stream_type_*, ...}` or `{datagram, ...}` events directly.
+`set_stream_handler` isn't involved unless the same connection is
+also serving plain HTTP/3 requests whose bodies benefit from
+streaming to a different process.
 
 ### HTTP Datagrams (RFC 9297)
 
@@ -460,6 +538,48 @@ Registered capsule type constants are in `include/quic_h3.hrl`:
 `?H3_CAPSULE_DATAGRAM` (`0x00`) and `?H3_CAPSULE_LEGACY_DATAGRAM`
 (`0xff37a0`). Unknown types are returned as their varint value so
 extensions can claim their own codepoints.
+
+### Building extension libraries
+
+The primitives above are designed to support both WebTransport and
+CONNECT-UDP (RFC 9298) as separate libraries. Here's which hook
+each one relies on:
+
+| Hook | WebTransport | CONNECT-UDP |
+|------|--------------|-------------|
+| Extended CONNECT (`enable_connect_protocol`) | `:protocol = webtransport` | `:protocol = connect-udp` |
+| H3 datagrams (`h3_datagram_enabled`) | WT datagrams keyed by the CONNECT stream | UDP payloads keyed by the CONNECT stream + Context ID |
+| Capsule codec (`quic_h3_capsule`) | `CLOSE_WEBTRANSPORT_SESSION`, `DRAIN_WEBTRANSPORT_SESSION` | RFC 9298 §3.5 DATAGRAM capsules |
+| Bidi 0x41 claim (`stream_type_handler`) | `WT_BIDI_SIGNAL` on new peer-initiated bidi streams | not used — one extended-CONNECT bidi stream per session is all |
+| Uni 0x54 claim (`stream_type_handler`) | `WT_STREAM` on new peer-initiated uni streams | not used |
+| Per-connection owner (`connection_handler`) | Dedicated session manager per H3 connection | Dedicated session manager per H3 connection |
+| Reset / STOP_SENDING (`stream_type_reset`, `stream_type_stop_sending`) | Propagates to WT stream FSM | Only fires on claimed streams, so unused by CONNECT-UDP |
+
+A CONNECT-UDP server looks like:
+
+```erlang
+{ok, _} = quic_h3:start_server(udp_proxy, 443, #{
+    cert => C, key => K,
+    settings => #{enable_connect_protocol => 1},
+    h3_datagram_enabled => true,
+    connection_handler => fun(_) ->
+        #{owner => spawn(fun udp_proxy_conn:loop/0)}
+    end,
+    handler => fun handle_connect_udp_request/5
+}).
+```
+
+The per-connection owner process receives
+`{quic_h3, Conn, {datagram, StreamId, Payload}}` and demultiplexes by
+`StreamId` (= CONNECT request stream id). It decodes RFC 9298's
+Context ID prefix out of `Payload`, then forwards the UDP bytes. Body
+capsules on the same stream go through `quic_h3_capsule:decode/1`.
+No `stream_type_handler` involvement at all.
+
+A WebTransport server adds a `stream_type_handler` that claims uni
+(`0x54`) and bidi (`0x41`) streams, mapping session-id bytes to its
+own router. Same `connection_handler` + `h3_datagram_enabled`
+pattern; the two extensions coexist on the same listener if needed.
 
 ### Messages to Owner
 

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -179,7 +179,7 @@
 -type error_code() :: non_neg_integer().
 
 -type stream_type_handler() ::
-    fun((uni, stream_id(), non_neg_integer()) -> claim | ignore).
+    fun((uni | bidi, stream_id(), non_neg_integer()) -> claim | ignore).
 
 -type connect_opts() :: #{
     %% TLS options

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -195,6 +195,19 @@
     stream_type_handler => stream_type_handler()
 }.
 
+%% Override function invoked once per newly accepted QUIC connection.
+%% Keys absent from the returned map inherit the listener-wide values.
+-type connection_handler_fun() ::
+    fun((QuicConnPid :: pid()) -> per_connection_opts()).
+
+-type per_connection_opts() :: #{
+    owner => pid(),
+    handler => fun((conn(), stream_id(), binary(), binary(), headers()) -> any()) | module(),
+    settings => map(),
+    stream_type_handler => stream_type_handler(),
+    h3_datagram_enabled => boolean()
+}.
+
 -type server_opts() :: #{
     %% TLS (required)
     cert := binary(),
@@ -206,7 +219,13 @@
     %% QUIC options
     quic_opts => map(),
     %% Extension hook for unknown uni-stream types (e.g. WebTransport).
-    stream_type_handler => stream_type_handler()
+    stream_type_handler => stream_type_handler(),
+    %% Per-connection configuration override; the returned map's
+    %% `owner', `handler', `stream_type_handler', `h3_datagram_enabled',
+    %% and `settings' keys replace the listener-wide defaults for that
+    %% single connection. Useful for spawning a dedicated router pid
+    %% per H3 connection rather than sharing one global owner.
+    connection_handler => connection_handler_fun()
 }.
 
 %%====================================================================
@@ -442,24 +461,34 @@ start_server(Name, Port, Opts) ->
     H3Settings = maps:get(settings, Opts, #{}),
     StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
     H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
+    PerConn = maps:get(connection_handler, Opts, undefined),
     QuicOpts0 = build_server_quic_opts(Opts),
-    %% Set up connection handler that starts H3 connection for each QUIC connection
-    Owner = self(),
+    Listener = self(),
+    ListenerDefaults = #{
+        handler => Handler,
+        settings => H3Settings,
+        stream_type_handler => StreamTypeHandler,
+        h3_datagram_enabled => H3DatagramEnabled,
+        owner => Listener
+    },
     QuicOpts = QuicOpts0#{
         connection_handler => fun(ConnPid, _ConnRef) ->
             h3_connection_handler(
-                ConnPid,
-                #{
-                    handler => Handler,
-                    settings => H3Settings,
-                    stream_type_handler => StreamTypeHandler,
-                    h3_datagram_enabled => H3DatagramEnabled,
-                    owner => Owner
-                }
+                ConnPid, resolve_per_conn_opts(ListenerDefaults, PerConn, ConnPid)
             )
         end
     },
     quic:start_server(Name, Port, QuicOpts).
+
+%% Merge per-connection overrides (returned by the caller-supplied
+%% connection_handler fun) over the listener defaults. Keeps the
+%% no-hook behaviour identical to the listener-wide setup.
+resolve_per_conn_opts(Defaults, undefined, _ConnPid) ->
+    Defaults;
+resolve_per_conn_opts(Defaults, Fun, ConnPid) when is_function(Fun, 1) ->
+    Overrides = Fun(ConnPid),
+    true = is_map(Overrides),
+    maps:merge(Defaults, Overrides).
 
 %% @doc Stop an HTTP/3 server.
 -spec stop_server(atom()) -> ok | {error, term()}.

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -76,6 +76,7 @@
 -export([
     handle_stream_data/4,
     handle_stream_closed/2,
+    handle_stream_closed/3,
     handle_control_frame/2,
     handle_request_frame/5,
     handle_new_stream/3,
@@ -579,10 +580,10 @@ h3_connecting(
     end;
 h3_connecting(
     info,
-    {quic, QuicConn, {stream_closed, StreamId, _ErrorCode}},
+    {quic, QuicConn, {stream_closed, StreamId, ErrorCode}},
     #state{quic_conn = QuicConn} = State
 ) ->
-    case handle_stream_closed(StreamId, State) of
+    case handle_stream_closed(StreamId, ErrorCode, State) of
         {ok, State1} ->
             {keep_state, State1};
         {error, Reason} ->
@@ -643,13 +644,29 @@ connected(
     {quic, QuicConn, {stream_closed, StreamId, ErrorCode}},
     #state{quic_conn = QuicConn} = State
 ) ->
-    case handle_stream_closed(StreamId, State) of
+    case handle_stream_closed(StreamId, ErrorCode, State) of
         {ok, State1} ->
-            notify_stream_reset(StreamId, ErrorCode, State1),
+            %% For non-claimed streams keep today's generic event;
+            %% claimed streams already got stream_type_reset/closed
+            %% inside handle_stream_closed/3.
+            case maps:is_key(StreamId, State#state.claimed_uni_streams) of
+                true -> ok;
+                false -> notify_stream_reset(StreamId, ErrorCode, State1)
+            end,
             {keep_state, State1};
         {error, Reason} ->
             handle_connection_error(Reason, State)
     end;
+connected(
+    info,
+    {quic, QuicConn, {stop_sending, StreamId, ErrorCode}},
+    #state{quic_conn = QuicConn, claimed_uni_streams = Claimed, owner = Owner} = State
+) ->
+    case maps:is_key(StreamId, Claimed) of
+        true -> Owner ! {quic_h3, self(), {stream_type_stop_sending, uni, StreamId, ErrorCode}};
+        false -> ok
+    end,
+    {keep_state, State};
 connected(
     info,
     {quic, QuicConn, {datagram, Data}},
@@ -2853,8 +2870,15 @@ parse_priority_params([Param | Rest], Urgency, Incremental) ->
             parse_priority_params(Rest, Urgency, Incremental)
     end.
 
+-ifdef(TEST).
+%% Legacy test entry point; production code always has the error code.
+handle_stream_closed(StreamId, State) ->
+    handle_stream_closed(StreamId, 0, State).
+-endif.
+
 handle_stream_closed(
     StreamId,
+    ErrorCode,
     #state{
         streams = Streams,
         stream_buffers = Buffers,
@@ -2873,7 +2897,12 @@ handle_stream_closed(
         false ->
             case maps:is_key(StreamId, Claimed) of
                 true ->
-                    Owner ! {quic_h3, self(), {stream_type_closed, uni, StreamId}};
+                    Event =
+                        case ErrorCode of
+                            0 -> {stream_type_closed, uni, StreamId};
+                            _ -> {stream_type_reset, uni, StreamId, ErrorCode}
+                        end,
+                    Owner ! {quic_h3, self(), Event};
                 false ->
                     ok
             end,

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -228,7 +228,7 @@
     %% subsequent bytes to the owner as `{stream_type_*, ...}` events
     %% instead of discarding them.
     stream_type_handler ::
-        fun((uni, stream_id(), non_neg_integer()) -> claim | ignore) | undefined,
+        fun((uni | bidi, stream_id(), non_neg_integer()) -> claim | ignore) | undefined,
 
     %% Uni streams that the stream_type_handler claimed; maps StreamId
     %% to the advertised varint stream type so owner messages can
@@ -239,7 +239,17 @@
     %% SETTINGS_H3_DATAGRAM = 1 AND non-zero max_datagram_frame_size on
     %% their QUIC transport parameters for the extension to go live.
     h3_datagram_enabled = false :: boolean(),
-    peer_h3_datagram_enabled = false :: boolean()
+    peer_h3_datagram_enabled = false :: boolean(),
+
+    %% Peer-initiated bidi streams pending varint-peek classification.
+    %% Populated when stream_type_handler is set so the handler can
+    %% decide whether to claim the stream (e.g. WebTransport
+    %% WT_BIDI_SIGNAL 0x41) or fall through to HTTP/3 request parsing.
+    bidi_type_buffers = #{} :: #{stream_id() => binary()},
+
+    %% Bidi streams the stream_type_handler claimed; maps StreamId to
+    %% the advertised varint type.
+    claimed_bidi_streams = #{} :: #{stream_id() => non_neg_integer()}
 }).
 
 %%====================================================================
@@ -649,9 +659,9 @@ connected(
             %% For non-claimed streams keep today's generic event;
             %% claimed streams already got stream_type_reset/closed
             %% inside handle_stream_closed/3.
-            case maps:is_key(StreamId, State#state.claimed_uni_streams) of
-                true -> ok;
-                false -> notify_stream_reset(StreamId, ErrorCode, State1)
+            case claimed_stream_direction(StreamId, State) of
+                {ok, _Dir} -> ok;
+                error -> notify_stream_reset(StreamId, ErrorCode, State1)
             end,
             {keep_state, State1};
         {error, Reason} ->
@@ -660,11 +670,14 @@ connected(
 connected(
     info,
     {quic, QuicConn, {stop_sending, StreamId, ErrorCode}},
-    #state{quic_conn = QuicConn, claimed_uni_streams = Claimed, owner = Owner} = State
+    #state{quic_conn = QuicConn, owner = Owner} = State
 ) ->
-    case maps:is_key(StreamId, Claimed) of
-        true -> Owner ! {quic_h3, self(), {stream_type_stop_sending, uni, StreamId, ErrorCode}};
-        false -> ok
+    case claimed_stream_direction(StreamId, State) of
+        {ok, Direction} ->
+            Owner !
+                {quic_h3, self(), {stream_type_stop_sending, Direction, StreamId, ErrorCode}};
+        error ->
+            ok
     end,
     {keep_state, State};
 connected(
@@ -994,7 +1007,7 @@ send_settings(
 handle_new_stream(StreamId, unidirectional, State) ->
     %% Unidirectional stream - need to read type first
     {ok, State#state{uni_stream_buffers = maps:put(StreamId, <<>>, State#state.uni_stream_buffers)}};
-handle_new_stream(StreamId, bidirectional, #state{streams = Streams, role = Role} = State) ->
+handle_new_stream(StreamId, bidirectional, #state{role = Role} = State) ->
     %% RFC 9114 Section 4.1: Validate stream ID parity
     %% Client-initiated streams are even (0, 4, 8...)
     %% Server-initiated streams are odd (1, 5, 9...)
@@ -1019,21 +1032,36 @@ handle_new_stream(StreamId, bidirectional, #state{streams = Streams, role = Role
                     ),
                     {ok, State};
                 false ->
-                    Stream = #h3_stream{
-                        id = StreamId,
-                        type = request,
-                        state = open
-                    },
-                    NewState = State#state{streams = Streams#{StreamId => Stream}},
-                    case Role of
-                        server ->
-                            {ok, NewState#state{
-                                last_stream_id = max(StreamId, State#state.last_stream_id)
-                            }};
-                        client ->
-                            {ok, NewState}
+                    case State#state.stream_type_handler of
+                        undefined ->
+                            open_bidi_request_stream(StreamId, State);
+                        _Fun ->
+                            %% Defer request-stream creation until we can
+                            %% peek the first varint and ask the handler.
+                            Buffers = State#state.bidi_type_buffers,
+                            {ok, State#state{
+                                bidi_type_buffers = Buffers#{StreamId => <<>>}
+                            }}
                     end
             end
+    end.
+
+open_bidi_request_stream(
+    StreamId, #state{streams = Streams, role = Role} = State
+) ->
+    Stream = #h3_stream{
+        id = StreamId,
+        type = request,
+        state = open
+    },
+    NewState = State#state{streams = Streams#{StreamId => Stream}},
+    case Role of
+        server ->
+            {ok, NewState#state{
+                last_stream_id = max(StreamId, State#state.last_stream_id)
+            }};
+        client ->
+            {ok, NewState}
     end.
 
 %% RFC 9114 §5.2: a sender MUST NOT initiate, and a receiver MUST treat as
@@ -1073,6 +1101,11 @@ handle_stream_data(StreamId, Data, Fin, State) ->
             handle_encoder_stream_data(Data, State);
         {uni, qpack_decoder} ->
             handle_decoder_stream_data(Data, State);
+        {bidi, pending_type} ->
+            handle_bidi_stream_type(StreamId, Data, Fin, State);
+        {bidi, {claimed, _Type}} ->
+            forward_claimed_bidi_data(StreamId, Data, Fin, State),
+            {ok, State};
         {bidi, request} ->
             handle_request_stream_data(StreamId, Data, Fin, State);
         unknown ->
@@ -1095,7 +1128,19 @@ classify_stream(StreamId, #state{uni_stream_buffers = Buffers, received_pushes =
                 {ok, Type} ->
                     {uni, {claimed, Type}};
                 error ->
-                    classify_fresh_uni_stream(StreamId, Buffers, Received, State)
+                    case maps:find(StreamId, State#state.claimed_bidi_streams) of
+                        {ok, BType} ->
+                            {bidi, {claimed, BType}};
+                        error ->
+                            case maps:is_key(StreamId, State#state.bidi_type_buffers) of
+                                true ->
+                                    {bidi, pending_type};
+                                false ->
+                                    classify_fresh_uni_stream(
+                                        StreamId, Buffers, Received, State
+                                    )
+                            end
+                    end
             end
     end.
 
@@ -1197,6 +1242,81 @@ forward_claimed_uni_data(_StreamId, <<>>, false, _State) ->
 forward_claimed_uni_data(StreamId, Data, Fin, #state{owner = Owner}) ->
     Owner ! {quic_h3, self(), {stream_type_data, uni, StreamId, Data, Fin}},
     ok.
+
+%% First bytes of a peer-initiated bidi stream arrive here when a
+%% stream_type_handler is set. Buffer until a full varint is available,
+%% then consult the handler. On `claim' record the stream and forward
+%% the remainder + any future bytes to the owner. On `ignore' create
+%% the HTTP/3 request stream lazily and re-feed every buffered byte
+%% (including the already-decoded varint) so HTTP/3 parsing sees a
+%% brand-new stream.
+handle_bidi_stream_type(StreamId, Data, Fin, State) ->
+    Buffers = State#state.bidi_type_buffers,
+    Buffer = maps:get(StreamId, Buffers, <<>>),
+    Combined = <<Buffer/binary, Data/binary>>,
+    case quic_h3_frame:decode_stream_type(Combined) of
+        {more, _} ->
+            {ok, State#state{bidi_type_buffers = Buffers#{StreamId => Combined}}};
+        {ok, Decoded, Rest} ->
+            VarintType = stream_type_varint(Decoded),
+            case consult_stream_type_handler(bidi, StreamId, VarintType, State) of
+                claim ->
+                    State1 = claim_bidi_stream(StreamId, VarintType, State),
+                    forward_claimed_bidi_data(StreamId, Rest, Fin, State1),
+                    {ok, State1};
+                ignore ->
+                    fall_back_to_request_stream(StreamId, Combined, Fin, State)
+            end
+    end.
+
+%% decode_stream_type surfaces known codepoints as atoms (control,
+%% qpack_encoder, ...) so convert them back to the numeric value the
+%% handler contract expects.
+stream_type_varint(control) -> ?H3_STREAM_CONTROL;
+stream_type_varint(push) -> ?H3_STREAM_PUSH;
+stream_type_varint(qpack_encoder) -> ?H3_STREAM_QPACK_ENCODER;
+stream_type_varint(qpack_decoder) -> ?H3_STREAM_QPACK_DECODER;
+stream_type_varint({unknown, V}) -> V.
+
+claim_bidi_stream(StreamId, Type, #state{owner = Owner} = State) ->
+    Owner ! {quic_h3, self(), {stream_type_open, bidi, StreamId, Type}},
+    State#state{
+        bidi_type_buffers = maps:remove(StreamId, State#state.bidi_type_buffers),
+        claimed_bidi_streams = maps:put(
+            StreamId, Type, State#state.claimed_bidi_streams
+        )
+    }.
+
+forward_claimed_bidi_data(_StreamId, <<>>, false, _State) ->
+    ok;
+forward_claimed_bidi_data(StreamId, Data, Fin, #state{owner = Owner}) ->
+    Owner ! {quic_h3, self(), {stream_type_data, bidi, StreamId, Data, Fin}},
+    ok.
+
+%% Handler said `ignore' on the first varint. Promote the pending bidi
+%% to a normal H3 request stream and replay every byte we'd buffered,
+%% including the varint itself, so the request parser sees the raw
+%% original stream.
+fall_back_to_request_stream(StreamId, Combined, Fin, State) ->
+    Buffers = State#state.bidi_type_buffers,
+    {ok, State1} = open_bidi_request_stream(StreamId, State#state{
+        bidi_type_buffers = maps:remove(StreamId, Buffers)
+    }),
+    handle_request_stream_data(StreamId, Combined, Fin, State1).
+
+%% Returns the direction a claimed stream was classified under, if any.
+claimed_stream_direction(StreamId, #state{
+    claimed_uni_streams = U, claimed_bidi_streams = B
+}) ->
+    case maps:is_key(StreamId, U) of
+        true ->
+            {ok, uni};
+        false ->
+            case maps:is_key(StreamId, B) of
+                true -> {ok, bidi};
+                false -> error
+            end
+    end.
 
 assign_uni_stream(StreamId, control, #state{peer_control_stream = undefined} = State) ->
     {ok, State#state{peer_control_stream = StreamId}};
@@ -2884,7 +3004,9 @@ handle_stream_closed(
         stream_buffers = Buffers,
         uni_stream_buffers = UniBuffers,
         discarded_uni_streams = Discarded,
-        claimed_uni_streams = Claimed,
+        claimed_uni_streams = ClaimedUni,
+        claimed_bidi_streams = ClaimedBidi,
+        bidi_type_buffers = BidiBuffers,
         owner = Owner
     } = State
 ) ->
@@ -2895,15 +3017,15 @@ handle_stream_closed(
                 {connection_error, ?H3_CLOSED_CRITICAL_STREAM,
                     iolist_to_binary(io_lib:format("~p stream closed", [Type]))}};
         false ->
-            case maps:is_key(StreamId, Claimed) of
-                true ->
+            case claimed_stream_direction(StreamId, State) of
+                {ok, Direction} ->
                     Event =
                         case ErrorCode of
-                            0 -> {stream_type_closed, uni, StreamId};
-                            _ -> {stream_type_reset, uni, StreamId, ErrorCode}
+                            0 -> {stream_type_closed, Direction, StreamId};
+                            _ -> {stream_type_reset, Direction, StreamId, ErrorCode}
                         end,
                     Owner ! {quic_h3, self(), Event};
-                false ->
+                error ->
                     ok
             end,
             %% RFC 9114 Section 4.1.1: server-side request stream that ends
@@ -2916,7 +3038,9 @@ handle_stream_closed(
                 stream_buffers = maps:remove(StreamId, Buffers),
                 uni_stream_buffers = maps:remove(StreamId, UniBuffers),
                 discarded_uni_streams = sets:del_element(StreamId, Discarded),
-                claimed_uni_streams = maps:remove(StreamId, Claimed)
+                claimed_uni_streams = maps:remove(StreamId, ClaimedUni),
+                claimed_bidi_streams = maps:remove(StreamId, ClaimedBidi),
+                bidi_type_buffers = maps:remove(StreamId, BidiBuffers)
             }}
     end.
 

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -1120,28 +1120,37 @@ classify_stream(StreamId, #state{peer_encoder_stream = StreamId}) ->
 classify_stream(StreamId, #state{peer_decoder_stream = StreamId}) ->
     {uni, qpack_decoder};
 classify_stream(StreamId, #state{uni_stream_buffers = Buffers, received_pushes = Received} = State) ->
+    case classify_by_extension_tables(StreamId, State) of
+        {ok, Classification} -> Classification;
+        error -> classify_fresh_uni_stream(StreamId, Buffers, Received, State)
+    end.
+
+%% Walk the extension bookkeeping (discarded / claimed uni / claimed
+%% bidi / pending bidi) once, keeping classify_stream/2 flat so elvis's
+%% no_deep_nesting rule stays happy.
+classify_by_extension_tables(StreamId, State) ->
     case sets:is_element(StreamId, State#state.discarded_uni_streams) of
         true ->
-            {uni, discarded};
+            {ok, {uni, discarded}};
         false ->
-            case maps:find(StreamId, State#state.claimed_uni_streams) of
-                {ok, Type} ->
-                    {uni, {claimed, Type}};
-                error ->
-                    case maps:find(StreamId, State#state.claimed_bidi_streams) of
-                        {ok, BType} ->
-                            {bidi, {claimed, BType}};
-                        error ->
-                            case maps:is_key(StreamId, State#state.bidi_type_buffers) of
-                                true ->
-                                    {bidi, pending_type};
-                                false ->
-                                    classify_fresh_uni_stream(
-                                        StreamId, Buffers, Received, State
-                                    )
-                            end
-                    end
+            classify_by_claim_tables(StreamId, State)
+    end.
+
+classify_by_claim_tables(StreamId, State) ->
+    case maps:find(StreamId, State#state.claimed_uni_streams) of
+        {ok, Type} ->
+            {ok, {uni, {claimed, Type}}};
+        error ->
+            case maps:find(StreamId, State#state.claimed_bidi_streams) of
+                {ok, BType} -> {ok, {bidi, {claimed, BType}}};
+                error -> classify_pending_bidi(StreamId, State)
             end
+    end.
+
+classify_pending_bidi(StreamId, State) ->
+    case maps:is_key(StreamId, State#state.bidi_type_buffers) of
+        true -> {ok, {bidi, pending_type}};
+        false -> error
     end.
 
 classify_fresh_uni_stream(StreamId, Buffers, Received, State) ->

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1610,6 +1610,42 @@ stream_type_handler_closure_notifies_owner_test() ->
     after 100 -> ?assert(false)
     end.
 
+%% R4: non-zero close code on a claimed uni stream surfaces as
+%% stream_type_reset with the peer's error code.
+stream_type_handler_non_zero_close_is_reset_test() ->
+    Claim = fun(uni, _StreamId, _Type) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54, 0>>, false, State1
+    ),
+    flush_mailbox(),
+    {ok, _State3} = quic_h3_connection:handle_stream_closed(StreamId, 42, State2),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_reset, uni, StreamId, 42}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+%% R4: zero close code keeps the stream_type_closed shape so graceful
+%% halves stay distinguishable from resets for callers.
+stream_type_handler_zero_close_stays_closed_test() ->
+    Claim = fun(uni, _StreamId, _Type) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54, 0>>, false, State1
+    ),
+    flush_mailbox(),
+    {ok, _State3} = quic_h3_connection:handle_stream_closed(StreamId, 0, State2),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_closed, uni, StreamId}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
 flush_mailbox() ->
     receive
         _ -> flush_mailbox()

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1646,6 +1646,83 @@ stream_type_handler_zero_close_stays_closed_test() ->
     after 100 -> ?assert(false)
     end.
 
+%% R1: WT_BIDI_SIGNAL (varint 0x41) on a fresh peer-initiated bidi
+%% stream is claimed; subsequent bytes surface as bidi stream_type_data
+%% events without hitting the HTTP/3 request parser.
+stream_type_handler_claims_bidi_stream_test() ->
+    Claim = fun(bidi, _StreamId, 16#41) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 0,
+    {ok, State1} = quic_h3_connection:handle_new_stream(
+        StreamId, bidirectional, State0
+    ),
+    flush_mailbox(),
+    {ok, _State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#41, "payload">>, false, State1
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, bidi, StreamId, 16#41}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, bidi, StreamId, <<"payload">>, false}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+%% R1: when the handler returns ignore, the bidi stream falls back to
+%% the HTTP/3 request path and every buffered byte (varint included)
+%% is re-fed so the request parser sees the raw stream.
+stream_type_handler_bidi_ignore_falls_through_test() ->
+    Ignore = fun(bidi, _StreamId, _Type) -> ignore end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Ignore}),
+    StreamId = 0,
+    {ok, State1} = quic_h3_connection:handle_new_stream(
+        StreamId, bidirectional, State0
+    ),
+    %% Feed a bogus first varint that's NOT a valid HEADERS frame. The
+    %% fall-through path forwards bytes to the request stream parser;
+    %% we only assert no crash and that the stream is now a request
+    %% stream (present in #state.streams at tuple position 21).
+    Result = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#41>>, false, State1
+    ),
+    ?assertMatch({ok, _}, Result),
+    {ok, State2} = Result,
+    ?assert(maps:is_key(StreamId, element(21, State2))).
+
+%% R1: bidi header split across two messages triggers the handler only
+%% once the varint is complete; intermediate delivery returns {more}.
+stream_type_handler_bidi_split_varint_test() ->
+    Claim = fun(bidi, _StreamId, 16#41) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 0,
+    {ok, State1} = quic_h3_connection:handle_new_stream(
+        StreamId, bidirectional, State0
+    ),
+    flush_mailbox(),
+    %% Send one byte of the 2-byte varint; handler must not fire yet.
+    {ok, State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40>>, false, State1
+    ),
+    receive
+        {quic_h3, _, {stream_type_open, bidi, _, _}} -> ?assert(false)
+    after 50 -> ok
+    end,
+    %% Completion byte plus payload → handler fires with type 0x41.
+    {ok, _State3} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#41, "rest">>, true, State2
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, bidi, StreamId, 16#41}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, bidi, StreamId, <<"rest">>, true}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
 flush_mailbox() ->
     receive
         _ -> flush_mailbox()
@@ -1712,7 +1789,9 @@ make_test_state(Overrides) ->
         stream_type_handler => undefined,
         claimed_uni_streams => #{},
         h3_datagram_enabled => false,
-        peer_h3_datagram_enabled => false
+        peer_h3_datagram_enabled => false,
+        bidi_type_buffers => #{},
+        claimed_bidi_streams => #{}
     },
     Merged = maps:merge(Default, Overrides),
     %% Build the state tuple in the same order as the record definition
@@ -1741,4 +1820,5 @@ make_test_state(Overrides) ->
         maps:get(stream_handlers, Merged), maps:get(stream_data_buffers, Merged),
         maps:get(stream_buffer_limit, Merged), maps:get(local_connect_enabled, Merged),
         maps:get(stream_type_handler, Merged), maps:get(claimed_uni_streams, Merged),
-        maps:get(h3_datagram_enabled, Merged), maps:get(peer_h3_datagram_enabled, Merged)}.
+        maps:get(h3_datagram_enabled, Merged), maps:get(peer_h3_datagram_enabled, Merged),
+        maps:get(bidi_type_buffers, Merged), maps:get(claimed_bidi_streams, Merged)}.

--- a/test/quic_h3_push_tests.erl
+++ b/test/quic_h3_push_tests.erl
@@ -379,7 +379,9 @@ make_test_state(Overrides) ->
         stream_type_handler => undefined,
         claimed_uni_streams => #{},
         h3_datagram_enabled => false,
-        peer_h3_datagram_enabled => false
+        peer_h3_datagram_enabled => false,
+        bidi_type_buffers => #{},
+        claimed_bidi_streams => #{}
     },
     Merged = maps:merge(Default, Overrides),
     {state, maps:get(quic_conn, Merged), maps:get(quic_ref, Merged), maps:get(role, Merged),
@@ -405,4 +407,5 @@ make_test_state(Overrides) ->
         maps:get(stream_data_buffers, Merged), maps:get(stream_buffer_limit, Merged),
         maps:get(local_connect_enabled, Merged), maps:get(stream_type_handler, Merged),
         maps:get(claimed_uni_streams, Merged), maps:get(h3_datagram_enabled, Merged),
-        maps:get(peer_h3_datagram_enabled, Merged)}.
+        maps:get(peer_h3_datagram_enabled, Merged), maps:get(bidi_type_buffers, Merged),
+        maps:get(claimed_bidi_streams, Merged)}.


### PR DESCRIPTION
An extension library (WebTransport, CONNECT-UDP) needs three hooks from this dep before it can realistically receive streams and react to peer-initiated resets. None of them is invasive; together they close the gap between what the extension-stream machinery already offers and what a session-aware router actually needs.

**Bidi stream-type hook.** `stream_type_handler` is now consulted on the first varint of any peer-initiated bidi stream, same `claim | ignore` contract that already works for uni. On claim the stream becomes `{quic_h3, _, {stream_type_{open,data,closed,reset,stop_sending}, bidi, ...}}` events addressed to the owner. On ignore (or when no handler is set) the stream falls back to the HTTP/3 request path with every buffered byte — including the peeked varint — replayed through the parser, so a peer sending `HEADERS` on a fresh bidi is unaffected.

```erlang
stream_type_handler => fun
    (uni,  _StreamId, 16#54) -> claim;   %% WT_STREAM
    (bidi, _StreamId, 16#41) -> claim;   %% WT_BIDI_SIGNAL
    (_, _, _)                -> ignore
end.
```

**Per-connection owner.** `quic_h3:start_server/3` accepts a `connection_handler` fun called once per accepted H3 connection. It can return an owner pid (plus optional handler / settings overrides) so a proxy hosting many concurrent sessions gets one router per connection instead of a single global demux. The docs contrast this with `set_stream_handler/3,4`: that one is per-stream and post-classification, this one is per-connection and pre-classification; they compose rather than overlap.

```erlang
connection_handler => fun(_QuicConnPid) ->
    #{owner => spawn(fun my_router:loop/0)}
end.
```

**Reset and stop_sending on claimed streams.** A claimed stream's close now surfaces the peer's error code: zero stays `{stream_type_closed, Dir, StreamId}`, non-zero becomes `{stream_type_reset, Dir, StreamId, ErrorCode}`. Peer STOP_SENDING lands as `{stream_type_stop_sending, Dir, StreamId, ErrorCode}`. Non-claimed streams keep today's generic event shape.

The same primitives serve CONNECT-UDP (RFC 9298), which rides on top of the H3 datagram path from #50. WebTransport uses the bidi claim hook; CONNECT-UDP skips it and just consumes `{datagram, StreamId, Payload}` events keyed by its CONNECT request stream. `docs/HTTP3.md` walks both scenarios.

Full gate green: 1880 eunit, elvis lint, xref, dialyzer, `quic_datagram_e2e_SUITE` 12/12.