### PR TITLE
perf(send): share one Now between loss and last_activity

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2893,12 +2893,17 @@ send_app_packet_internal(Payload, Frames, State) ->
                 frames => Frames
             }),
 
-            %% Track sent packet for loss detection and congestion control
+            %% Single monotonic_time sample shared between loss
+            %% tracking and last_activity; saves one BIF call per
+            %% packet on the bulk-send hot path.
+            Now = erlang:monotonic_time(millisecond),
+
+            %% Track sent packet for loss detection and congestion control.
             %% Determine if ack-eliciting by checking the actual frames list
-            %% This properly handles coalesced packets with multiple frames
+            %% so coalesced packets with multiple frames are handled.
             AckEliciting = contains_ack_eliciting_frames(Frames),
             NewLossState = quic_loss:on_packet_sent(
-                LossState, PN, PacketSize, AckEliciting, Frames
+                LossState, PN, PacketSize, AckEliciting, Frames, Now
             ),
             NewCCState =
                 case AckEliciting of
@@ -2921,7 +2926,7 @@ send_app_packet_internal(Payload, Frames, State) ->
                 loss_state = NewLossState,
                 packets_sent = State#state.packets_sent + 1,
                 socket_state = NewSocketState,
-                last_activity = erlang:monotonic_time(millisecond),
+                last_activity = Now,
                 timer_dirty = true,
                 pto_dirty = true
             };

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -36,6 +36,7 @@
     %% Packet tracking
     on_packet_sent/4,
     on_packet_sent/5,
+    on_packet_sent/6,
     on_ack_received/3,
 
     %% Retransmission
@@ -141,9 +142,27 @@ new(Opts) ->
 on_packet_sent(State, PacketNumber, Size, AckEliciting) ->
     on_packet_sent(State, PacketNumber, Size, AckEliciting, []).
 
-%% @doc Record that a packet was sent with frames.
+%% @doc Record that a packet was sent with frames. Samples the send
+%% time itself. Callers that already hold a Now should use
+%% on_packet_sent/6 to avoid a duplicate monotonic_time/1 BIF call.
 -spec on_packet_sent(loss_state(), non_neg_integer(), non_neg_integer(), boolean(), [term()]) ->
     loss_state().
+on_packet_sent(State, PacketNumber, Size, AckEliciting, Frames) ->
+    Now = erlang:monotonic_time(millisecond),
+    on_packet_sent(State, PacketNumber, Size, AckEliciting, Frames, Now).
+
+%% @doc Like on_packet_sent/5 but uses the caller-supplied monotonic
+%% millisecond timestamp. The connection send loop reuses one Now
+%% per packet for both loss tracking and last_activity, saving a
+%% BIF call.
+-spec on_packet_sent(
+    loss_state(),
+    non_neg_integer(),
+    non_neg_integer(),
+    boolean(),
+    [term()],
+    integer()
+) -> loss_state().
 on_packet_sent(
     #loss_state{
         sent_packets = Sent,
@@ -154,9 +173,9 @@ on_packet_sent(
     PacketNumber,
     Size,
     AckEliciting,
-    Frames
+    Frames,
+    Now
 ) ->
-    Now = erlang:monotonic_time(millisecond),
     SentPacket = #sent_packet{
         pn = PacketNumber,
         time_sent = Now,


### PR DESCRIPTION
send_app_packet_internal samples monotonic_time once per packet and reuses it for both quic_loss:on_packet_sent (new /6 arity) and last_activity. One BIF call saved per packet on bulk sends. /5 shim preserved.