### PR TITLE
fix(client): update socket_state handle on gen_udp migrate

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8046,10 +8046,30 @@ rebind_socket(OldSocket) ->
 -spec rebind_client_socket(#state{}) -> {ok, #state{}} | {error, term()}.
 rebind_client_socket(#state{client_socket_backend = socket} = State) ->
     rebind_client_socket_otp(State);
-rebind_client_socket(#state{socket = OldSocket} = State) ->
+rebind_client_socket(#state{socket = OldSocket, socket_state = OldSocketState} = State) ->
+    %% Flush any pending batch to the old socket before rebinding so
+    %% already-sequenced packets reach the server under the pre-migrate
+    %% path. Without this flush, encrypted packets sitting in
+    %% `#socket_state.batch_buffer' would either be silently dropped
+    %% (old closed socket) or replayed from the new addr with stale
+    %% CIDs (mis-routed on the server side).
+    State0 = flush_socket_batch(State),
     case rebind_socket(OldSocket) of
-        {ok, NewSocket} -> {ok, State#state{socket = NewSocket}};
-        {error, _} = Error -> Error
+        {ok, NewSocket} ->
+            %% `#socket_state{}' kept its reference to the now-closed
+            %% old socket. Swap the handle while preserving batching
+            %% configuration; the clean batch buffer (from the flush
+            %% above) starts fresh for post-migrate traffic.
+            NewSocketState =
+                case OldSocketState of
+                    undefined ->
+                        undefined;
+                    _ ->
+                        quic_socket:set_socket(State0#state.socket_state, NewSocket)
+                end,
+            {ok, State0#state{socket = NewSocket, socket_state = NewSocketState}};
+        {error, _} = Error ->
+            Error
     end.
 
 %% Socket-NIF rebind: stop the old receiver, close the old OTP socket

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -57,7 +57,8 @@
     gso_supported/1,
     info/1,
     start_client_receiver/2,
-    stop_client_receiver/1
+    stop_client_receiver/1,
+    set_socket/2
 ]).
 
 -include("quic.hrl").
@@ -284,6 +285,16 @@ open_server_send_genudp(LocalIP, LocalPort, Opts, BatchConfig) ->
 -spec get_socket(socket_state()) -> socket:socket() | gen_udp:socket().
 get_socket(#socket_state{socket = Socket}) ->
     Socket.
+
+%% @doc Swap the underlying socket handle without rebuilding the
+%% `#socket_state{}'. Used by client-migration rebind so batching
+%% configuration is preserved while the handle points at a fresh
+%% ephemeral port. Callers must flush any pending batch before
+%% swapping; packets buffered under the old handle cannot migrate to
+%% the new one.
+-spec set_socket(socket_state(), gen_udp:socket() | socket:socket()) -> socket_state().
+set_socket(#socket_state{} = State, NewSocket) ->
+    State#socket_state{socket = NewSocket}.
 
 %% @doc Check if GSO is supported for this socket_state.
 -spec gso_supported(socket_state()) -> boolean().

--- a/test/quic_client_migrate_tests.erl
+++ b/test/quic_client_migrate_tests.erl
@@ -1,0 +1,63 @@
+%%% -*- erlang -*-
+%%%
+%%% Regression test for the default gen_udp client migration path.
+%%% Mirrors the socket-backend migrate test so the shared
+%%% `rebind_client_socket/1' dispatcher has coverage on both backends.
+
+-module(quic_client_migrate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+client_gen_udp_migrate_test_() ->
+    {timeout, 30, fun client_gen_udp_migrate/0}.
+
+client_gen_udp_migrate() ->
+    {ok, Srv} = quic_test_echo_server:start(#{
+        max_data => 16 * 1024 * 1024,
+        max_stream_data_bidi_local => 8 * 1024 * 1024,
+        max_stream_data_bidi_remote => 8 * 1024 * 1024,
+        max_stream_data_uni => 8 * 1024 * 1024
+    }),
+    try
+        #{port := Port} = Srv,
+        ClientOpts = maps:merge(quic_test_echo_server:client_opts(), #{
+            max_data => 16 * 1024 * 1024,
+            max_stream_data_bidi_local => 8 * 1024 * 1024,
+            max_stream_data_bidi_remote => 8 * 1024 * 1024,
+            max_stream_data_uni => 8 * 1024 * 1024
+        }),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, ClientOpts, self()),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 ->
+                ?assert(false)
+            end,
+            ?assertEqual(ok, quic:migrate(Conn)),
+            {ok, StreamId} = quic:open_stream(Conn),
+            Payload = crypto:strong_rand_bytes(4096),
+            ok = quic:send_data(Conn, StreamId, Payload, true),
+            Received = collect_echo(Conn, StreamId, <<>>, 10000),
+            ?assertEqual(Payload, Received)
+        after
+            catch quic:close(Conn)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+collect_echo(Conn, StreamId, Acc, Timeout) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            collect_echo(Conn, StreamId, <<Acc/binary, Data/binary>>, Timeout);
+        {quic, Conn, {stream_closed, StreamId, _}} ->
+            Acc;
+        {quic, Conn, {closed, _}} ->
+            Acc;
+        {quic, Conn, _Other} ->
+            collect_echo(Conn, StreamId, Acc, Timeout)
+    after Timeout ->
+        error({collect_timeout, byte_size(Acc)})
+    end.


### PR DESCRIPTION
## Summary
Rebinding the gen_udp client left `#state.socket_state` pointing at the just-closed old socket. Post-migrate sends went through `quic_socket:send/4`, hit the dead handle, and dropped silently — the stream echo test timed out at 0 bytes.

Fix:
- Flush the pending batch to the old socket **before** rebinding so pre-migrate packets reach the server under their original CID.
- Swap the socket handle inside `#socket_state{}` via a new `quic_socket:set_socket/2` so batching configuration is preserved.
- Add a regression eunit covering the gen_udp migrate path (mirrors the existing socket-backend migrate test).