### PR TITLE
fix(socket): exit client_recv_loop on unexpected socket error

### DIFF
--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -593,8 +593,9 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
             client_recv_loop(SocketState, Owner);
         {error, closed} ->
             ok;
-        {error, _Reason} ->
-            client_recv_loop(SocketState, Owner)
+        {error, Reason} ->
+            ?LOG_WARNING(#{what => client_recv_loop_exit, reason => Reason}),
+            ok
     end.
 
 %% @doc Detect platform capabilities for GSO/GRO.


### PR DESCRIPTION
The catch-all `{error, _}` branch in `client_recv_loop/2` recursed immediately on any reason other than `timeout` or `closed`. On a persistent socket-NIF error (`einval`, `ebadf`, `enotconn`) the loop pegged a scheduler with no log and no backoff. Now log the reason at warning and exit cleanly; the connection's terminate path owns socket cleanup.