### PR TITLE
perf(qlog): inline enabled-check at hot-path call sites

### DIFF
--- a/include/quic_qlog.hrl
+++ b/include/quic_qlog.hrl
@@ -64,6 +64,46 @@
             lists:member(Event, Ctx#qlog_ctx.events)))
 ).
 
+%% Hot-path emit wrappers. The `Info' / `Frames' / `PNs' argument is
+%% only evaluated when qlog is enabled, so the common disabled-by-
+%% default path does not pay for map / list construction at every
+%% sent / received packet. Use these at any send/recv/ack site that
+%% fires on the per-packet hot path.
+-define(QLOG_EMIT_PACKET_SENT(Ctx, Info),
+    case ?QLOG_ENABLED(Ctx) of
+        true -> quic_qlog:packet_sent(Ctx, Info);
+        false -> ok
+    end
+).
+
+-define(QLOG_EMIT_PACKET_RECEIVED(Ctx, Info),
+    case ?QLOG_ENABLED(Ctx) of
+        true -> quic_qlog:packet_received(Ctx, Info);
+        false -> ok
+    end
+).
+
+-define(QLOG_EMIT_FRAMES_PROCESSED(Ctx, Frames),
+    case ?QLOG_ENABLED(Ctx) of
+        true -> quic_qlog:frames_processed(Ctx, Frames);
+        false -> ok
+    end
+).
+
+-define(QLOG_EMIT_PACKETS_ACKED(Ctx, PNs, Info),
+    case ?QLOG_ENABLED(Ctx) of
+        true -> quic_qlog:packets_acked(Ctx, PNs, Info);
+        false -> ok
+    end
+).
+
+-define(QLOG_EMIT_PACKET_LOST(Ctx, Info),
+    case ?QLOG_ENABLED(Ctx) of
+        true -> quic_qlog:packet_lost(Ctx, Info);
+        false -> ok
+    end
+).
+
 %%====================================================================
 %% Writer Configuration
 %%====================================================================

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2909,8 +2909,8 @@ send_app_packet_internal(Payload, Frames, State) ->
     %% Handle send result - only track packet and update state if send succeeded
     case SendResult of
         {ok, NewSocketState} ->
-            %% Emit qlog packet_sent event
-            quic_qlog:packet_sent(State#state.qlog_ctx, #{
+            %% Emit qlog packet_sent event (no-op when qlog disabled)
+            ?QLOG_EMIT_PACKET_SENT(State#state.qlog_ctx, #{
                 packet_type => one_rtt,
                 packet_number => PN,
                 length => PacketSize,
@@ -3073,8 +3073,7 @@ handle_packet_loop(Data, State) ->
     case decode_and_decrypt_packet(Data, State) of
         {ok, Type, Frames, RemainingData, NewState, processed} ->
             %% Frames already processed by streaming decode
-            %% Emit qlog packet_received event
-            quic_qlog:packet_received(NewState#state.qlog_ctx, #{
+            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
                 packet_type => Type,
                 frames => Frames
             }),
@@ -3084,8 +3083,7 @@ handle_packet_loop(Data, State) ->
                 packets_received = NewState#state.packets_received + 1
             },
 
-            %% Emit qlog frames_processed event
-            quic_qlog:frames_processed(NewState1#state.qlog_ctx, Frames),
+            ?QLOG_EMIT_FRAMES_PROCESSED(NewState1#state.qlog_ctx, Frames),
 
             %% Send ACK if packet contained ack-eliciting frames
             State2 = maybe_send_ack(Type, Frames, NewState1),
@@ -3093,7 +3091,7 @@ handle_packet_loop(Data, State) ->
             handle_packet_loop(RemainingData, State2);
         {ok, Type, Frames, RemainingData, NewState} ->
             %% Legacy path - frames need to be processed
-            quic_qlog:packet_received(NewState#state.qlog_ctx, #{
+            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
                 packet_type => Type,
                 frames => Frames
             }),
@@ -3102,7 +3100,7 @@ handle_packet_loop(Data, State) ->
                 packets_received = NewState#state.packets_received + 1
             },
             State1 = process_frames_noreenbl(Type, Frames, NewState1),
-            quic_qlog:frames_processed(State1#state.qlog_ctx, Frames),
+            ?QLOG_EMIT_FRAMES_PROCESSED(State1#state.qlog_ctx, Frames),
             State2 = maybe_send_ack(Type, Frames, State1),
             handle_packet_loop(RemainingData, State2);
         {error, stateless_reset} ->
@@ -3678,14 +3676,14 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
                             [] -> undefined;
                             _ -> Now - LargestAckedSentTime
                         end,
-                    quic_qlog:packets_acked(State1#state.qlog_ctx, AckedPNs, #{
+                    ?QLOG_EMIT_PACKETS_ACKED(State1#state.qlog_ctx, AckedPNs, #{
                         rtt_sample => RTTSample
                     }),
 
                     %% Emit qlog packet_lost events
                     lists:foreach(
                         fun(#sent_packet{pn = LostPN}) ->
-                            quic_qlog:packet_lost(State1#state.qlog_ctx, #{
+                            ?QLOG_EMIT_PACKET_LOST(State1#state.qlog_ctx, #{
                                 packet_number => LostPN,
                                 reason => timeout
                             })


### PR DESCRIPTION
\`quic_qlog:packet_sent\` / \`packet_received\` / \`frames_processed\` / \`packets_acked\` / \`packet_lost\` always built their Info map (or collected the Frames / PNs list) at the call site, then checked \`enabled\` inside and returned \`ok\` when disabled. With qlog off by default on the bench, the map construction cost for ~16k events per 10 MB upload was pure waste.

Added five \`QLOG_EMIT_*\` macros in \`include/quic_qlog.hrl\` that inline the \`QLOG_ENABLED\` check around the call. The \`Info\` / \`Frames\` / \`PNs\` argument is only evaluated on the \`true\` branch, so disabled connections stop paying for the map/list construction.

Converted the five hot-path sites in \`quic_connection.erl\` (\`send_app_packet_internal\`, \`handle_packet_loop\` x2, and the process_ack \`packets_acked\` / \`packet_lost\` loop). Initial/Handshake sites and connection lifecycle events stay as direct calls (cold path).

fprof (10 MB sink upload):

| | before | after |
|---|---|---|
| \`quic_qlog:packet_sent\` calls | 7562 | 5 |
| \`quic_qlog:packet_sent\` own | 7.6 ms | 0.005 ms |
| \`quic_qlog:packet_received\` | 3035 calls | off top 50 |
| \`quic_qlog:frames_processed\` | 3035 calls | off top 50 |
| \`quic_qlog:packets_acked\` | 3024 calls | off top 50 |
| **total own** | **2229 ms** | **2198 ms (-31 ms, -1.4%)** |