### PR TITLE
perf(socket): multi-iov GSO sendmsg

### DIFF
--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -717,17 +717,17 @@ flush_gso(
         gso_size = SegmentSize
     } = State
 ) ->
-    %% Combine all packets into a single super-datagram
-    %% Packets are in reverse order, so reverse them first
-    %% Normalize packet_view to binary for GSO (kernel needs contiguous buffer)
+    %% Pass the batch as a multi-iov to socket:sendmsg/2. The kernel
+    %% treats concatenated iov buffers as a single logical payload and
+    %% segments at SegmentSize byte boundaries via the UDP_SEGMENT
+    %% cmsg, so the wire bytes are identical to the old flatten-first
+    %% shape. We save a full user-space copy per flush (up to ~76 KB
+    %% at a 64-packet batch of 1200-byte segments).
     Packets = lists:reverse(Buffer),
-    PacketBins = [normalize_packet(P) || P <- Packets],
-    CombinedData = iolist_to_binary(PacketBins),
-
-    %% Build sendmsg with GSO control message
+    PacketIov = [normalize_packet(P) || P <- Packets],
     Msg = #{
         addr => #{family => family(IP), addr => IP, port => Port},
-        iov => [CombinedData],
+        iov => PacketIov,
         ctrl => [#{level => udp, type => ?UDP_SEGMENT, data => <<SegmentSize:16/native>>}]
     },
 
@@ -735,11 +735,13 @@ flush_gso(
         ok ->
             {ok, record_flush(State)};
         {ok, RestData} ->
-            %% Partial send - GSO didn't send all data
+            %% Partial send - GSO didn't send all data.
+            TotalBytes = iolist_size(PacketIov),
+            Remaining = iolist_size(RestData),
             ?LOG_WARNING(#{
                 what => gso_partial_send,
-                sent => byte_size(CombinedData) - iolist_size(RestData),
-                remaining => iolist_size(RestData)
+                sent => TotalBytes - Remaining,
+                remaining => Remaining
             }),
             %% Disable GSO and retry remaining data individually. The
             %% retry path accounts for the coalesced packets itself, so

--- a/test/quic_server_batching_SUITE.erl
+++ b/test/quic_server_batching_SUITE.erl
@@ -275,14 +275,14 @@ run_download(#{name := Name, port := Port}, Size) ->
         %% trivially pass. Taking a before/after delta scopes the
         %% assertion to the download-path traffic only.
         ServerPid = server_connection_pid(Name),
-        {ok, Before} = quic:get_stats(ServerPid),
+        {ok, Before} = poll_stats(ServerPid),
 
         {ok, StreamId} = quic:open_stream(Conn),
         Request = <<Size:64/big-unsigned-integer>>,
         ok = quic:send_data(Conn, StreamId, Request, true),
         Received = collect_stream_data(Conn, StreamId, <<>>),
 
-        {ok, After} = quic:get_stats(ServerPid),
+        {ok, After} = poll_stats(ServerPid),
         {Received, stats_delta(After, Before)}
     after
         quic:close(Conn)
@@ -302,6 +302,26 @@ stats_delta(After, Before) ->
          || K <- [packets_sent, batch_flushes, packets_coalesced]
         ]
     ).
+
+%% Retry get_stats while the server connection is still transitioning
+%% out of idle. The client sees {connected, _} before the server
+%% gen_statem finishes its side of the handshake, so a fresh
+%% get_stats can briefly return {error, {invalid_state, idle}}.
+poll_stats(Pid) ->
+    poll_stats(Pid, 200).
+
+poll_stats(_Pid, 0) ->
+    {error, stats_timeout};
+poll_stats(Pid, N) ->
+    case quic:get_stats(Pid) of
+        {ok, _} = R ->
+            R;
+        {error, {invalid_state, _}} ->
+            timer:sleep(5),
+            poll_stats(Pid, N - 1);
+        {error, _} = Err ->
+            Err
+    end.
 
 collect_stream_data(Conn, StreamId, Acc) ->
     receive


### PR DESCRIPTION
Pass the batch as an iov list to socket:sendmsg/2 with UDP_SEGMENT cmsg instead of flattening first. Wire bytes unchanged, saves one user-space copy per flush. Linux + socket backend only; gen_udp no-op.