### PR TITLE
perf(client): re-enable GSO on opt-in socket backend

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1139,24 +1139,12 @@ open_client_socket_genudp(IP, Opts, ExtraOpts) ->
     end.
 
 %% Opt-in socket-backend path. Uses `quic_socket:open_for_send/2' so
-%% the connection gets an OTP socket with GSO enabled on Linux. The
-%% wrapping `#socket_state{}' is stashed in the process dictionary for
-%% `init_client_state/8' to adopt without widening the tuple shape
-%% returned by `open_client_socket/4'. Migration / rebind are disabled
-%% on this path.
+%% the connection gets an OTP socket with GSO available per-message via
+%% cmsg on uniform batches. The wrapping `#socket_state{}' is stashed
+%% in the process dictionary for `init_client_state/8' to adopt without
+%% widening the tuple shape returned by `open_client_socket/4'.
 open_client_socket_backend({IP, _Port}, Opts) ->
-    %% Disable batching + GSO on the opt-in socket path for now. The
-    %% multi-packet coalesced UDP_SEGMENT flush path needs more
-    %% validation against gen_udp servers (see Phase 1b follow-up);
-    %% direct `socket:sendmsg' one packet at a time keeps the MVP
-    %% simple and matches what every QUIC server on the wire expects.
-    BatchingOpt = maps:get(batching, Opts, #{}),
-    BatchingOff = BatchingOpt#{enabled => false},
-    OpenOpts = Opts#{
-        backend => socket,
-        gso => false,
-        batching => BatchingOff
-    },
+    OpenOpts = Opts#{backend => socket},
     case quic_socket:open_for_send(IP, OpenOpts) of
         {ok, SocketState} ->
             case quic_socket:sockname(SocketState) of
@@ -8058,10 +8046,8 @@ rebind_client_socket(#state{socket = OldSocket} = State) ->
     end.
 
 %% Socket-NIF rebind: stop the old receiver, close the old OTP socket
-%% via its `#socket_state{}' wrapper, open a fresh socket with the
-%% same opt-in profile (batching + GSO off — see
-%% `open_client_socket_backend/2'), and start a new receiver linked
-%% to this connection process.
+%% via its `#socket_state{}' wrapper, open a fresh send socket, and
+%% start a new receiver linked to this connection process.
 rebind_client_socket_otp(
     #state{
         remote_addr = {RemoteIP, _},
@@ -8080,11 +8066,7 @@ rebind_client_socket_otp(
                 _:_ -> ok
             end
     end,
-    OpenOpts = #{
-        backend => socket,
-        gso => false,
-        batching => #{enabled => false}
-    },
+    OpenOpts = #{backend => socket},
     case quic_socket:open_for_send(RemoteIP, OpenOpts) of
         {ok, NewSocketState} ->
             case quic_socket:start_client_receiver(NewSocketState, self()) of

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -694,7 +694,13 @@ open_send_socket_backend(RemoteIP, Opts, BatchConfig) ->
 configure_send_socket(Socket, Opts, BatchConfig) ->
     ok = socket:setopt(Socket, {socket, reuseaddr}, true),
     set_socket_buffer_sizes(Socket, Opts),
-    GSOEnabled = maybe_enable_gso(Socket, BatchConfig),
+    %% GSO is applied per-message via the UDP_SEGMENT cmsg in
+    %% flush_gso/1, never as a socket-level setsockopt. A socket-level
+    %% UDP_SEGMENT would force GSO segmentation on every outbound
+    %% datagram, including short handshake packets and non-uniform
+    %% fallback sends, which stalled handshakes and mis-segmented
+    %% coalesced Initial+Handshake flights against gen_udp servers.
+    GSOEnabled = maps:get(gso_supported, BatchConfig, false),
     State = #socket_state{
         socket = Socket,
         backend = socket,


### PR DESCRIPTION
## Summary
- Drop the socket-level `UDP_SEGMENT` setsockopt on `configure_send_socket/2`.
- Remove the `gso => false, batching => #{enabled => false}` overrides on the opt-in client path and on `rebind_client_socket_otp/1`.
- GSO fires only via per-message cmsg in `flush_gso/1`, so short handshake packets and non-uniform fallback sends no longer get force-segmented.

Unblocks the Phase 1b follow-up noted after PR #88/#90. Both eunit roundtrip and migrate tests on the socket backend remain green.