### PR TITLE
fix(dist): prevent batch-yield reordering of dist byte stream

### DIFF
--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -94,6 +94,10 @@
     connected/3
 ]).
 
+-ifdef(TEST).
+-export([deliver_complete_messages/3]).
+-endif.
+
 %% Internal state
 -record(state, {
     %% Connection (pid, receives {quic, Conn, Event} messages)

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -95,7 +95,7 @@
 ]).
 
 -ifdef(TEST).
--export([deliver_complete_messages/3]).
+-export([deliver_complete_messages/3, deliver_complete_messages/4, input_handler_loop/6]).
 -endif.
 
 %% Internal state
@@ -1271,43 +1271,45 @@ send_one_frame(Conn, StreamId, Data) ->
 %% We MUST buffer incoming data and only pass complete messages to the VM.
 %% Passing partial messages causes "corrupted distribution header" errors.
 input_handler_loop(DHandle, Controller, Conn, ControlStream) ->
-    %% Start with empty buffer
-    input_handler_loop(DHandle, Controller, Conn, ControlStream, <<>>).
+    input_handler_loop(
+        DHandle, Controller, Conn, ControlStream, <<>>, fun erlang:dist_ctrl_put_data/2
+    ).
 
-input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer) ->
+input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer, Deliver) ->
     receive
-        {continue_delivery, PendingBuffer} ->
-            %% Continue processing after batch yield
-            case deliver_complete_messages(DHandle, PendingBuffer) of
+        continue_delivery ->
+            %% Resume processing whatever is already in Buffer after a
+            %% prior batch yield.
+            case deliver_complete_messages(DHandle, Buffer, ?INPUT_HANDLER_BATCH_SIZE, Deliver) of
                 {ok, RemainingBuffer} ->
                     input_handler_loop(
-                        DHandle, Controller, Conn, ControlStream, RemainingBuffer
+                        DHandle, Controller, Conn, ControlStream, RemainingBuffer, Deliver
                     );
                 {error, _Reason} ->
                     exit(normal)
             end;
         {dist_data, Data} ->
-            %% Data received from QUIC - buffer and deliver complete messages
             NewBuffer = <<Buffer/binary, Data/binary>>,
-            case deliver_complete_messages(DHandle, NewBuffer) of
+            case
+                deliver_complete_messages(DHandle, NewBuffer, ?INPUT_HANDLER_BATCH_SIZE, Deliver)
+            of
                 {ok, RemainingBuffer} ->
                     input_handler_loop(
-                        DHandle, Controller, Conn, ControlStream, RemainingBuffer
+                        DHandle, Controller, Conn, ControlStream, RemainingBuffer, Deliver
                     );
                 {error, _Reason} ->
-                    %% Error delivering to VM, connection is broken
                     exit(normal)
             end;
         {'EXIT', Controller, Reason} ->
-            %% Controller died, exit
             exit(Reason);
         {quic, Conn, {stream_data, _StreamId, Data, _Fin}} ->
-            %% Direct QUIC data (if we're receiving messages directly)
             NewBuffer = <<Buffer/binary, Data/binary>>,
-            case deliver_complete_messages(DHandle, NewBuffer) of
+            case
+                deliver_complete_messages(DHandle, NewBuffer, ?INPUT_HANDLER_BATCH_SIZE, Deliver)
+            of
                 {ok, RemainingBuffer} ->
                     input_handler_loop(
-                        DHandle, Controller, Conn, ControlStream, RemainingBuffer
+                        DHandle, Controller, Conn, ControlStream, RemainingBuffer, Deliver
                     );
                 {error, _Reason} ->
                     exit(normal)
@@ -1319,7 +1321,7 @@ input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer) ->
                 #{what => input_handler_unexpected_msg, msg => Other},
                 ?QUIC_LOG_META
             ),
-            input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer)
+            input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer, Deliver)
     end.
 
 %% @private
@@ -1328,23 +1330,28 @@ input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer) ->
 %% The payload (WITHOUT length header) is passed to dist_ctrl_put_data.
 %% Empty frames (Length=0) are tick signals - no payload to deliver.
 %% Returns {ok, RemainingBuffer} or {error, Reason}
-deliver_complete_messages(DHandle, Buffer) ->
-    deliver_complete_messages(DHandle, Buffer, ?INPUT_HANDLER_BATCH_SIZE).
+-ifdef(TEST).
+%% Test-only convenience: exercised by
+%% `quic_dist_controller_tests:deliver_yield_returns_remainder_test/0'.
+%% Production code calls the /4 arity directly.
+deliver_complete_messages(DHandle, Buffer, Remaining) ->
+    deliver_complete_messages(DHandle, Buffer, Remaining, fun erlang:dist_ctrl_put_data/2).
+-endif.
 
 %% @private
 %% Deliver complete messages with batch limit to prevent blocking.
-%% After processing batch limit messages, yields back to receive loop
-%% via continue_delivery message to allow processing incoming ticks.
-deliver_complete_messages(_DHandle, Buffer, 0) ->
-    %% Reached batch limit - yield to allow processing other messages (e.g., ticks)
-    self() ! {continue_delivery, Buffer},
-    {ok, <<>>};
-deliver_complete_messages(DHandle, Buffer, Remaining) ->
+%% The unprocessed remnant comes back via `{ok, RemainingBuffer}`; the
+%% yield signal is a tag-only `continue_delivery' atom so the buffer
+%% cannot race against an incoming `{dist_data, _}' message.
+deliver_complete_messages(_DHandle, Buffer, 0, _Deliver) ->
+    self() ! continue_delivery,
+    {ok, Buffer};
+deliver_complete_messages(DHandle, Buffer, Remaining, Deliver) ->
     case Buffer of
         <<0:32/big-unsigned, Rest/binary>> ->
             %% Empty frame = tick signal - just continue (ticks don't count against batch limit)
             logger:debug(#{what => tick_frame_received}, ?QUIC_LOG_META),
-            deliver_complete_messages(DHandle, Rest, Remaining);
+            deliver_complete_messages(DHandle, Rest, Remaining, Deliver);
         <<Length:32/big-unsigned, Rest/binary>> when byte_size(Rest) >= Length ->
             %% We have a complete message - extract payload only
             <<Payload:Length/binary, Tail/binary>> = Rest,
@@ -1357,10 +1364,12 @@ deliver_complete_messages(DHandle, Buffer, Remaining) ->
                 ?QUIC_LOG_META
             ),
             try
-                %% Pass ONLY the payload to dist_ctrl_put_data (no length header)
-                erlang:dist_ctrl_put_data(DHandle, Payload),
-                %% Continue with remaining data, decrement batch counter
-                deliver_complete_messages(DHandle, Tail, Remaining - 1)
+                %% Pass ONLY the payload (no length header) to the
+                %% delivery fn. Production default is
+                %% `erlang:dist_ctrl_put_data/2'; tests inject a fn
+                %% that records payloads for assertion.
+                Deliver(DHandle, Payload),
+                deliver_complete_messages(DHandle, Tail, Remaining - 1, Deliver)
             catch
                 Class:Reason ->
                     logger:error(

--- a/test/quic_dist_controller_tests.erl
+++ b/test/quic_dist_controller_tests.erl
@@ -1007,6 +1007,58 @@ drain_mailbox() ->
         ok
     end.
 
+%% Exercise the full input_handler_loop under a backlog: while the
+%% loop is still inside `deliver_complete_messages`, a second
+%% `{dist_data, _}' lands in the mailbox. The batch yield must keep
+%% the dist byte stream in FIFO order and deliver every payload exactly
+%% once.
+input_handler_mailbox_ordering_test() ->
+    process_flag(trap_exit, true),
+    %% Test delivery fn records payloads in order into a test process.
+    Self = self(),
+    Deliver = fun(_DH, Payload) ->
+        Self ! {recorded, Payload},
+        ok
+    end,
+    %% Build N complete length-prefixed frames, bigger than
+    %% INPUT_HANDLER_BATCH_SIZE (32) to force a yield.
+    N = 64,
+    Frames = [frame(I) || I <- lists:seq(1, N)],
+    AllBytes = iolist_to_binary(Frames),
+    Split = byte_size(AllBytes) div 2,
+    <<Part1:Split/binary, Part2/binary>> = AllBytes,
+    %% Spawn the loop with a dummy DHandle; it never reaches
+    %% dist_ctrl_put_data/2 because Deliver takes its place.
+    Controller = self(),
+    Loop = spawn_link(fun() ->
+        quic_dist_controller:input_handler_loop(
+            test_dhandle, Controller, test_conn, test_stream, <<>>, Deliver
+        )
+    end),
+    Loop ! {dist_data, Part1},
+    Loop ! {dist_data, Part2},
+    Received = collect_payloads(N, []),
+    exit(Loop, shutdown),
+    Expected = [payload(I) || I <- lists:seq(1, N)],
+    ?assertEqual(Expected, Received).
+
+frame(I) ->
+    Payload = payload(I),
+    <<(byte_size(Payload)):32/big-unsigned, Payload/binary>>.
+
+payload(I) ->
+    integer_to_binary(I).
+
+collect_payloads(0, Acc) ->
+    lists:reverse(Acc);
+collect_payloads(N, Acc) ->
+    receive
+        {recorded, Payload} ->
+            collect_payloads(N - 1, [Payload | Acc])
+    after 2000 ->
+        error({collect_timeout, {remaining, N}, {got, lists:reverse(Acc)}})
+    end.
+
 %% Test tick frame independent of congestion (Fix 1 + Fix 2)
 tick_independent_of_congestion_test() ->
     %% The tick frame should be sent regardless of congestion state

--- a/test/quic_dist_controller_tests.erl
+++ b/test/quic_dist_controller_tests.erl
@@ -974,6 +974,39 @@ continue_delivery_format_test() ->
     {continue_delivery, Buffer} = Msg,
     ?assertEqual(<<"remaining data">>, Buffer).
 
+%% Regression: the batch-yield base case must return the unprocessed
+%% remnant through the normal {ok, _} channel instead of stashing it
+%% inside a self-message. On main, the remnant rides on
+%% {continue_delivery, Buffer} and any {dist_data, _} that lands in
+%% the mailbox first gets concatenated against an empty Buffer,
+%% reordering the dist byte stream.
+deliver_yield_returns_remainder_test() ->
+    %% Drain any earlier messages so we only observe what the call
+    %% under test posts.
+    _ = drain_mailbox(),
+    Remainder = <<"pending-dist-bytes">>,
+    Result = quic_dist_controller:deliver_complete_messages(
+        test_dhandle, Remainder, 0
+    ),
+    ?assertEqual({ok, Remainder}, Result),
+    %% The yield must be a tag-only atom so the mailbox cannot carry
+    %% a stale buffer.
+    receive
+        continue_delivery ->
+            ok;
+        {continue_delivery, _} = Wrong ->
+            ?assertEqual(continue_delivery, Wrong)
+    after 200 ->
+        error(no_yield_signal)
+    end.
+
+drain_mailbox() ->
+    receive
+        _ -> drain_mailbox()
+    after 0 ->
+        ok
+    end.
+
 %% Test tick frame independent of congestion (Fix 1 + Fix 2)
 tick_independent_of_congestion_test() ->
     %% The tick frame should be sent regardless of congestion state


### PR DESCRIPTION
`deliver_complete_messages` used to stash the unprocessed remnant on a `{continue_delivery, Buffer}` self-message and return `{ok, <<>>}`. If a `{dist_data, D2}` landed in the mailbox while the handler was inside the delivery loop, the next receive picked `{dist_data, D2}` first, concatenated it against an empty Buffer, and the later `continue_delivery` processed the stashed remnant without the data that followed it — reordering the dist byte stream.

Flip the contract: the remnant comes back through `{ok, Remainder}` and the yield is a tag-only `continue_delivery` atom. Incoming `{dist_data, _}` now concatenates against the threaded Remainder in FIFO order regardless of which receive clause matches first.

Also plumb a delivery fn through `input_handler_loop/6` and `deliver_complete_messages/4` so the mailbox-ordering regression can be driven from a unit test. The production default stays `erlang:dist_ctrl_put_data/2`.