### PR TITLE
fix(h3): preserve WebTransport and unknown SETTINGS in peer map

### DIFF
--- a/include/quic_h3.hrl
+++ b/include/quic_h3.hrl
@@ -50,6 +50,12 @@
 %% RFC 9297 §2.1
 -define(H3_SETTINGS_H3_DATAGRAM, 16#33).
 
+%% WebTransport over HTTP/3 (draft-ietf-webtrans-http3-15 §9.2)
+-define(H3_SETTINGS_WT_ENABLED, 16#2c7cf000).
+-define(H3_SETTINGS_WT_INITIAL_MAX_DATA, 16#2b61).
+-define(H3_SETTINGS_WT_INITIAL_MAX_STREAMS_UNI, 16#2b64).
+-define(H3_SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI, 16#2b65).
+
 %% RFC 9297 §3.2 registered capsule types
 -define(H3_CAPSULE_DATAGRAM, 16#00).
 -define(H3_CAPSULE_LEGACY_DATAGRAM, 16#ff37a0).

--- a/src/h3/quic_h3_frame.erl
+++ b/src/h3/quic_h3_frame.erl
@@ -315,18 +315,16 @@ decode_settings_pairs(Data, Acc) ->
         true ->
             throw({forbidden_setting, Id});
         false ->
+            %% RFC 9114 §7.2.4.1: unknown setting IDs MUST be ignored.
+            %% "Ignored" means not applied to connection behaviour; the
+            %% identifier is still surfaced in the decoded map (as its
+            %% integer ID) so upper layers can observe extension settings
+            %% (e.g. WebTransport over HTTP/3, draft-15 §9.2) without
+            %% requiring a new atom mapping for every draft revision.
             Key = id_to_setting(Id),
-            %% RFC 9114 §7.2.4.1: unknown setting IDs (those not mapped to
-            %% a known atom) MUST be ignored. Drop them from the result map
-            %% so they cannot influence later peer-settings application.
-            case is_atom(Key) of
-                true ->
-                    case maps:is_key(Key, Acc) of
-                        true -> throw({duplicate_setting, Key});
-                        false -> decode_settings_pairs(Rest2, Acc#{Key => Value})
-                    end;
-                false ->
-                    decode_settings_pairs(Rest2, Acc)
+            case maps:is_key(Key, Acc) of
+                true -> throw({duplicate_setting, Key});
+                false -> decode_settings_pairs(Rest2, Acc#{Key => Value})
             end
     end.
 
@@ -349,6 +347,10 @@ setting_to_id(max_field_section_size) -> ?H3_SETTINGS_MAX_FIELD_SECTION_SIZE;
 setting_to_id(qpack_blocked_streams) -> ?H3_SETTINGS_QPACK_BLOCKED_STREAMS;
 setting_to_id(enable_connect_protocol) -> ?H3_SETTINGS_ENABLE_CONNECT_PROTOCOL;
 setting_to_id(h3_datagram) -> ?H3_SETTINGS_H3_DATAGRAM;
+setting_to_id(wt_enabled) -> ?H3_SETTINGS_WT_ENABLED;
+setting_to_id(wt_initial_max_data) -> ?H3_SETTINGS_WT_INITIAL_MAX_DATA;
+setting_to_id(wt_initial_max_streams_uni) -> ?H3_SETTINGS_WT_INITIAL_MAX_STREAMS_UNI;
+setting_to_id(wt_initial_max_streams_bidi) -> ?H3_SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI;
 setting_to_id(Id) when is_integer(Id) -> Id.
 
 -spec id_to_setting(non_neg_integer()) -> atom() | non_neg_integer().
@@ -357,6 +359,10 @@ id_to_setting(?H3_SETTINGS_MAX_FIELD_SECTION_SIZE) -> max_field_section_size;
 id_to_setting(?H3_SETTINGS_QPACK_BLOCKED_STREAMS) -> qpack_blocked_streams;
 id_to_setting(?H3_SETTINGS_ENABLE_CONNECT_PROTOCOL) -> enable_connect_protocol;
 id_to_setting(?H3_SETTINGS_H3_DATAGRAM) -> h3_datagram;
+id_to_setting(?H3_SETTINGS_WT_ENABLED) -> wt_enabled;
+id_to_setting(?H3_SETTINGS_WT_INITIAL_MAX_DATA) -> wt_initial_max_data;
+id_to_setting(?H3_SETTINGS_WT_INITIAL_MAX_STREAMS_UNI) -> wt_initial_max_streams_uni;
+id_to_setting(?H3_SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI) -> wt_initial_max_streams_bidi;
 id_to_setting(Id) -> Id.
 
 %%====================================================================

--- a/test/quic_h3_frame_tests.erl
+++ b/test/quic_h3_frame_tests.erl
@@ -85,6 +85,59 @@ settings_payload_test() ->
     {ok, DecodedSettings} = quic_h3_frame:decode_settings_payload(Payload),
     ?assertEqual(1024, maps:get(qpack_max_table_capacity, DecodedSettings)).
 
+%% WebTransport setting IDs (draft-ietf-webtrans-http3-15 §9.2) round-trip
+%% through the SETTINGS frame as dedicated atoms.
+settings_wt_atoms_roundtrip_test() ->
+    Settings = #{
+        wt_enabled => 1,
+        wt_initial_max_data => 1048576,
+        wt_initial_max_streams_uni => 100,
+        wt_initial_max_streams_bidi => 50
+    },
+    Encoded = quic_h3_frame:encode_settings(Settings),
+    {ok, {settings, Decoded}, <<>>} = quic_h3_frame:decode(Encoded),
+    ?assertEqual(1, maps:get(wt_enabled, Decoded)),
+    ?assertEqual(1048576, maps:get(wt_initial_max_data, Decoded)),
+    ?assertEqual(100, maps:get(wt_initial_max_streams_uni, Decoded)),
+    ?assertEqual(50, maps:get(wt_initial_max_streams_bidi, Decoded)).
+
+%% Unknown (non-forbidden) setting IDs are preserved in the decoded map
+%% under their integer key so upper layers can observe future IETF
+%% extensions without waiting for a code change.
+settings_unknown_id_preserved_test() ->
+    Payload = quic_h3_frame:encode_settings_payload(#{16#4abc => 42}),
+    {ok, Decoded} = quic_h3_frame:decode_settings_payload(Payload),
+    ?assertEqual(42, maps:get(16#4abc, Decoded)).
+
+%% Forbidden HTTP/2 settings (RFC 9114 §7.2.4.1) must still be rejected.
+%% `decode_settings_payload/1' catches the internal throw and returns
+%% `{error, {forbidden_setting, Id}}'.
+settings_forbidden_still_rejected_test() ->
+    Forbidden = [16#02, 16#03, 16#04, 16#05],
+    lists:foreach(
+        fun(Id) ->
+            Payload = quic_h3_frame:encode_settings_payload(#{Id => 1}),
+            ?assertEqual(
+                {error, {forbidden_setting, Id}},
+                quic_h3_frame:decode_settings_payload(Payload)
+            )
+        end,
+        Forbidden
+    ).
+
+%% Duplicate detection applies to unknown integer IDs too, not only
+%% known atoms.
+settings_duplicate_integer_id_rejected_test() ->
+    Id = 16#4abc,
+    IdVarint = quic_varint:encode(Id),
+    Payload =
+        <<IdVarint/binary, (quic_varint:encode(1))/binary, IdVarint/binary,
+            (quic_varint:encode(2))/binary>>,
+    ?assertEqual(
+        {error, {duplicate_setting, Id}},
+        quic_h3_frame:decode_settings_payload(Payload)
+    ).
+
 %%====================================================================
 %% GOAWAY Frame Tests
 %%====================================================================
@@ -382,16 +435,20 @@ settings_connect_protocol_disabled_test() ->
     {ok, {settings, Decoded}, <<>>} = quic_h3_frame:decode(Encoded),
     ?assertEqual(0, maps:get(enable_connect_protocol, Decoded)).
 
-%% RFC 9114 §7.2.4.1: unknown setting identifiers (including grease values
-%% per §7.2.8) MUST be ignored on the receiving side. Encoding still emits
-%% them; decoding drops them from the result map.
-settings_grease_dropped_on_decode_test() ->
+%% RFC 9114 §7.2.4.1 / §7.2.8: unknown setting identifiers (including
+%% grease values) MUST be ignored on the receiving side. "Ignored"
+%% means not applied to connection behaviour; the identifier is still
+%% surfaced in the decoded map under its integer key so upper layers
+%% can observe extension settings. See `apply_peer_settings/2' in
+%% `quic_h3_connection' — it pattern-matches known atoms and never
+%% consults integer keys.
+settings_grease_preserved_on_decode_test() ->
     %% N=0 grease setting (0x1f*0 + 0x21)
     GREASEId = 16#21,
     Settings = #{GREASEId => 12345},
     Encoded = quic_h3_frame:encode_settings(Settings),
     {ok, {settings, Decoded}, <<>>} = quic_h3_frame:decode(Encoded),
-    ?assertNot(maps:is_key(GREASEId, Decoded)).
+    ?assertEqual(12345, maps:get(GREASEId, Decoded)).
 
 %%====================================================================
 %% Edge Case Tests (inspired by quiche)


### PR DESCRIPTION
HTTP/3 SETTINGS decode used to drop any identifier not mapped to one of the five hard-wired atoms, which meant WebTransport-over-HTTP/3 (draft-ietf-webtrans-http3-15 §9.2) could never negotiate, and upper layers had no way to observe any future extension setting.

RFC 9114 §7.2.4.1 "MUST be ignored" applies to connection behaviour, not to discarding the identifier from the decoded map. This PR:

- Keeps unknown integer IDs in the result map (extensibility).
- Adds four WebTransport atoms for the known IDs: \`wt_enabled\`, \`wt_initial_max_data\`, \`wt_initial_max_streams_uni\`, \`wt_initial_max_streams_bidi\`.
- No change needed in \`apply_peer_settings/2\`: it reads known atoms only via \`maps:get(atom, _, Default)\`, so integer keys fall through harmlessly.