### PR TITLE
fix(h3): default server owner to listener gen_server

### DIFF
--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -451,7 +451,14 @@ unset_stream_handler(Conn, StreamId) ->
 %%%     end
 %%% }).
 %%% '''
-%%% @end
+%%
+%% Receiving datagrams / stream-type events: when `h3_datagram_enabled'
+%% or `stream_type_handler' is used, owner-addressed messages are
+%% emitted per connection. Supply a durable receiver by returning
+%% `#{owner => Pid}' from the per-connection `connection_handler'
+%% callback. Without an explicit owner those messages route to the
+%% listener process, where they are discarded.
+%% @end
 -spec start_server(Name, Port, Opts) -> {ok, pid()} | {error, term()} when
     Name :: atom(),
     Port :: inet:port_number(),
@@ -463,13 +470,11 @@ start_server(Name, Port, Opts) ->
     H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
     PerConn = maps:get(connection_handler, Opts, undefined),
     QuicOpts0 = build_server_quic_opts(Opts),
-    Listener = self(),
     ListenerDefaults = #{
         handler => Handler,
         settings => H3Settings,
         stream_type_handler => StreamTypeHandler,
-        h3_datagram_enabled => H3DatagramEnabled,
-        owner => Listener
+        h3_datagram_enabled => H3DatagramEnabled
     },
     QuicOpts = QuicOpts0#{
         connection_handler => fun(ConnPid, _ConnRef) ->
@@ -705,26 +710,20 @@ maybe_enable_quic_datagrams(Opts, QuicOpts) ->
 %% @private
 %% Connection handler callback for QUIC server.
 %% Called when a new QUIC connection is established (before handshake completes).
-%% `Opts' carries the per-server configuration captured in start_server/3:
-%% `handler', `settings', `stream_type_handler', `h3_datagram_enabled',
-%% and the calling process pid as `owner' (used when any extension hook
-%% needs owner-delivered messages).
+%% Runs inside the listener gen_server process, so `self()' is the listener
+%% pid — long-lived and trap_exit'ed, suitable as the default H3 owner.
+%% `Opts' carries the per-server configuration: `handler', `settings',
+%% `stream_type_handler', `h3_datagram_enabled'. A per-connection
+%% `connection_handler' callback may supply `owner => Pid' to route
+%% extension events (datagrams, stream-type) to a durable receiver.
 h3_connection_handler(QuicConnPid, #{handler := Handler, settings := Settings} = Opts) ->
     StreamTypeHandler = maps:get(stream_type_handler, Opts, undefined),
     H3DatagramEnabled = maps:get(h3_datagram_enabled, Opts, false),
     Owner = maps:get(owner, Opts, self()),
     H3Opts = build_h3_opts(Settings, Handler, StreamTypeHandler, H3DatagramEnabled),
-    %% When an extension hook is active, owner-addressed events need to
-    %% reach the caller of start_server/3 rather than this transient
-    %% callback process.
-    OwnerForH3 =
-        case (StreamTypeHandler =/= undefined) orelse H3DatagramEnabled of
-            true -> Owner;
-            false -> self()
-        end,
     case
         gen_statem:start_link(
-            quic_h3_connection, {server, QuicConnPid, H3Opts, OwnerForH3}, []
+            quic_h3_connection, {server, QuicConnPid, H3Opts, Owner}, []
         )
     of
         {ok, H3Conn} ->

--- a/test/quic_h3_owner_SUITE.erl
+++ b/test/quic_h3_owner_SUITE.erl
@@ -1,0 +1,207 @@
+%%% -*- erlang -*-
+%%%
+%%% Regression + coverage for the H3 server owner wiring.
+%%%
+%%% `quic_h3:start_server/3' used to capture `self()' as the default
+%%% owner pid for H3 connections. When the caller was a transient
+%%% process (spawned helper, init_per_suite), the owner pid would be
+%%% dead by the time a client arrived, tripping the
+%%% `monitor(process, Owner)' in `quic_h3_connection:init/1' and
+%%% transitioning the server's H3 fsm to `closing' before SETTINGS
+%%% could flow. Clients saw `connect_timeout'.
+%%%
+%%% Two cases:
+%%%   1. Transient caller + `h3_datagram_enabled => true' — verifies a
+%%%      dead start_server caller no longer wedges client handshakes.
+%%%   2. Per-conn `connection_handler' hook supplying `owner => Pid' —
+%%%      verifies datagrams route to the explicit owner.
+
+-module(quic_h3_owner_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    transient_caller_with_datagram_flag/1,
+    custom_owner_receives_datagram/1
+]).
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [transient_caller_with_datagram_flag, custom_owner_receives_datagram].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(quic),
+    {Cert, Key} = load_certs(),
+    [{cert, Cert}, {key, Key} | Config].
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Test cases
+%%====================================================================
+
+%% A process that called start_server and exited must not kill the
+%% server's ability to accept new connections when the H3 datagram
+%% extension is enabled.
+transient_caller_with_datagram_flag(Config) ->
+    Cert = ?config(cert, Config),
+    Key = ?config(key, Config),
+    Name = unique_name("h3_owner_transient"),
+
+    Parent = self(),
+    Spawner = spawn(fun() ->
+        {ok, _} = quic_h3:start_server(Name, 0, #{
+            cert => Cert,
+            key => Key,
+            handler => fun handle_hello/5,
+            h3_datagram_enabled => true
+        }),
+        {ok, P} = quic:get_server_port(Name),
+        Parent ! {port, P}
+    end),
+    Ref = monitor(process, Spawner),
+    Port =
+        receive
+            {port, P} -> P
+        after 5000 -> ct:fail(start_server_timeout)
+        end,
+    receive
+        {'DOWN', Ref, process, Spawner, _} -> ok
+    after 2000 -> ct:fail(spawner_did_not_exit)
+    end,
+    false = is_process_alive(Spawner),
+
+    try
+        {200, <<"hello">>} = do_get(Port)
+    after
+        catch quic_h3:stop_server(Name)
+    end,
+    ok.
+
+%% With `connection_handler => fun(_) -> #{owner => Parent} end', an
+%% H3 datagram sent by the client must reach Parent as
+%% `{quic_h3, _, {datagram, StreamId, Payload}}'.
+custom_owner_receives_datagram(Config) ->
+    Cert = ?config(cert, Config),
+    Key = ?config(key, Config),
+    Name = unique_name("h3_owner_explicit"),
+
+    Parent = self(),
+    Hook = fun(_ConnPid) -> #{owner => Parent} end,
+    {ok, _} = quic_h3:start_server(Name, 0, #{
+        cert => Cert,
+        key => Key,
+        handler => fun handle_hello/5,
+        h3_datagram_enabled => true,
+        connection_handler => Hook
+    }),
+    {ok, Port} = quic:get_server_port(Name),
+
+    try
+        {ok, Conn} = quic_h3:connect("localhost", Port, #{
+            verify => false,
+            sync => true,
+            h3_datagram_enabled => true
+        }),
+        Headers = [
+            {<<":method">>, <<"GET">>},
+            {<<":scheme">>, <<"https">>},
+            {<<":path">>, <<"/">>},
+            {<<":authority">>, <<"localhost">>}
+        ],
+        {ok, StreamId} = quic_h3:request(Conn, Headers),
+        {200, <<"hello">>} = recv_response(Conn, StreamId, 5000),
+
+        Payload = <<"ping-payload">>,
+        ok = quic_h3:send_datagram(Conn, StreamId, Payload),
+
+        receive
+            {quic_h3, _H3Conn, {datagram, StreamId, Payload}} -> ok
+        after 3000 ->
+            ct:fail(datagram_not_received_by_explicit_owner)
+        end,
+
+        quic_h3:close(Conn)
+    after
+        catch quic_h3:stop_server(Name)
+    end,
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+handle_hello(Conn, StreamId, _Method, _Path, _Headers) ->
+    quic_h3:send_response(Conn, StreamId, 200, [
+        {<<"content-type">>, <<"text/plain">>}
+    ]),
+    quic_h3:send_data(Conn, StreamId, <<"hello">>, true).
+
+do_get(Port) ->
+    {ok, Conn} = quic_h3:connect("localhost", Port, #{verify => false, sync => true}),
+    Headers = [
+        {<<":method">>, <<"GET">>},
+        {<<":scheme">>, <<"https">>},
+        {<<":path">>, <<"/">>},
+        {<<":authority">>, <<"localhost">>}
+    ],
+    {ok, StreamId} = quic_h3:request(Conn, Headers),
+    Result = recv_response(Conn, StreamId, 5000),
+    quic_h3:close(Conn),
+    Result.
+
+recv_response(Conn, StreamId, Timeout) ->
+    recv_response(Conn, StreamId, Timeout, undefined, <<>>).
+
+recv_response(Conn, StreamId, Timeout, Status, Acc) ->
+    receive
+        {quic_h3, Conn, {response, StreamId, S, _}} ->
+            recv_response(Conn, StreamId, Timeout, S, Acc);
+        {quic_h3, Conn, {headers, StreamId, S, _}} ->
+            recv_response(Conn, StreamId, Timeout, S, Acc);
+        {quic_h3, Conn, {data, StreamId, Data, true}} ->
+            {Status, <<Acc/binary, Data/binary>>};
+        {quic_h3, Conn, {data, StreamId, Data, false}} ->
+            recv_response(Conn, StreamId, Timeout, Status, <<Acc/binary, Data/binary>>);
+        {quic_h3, Conn, {stream_end, StreamId}} ->
+            {Status, Acc}
+    after Timeout ->
+        ct:fail({response_timeout, StreamId, Status, byte_size(Acc)})
+    end.
+
+unique_name(Base) ->
+    list_to_atom(Base ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+load_certs() ->
+    {ok, Cwd} = file:get_cwd(),
+    Root = find_root(Cwd),
+    CertFile = filename:join([Root, "certs", "cert.pem"]),
+    KeyFile = filename:join([Root, "certs", "priv.key"]),
+    {ok, CertPem} = file:read_file(CertFile),
+    {ok, KeyPem} = file:read_file(KeyFile),
+    [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+    [{Type, KeyDer, not_encrypted} | _] = public_key:pem_decode(KeyPem),
+    {CertDer, public_key:der_decode(Type, KeyDer)}.
+
+find_root(Dir) ->
+    case filelib:is_file(filename:join(Dir, "rebar.config")) of
+        true ->
+            Dir;
+        false ->
+            Parent = filename:dirname(Dir),
+            case Parent of
+                Dir -> error(no_project_root);
+                _ -> find_root(Parent)
+            end
+    end.


### PR DESCRIPTION
`quic_h3:start_server/3` captured `self()` as the default H3 connection owner. When the caller exited before a client connected and either `h3_datagram_enabled` or `stream_type_handler` was set, `monitor(process, Owner)` fired DOWN immediately in the H3 fsm, transitioning to `closing` before SETTINGS could flow and wedging all clients with `connect_timeout`.

Drop the capture; let `Owner` default to `self()` inside `h3_connection_handler/2` (which runs inside the listener gen_server, long-lived and `trap_exit`'ed). Callers wanting to receive datagram or stream-type events supply a durable owner via the per-conn `connection_handler` hook:

```erlang
quic_h3:start_server(Name, 0, #{
    cert => Cert, key => Key,
    handler => fun handle/5,
    h3_datagram_enabled => true,
    connection_handler => fun(_ConnPid) -> #{owner => MyServicePid} end
}).
```

New `quic_h3_owner_SUITE` covers the regression (transient caller + datagram flag) and the explicit-owner hook path.