### PR TITLE
test: start quic app in h3spec, add make test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,38 @@ erlang.mk:
 endif
 
 include $(if $(ERLANG_MK_FILENAME),$(ERLANG_MK_FILENAME),erlang.mk)
+
+##
+## Test convenience targets layered on top of rebar3.
+##
+## `make test-local` runs everything that doesn't need Docker.
+## `make test-docker` runs the h3spec conformance suite, which drives
+## the kazu-yamamoto/h3spec container against our in-process server.
+## `make test-all` runs both stages followed by static checks.
+##
+
+.PHONY: test-local test-docker test-all test-static
+
+test-static:
+	rebar3 fmt --check
+	rebar3 xref
+	rebar3 lint
+	rebar3 dialyzer
+
+test-local:
+	rebar3 eunit
+	rebar3 proper
+	rebar3 ct --suite=quic_e2e_SUITE,\
+	quic_e2e_bbr_SUITE,\
+	quic_e2e_cubic_SUITE,\
+	quic_h3_e2e_SUITE,\
+	quic_datagram_e2e_SUITE,\
+	quic_lb_e2e_SUITE,\
+	quic_client_compliance_SUITE,\
+	quic_interop_SUITE,\
+	quic_h3_server_SUITE
+
+test-docker:
+	rebar3 ct --suite=quic_h3_h3spec_SUITE
+
+test-all: test-local test-docker test-static

--- a/test/quic_h3_h3spec_SUITE.erl
+++ b/test/quic_h3_h3spec_SUITE.erl
@@ -48,6 +48,7 @@ all() ->
 init_per_suite(Config) ->
     application:ensure_all_started(crypto),
     application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(quic),
 
     %% Check if docker is available
     case os:find_executable("docker") of


### PR DESCRIPTION
`quic_h3_h3spec_SUITE:init_per_suite` only started `crypto` and `ssl`, so `quic:start_server/3` inside the test body crashed on an uninitialised server registry ETS table.

Adds `make test-local` (eunit + proper + in-process CT), `make test-docker` (h3spec_conformance, the only suite that still needs a container), `make test-static`, `make test-all`.

Replaces #53.