### PR TITLE
h3: consult stream_type_handler on fresh peer-initiated bidi streams

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -1027,6 +1027,10 @@ handle_new_stream(StreamId, unidirectional, State) ->
     %% Unidirectional stream - need to read type first
     {ok, State#state{uni_stream_buffers = maps:put(StreamId, <<>>, State#state.uni_stream_buffers)}};
 handle_new_stream(StreamId, bidirectional, #state{role = Role} = State) ->
+    %% Note: quic_connection does not emit {new_stream, _, _} in
+    %% production, so this clause is currently only exercised by
+    %% eunit. Real dispatch for fresh peer-initiated bidi streams
+    %% flows through classify_stream_type/2 → handle_bidi_stream_type/4.
     %% RFC 9114 Section 4.1: Validate stream ID parity
     %% Client-initiated streams are even (0, 4, 8...)
     %% Server-initiated streams are odd (1, 5, 9...)
@@ -1188,10 +1192,15 @@ classify_fresh_uni_stream(StreamId, Buffers, Received, State) ->
             end
     end.
 
-%% Helper to classify stream by ID pattern
-classify_stream_type(StreamId, _State) ->
+%% Helper to classify stream by ID pattern. For peer-initiated bidi
+%% streams with a stream_type_handler configured, return
+%% {bidi, pending_type} so the dispatcher lets handle_bidi_stream_type/4
+%% peek the first varint and consult the handler (claim vs. ignore).
+%% Without a handler the stream goes straight to the HTTP/3 request path.
+classify_stream_type(StreamId, #state{stream_type_handler = Handler}) ->
     %% Check if it's a bidirectional stream (bit 1 = 0 for bidi)
     case StreamId band 2 of
+        0 when Handler =/= undefined -> {bidi, pending_type};
         0 -> {bidi, request};
         2 -> unknown
     end.

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1691,6 +1691,50 @@ stream_type_handler_bidi_ignore_falls_through_test() ->
     {ok, State2} = Result,
     ?assert(maps:is_key(StreamId, element(21, State2))).
 
+%% Real dispatch path: fresh peer-initiated bidi stream arrives via
+%% handle_stream_data/4 without a prior handle_new_stream/3 call
+%% (quic_connection never emits new_stream in production). The
+%% classifier must still consult stream_type_handler and claim the
+%% stream, not drop it into the HTTP/3 request parser.
+stream_type_handler_claims_bidi_stream_via_dispatch_test() ->
+    Claim = fun(bidi, _StreamId, 16#41) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 0,
+    flush_mailbox(),
+    {ok, _State1} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#41, "payload">>, false, State0
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, bidi, StreamId, 16#41}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, bidi, StreamId, <<"payload">>, false}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
+%% Same dispatch-path entry for the ignore case: handler declines,
+%% varint + payload replay through the request parser, no
+%% stream_type_open message fires.
+stream_type_handler_bidi_ignore_via_dispatch_test() ->
+    Ignore = fun(bidi, _StreamId, _Type) -> ignore end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Ignore}),
+    StreamId = 0,
+    flush_mailbox(),
+    Result = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#41>>, false, State0
+    ),
+    ?assertMatch({ok, _}, Result),
+    {ok, State1} = Result,
+    %% Stream recorded in #state.streams (tuple position 21, same
+    %% as the pre-existing *_falls_through_test assertion).
+    ?assert(maps:is_key(StreamId, element(21, State1))),
+    receive
+        {quic_h3, _, {stream_type_open, bidi, _, _}} -> ?assert(false)
+    after 50 -> ok
+    end.
+
 %% R1: bidi header split across two messages triggers the handler only
 %% once the varint is complete; intermediate delivery returns {more}.
 stream_type_handler_bidi_split_varint_test() ->


### PR DESCRIPTION
`classify_stream_type/2` ignored state and always returned `{bidi, request}` for bidi stream IDs, so a server configured with `stream_type_handler` never saw peer-initiated bidi streams with an extension signal (e.g. WebTransport's `0x41`) — the bytes landed in the HTTP/3 request parser instead.

The existing `handle_bidi_stream_type/4` path was only reachable via `handle_new_stream/3`, which is never exercised in production: `quic_connection` does not emit `{new_stream, _, _}` events, only `{stream_data, _, _, _}` / `{stream_reset, _, _}`. The only caller of `handle_new_stream/3` was an eunit that primed it manually.

Make the classifier state-aware so the dispatch path reaches the handler for real:

```erlang
classify_stream_type(StreamId, #state{stream_type_handler = Handler}) ->
    case StreamId band 2 of
        0 when Handler =/= undefined -> {bidi, pending_type};
        0 -> {bidi, request};
        2 -> unknown
    end.
```

New eunit enters through `handle_stream_data/4` directly (no `handle_new_stream/3` priming) to lock down the real dispatch path for both claim and ignore. `handle_new_stream/3` is left in place with a note; removing it is a follow-up.