### PR TITLE
fix(server): build per-connection sender even with batching disabled

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -926,23 +926,11 @@ init({server, Opts}) ->
     %% on Linux with socket backend, use GSO via sendmsg. Gated on
     %% server_send_batching (default true) so operators can fall back to
     %% the direct gen_udp:send/4 path if needed.
-    SocketState =
-        case maps:get(server_send_batching, Opts, true) of
-            true ->
-                ListenerBackend = maps:get(listener_socket_backend, Opts, gen_udp),
-                ListenerGSO = maps:get(listener_gso_supported, Opts, false),
-                SenderOpts = #{
-                    backend => ListenerBackend,
-                    gso_supported => ListenerGSO,
-                    batching => maps:get(batching, Opts, #{})
-                },
-                case quic_socket:new_sender(Socket, SenderOpts) of
-                    {ok, S} -> S;
-                    {error, _} -> undefined
-                end;
-            false ->
-                undefined
-        end,
+    %% Build a per-connection sender even with batching off so sends
+    %% dispatch on `#socket_state.backend'. On the socket listener,
+    %% `#state.socket' is an OTP socket handle that `gen_udp:send/4'
+    %% cannot accept.
+    SocketState = build_server_socket_state(Socket, Opts),
 
     %% Initialize state
     State = #state{
@@ -1112,6 +1100,22 @@ open_client_socket(S, _RemoteAddr, _Opts, _ExtraOpts) ->
     case inet:sockname(S) of
         {ok, LA} -> {ok, S, LA, false};
         {error, Reason} -> {error, Reason}
+    end.
+
+build_server_socket_state(Socket, Opts) ->
+    BatchOpts =
+        case maps:get(server_send_batching, Opts, true) of
+            true -> maps:get(batching, Opts, #{});
+            false -> #{enabled => false}
+        end,
+    SenderOpts = #{
+        backend => maps:get(listener_socket_backend, Opts, gen_udp),
+        gso_supported => maps:get(listener_gso_supported, Opts, false),
+        batching => BatchOpts
+    },
+    case quic_socket:new_sender(Socket, SenderOpts) of
+        {ok, S} -> S;
+        {error, _} -> undefined
     end.
 
 open_client_socket_genudp(IP, Opts, ExtraOpts) ->

--- a/test/quic_server_send_batching_off_tests.erl
+++ b/test/quic_server_send_batching_off_tests.erl
@@ -1,0 +1,54 @@
+%%% Regression test: server with socket_backend => socket and
+%%% server_send_batching => false must still be able to send packets.
+%%% Before the fix, server init dropped socket_state to undefined in
+%%% that mode and do_socket_send / send_packet_to_addr fell back to
+%%% gen_udp:send/4, but on the socket backend #state.socket is an OTP
+%%% socket handle, so all server-side sends failed silently.
+
+-module(quic_server_send_batching_off_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+server_socket_backend_batching_off_test_() ->
+    {timeout, 15, fun server_socket_backend_batching_off/0}.
+
+server_socket_backend_batching_off() ->
+    {ok, Srv} = quic_test_echo_server:start(#{
+        socket_backend => socket,
+        server_send_batching => false
+    }),
+    try
+        #{port := Port} = Srv,
+        ClientOpts = quic_test_echo_server:client_opts(),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, ClientOpts, self()),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 ->
+                error(connect_timeout)
+            end,
+            {ok, StreamId} = quic:open_stream(Conn),
+            Payload = <<"hello">>,
+            ok = quic:send_data(Conn, StreamId, Payload, true),
+            Received = collect_echo(Conn, StreamId, <<>>, 5000),
+            ?assertEqual(Payload, Received)
+        after
+            catch quic:close(Conn)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+collect_echo(Conn, StreamId, Acc, Timeout) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            collect_echo(Conn, StreamId, <<Acc/binary, Data/binary>>, Timeout);
+        {quic, Conn, {closed, _}} ->
+            Acc;
+        {quic, Conn, _Other} ->
+            collect_echo(Conn, StreamId, Acc, Timeout)
+    after Timeout ->
+        error({collect_timeout, byte_size(Acc)})
+    end.

--- a/test/quic_server_send_batching_off_tests.erl
+++ b/test/quic_server_send_batching_off_tests.erl
@@ -10,7 +10,13 @@
 -include_lib("eunit/include/eunit.hrl").
 
 server_socket_backend_batching_off_test_() ->
-    {timeout, 15, fun server_socket_backend_batching_off/0}.
+    %% Linux-only: detect_capabilities/0 only exposes the OTP socket
+    %% NIF as the listener backend there. Elsewhere the bug this test
+    %% targets (gen_udp:send/4 on an OTP socket handle) cannot fire.
+    case os:type() of
+        {unix, linux} -> [{timeout, 15, fun server_socket_backend_batching_off/0}];
+        _ -> []
+    end.
 
 server_socket_backend_batching_off() ->
     {ok, Srv} = quic_test_echo_server:start(#{


### PR DESCRIPTION
When a listener is opened with `socket_backend => socket` and the caller asks for `server_send_batching => false`, every server-side send failed silently: `do_socket_send`/`send_packet_to_addr` fell back to `gen_udp:send/4` on the undefined `socket_state` branch, but `#state.socket` is an OTP socket handle in that mode.

Always build a `#socket_state{}` via `quic_socket:new_sender/2` using the listener's actual backend; when batching is disabled, pass `batching => #{enabled => false}` so `quic_socket:send/4` short-circuits to `do_send_immediate` and dispatches on the backend field.