### PR TITLE
fix(test): align server_connection_batching_opt_out with PR #102

### DIFF
--- a/test/quic_server_e2e_SUITE.erl
+++ b/test/quic_server_e2e_SUITE.erl
@@ -170,9 +170,10 @@ server_connection_batching_opt_out(Config) ->
         {ok, ConnPids} = quic:get_server_connections(Name),
         [ServerPid | _] = lists:usort(ConnPids),
         {_State, Info} = quic_connection:get_state(ServerPid),
-        %% Opt-out: no socket_state, so direct send path with no
-        %% batching wrapper.
-        ?assertEqual(direct, maps:get(send_backend, Info)),
+        %% Opt-out: per-connection socket_state wraps the listener
+        %% backend but batching is disabled. `send_backend' reports
+        %% the actual backend (gen_udp or socket); the visible contract
+        %% is `send_batching_enabled = false'.
         ?assertEqual(false, maps:get(send_batching_enabled, Info)),
         ?assertEqual(false, maps:get(send_gso_supported, Info)),
         quic:close(Conn)


### PR DESCRIPTION
PR #102 wraps the listener socket in a `#socket_state{}` even when `server_send_batching => false` so sends dispatch on the real backend. `send_backend` now reports `gen_udp` (or `socket`) instead of the sentinel `direct`. The observable contract is unchanged: `send_batching_enabled` is still `false`.

Update the assertion to match: drop the `send_backend` check, keep the batching-disabled checks.