### PR TITLE
perf(ack): ACK reordered 1-RTT packets immediately (RFC 9002 §6.2)

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -161,7 +161,9 @@
     %% Test helpers for 1-RTT ACK decimation (RFC 9002 §6.2)
     test_decimate_initial_state/0,
     test_decimate_step/1,
-    test_decimate_on_timer_fire/1
+    test_decimate_on_timer_fire/1,
+    test_maybe_send_ack_app/2,
+    test_classify_recv_trigger/2
 ]).
 -endif.
 
@@ -525,6 +527,12 @@
     %% the first ack-eliciting packet in the window.
     ack_elicited_count = 0 :: non_neg_integer(),
     ack_timer = undefined :: reference() | undefined,
+    %% Transient: classification of the most recently received 1-RTT
+    %% packet. Set by `record_received_pn/3` and consumed once by
+    %% `maybe_send_ack(app, ...)` to choose between immediate ACK
+    %% (RFC 9002 §6.2 reordering recommendation) and count-based
+    %% decimation.
+    last_recv_trigger = sequential :: sequential | reordered,
 
     %% QLOG Tracing (draft-ietf-quic-qlog-quic-events)
     qlog_ctx :: #qlog_ctx{} | undefined
@@ -5261,9 +5269,13 @@ maybe_send_ack(app, Frames, State) ->
                     %% Datagram-only packets: delay up to max_ack_delay.
                     schedule_delayed_ack(app, State);
                 false ->
-                    %% Normal stream / control traffic: count-based
-                    %% decimation + max_ack_delay timer.
-                    maybe_decimate_app_ack(State)
+                    %% Normal stream / control traffic: ACK immediately when
+                    %% the last received packet was reordered (RFC 9002 §6.2);
+                    %% otherwise count-based decimation + max_ack_delay timer.
+                    case State#state.last_recv_trigger of
+                        reordered -> send_app_ack(State);
+                        sequential -> maybe_decimate_app_ack(State)
+                    end
             end;
         false ->
             State
@@ -5496,7 +5508,12 @@ close_reason_to_code(_) -> unknown.
 has_app_keys(#state{app_keys = undefined}) -> false;
 has_app_keys(_) -> true.
 
-%% Record a received packet number for ACK generation
+%% Record a received packet number for ACK generation.
+%% For the 1-RTT (`app') space we also classify whether the PN is
+%% sequential (= largest_recv + 1 or the very first packet) or
+%% reordered, and stash that on `last_recv_trigger' so the subsequent
+%% `maybe_send_ack(app, ...)' can honour RFC 9002 §6.2's recommendation
+%% to ACK reordered packets immediately instead of delaying.
 record_received_pn(initial, PN, State) ->
     PNSpace = State#state.pn_initial,
     NewPNSpace = update_pn_space_recv(PN, PNSpace),
@@ -5507,15 +5524,29 @@ record_received_pn(handshake, PN, State) ->
     State#state{pn_handshake = NewPNSpace};
 record_received_pn(app, PN, State) ->
     PNSpace = State#state.pn_app,
+    Trigger = classify_recv_trigger(PN, PNSpace),
     NewPNSpace = update_pn_space_recv(PN, PNSpace),
-    State#state{pn_app = NewPNSpace};
+    State#state{pn_app = NewPNSpace, last_recv_trigger = Trigger};
 record_received_pn(zero_rtt, PN, State) ->
     %% 0-RTT uses the same PN space as 1-RTT (app)
     PNSpace = State#state.pn_app,
+    Trigger = classify_recv_trigger(PN, PNSpace),
     NewPNSpace = update_pn_space_recv(PN, PNSpace),
-    State#state{pn_app = NewPNSpace};
+    State#state{pn_app = NewPNSpace, last_recv_trigger = Trigger};
 record_received_pn(_, _PN, State) ->
     State.
+
+%% Classify a received PN as sequential (monotonic continuation of the
+%% largest received) or reordered (gap above, or filling a gap below).
+%% Duplicates (PN =:= largest_recv) are treated as reordered so a
+%% duplicate in the middle of a flow still forces an immediate ACK;
+%% the duplicate itself is filtered elsewhere.
+classify_recv_trigger(_PN, #pn_space{largest_recv = undefined}) ->
+    sequential;
+classify_recv_trigger(PN, #pn_space{largest_recv = L}) when PN =:= L + 1 ->
+    sequential;
+classify_recv_trigger(_PN, _PNSpace) ->
+    reordered.
 
 %% Get largest received PN for a given encryption level
 get_largest_recv(initial, State) ->
@@ -9171,4 +9202,28 @@ test_decimate_on_timer_fire(State) ->
         ack_elicited_count => NewState#state.ack_elicited_count,
         ack_timer_armed => NewState#state.ack_timer =/= undefined
     }.
+
+%% Run `maybe_send_ack(app, Frames, State)' under a given
+%% `last_recv_trigger' and return the observable post-state so tests
+%% can assert reordered → immediate ACK, sequential → decimate.
+-spec test_maybe_send_ack_app(sequential | reordered, #state{}) ->
+    #{
+        ack_elicited_count := non_neg_integer(),
+        ack_timer_armed := boolean()
+    }.
+test_maybe_send_ack_app(Trigger, State) ->
+    Frame = {stream, 0, 0, <<"x">>, false},
+    NewState = maybe_send_ack(app, [Frame], State#state{last_recv_trigger = Trigger}),
+    #{
+        ack_elicited_count => NewState#state.ack_elicited_count,
+        ack_timer_armed => NewState#state.ack_timer =/= undefined
+    }.
+
+%% Expose `classify_recv_trigger/2' for direct unit coverage of the
+%% sequential / reordered classifier without going through the full
+%% receive path.
+-spec test_classify_recv_trigger(non_neg_integer(), non_neg_integer() | undefined) ->
+    sequential | reordered.
+test_classify_recv_trigger(PN, LargestRecv) ->
+    classify_recv_trigger(PN, #pn_space{largest_recv = LargestRecv}).
 -endif.

--- a/test/quic_connection_tests.erl
+++ b/test/quic_connection_tests.erl
@@ -666,3 +666,31 @@ ack_decimation_timer_idempotent_test() ->
     {_S1, Info} = quic_connection:test_decimate_step(S0),
     ?assertEqual(1, maps:get(ack_elicited_count, Info)),
     ?assertEqual(true, maps:get(ack_timer_armed, Info)).
+
+%% RFC 9002 §6.2: reordered 1-RTT packets should elicit an immediate
+%% ACK instead of being decimated. First ack-eliciting packet is still
+%% decimated when classified as sequential.
+ack_reorder_triggers_immediate_ack_test() ->
+    S0 = quic_connection:test_decimate_initial_state(),
+    Info = quic_connection:test_maybe_send_ack_app(reordered, S0),
+    %% send_app_ack/1 runs its decimation-clear branch even when
+    %% ack_ranges is empty, so count stays at 0 and timer stays unarmed.
+    ?assertEqual(0, maps:get(ack_elicited_count, Info)),
+    ?assertEqual(false, maps:get(ack_timer_armed, Info)).
+
+ack_sequential_uses_decimation_test() ->
+    S0 = quic_connection:test_decimate_initial_state(),
+    Info = quic_connection:test_maybe_send_ack_app(sequential, S0),
+    %% Sequential first packet arms the timer, count goes to 1.
+    ?assertEqual(1, maps:get(ack_elicited_count, Info)),
+    ?assertEqual(true, maps:get(ack_timer_armed, Info)).
+
+%% `classify_recv_trigger/2' returns sequential for the first packet
+%% (largest_recv = undefined) and for PN = largest_recv + 1; every other
+%% PN (gap above, dup, below) is reordered.
+ack_classify_recv_trigger_test() ->
+    ?assertEqual(sequential, quic_connection:test_classify_recv_trigger(0, undefined)),
+    ?assertEqual(sequential, quic_connection:test_classify_recv_trigger(7, 6)),
+    ?assertEqual(reordered, quic_connection:test_classify_recv_trigger(9, 6)),
+    ?assertEqual(reordered, quic_connection:test_classify_recv_trigger(3, 6)),
+    ?assertEqual(reordered, quic_connection:test_classify_recv_trigger(6, 6)).


### PR DESCRIPTION
## Summary

Reordered 1-RTT packets now elicit an immediate ACK instead of going through the count/time-based decimation path. In-order packets are unchanged.

Every received 1-RTT / 0-RTT packet is classified before \`update_pn_space_recv/2\` modifies \`largest_recv\`:

- **sequential** — \`PN = largest_recv + 1\`, or the first packet in the space.
- **reordered** — anything else: gap above, filling a gap below, duplicate.

The classification is stashed on a transient \`last_recv_trigger\` field on \`#state\` and consumed by \`maybe_send_ack(app, _, _)\`. Sequential → existing decimate / max_ack_delay path. Reordered → \`send_app_ack/1\` immediately.

RFC 9002 §6.2 recommends this so peers detect loss faster and avoid spurious retransmits. No observable effect on loopback benches (no reordering), but reduces ACK latency on real networks.

## Touches

- \`src/quic_connection.erl\`:
  - \`#state.last_recv_trigger\` (new transient field).
  - \`classify_recv_trigger/2\` (new).
  - \`record_received_pn(app | zero_rtt, ...)\` populates the trigger.
  - \`maybe_send_ack(app, ...)\` branches on the trigger.
- \`test/quic_connection_tests.erl\`: three new tests covering the reorder, sequential, and classifier boundary cases (first packet, +1, gap above, gap below, duplicate).

## Verification

\`\`\`
rebar3 fmt && rebar3 compile && rebar3 eunit && rebar3 lint && rebar3 dialyzer && rebar3 xref
\`\`\`

All green. Eunit: 1940 tests (was 1937; +3 new).