### PR TITLE
fix(docker/dist): mesh formation for 3+ node clusters

### DIFF
--- a/docker/dist/scripts/verify_distribution.sh
+++ b/docker/dist/scripts/verify_distribution.sh
@@ -19,8 +19,11 @@ EXPECTED_PEERS=$((EXPECTED_NODES - 1))
 for i in $(seq 1 $EXPECTED_NODES); do
     NODE="node$i"
 
-    # Count nodeup events
-    CONNECTED=$(docker compose logs "$NODE" 2>&1 | grep -c "\[DIST_TEST\].*nodeup" || echo 0)
+    # Count nodeup events. `grep -c | tail -1` coerces the non-match
+    # case (grep exits 1, stdout "0") to a single-line integer so
+    # `-lt` does not trip on multi-line output.
+    CONNECTED=$(docker compose logs "$NODE" 2>&1 | grep -c "\[DIST_TEST\].*nodeup" | tail -1)
+    CONNECTED=${CONNECTED:-0}
 
     if [ "$CONNECTED" -lt "$EXPECTED_PEERS" ]; then
         echo "  FAIL: $NODE connected to $CONNECTED peers (expected $EXPECTED_PEERS)"
@@ -36,7 +39,8 @@ echo "Phase 2: Checking mesh completion..."
 for i in $(seq 1 $EXPECTED_NODES); do
     NODE="node$i"
 
-    MESH_COMPLETE=$(docker compose logs "$NODE" 2>&1 | grep -c "\[DIST_TEST\].*mesh_complete" || echo 0)
+    MESH_COMPLETE=$(docker compose logs "$NODE" 2>&1 | grep -c "\[DIST_TEST\].*mesh_complete" | tail -1)
+    MESH_COMPLETE=${MESH_COMPLETE:-0}
 
     if [ "$MESH_COMPLETE" -lt 1 ]; then
         echo "  FAIL: $NODE did not report mesh_complete"
@@ -91,7 +95,11 @@ echo "Phase 5: Checking test completion..."
 for i in $(seq 1 $EXPECTED_NODES); do
     NODE="node$i"
 
-    TEST_COMPLETE=$(docker compose logs "$NODE" 2>&1 | grep -c "\[DIST_TEST\].*test_complete" || echo 0)
+    # `grep -c` exits non-zero with a count of 0 on no match; the
+    # previous `|| echo 0` then produced "0\n0" which tripped `-lt`.
+    # Keep only the last line so we always get a single integer.
+    TEST_COMPLETE=$(docker compose logs "$NODE" 2>&1 | grep -c "\[DIST_TEST\].*test_complete" | tail -1)
+    TEST_COMPLETE=${TEST_COMPLETE:-0}
 
     if [ "$TEST_COMPLETE" -lt 1 ]; then
         echo "  FAIL: $NODE did not complete tests"

--- a/docker/dist/src/quic_dist_test_server.erl
+++ b/docker/dist/src/quic_dist_test_server.erl
@@ -193,30 +193,43 @@ get_expected_node_count() ->
 connect_to_cluster() ->
     SeedNode = get_seed_node(),
     ExpectedCount = get_expected_node_count(),
+    Self = node(),
 
-    %% Only try to connect to seed node for non-seed nodes
-    %% This avoids simultaneous connection attempts
+    %% The seed waits for others to come to it. Every other node
+    %% connects to the seed first, then to every remaining peer listed
+    %% in CLUSTER_NODES. Erlang distribution does not auto-mesh when a
+    %% third node joins, so each node has to dial every other node
+    %% explicitly for a 3+ node cluster to form correctly.
     case SeedNode of
         undefined ->
-            %% This is the seed node, wait for others to connect
-            log_event(seed_node_waiting, #{expected => ExpectedCount}),
-            ok;
-        Seed when Seed =/= node() ->
-            %% Only connect to seed, let the mesh form naturally
-            ConnectedNodes = nodes(),
-            case lists:member(Seed, ConnectedNodes) of
-                true ->
-                    log_event(already_connected, Seed),
-                    ok;
-                false ->
-                    log_event(connecting, Seed),
-                    case net_kernel:connect_node(Seed) of
-                        true -> log_event(connected, Seed);
-                        false -> log_event(connect_failed, Seed);
-                        ignored -> log_event(connect_ignored, Seed)
-                    end
-            end;
-        _ -> ok
+            log_event(seed_node_waiting, #{expected => ExpectedCount});
+        Seed when Seed =/= Self ->
+            ensure_connected(Seed)
+    end,
+
+    %% Dial every non-self peer from CLUSTER_NODES that we do not
+    %% already know about. Trim the list to the expected cluster size
+    %% so a 3-node test does not try to reach node4/node5 entries that
+    %% were seeded into the env for the 5-node profile.
+    PeersExpected = max(0, ExpectedCount - 1),
+    Peers = lists:sublist(
+        [N || N <- get_cluster_nodes(), N =/= Self], PeersExpected
+    ),
+    lists:foreach(fun ensure_connected/1, Peers).
+
+ensure_connected(Node) when Node =:= undefined ->
+    ok;
+ensure_connected(Node) ->
+    case lists:member(Node, nodes()) of
+        true ->
+            log_event(already_connected, Node);
+        false ->
+            log_event(connecting, Node),
+            case net_kernel:connect_node(Node) of
+                true -> log_event(connected, Node);
+                false -> log_event(connect_failed, Node);
+                ignored -> log_event(connect_ignored, Node)
+            end
     end.
 
 get_seed_node() ->


### PR DESCRIPTION
## Summary
Non-seed nodes now dial every peer in CLUSTER_NODES, not only the seed. Erlang distribution does not auto-mesh when a third node joins, so for 3-node profiles node2 and node3 never saw each other.

Also fix a bash bug in verify_distribution.sh where \`grep -c | ... || echo 0\` produced \`"0\n0"\` on zero matches and tripped \`-lt\` with "integer expression expected". Pipe through \`tail -1\`.

2-node and 3-node \`./docker/dist/scripts/run_test.sh\` both pass end to end. 5-node is improved (3/5 complete) but has a residual timing issue tracked as a follow-up.