### PR TITLE
feat(h3): add open_bidi_stream/1,2 for extension-claimed streams

### DIFF
--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -98,6 +98,8 @@
     connect/3,
     request/2,
     request/3,
+    open_bidi_stream/1,
+    open_bidi_stream/2,
     wait_connected/2
 ]).
 
@@ -317,6 +319,39 @@ request(Conn, Headers) ->
 -spec request(conn(), headers(), map()) -> {ok, stream_id()} | {error, term()}.
 request(Conn, Headers, Opts) ->
     quic_h3_connection:request(Conn, Headers, Opts).
+
+%% @doc Open a client-initiated bidirectional stream outside the H3
+%% request/response flow. Equivalent to `open_bidi_stream(Conn, undefined)'
+%% — the stream is a plain request stream and the caller is responsible
+%% for HEADERS/DATA framing (typically not useful on its own; prefer the
+%% `/2' form below).
+%% @end
+-spec open_bidi_stream(conn()) -> {ok, stream_id()} | {error, term()}.
+open_bidi_stream(Conn) ->
+    quic_h3_connection:open_bidi_stream(Conn, undefined).
+
+%% @doc Open a client-initiated bidirectional stream and pre-claim it
+%% with an extension signal type (e.g. WebTransport's `16#41').
+%%
+%% When `SignalType' is a non-negative integer, the stream is recorded
+%% in the H3 connection's claimed-bidi table. Subsequent inbound data
+%% on that stream bypasses the HTTP/3 request parser and is delivered
+%% to the connection owner as
+%% `{quic_h3, Conn, {stream_type_data, bidi, StreamId, Data, Fin}}'.
+%% The owner also receives
+%% `{quic_h3, Conn, {stream_type_open, bidi, StreamId, SignalType}}'
+%% at open time, mirroring the peer-initiated claimed-bidi path.
+%%
+%% The caller sends the extension signal varint (and any session/header
+%% prefix) itself via `send_data/4' — this API is extension-agnostic.
+%%
+%% When `SignalType' is `undefined', no claim is recorded and the stream
+%% behaves as a normal H3 request stream.
+%% @end
+-spec open_bidi_stream(conn(), non_neg_integer() | undefined) ->
+    {ok, stream_id()} | {error, term()}.
+open_bidi_stream(Conn, SignalType) ->
+    quic_h3_connection:open_bidi_stream(Conn, SignalType).
 
 %%====================================================================
 %% Shared API (Client and Server)

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -22,6 +22,7 @@
     start_link/4,
     request/2,
     request/3,
+    open_bidi_stream/2,
     send_response/4,
     send_data/3,
     send_data/4,
@@ -98,7 +99,8 @@
     handle_push_frame/5,
     handle_priority_update_frame/2,
     handle_priority_update_push_frame/2,
-    do_send_trailers/3
+    do_send_trailers/3,
+    pre_claim_bidi_stream/3
 ]).
 -endif.
 
@@ -279,6 +281,16 @@ request(Conn, Headers) ->
     {ok, stream_id()} | {error, term()}.
 request(Conn, Headers, Opts) ->
     gen_statem:call(Conn, {request, Headers, Opts}).
+
+%% @doc Open a client-initiated bidirectional stream outside the H3
+%% request/response flow. When `SignalType' is a non-negative integer,
+%% the stream is pre-claimed so inbound data is delivered as
+%% `stream_type_data' owner messages. When `undefined', behaves as a
+%% plain unclaimed stream.
+-spec open_bidi_stream(pid(), non_neg_integer() | undefined) ->
+    {ok, stream_id()} | {error, term()}.
+open_bidi_stream(Conn, SignalType) ->
+    gen_statem:call(Conn, {open_bidi_stream, SignalType}).
 
 %% @doc Send a response (server only).
 -spec send_response(pid(), stream_id(), pos_integer(), [{binary(), binary()}]) ->
@@ -716,6 +728,13 @@ connected({call, From}, {request, Headers, Opts}, #state{role = client} = State)
     end;
 connected({call, From}, {request, _Headers, _Opts}, #state{role = server}) ->
     {keep_state_and_data, [{reply, From, {error, server_cannot_request}}]};
+connected({call, From}, {open_bidi_stream, SignalType}, State) ->
+    case do_open_bidi_stream(SignalType, State) of
+        {ok, StreamId, State1} ->
+            {keep_state, State1, [{reply, From, {ok, StreamId}}]};
+        {error, Reason} ->
+            {keep_state_and_data, [{reply, From, {error, Reason}}]}
+    end;
 connected({call, From}, {send_response, StreamId, Status, Headers}, State) ->
     case do_send_response(StreamId, Status, Headers, State) of
         {ok, State1} ->
@@ -1291,6 +1310,32 @@ claim_bidi_stream(StreamId, Type, #state{owner = Owner} = State) ->
     Owner ! {quic_h3, self(), {stream_type_open, bidi, StreamId, Type}},
     State#state{
         bidi_type_buffers = maps:remove(StreamId, State#state.bidi_type_buffers),
+        claimed_bidi_streams = maps:put(
+            StreamId, Type, State#state.claimed_bidi_streams
+        )
+    }.
+
+%% Local-open counterpart of claim_bidi_stream/3. Opens a client-initiated
+%% bidi stream on the underlying QUIC connection and, when SignalType is
+%% set, pre-claims it so inbound bytes bypass the H3 request parser and
+%% land as {stream_type_data, bidi, ...} owner messages.
+do_open_bidi_stream(SignalType, #state{quic_conn = QuicConn} = State) ->
+    case quic:open_stream(QuicConn) of
+        {ok, StreamId} ->
+            {ok, StreamId, pre_claim_bidi_stream(StreamId, SignalType, State)};
+        {error, _} = Err ->
+            Err
+    end.
+
+%% Pure half of do_open_bidi_stream/2: given a freshly opened StreamId,
+%% record the claim (if any) and notify the owner.
+pre_claim_bidi_stream(_StreamId, undefined, State) ->
+    State;
+pre_claim_bidi_stream(StreamId, Type, #state{owner = Owner} = State) when
+    is_integer(Type), Type >= 0
+->
+    Owner ! {quic_h3, self(), {stream_type_open, bidi, StreamId, Type}},
+    State#state{
         claimed_bidi_streams = maps:put(
             StreamId, Type, State#state.claimed_bidi_streams
         )

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1723,6 +1723,43 @@ stream_type_handler_bidi_split_varint_test() ->
     after 100 -> ?assert(false)
     end.
 
+%% Local-open: pre-claiming a client-initiated bidi stream registers
+%% the type and notifies the owner, mirroring the peer-initiated claim.
+open_bidi_stream_pre_claims_stream_test() ->
+    State0 = make_test_state(#{role => client}),
+    flush_mailbox(),
+    StreamId = 4,
+    Type = 16#41,
+    State1 = quic_h3_connection:pre_claim_bidi_stream(StreamId, Type, State0),
+    %% claimed_bidi_streams is record field — accessed via map gymnastics
+    %% would require knowing the position; instead verify behavior end-
+    %% to-end by feeding data and asserting the claimed-bidi dispatch.
+    {ok, _State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<"payload">>, false, State1
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, bidi, StreamId, Type}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, bidi, StreamId, <<"payload">>, false}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+%% Local-open with SignalType = undefined skips the claim entirely:
+%% no owner notification, no claimed-bidi entry. State must be untouched.
+open_bidi_stream_undefined_passthrough_test() ->
+    State0 = make_test_state(#{role => client}),
+    flush_mailbox(),
+    StreamId = 4,
+    State1 = quic_h3_connection:pre_claim_bidi_stream(StreamId, undefined, State0),
+    ?assertEqual(State0, State1),
+    receive
+        {quic_h3, _, {stream_type_open, _, _, _}} -> ?assert(false)
+    after 50 -> ok
+    end.
+
 flush_mailbox() ->
     receive
         _ -> flush_mailbox()


### PR DESCRIPTION
Symmetric local-open counterpart to the peer-initiated `stream_type_handler` claim path. Caller passes a `SignalType` varint (e.g. WebTransport's `0x41`) and inbound data on the resulting stream is delivered as `{stream_type_data, bidi, StreamId, Data, Fin}` owner messages instead of being parsed as an HTTP/3 request. The owner also receives `{stream_type_open, bidi, StreamId, SignalType}` at open time, mirroring peer-initiated claimed bidi streams.

\`SignalType = undefined\` leaves the stream as a plain request stream (no claim, no owner message).

\`\`\`erlang
{ok, StreamId} = quic_h3:open_bidi_stream(H3Conn, 16#41),
ok = quic:send_data(QuicConn, StreamId, <<SignalVarint/binary, SessionVarint/binary, Payload/binary>>, false).
\`\`\`

Closes the case where downstream code (e.g. \`erlang-webtransport\`) opened bidi streams via \`quic:open_stream/1\` and the H3 layer then misclassified inbound echo data as an HTTP/3 request.