### PR TITLE
fix(socket): clear batch buffer on flush error

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -3021,21 +3021,29 @@ send_app_packet_internal(Payload, Frames, State) ->
                 timer_dirty = true,
                 pto_dirty = true
             };
+        {error, Reason, ClearedSocketState} ->
+            send_app_packet_internal_error(
+                Reason, PN, PacketSize, PNSpace, State, ClearedSocketState
+            );
         {error, Reason} ->
-            %% Send failed - do NOT track packet as sent to avoid CC/loss inconsistency
-            %% The data will be re-sent via the PTO timeout mechanism
-            ?LOG_WARNING(
-                #{
-                    what => udp_send_failed,
-                    reason => Reason,
-                    pn => PN,
-                    size => PacketSize
-                },
-                ?QUIC_LOG_META
-            ),
-            %% Still bump PN to avoid reusing packet numbers
-            NewPNSpace = PNSpace#pn_space{next_pn = PN + 1},
-            State#state{pn_app = NewPNSpace}
+            send_app_packet_internal_error(Reason, PN, PacketSize, PNSpace, State, undefined)
+    end.
+
+%% Common error handling for send_app_packet_internal: bump PN without
+%% tracking the packet (PTO owns retransmission) and, on the 3-tuple
+%% error path, write back the cleared socket_state so the stale batch
+%% does not linger.
+send_app_packet_internal_error(Reason, PN, PacketSize, PNSpace, State, ClearedSocketState) ->
+    ?LOG_WARNING(
+        #{what => udp_send_failed, reason => Reason, pn => PN, size => PacketSize},
+        ?QUIC_LOG_META
+    ),
+    NewPNSpace = PNSpace#pn_space{next_pn = PN + 1},
+    case ClearedSocketState of
+        undefined ->
+            State#state{pn_app = NewPNSpace};
+        _ ->
+            State#state{pn_app = NewPNSpace, socket_state = ClearedSocketState}
     end.
 
 %% Pad Initial packet to minimum 1200 bytes
@@ -5298,7 +5306,9 @@ get_max_stream_recv_window(#state{fc_max_stream_recv_window = CachedMax}) ->
 %% `undefined' to leave the state unchanged). Callers thread the
 %% returned state into their subsequent `#state{}' record update.
 -spec do_socket_send(iodata(), #state{}) ->
-    {ok, undefined | quic_socket:socket_state()} | {error, term()}.
+    {ok, undefined | quic_socket:socket_state()}
+    | {error, term()}
+    | {error, term(), undefined | quic_socket:socket_state()}.
 do_socket_send(Packet, #state{socket_state = undefined, socket = Socket, remote_addr = {IP, Port}}) ->
     case gen_udp:send(Socket, IP, Port, Packet) of
         ok -> {ok, undefined};
@@ -5315,6 +5325,7 @@ send_and_take_socket_state(Packet, State) ->
     case do_socket_send(Packet, State) of
         {ok, undefined} -> State#state.socket_state;
         {ok, NewSocketState} -> NewSocketState;
+        {error, _, NewSocketState} -> NewSocketState;
         {error, _} -> State#state.socket_state
     end.
 
@@ -5382,8 +5393,8 @@ flush_socket_batch(#state{socket_state = SocketState} = State) ->
     case quic_socket:flush(SocketState) of
         {ok, NewSocketState} ->
             State#state{socket_state = NewSocketState};
-        {error, _} ->
-            State
+        {error, _, ClearedSocketState} ->
+            State#state{socket_state = ClearedSocketState}
     end.
 
 %% Send ACK if packet contained any ack-eliciting frames.

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -418,7 +418,7 @@ send_immediate(State, IP, Port, Packet) ->
 %% - Batch is full (max_batch_packets reached)
 %% - Destination address changes
 -spec send(socket_state(), inet:ip_address(), inet:port_number(), packet_view()) ->
-    {ok, socket_state()} | {error, term()}.
+    {ok, socket_state()} | {error, term()} | {error, term(), socket_state()}.
 send(#socket_state{batching_enabled = false} = State, IP, Port, Packet) ->
     %% Batching disabled - send immediately
     do_send_immediate(State, IP, Port, Packet);
@@ -433,12 +433,16 @@ send(#socket_state{} = State, IP, Port, Packet) ->
     case flush(State) of
         {ok, State1} ->
             add_to_batch(State1#socket_state{batch_addr = {IP, Port}}, Packet);
-        {error, _} = Error ->
+        {error, _, _} = Error ->
             Error
     end.
 
-%% @doc Flush all buffered packets.
--spec flush(socket_state()) -> {ok, socket_state()} | {error, term()}.
+%% @doc Flush all buffered packets. On hard send error the batch is
+%% cleared in the returned state so callers thread a clean buffer;
+%% PTO-driven retransmission owns recovery of any packets the CC has
+%% already tracked.
+-spec flush(socket_state()) ->
+    {ok, socket_state()} | {error, term(), socket_state()}.
 flush(#socket_state{batch_count = 0} = State) ->
     %% Nothing to flush
     {ok, State};
@@ -841,22 +845,24 @@ flush_gso(
         ok ->
             {ok, record_flush(State)};
         {ok, RestData} ->
-            %% Partial send - GSO didn't send all data.
-            TotalBytes = iolist_size(PacketIov),
-            Remaining = iolist_size(RestData),
-            ?LOG_WARNING(#{
-                what => gso_partial_send,
-                sent => TotalBytes - Remaining,
-                remaining => Remaining
-            }),
-            %% Disable GSO and retry remaining data individually. The
-            %% retry path accounts for the coalesced packets itself, so
-            %% clear batch state here without bumping counters.
-            State1 = clear_batch(State#socket_state{gso_supported = false}),
-            send_remaining_individually(State1, IP, Port, RestData);
-        {error, _} = Error ->
-            Error
+            flush_gso_partial(State, IP, Port, PacketIov, RestData);
+        {error, Reason} ->
+            ?LOG_WARNING(#{what => gso_send_error, reason => Reason}),
+            {error, Reason, clear_batch(State)}
     end.
+
+%% Partial GSO send: log, disable GSO on this socket, and retry the
+%% remaining bytes segment-by-segment.
+flush_gso_partial(State, IP, Port, PacketIov, RestData) ->
+    TotalBytes = iolist_size(PacketIov),
+    Remaining = iolist_size(RestData),
+    ?LOG_WARNING(#{
+        what => gso_partial_send,
+        sent => TotalBytes - Remaining,
+        remaining => Remaining
+    }),
+    State1 = clear_batch(State#socket_state{gso_supported = false}),
+    send_remaining_individually(State1, IP, Port, RestData).
 
 flush_individual(#socket_state{backend = socket} = State) ->
     flush_individual_socket(State);
@@ -877,7 +883,7 @@ flush_individual_socket(
         {ok, _Sent} ->
             {ok, record_flush(State)};
         {error, Reason, _Sent} ->
-            {error, Reason}
+            {error, Reason, clear_batch(State)}
     end.
 
 flush_individual_genudp(
@@ -893,7 +899,7 @@ flush_individual_genudp(
         {ok, _Sent} ->
             {ok, record_flush(State)};
         {error, Reason, _Sent} ->
-            {error, Reason}
+            {error, Reason, clear_batch(State)}
     end.
 
 %% Send packets using socket:sendmsg with iov (no flattening for socket backend)
@@ -953,7 +959,7 @@ send_segments(_Socket, _Dest, [], State) ->
 send_segments(Socket, Dest, [Packet | Rest], State) ->
     case socket:sendto(Socket, Packet, Dest) of
         ok -> send_segments(Socket, Dest, Rest, State);
-        {error, _} = Error -> Error
+        {error, Reason} -> {error, Reason, State}
     end.
 
 do_send_immediate(#socket_state{socket = Socket, backend = socket} = State, IP, Port, Packet) ->


### PR DESCRIPTION
On a hard sendmsg failure \`quic_socket:flush/1\` used to return \`{error, Reason}\` without clearing \`#socket_state.batch_buffer\`, and the connection-side caller (\`flush_socket_batch/1\`) kept the old state. The stale buffer sat there until a later flush succeeded, at which point already-tracked packets got resent on top of their PTO retransmits.

\`flush/1\` now returns \`{ok, State} | {error, Reason, ClearedState}\` and each error path on \`flush_gso\`, \`flush_individual_socket\`, and \`flush_individual_genudp\` calls \`clear_batch/1\` before returning. Callers (\`send/4\`, \`add_to_batch/2\`, \`quic_connection:do_socket_send/2\`, \`send_app_packet_internal/3\`, \`flush_socket_batch/1\`) thread the cleared state. Already-sent-and-tracked packets still rely on PTO for retransmission; the error path just stops pinning memory and stops resending ghosts.