### PR TITLE
fix(docs): make rebar3 ex_doc run clean

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -200,12 +200,7 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `quic:set_stream_priority/4` - Set stream priority (urgency, incremental)
 - `quic:get_stream_priority/2` - Get stream priority
 
-### Server
-- `quic:listen/2` - Start listener
-- `quic:accept/1,2` - Accept connection
-- `quic:close_listener/1` - Close listener
-
-### Multi-Pool Server Management
+### Server / Multi-Pool Server Management
 - `quic:start_server/3` - Start named server pool
 - `quic:stop_server/1` - Stop named server
 - `quic:get_server_info/1` - Get server information

--- a/rebar.config
+++ b/rebar.config
@@ -77,7 +77,8 @@
         <<"docs/SERVER_GUIDE.md">>,
         <<"docs/CLIENT_GUIDE.md">>,
         <<"docs/QUIC_DIST.md">>,
-        <<"docs/QLOG_GUIDE.md">>
+        <<"docs/QLOG_GUIDE.md">>,
+        <<"docs/HTTP3.md">>
     ]},
     {groups_for_extras, [
         {<<"Guides">>, [
@@ -92,7 +93,8 @@
         ]},
         {<<"Advanced">>, [
             <<"docs/QUIC_DIST.md">>,
-            <<"docs/QLOG_GUIDE.md">>
+            <<"docs/QLOG_GUIDE.md">>,
+            <<"docs/HTTP3.md">>
         ]}
     ]},
     {main, <<"readme">>},

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -405,7 +405,7 @@ max_datagram_size(Conn, StreamId) ->
     gen_statem:call(Conn, {h3_max_datagram_size, StreamId}).
 
 %% @doc Register a handler process to receive stream data.
-%% The handler will receive `{quic_h3, Conn, {data, StreamId, Data, Fin}}` messages.
+%% The handler will receive `{quic_h3, Conn, {data, StreamId, Data, Fin}}' messages.
 %% Any data buffered before registration is returned.
 %% @see set_stream_handler/4
 -spec set_stream_handler(pid(), stream_id(), pid()) ->


### PR DESCRIPTION
`rebar3 ex_doc` failed on the 1.0.0 tree: an unterminated inline-code span in the `set_stream_handler/3` edoc aborted the doclet, and the remaining run warned on stale `quic:listen/2` / `quic:close_listener/1` references plus a missing `docs/HTTP3.md` entry in the extras list.

- Close the code span with an apostrophe (edoc style, not Markdown backticks)
- Drop the three stale Server-section entries from `docs/features.md`; the canonical API is `start_server/3` / `stop_server/1`
- Add `docs/HTTP3.md` to `ex_doc` `extras` and the Advanced group

`rebar3 ex_doc` now runs clean.