### PR TITLE
fix(socket): bypass GSO for non-uniform batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,9 @@ jobs:
       - name: Compile
         run: rebar3 compile
 
-      - name: Run batching CT suite
-        # GSO case still skipped: handshake on socket_backend stalls
-        # on ubuntu-24.04 even after the UDP_SEGMENT sockopt + single-
-        # packet skip fixes. Root cause not yet identified; needs
-        # direct Linux-host qlog debug.
+      - name: Run batching CT suite (with GSO)
+        env:
+          QUIC_ENABLE_GSO_TEST: "1"
         run: rebar3 ct --suite=quic_server_batching_SUITE
 
   h3-e2e:

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -425,17 +425,30 @@ flush(#socket_state{batch_count = Count, batch_addr = undefined} = State) ->
     ?LOG_WARNING(#{what => flush_no_addr, buffer_size => Count}),
     {ok, clear_batch(State)};
 flush(#socket_state{gso_supported = true, batch_count = 1} = State) ->
-    %% Single-packet batch adds no segmentation work, and on some Linux
-    %% kernels sendmsg with UDP_SEGMENT + a sub-gso_size payload stalls
-    %% the handshake (server's ServerHello is shorter than gso_size and
-    %% always alone in the batch). Take the direct-send path.
+    %% Single-packet batch has no segmentation work; direct send.
     flush_individual(State);
-flush(#socket_state{gso_supported = true} = State) ->
-    %% GSO path - send all packets in one syscall
-    flush_gso(State);
+flush(#socket_state{gso_supported = true, batch_buffer = Buffer, gso_size = GSO} = State) ->
+    %% UDP_SEGMENT requires every segment except the last to be
+    %% exactly gso_size. Handshake flights coalesce Initial-padded-to-
+    %% 1200 with a ~400 byte Handshake packet; a naive GSO split
+    %% mis-aligns those boundaries and the client cannot decode. When
+    %% the batch is not uniform, fall through to individual sends.
+    case gso_batch_uniform(Buffer, GSO) of
+        true -> flush_gso(State);
+        false -> flush_individual(State)
+    end;
 flush(#socket_state{} = State) ->
     %% Fallback path - send packets individually
     flush_individual(State).
+
+%% Batch buffer is stored newest-first (head was last added). For GSO
+%% correctness we need all packets EXCEPT the last-transmitted one
+%% (which is the head of the buffer) to be exactly gso_size. The
+%% last-transmitted packet may be shorter.
+gso_batch_uniform([], _GSO) ->
+    true;
+gso_batch_uniform([_Last | Earlier], GSO) ->
+    lists:all(fun(P) -> iolist_size(P) =:= GSO end, Earlier).
 
 %% @doc Receive packets from the socket.
 %% On Linux with GRO, may return multiple coalesced packets.


### PR DESCRIPTION
UDP_SEGMENT needs every segment before the last to be exactly gso_size. Handshake flights (Initial padded to 1200 + ~400 byte Handshake) violated that and the client stalled at awaiting_encrypted_extensions. Check batch uniformity before flush_gso; fall through to flush_individual when mixed. Verified in the docker/gso-debug reproducer: all 4 batching cases pass on Linux with QUIC_ENABLE_GSO_TEST=1.