### PR TITLE
fix(socket): UDP_SEGMENT setsockopt needs sizeof(int)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,11 @@ jobs:
   server-batching-gso:
     name: Server Batching + Linux GSO
     needs: unit-tests
-    runs-on: ubuntu-latest
+    # Pinned to ubuntu-24.04 (kernel 6.x) so UDP_SEGMENT / GSO is
+    # guaranteed available; the suite hard-fails when GSO is expected
+    # but missing, so we must not let the runner label drift onto a
+    # kernel without UDP GSO support.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -569,9 +569,9 @@ build_socket_state(Socket, BatchConfig) ->
     {ok, State}.
 
 maybe_enable_gso(Socket, #{gso_supported := true, gso_size := Size}) ->
-    %% Try to set GSO segment size
-    %% UDP_SEGMENT = 103
-    case socket:setopt_native(Socket, {udp, ?UDP_SEGMENT}, <<Size:16/native>>) of
+    %% UDP_SEGMENT setsockopt expects sizeof(int); the cmsg variant
+    %% (see flush path) is the one that takes u16.
+    case socket:setopt_native(Socket, {udp, ?UDP_SEGMENT}, <<Size:32/native>>) of
         ok -> true;
         {error, _} -> false
     end;
@@ -1031,8 +1031,10 @@ test_linux_socket_capabilities() ->
     end.
 
 test_gso(Socket) ->
-    %% Try to set UDP_SEGMENT option
-    case socket:setopt_native(Socket, {udp, ?UDP_SEGMENT}, <<1200:16/native>>) of
+    %% UDP_SEGMENT setsockopt expects sizeof(int) on Linux; passing 2
+    %% bytes makes the kernel reject with EINVAL and GSO is reported as
+    %% unsupported even on kernels that have it.
+    case socket:setopt_native(Socket, {udp, ?UDP_SEGMENT}, <<1200:32/native>>) of
         ok -> true;
         {error, _} -> false
     end.

--- a/test/quic_server_batching_SUITE.erl
+++ b/test/quic_server_batching_SUITE.erl
@@ -150,16 +150,21 @@ opt_out_still_completes_transfer(Config) ->
     Config.
 
 %% Linux-only: proves GSO actually kicks in on a capable host.
-%% Skipped on non-Linux, on Linux without UDP_SEGMENT support, or when
-%% the opt-in env var QUIC_ENABLE_GSO_TEST is not set. Starts the
-%% listener with socket_backend => socket so the quic_socket abstraction
-%% is active on the listener's UDP socket and GSO propagates into each
-%% server connection's per-connection sender.
+%% Skipped when the opt-in env var QUIC_ENABLE_GSO_TEST is not set.
+%% When the env var IS set (as in the dedicated CI job), the test hard
+%% fails if we are not on Linux or if UDP_SEGMENT is unsupported, so a
+%% silent skip in CI cannot mask a regression in GSO detection.
+%% Starts the listener with socket_backend => socket so the quic_socket
+%% abstraction is active on the listener's UDP socket and GSO propagates
+%% into each server connection's per-connection sender.
 server_download_uses_gso_on_linux(Config) ->
-    case should_run_gso_test() of
+    case os:getenv("QUIC_ENABLE_GSO_TEST") of
         false ->
-            {skip, "Linux + GSO capability + QUIC_ENABLE_GSO_TEST required"};
-        true ->
+            {skip, "QUIC_ENABLE_GSO_TEST not set"};
+        _ ->
+            ?assertEqual({unix, linux}, os:type()),
+            Caps = quic_socket:detect_capabilities(),
+            ?assertEqual(true, maps:get(gso, Caps, false)),
             {ok, Srv} = start_download_server(#{socket_backend => socket}),
             try
                 {Received, Delta} = run_download(Srv, ?DOWNLOAD_SIZE),
@@ -190,11 +195,6 @@ server_download_uses_gso_on_linux(Config) ->
             end,
             Config
     end.
-
-should_run_gso_test() ->
-    os:type() =:= {unix, linux} andalso
-        maps:get(gso, quic_socket:detect_capabilities(), false) andalso
-        os:getenv("QUIC_ENABLE_GSO_TEST") =/= false.
 
 %%====================================================================
 %% Download server


### PR DESCRIPTION
`setsockopt(UDP_SEGMENT)` was encoded as a `u16` (2 bytes), but the Linux kernel requires `sizeof(int)`. Detection in `quic_socket:detect_capabilities/0` and `maybe_enable_gso/2` always hit `EINVAL`, so the `server_download_uses_gso_on_linux` CT case silently skipped on the runner even with `QUIC_ENABLE_GSO_TEST=1`.

- Setsockopt path encodes `UDP_SEGMENT` as 32-bit native; the cmsg path correctly stays on `u16`.
- GSO CT case now hard-fails when `QUIC_ENABLE_GSO_TEST` is set but we are not on Linux or GSO is undetected, so the silent skip can no longer mask a regression.
- Pinned the Server Batching + Linux GSO job to `ubuntu-24.04` so the runner label cannot drift onto a kernel without UDP GSO.