### PR TITLE
fix(client): reject socket + socket_backend option combination

### DIFF
--- a/src/quic.erl
+++ b/src/quic.erl
@@ -178,14 +178,27 @@ connect(Host, Port, Opts, Owner) when
 ->
     %% Extract socket option for pre-opened socket support
     Socket = maps:get(socket, Opts, undefined),
-    case quic_connection:start_link(Host, Port, Opts, Owner, Socket) of
-        {ok, Pid} ->
-            {ok, Pid};
-        Error ->
+    case validate_connect_opts(Socket, Opts) of
+        ok ->
+            case quic_connection:start_link(Host, Port, Opts, Owner, Socket) of
+                {ok, Pid} -> {ok, Pid};
+                Error -> Error
+            end;
+        {error, _} = Error ->
             Error
     end;
 connect(_Host, _Port, _Opts, _Owner) ->
     {error, badarg}.
+
+%% A pre-opened `socket' is always a gen_udp handle; requesting the
+%% OTP socket NIF backend at the same time cannot be honoured.
+validate_connect_opts(Socket, Opts) when Socket =/= undefined ->
+    case maps:get(socket_backend, Opts, gen_udp) of
+        socket -> {error, {incompatible_options, [socket, {socket_backend, socket}]}};
+        _ -> ok
+    end;
+validate_connect_opts(undefined, _Opts) ->
+    ok.
 
 %% @doc Close a QUIC connection with normal reason.
 -spec close(Conn) -> ok when

--- a/test/quic_client_socket_backend_tests.erl
+++ b/test/quic_client_socket_backend_tests.erl
@@ -89,6 +89,33 @@ client_socket_backend_migrate() ->
         quic_test_echo_server:stop(Srv)
     end.
 
+client_pre_opened_socket_rejects_socket_backend_test_() ->
+    {timeout, 10, fun client_pre_opened_socket_rejects_socket_backend/0}.
+
+%% A caller that passes a pre-opened gen_udp socket via the `socket'
+%% option *and* requests `socket_backend => socket' asks for two
+%% incompatible things: the pre-opened handle is a gen_udp port, not
+%% an OTP socket NIF handle. `quic:connect/4' must reject the
+%% combination with an error, not crash inside init.
+client_pre_opened_socket_rejects_socket_backend() ->
+    {ok, Srv} = quic_test_echo_server:start(#{}),
+    try
+        #{port := Port} = Srv,
+        {ok, UdpSocket} = gen_udp:open(0, [binary, {active, false}]),
+        try
+            Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+                socket => UdpSocket,
+                socket_backend => socket
+            }),
+            Result = quic:connect("127.0.0.1", Port, Opts, self()),
+            ?assertMatch({error, {incompatible_options, _}}, Result)
+        after
+            catch gen_udp:close(UdpSocket)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
 collect_echo(Conn, StreamId, Acc, Timeout) ->
     receive
         {quic, Conn, {stream_data, StreamId, Data, true}} ->


### PR DESCRIPTION
A pre-opened socket passed via `socket => ` is always a `gen_udp` handle. Combined with `socket_backend => socket`, init fell into `{badmatch,{error,not_supported_on_gen_udp}}` when `start_client_receiver/2` refused to attach to the gen_udp wrapper. Validate at the API boundary and return `{error, {incompatible_options, [socket, {socket_backend, socket}]}}` instead of crashing.