### PR TITLE
perf(send): hoist per-chunk lookups out of chunked send loop

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -6347,11 +6347,73 @@ cwnd_only_check(CCState, Size, Urgency) ->
     end.
 
 %% @doc Send stream data that requires chunking.
+%%
+%% Per-drain constants — `Urgency`, `MaxChunkSize`, `PacketSize` — are cached
+%% here once and threaded through `send_stream_chunked_loop/9` instead of being
+%% re-looked-up for every chunk via a tail-call back into
+%% `send_stream_data_fragmented_tracked/6`. For a 10 MB upload this cuts
+%% thousands of `get_stream_urgency/2` / `get_max_stream_data_per_packet/1`
+%% calls and record-pattern matches out of the hot send loop.
 send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize) ->
-    #state{cc_state = CCState, pacing_enabled = PacingEnabled, streams = Streams} = State,
+    Urgency = get_stream_urgency(StreamId, State#state.streams),
     PacketSize = MaxChunkSize + ?PACKET_OVERHEAD,
-    %% Control streams (urgency 0) can exceed cwnd to prevent tick blocking
-    Urgency = get_stream_urgency(StreamId, Streams),
+    send_stream_chunked_loop(
+        StreamId,
+        Offset,
+        Data,
+        Fin,
+        State,
+        BytesSentSoFar,
+        MaxChunkSize,
+        Urgency,
+        PacketSize
+    ).
+
+%% Inner chunked-send loop. Cached values never change within a single drain.
+%% The final sub-MaxChunkSize remainder falls through to
+%% `send_stream_single_packet/6` so a partial last chunk gets a correctly
+%% sized packet (Length != MaxChunkSize) and can also carry a FIN.
+send_stream_chunked_loop(
+    StreamId,
+    Offset,
+    Data,
+    Fin,
+    State,
+    BytesSentSoFar,
+    MaxChunkSize,
+    Urgency,
+    PacketSize
+) ->
+    DataSize = byte_size(Data),
+    case DataSize =< MaxChunkSize of
+        true ->
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+        false ->
+            send_stream_chunked_step(
+                StreamId,
+                Offset,
+                Data,
+                Fin,
+                State,
+                BytesSentSoFar,
+                MaxChunkSize,
+                Urgency,
+                PacketSize
+            )
+    end.
+
+send_stream_chunked_step(
+    StreamId,
+    Offset,
+    Data,
+    Fin,
+    State,
+    BytesSentSoFar,
+    MaxChunkSize,
+    Urgency,
+    PacketSize
+) ->
+    #state{cc_state = CCState, pacing_enabled = PacingEnabled} = State,
     Check =
         case PacingEnabled of
             true -> quic_cc:send_check(CCState, PacketSize, Urgency);
@@ -6364,10 +6426,16 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
             Frame = {stream, StreamId, Offset, Chunk, false},
             Payload = quic_frame:encode_iodata(Frame),
             State1 = send_app_packet_internal(Payload, [Frame], State0),
-            NewOffset = Offset + MaxChunkSize,
-            NewBytesSent = BytesSentSoFar + MaxChunkSize,
-            send_stream_data_fragmented_tracked(
-                StreamId, NewOffset, Rest, Fin, State1, NewBytesSent
+            send_stream_chunked_loop(
+                StreamId,
+                Offset + MaxChunkSize,
+                Rest,
+                Fin,
+                State1,
+                BytesSentSoFar + MaxChunkSize,
+                MaxChunkSize,
+                Urgency,
+                PacketSize
             );
         {blocked_pacing, Delay} ->
             ?LOG_DEBUG(


### PR DESCRIPTION
## Summary

Caches \`get_stream_urgency/2\` and \`get_max_stream_data_per_packet/1\` once at the top of \`send_stream_chunked/7\`, and introduces an inner \`send_stream_chunked_loop/9\` that tail-recurses on itself for mid-chunks instead of bouncing back through \`send_stream_data_fragmented_tracked/6\`. That bounce re-ran both lookups, re-matched the \`#state\` record for \`{cc_state, pacing_enabled, streams}\`, and re-checked \`DataSize\` vs \`MaxChunkSize\` on every chunk.

Final sub-\`MaxChunkSize\` remainder still falls through to \`send_stream_single_packet/6\` so a partial last chunk keeps its proper \`Length\` varint and can carry a FIN.

## Profile (fprof, 10 MB sink upload)

| Function | Before (own ms) | After (own ms) | Δ |
|---|---|---|---|
| **Total** | 2464.5 | 2408.7 | **-55.8 (-2.3%)** |
| \`send_stream_chunked/7\` | 47.2 | 3.8 (outer) + 37.8 (step) + 9.4 (loop) | |
| \`get_stream_urgency/2\` | 22.7 | 7.6 | -15.1 |
| \`get_max_stream_data_per_packet/1\` | 18.9 | 3.8 | -15.1 |
| \`send_stream_data_fragmented_tracked/6\` | 18.9 | 3.8 | -15.1 |

## Bench (docker Linux, 3 runs each, vs \`bench/profile/baseline-1.1.0.md\`)

| Backend | Dir | Size | Before | After |
|---|---|---|---|---|
| socket+GSO | Upload | 1 MB | 34.97 | 41.71 (+19%) |
| socket+GSO | Upload | 5 MB | 50.53 | 55.32 (+9.5%) |
| socket+GSO | Upload | 10 MB | 62.61 | 66.88 (+6.8%) |
| gen_udp | Upload | 5 MB | 52.78 | 59.33 (+12%) |
| gen_udp | Upload | 10 MB | 63.08 | 65.50 (+4%) |

Downloads unchanged (the hoist is on the send side). Full matrix results are noisy at 1 MB per the baseline doc — 5 MB and 10 MB are the primary signal.