### PR TITLE
perf(send): fast-path single-stream-frame in contains_ack_eliciting_frames

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5329,7 +5329,12 @@ should_delay_ack(Frames) ->
 schedule_delayed_ack(app, State) ->
     arm_ack_timer(State).
 
-%% Check if any frame in the list is ack-eliciting
+%% Check if any frame in the list is ack-eliciting. Fast-path the
+%% single-stream-frame list produced by every chunked / single stream
+%% send on the hot path — skips the `is_ack_eliciting_frame/1' dispatch
+%% plus list tail-walk.
+contains_ack_eliciting_frames([{stream, _, _, _, _}]) ->
+    true;
 contains_ack_eliciting_frames([]) ->
     false;
 contains_ack_eliciting_frames([Frame | Rest]) ->


### PR DESCRIPTION
Every chunked / single stream send hands \`contains_ack_eliciting_frames\` a \`[{stream, _, _, _, _}]\` list. Matching at the function head skips the \`is_ack_eliciting_frame/1\` dispatch and list-tail walk.

fprof (10 MB sink upload):

| | before | after |
|---|---|---|
| \`contains_ack_eliciting_frames\` own | 24.2 ms | 16.7 ms |
| \`is_ack_eliciting_frame\` own | 17.7 ms | 10.1 ms |
| \`is_ack_eliciting_frame\` calls | 13625 | 10130 |

~15 ms on a 2.4 s run. 3495 calls bypass dispatch via fast path.