### PR TITLE
perf(ack): flush stream-data batch before ACK-only packet

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2763,8 +2763,15 @@ maybe_coalesce_ack_with_data(AckFrameTuple, State) ->
             %% Send coalesced frames - pass tuples directly
             send_frame_tuples([AckFrameTuple, StreamFrameTuple], State1);
         none ->
-            %% Single frame - encode and send
-            send_app_packet_internal(quic_frame:encode(AckFrameTuple), [AckFrameTuple], State)
+            %% Flush the pending stream-data batch first: the ACK-only
+            %% packet is ~60 bytes and would break GSO uniformity on the
+            %% opt-in socket backend (see `quic_socket:gso_batch_uniform/2'),
+            %% pushing the whole flush onto `flush_individual'. A
+            %% preemptive flush keeps the stream batch uniform and lets
+            %% the ACK start a fresh batch that flushes at the next
+            %% send-cycle boundary.
+            State1 = flush_socket_batch(State),
+            send_app_packet_internal(quic_frame:encode(AckFrameTuple), [AckFrameTuple], State1)
     end.
 
 %% Dequeue a small stream frame tuple if available (< 500 bytes)


### PR DESCRIPTION
## Summary
In `maybe_coalesce_ack_with_data/2`, when no small stream frame is available to piggyback on the ACK, flush any pending stream-data batch before queuing the ACK packet. Stops a ~60-byte ACK from breaking GSO uniformity on a batch of 1200-byte stream chunks and forcing `flush_individual/1`.

## Bench (10 MB, Linux docker, OTP 28, opt-in socket backend, n=5)

| | before | after |
|---|---|---|
| Upload socket (median MB/s) | 67.11 | 71.43 |

Gap vs gen_udp narrows from -11% to -8%.