### PR TITLE
h3: thread FIN through peer uni stream-type dispatch

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -225,7 +225,7 @@
     %% Placed at the end so prior tuple positions stay stable for tests.
     local_connect_enabled = false :: boolean(),
 
-    %% Extension hook. When set, `handle_uni_stream_type/3` consults
+    %% Extension hook. When set, `handle_uni_stream_type/4` consults
     %% this function for unknown stream types and, on `claim`, routes
     %% subsequent bytes to the owner as `{stream_type_*, ...}` events
     %% instead of discarding them.
@@ -1110,7 +1110,7 @@ handle_stream_data(StreamId, Data, Fin, State) ->
             forward_claimed_uni_data(StreamId, Data, Fin, State),
             {ok, State};
         {uni, pending} ->
-            handle_uni_stream_type(StreamId, Data, State);
+            handle_uni_stream_type(StreamId, Data, Fin, State);
         {uni, push_pending} ->
             %% Push stream waiting for push ID parsing
             handle_push_stream_id(StreamId, Data, State);
@@ -1133,7 +1133,7 @@ handle_stream_data(StreamId, Data, Fin, State) ->
             handle_request_stream_data(StreamId, Data, Fin, State);
         unknown ->
             %% New unidirectional stream
-            handle_uni_stream_type(StreamId, Data, State)
+            handle_uni_stream_type(StreamId, Data, Fin, State)
     end.
 
 classify_stream(StreamId, #state{peer_control_stream = StreamId}) ->
@@ -1218,7 +1218,7 @@ find_push_by_stream_id(StreamId, Received) ->
         Received
     ).
 
-handle_uni_stream_type(StreamId, Data, #state{uni_stream_buffers = Buffers} = State) ->
+handle_uni_stream_type(StreamId, Data, Fin, #state{uni_stream_buffers = Buffers} = State) ->
     Buffer = maps:get(StreamId, Buffers, <<>>),
     Combined = <<Buffer/binary, Data/binary>>,
     case quic_h3_frame:decode_stream_type(Combined) of
@@ -1226,7 +1226,7 @@ handle_uni_stream_type(StreamId, Data, #state{uni_stream_buffers = Buffers} = St
             State1 = State#state{uni_stream_buffers = maps:remove(StreamId, Buffers)},
             case assign_uni_stream(StreamId, Type, State1) of
                 {ok, State2} ->
-                    dispatch_remaining_uni_data(StreamId, Type, Rest, State2);
+                    dispatch_remaining_uni_data(StreamId, Type, Rest, Fin, State2);
                 {error, Reason} ->
                     {error, Reason, State1}
             end;
@@ -1237,12 +1237,14 @@ handle_uni_stream_type(StreamId, Data, #state{uni_stream_buffers = Buffers} = St
 %% After classifying a uni stream, either hand off to an extension
 %% handler (when one claims the type), discard the rest (unknown types
 %% with no handler, RFC 9114 §6.2.3), or re-enter stream dispatch so
-%% known types process their payload.
-dispatch_remaining_uni_data(StreamId, {unknown, Type}, Rest, State) ->
+%% known types process their payload. Fin propagates so a single
+%% STREAM frame carrying type-varint + payload + FIN surfaces as one
+%% {stream_type_data, uni, _, _, true} event.
+dispatch_remaining_uni_data(StreamId, {unknown, Type}, Rest, Fin, State) ->
     case consult_stream_type_handler(uni, StreamId, Type, State) of
         claim ->
             State1 = claim_uni_stream(StreamId, Type, State),
-            forward_claimed_uni_data(StreamId, Rest, false, State1),
+            forward_claimed_uni_data(StreamId, Rest, Fin, State1),
             {ok, State1};
         ignore ->
             {ok, State#state{
@@ -1251,10 +1253,11 @@ dispatch_remaining_uni_data(StreamId, {unknown, Type}, Rest, State) ->
                 )
             }}
     end;
-dispatch_remaining_uni_data(_StreamId, _Type, <<>>, State) ->
+dispatch_remaining_uni_data(_StreamId, _Type, <<>>, Fin, State) ->
+    _ = Fin,
     {ok, State};
-dispatch_remaining_uni_data(StreamId, _Type, Rest, State) ->
-    handle_stream_data(StreamId, Rest, false, State).
+dispatch_remaining_uni_data(StreamId, _Type, Rest, Fin, State) ->
+    handle_stream_data(StreamId, Rest, Fin, State).
 
 consult_stream_type_handler(_Direction, _StreamId, _Type, #state{
     stream_type_handler = undefined

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -1580,6 +1580,54 @@ stream_type_handler_follow_up_data_forwarded_test() ->
     after 100 -> ?assert(false)
     end.
 
+%% Regression: a peer that packs type-varint + payload + FIN into a
+%% single STREAM frame must surface exactly one
+%% {stream_type_data, uni, _, _, true} event to the owner.
+stream_type_handler_claims_uni_stream_with_fin_test() ->
+    Claim = fun(uni, _StreamId, 16#54) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    flush_mailbox(),
+    {ok, _State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54, 0, "hello">>, true, State1
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, uni, StreamId, 16#54}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, uni, StreamId, <<0, "hello">>, true}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, _Extra} -> ?assert(false)
+    after 50 -> ok
+    end.
+
+%% Peer sends only the type varint with FIN set (zero payload after
+%% the type). The owner still needs a fin event so it knows the stream
+%% is done.
+stream_type_handler_claims_uni_stream_type_only_fin_test() ->
+    Claim = fun(uni, _StreamId, 16#54) -> claim end,
+    State0 = make_test_state(#{role => server, stream_type_handler => Claim}),
+    StreamId = 3,
+    State1 = mark_uni_stream_open(StreamId, State0),
+    flush_mailbox(),
+    {ok, _State2} = quic_h3_connection:handle_stream_data(
+        StreamId, <<16#40, 16#54>>, true, State1
+    ),
+    Self = self(),
+    receive
+        {quic_h3, Self, {stream_type_open, uni, StreamId, 16#54}} -> ok
+    after 100 -> ?assert(false)
+    end,
+    receive
+        {quic_h3, Self, {stream_type_data, uni, StreamId, <<>>, true}} -> ok
+    after 100 -> ?assert(false)
+    end.
+
 stream_type_handler_ignore_falls_back_to_discard_test() ->
     Ignore = fun(uni, _StreamId, _Type) -> ignore end,
     State0 = make_test_state(#{role => server, stream_type_handler => Ignore}),


### PR DESCRIPTION
When a peer opens a unidirectional stream and packs type-varint + payload + FIN into a single STREAM frame (as quic-go/webtransport-go does on `SendStream.Close()`), `quic_h3_connection` dropped the FIN: the uni pending path called `handle_uni_stream_type/3` and `dispatch_remaining_uni_data/4` without `Fin`, and the claim branch hardcoded `forward_claimed_uni_data(..., false, ...)`. Owners waiting on FIN never saw `stream_type_closed` either, so the application timed out with data buffered.

Fix mirrors the bidi path (`handle_bidi_stream_type/4` already threads `Fin`): promote `handle_uni_stream_type` to /4 and `dispatch_remaining_uni_data` to /5, propagate `Fin` to the claim branch and to the known-type re-dispatch, leave the `ignore` branch unchanged. Extensions now receive `{stream_type_data, uni, StreamId, Payload, true}` in one event when the peer sends data+FIN atomically, and `{stream_type_data, uni, StreamId, <<>>, true}` when only the type varint arrives with FIN.

Two regression tests in `quic_h3_compliance_tests.erl` cover the payload+FIN and type-only+FIN cases.