### PR TITLE
fix(dist): simultaneous-connect deadlock in accept path

### DIFF
--- a/docker/dist/config/vm.args.src
+++ b/docker/dist/config/vm.args.src
@@ -4,6 +4,11 @@
 ## Cookie for cluster authentication
 -setcookie ${ERLANG_COOKIE}
 
+## Disable automatic mesh connections. global would otherwise
+## cross-connect nodes that hear about each other, creating
+## simultaneous-connect races on top of the explicit test topology.
+-connect_all false
+
 ## QUIC distribution
 -proto_dist quic
 -epmd_module quic_epmd

--- a/docker/dist/src/quic_dist_test_server.erl
+++ b/docker/dist/src/quic_dist_test_server.erl
@@ -191,30 +191,18 @@ get_expected_node_count() ->
     end.
 
 connect_to_cluster() ->
-    SeedNode = get_seed_node(),
     ExpectedCount = get_expected_node_count(),
     Self = node(),
 
-    %% The seed waits for others to come to it. Every other node
-    %% connects to the seed first, then to every remaining peer listed
-    %% in CLUSTER_NODES. Erlang distribution does not auto-mesh when a
-    %% third node joins, so each node has to dial every other node
-    %% explicitly for a 3+ node cluster to form correctly.
-    case SeedNode of
-        undefined ->
-            log_event(seed_node_waiting, #{expected => ExpectedCount});
-        Seed when Seed =/= Self ->
-            ensure_connected(Seed)
-    end,
-
-    %% Dial every non-self peer from CLUSTER_NODES that we do not
-    %% already know about. Trim the list to the expected cluster size
-    %% so a 3-node test does not try to reach node4/node5 entries that
-    %% were seeded into the env for the 5-node profile.
+    %% Only dial peers whose name sorts greater than self. Each pair
+    %% is dialled by exactly one side, so simultaneous-connect never
+    %% happens. Erlang dist links are bidirectional: when lowerN dials
+    %% higherN, both sides see the peer in nodes() and get nodeup.
     PeersExpected = max(0, ExpectedCount - 1),
-    Peers = lists:sublist(
+    Candidates = lists:sublist(
         [N || N <- get_cluster_nodes(), N =/= Self], PeersExpected
     ),
+    Peers = [N || N <- Candidates, N > Self],
     lists:foreach(fun ensure_connected/1, Peers).
 
 ensure_connected(Node) when Node =:= undefined ->
@@ -230,13 +218,6 @@ ensure_connected(Node) ->
                 false -> log_event(connect_failed, Node);
                 ignored -> log_event(connect_ignored, Node)
             end
-    end.
-
-get_seed_node() ->
-    case os:getenv("SEED_NODE") of
-        false -> undefined;
-        "" -> undefined;
-        NodeStr -> list_to_atom(NodeStr)
     end.
 
 get_cluster_nodes() ->

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -48,13 +48,8 @@
 -include_lib("kernel/include/net_address.hrl").
 
 %% Dialyzer suppressions:
-%% - accept/do_accept_connection: handshake functions have complex control flow
--dialyzer(
-    {nowarn_function, [
-        accept_connection/5,
-        do_accept_connection/6
-    ]}
-).
+%% - accept_connection: handshake functions have complex control flow
+-dialyzer({nowarn_function, [accept_connection/5]}).
 
 %% Distribution module callbacks
 -export([
@@ -226,14 +221,23 @@ accept(#quic_dist_listener{server_name = ServerName} = Listener) ->
     Allowed :: term(),
     SetupTime :: non_neg_integer()
 ) -> pid().
-accept_connection(AcceptPid, DistCtrl, MyNode, Allowed, SetupTime) ->
-    %% IMPORTANT: self() here is net_kernel - capture it before spawning
+accept_connection(_AcceptPid, DistCtrl, MyNode, Allowed, SetupTime) ->
+    %% self() is net_kernel here - capture before spawning.
     Kernel = self(),
     spawn_opt(
         fun() ->
-            %% Register with acceptor so we receive the controller message
-            AcceptPid ! {register_pending, DistCtrl, self()},
-            do_accept_connection(AcceptPid, DistCtrl, MyNode, Allowed, SetupTime, Kernel)
+            %% The controller already owns the QUIC connection (listener
+            %% transferred ownership in handle_new_connection), so there
+            %% is no socket-handoff rendezvous to wait for. Proceed
+            %% straight to the dist handshake - reaching mark_pending
+            %% fast is what lets dist_util resolve simultaneous connects.
+            %%
+            %% Do NOT trap exits: dist_util:start_timer/1 spawns a linked
+            %% timer whose exit must kill this process on timeout.
+            ok = quic_dist_controller:set_supervisor(DistCtrl, Kernel),
+            Timer = dist_util:start_timer(SetupTime),
+            HSData = create_hs_data(DistCtrl, MyNode, Timer, Allowed, Kernel),
+            dist_util:handshake_other_started(HSData)
         end,
         [link, {priority, max}]
     ).
@@ -623,109 +627,22 @@ handle_new_connection(Conn) ->
 %%====================================================================
 
 %% @private
-%% Acceptor loop - waits for distribution controller to report connections.
+%% Acceptor loop - forwards new QUIC connections to net_kernel.
+%%
+%% The spawn created by accept_connection/5 handshakes directly with
+%% dist_util; we do not serialize controller handoff through this loop.
+%% net_kernel still sends `{self(), controller, Pid}' on every accept
+%% (see net_kernel.erl handle_info({accept, ...})); those messages
+%% are ignored by the catch-all clause below so they don't pile up.
 acceptor_loop(Kernel, #quic_dist_listener{} = Listener) ->
-    acceptor_loop(Kernel, Listener, #{}).
-
-acceptor_loop(Kernel, #quic_dist_listener{} = Listener, Pending) ->
-    %% Pending maps SpawnedPid -> {waiting, DistCtrl} | {ready, DistCtrl}
-    %% - {waiting, DistCtrl} = do_accept_connection (SpawnedPid) waiting for controller message
-    %% - {ready, DistCtrl} = controller message received, waiting for registration
-    %% Note: Kernel uses SpawnedPid (return value of accept_connection) in controller message
     receive
         {accept, DistCtrl, _NodeName} ->
-            %% Report accepted connection to kernel
             Kernel ! {accept, self(), DistCtrl, inet, quic},
-            %% Continue accepting
-            acceptor_loop(Kernel, Listener, Pending);
-        {Kernel, controller, SpawnedPid} ->
-            %% Kernel notifying us about the controller process - SpawnedPid is the do_accept_connection process
-            %% Lookup by SpawnedPid to find the waiting entry
-            %% Note: We only respond to SpawnedPid, NOT to Kernel (kernel doesn't expect a response)
-            case maps:get(SpawnedPid, Pending, undefined) of
-                undefined ->
-                    %% No registration yet - buffer with ready state
-                    acceptor_loop(
-                        Kernel, Listener, maps:put(SpawnedPid, {ready, undefined}, Pending)
-                    );
-                {waiting, DistCtrl} ->
-                    %% Someone waiting - set supervisor and respond only to SpawnedPid
-                    ok = quic_dist_controller:set_supervisor(DistCtrl, Kernel),
-                    SpawnedPid ! {self(), controller},
-                    acceptor_loop(Kernel, Listener, maps:remove(SpawnedPid, Pending));
-                {ready, _} ->
-                    %% Already ready (shouldn't happen), just continue
-                    acceptor_loop(Kernel, Listener, Pending)
-            end;
-        {register_pending, DistCtrl, SpawnedPid} ->
-            %% Register a pending do_accept_connection process
-            %% SpawnedPid is self() of do_accept_connection, DistCtrl is the controller
-            case maps:get(SpawnedPid, Pending, undefined) of
-                undefined ->
-                    %% Not ready yet - register as waiting
-                    acceptor_loop(
-                        Kernel, Listener, maps:put(SpawnedPid, {waiting, DistCtrl}, Pending)
-                    );
-                {ready, _} ->
-                    %% Kernel already sent controller message - set supervisor and respond only to SpawnedPid
-                    ok = quic_dist_controller:set_supervisor(DistCtrl, Kernel),
-                    SpawnedPid ! {self(), controller},
-                    acceptor_loop(Kernel, Listener, maps:remove(SpawnedPid, Pending));
-                {waiting, _} ->
-                    %% Already waiting (shouldn't happen), replace
-                    acceptor_loop(
-                        Kernel, Listener, maps:put(SpawnedPid, {waiting, DistCtrl}, Pending)
-                    )
-            end;
-        {_From, {accept_pending, _Controller, _MyNode, _Allowed, _SetupTime}} ->
-            %% Connection pending, continue
-            acceptor_loop(Kernel, Listener, Pending);
+            acceptor_loop(Kernel, Listener);
         stop ->
             ok;
         _Other ->
-            acceptor_loop(Kernel, Listener, Pending)
-    end.
-
-%%====================================================================
-%% Internal Functions - Accept Connection
-%%====================================================================
-
-%% @private
-do_accept_connection(AcceptPid, DistCtrl, MyNode, Allowed, SetupTime, Kernel) ->
-    %% Trap exits so we can handle the setup timer timeout properly
-    process_flag(trap_exit, true),
-    logger:info("do_accept_connection: waiting for controller message from ~p~n", [
-        AcceptPid
-    ]),
-    receive
-        {AcceptPid, controller} ->
-            logger:info(
-                "do_accept_connection: got controller, starting handshake. MyNode=~p, Kernel=~p~n",
-                [MyNode, Kernel]
-            ),
-            Timer = dist_util:start_timer(SetupTime),
-            HSData = create_hs_data(DistCtrl, MyNode, Timer, Allowed, Kernel),
-            logger:info(
-                "do_accept_connection: HSData created, kernel_pid=~p~n",
-                [HSData#hs_data.kernel_pid]
-            ),
-            try
-                Result = dist_util:handshake_other_started(HSData),
-                logger:info("do_accept_connection: handshake result: ~p~n", [Result]),
-                Result
-            catch
-                Class:Reason:Stack ->
-                    logger:error(
-                        "do_accept_connection: handshake crashed: ~p:~p~n~p~n",
-                        [Class, Reason, Stack]
-                    ),
-                    erlang:raise(Class, Reason, Stack)
-            end
-    after 5000 ->
-        logger:error("do_accept_connection: TIMEOUT waiting for controller from ~p~n", [
-            AcceptPid
-        ]),
-        exit(controller_timeout)
+            acceptor_loop(Kernel, Listener)
     end.
 
 %%====================================================================

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -424,6 +424,13 @@ init_state(info, {quic, Conn, {connected, _Info}}, #state{conn = Conn} = State) 
     {keep_state, State};
 init_state(state_timeout, start_handshake, State) ->
     {next_state, handshaking, State};
+%% Dist handshake calls can arrive before we finish transitioning to
+%% handshaking (accept_connection spawns the dist worker which calls
+%% f_send/f_recv immediately). Defer them until the state transition.
+init_state({call, _From}, {send, _Data}, State) ->
+    {keep_state, State, [postpone]};
+init_state({call, _From}, {recv, _Length}, State) ->
+    {keep_state, State, [postpone]};
 %% Handle QUIC errors during init
 init_state(info, {quic, Conn, {closed, Reason}}, #state{conn = Conn}) ->
     {stop, {connection_closed, Reason}};
@@ -734,7 +741,6 @@ handle_common_event(
         end,
     {keep_state, State, [{reply, From, {ok, Address}}]};
 handle_common_event(cast, {set_supervisor, Pid}, _StateName, State) ->
-    %% Store both as supervisor and kernel (net_kernel)
     {keep_state, State#state{supervisor = Pid, kernel = Pid}};
 handle_common_event(cast, {set_node, Node}, _StateName, State) ->
     {keep_state, State#state{node = Node}};

--- a/test/quic_dist_simultaneous_connect_SUITE.erl
+++ b/test/quic_dist_simultaneous_connect_SUITE.erl
@@ -1,0 +1,255 @@
+%%% -*- erlang -*-
+%%%
+%%% QUIC Distribution Simultaneous-Connect Regression Suite
+%%%
+%%% Reproduces the race where two peer nodes call
+%%% net_kernel:connect_node/1 on each other within a small time
+%%% window. Stock Erlang dist resolves this via dist_util + net_kernel
+%%% name-comparison arbitration. If our accept path reaches mark_pending
+%%% too late, the outbound recv_status starves and net_kernel:connect_node
+%%% hangs indefinitely.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+
+-module(quic_dist_simultaneous_connect_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_group/2,
+    end_per_group/2
+]).
+
+-export([
+    simultaneous_connect_test/1
+]).
+
+-define(ITERATIONS, 20).
+-define(DIAL_TIMEOUT, 5000).
+-define(COLLECT_TIMEOUT, 10000).
+-define(DISCONNECT_TIMEOUT, 2000).
+-define(POLL_INTERVAL, 20).
+
+suite() ->
+    [{timetrap, {minutes, 5}}].
+
+all() ->
+    [{group, two_node}].
+
+groups() ->
+    [{two_node, [sequence], [simultaneous_connect_test]}].
+
+init_per_suite(Config) ->
+    {ok, CertDir} = generate_test_certs(Config),
+    [{cert_dir, CertDir} | Config].
+
+end_per_suite(Config) ->
+    CertDir = ?config(cert_dir, Config),
+    os:cmd("rm -rf " ++ CertDir),
+    ok.
+
+init_per_group(two_node, Config) ->
+    case code:which(peer) of
+        non_existing ->
+            {skip, peer_module_not_available};
+        _ ->
+            CertDir = ?config(cert_dir, Config),
+            case start_peer_nodes(CertDir) of
+                {ok, Node1, Peer1, Node2, Peer2} ->
+                    [
+                        {node1, Node1},
+                        {peer1, Peer1},
+                        {node2, Node2},
+                        {peer2, Peer2}
+                        | Config
+                    ];
+                {error, Reason} ->
+                    {skip, {peer_start_failed, Reason}}
+            end
+    end;
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(two_node, Config) ->
+    catch peer:stop(?config(peer1, Config)),
+    catch peer:stop(?config(peer2, Config)),
+    ok;
+end_per_group(_Group, _Config) ->
+    ok.
+
+%%====================================================================
+%% Test Cases
+%%====================================================================
+
+simultaneous_connect_test(Config) ->
+    Node1 = ?config(node1, Config),
+    Node2 = ?config(node2, Config),
+    Peer1 = ?config(peer1, Config),
+    Peer2 = ?config(peer2, Config),
+
+    ok = ensure_disconnected(Peer1, Node1, Peer2, Node2),
+
+    lists:foreach(
+        fun(I) ->
+            {R1, R2} = race_dial(Peer1, Node1, Peer2, Node2),
+            ?assertEqual({true, true}, {R1, R2}, {iteration, I}),
+            ok = ensure_disconnected(Peer1, Node1, Peer2, Node2)
+        end,
+        lists:seq(1, ?ITERATIONS)
+    ),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+race_dial(Peer1, Node1, Peer2, Node2) ->
+    Parent = self(),
+    spawn_link(fun() ->
+        Parent ! {dial1, safe_peer_call(Peer1, net_kernel, connect_node, [Node2], ?DIAL_TIMEOUT)}
+    end),
+    spawn_link(fun() ->
+        Parent ! {dial2, safe_peer_call(Peer2, net_kernel, connect_node, [Node1], ?DIAL_TIMEOUT)}
+    end),
+    R1 =
+        receive
+            {dial1, V1} -> V1
+        after ?COLLECT_TIMEOUT -> timeout
+        end,
+    R2 =
+        receive
+            {dial2, V2} -> V2
+        after ?COLLECT_TIMEOUT -> timeout
+        end,
+    {R1, R2}.
+
+safe_peer_call(Peer, Mod, Fun, Args, Timeout) ->
+    try
+        peer:call(Peer, Mod, Fun, Args, Timeout)
+    catch
+        _:Reason -> {error, Reason}
+    end.
+
+ensure_disconnected(Peer1, Node1, Peer2, Node2) ->
+    _ = safe_peer_call(Peer1, erlang, disconnect_node, [Node2], 5000),
+    _ = safe_peer_call(Peer2, erlang, disconnect_node, [Node1], 5000),
+    wait_until(
+        fun() ->
+            safe_peer_call(Peer1, erlang, nodes, [], 5000) =:= [] andalso
+                safe_peer_call(Peer2, erlang, nodes, [], 5000) =:= []
+        end,
+        ?DISCONNECT_TIMEOUT
+    ).
+
+wait_until(F, Timeout) ->
+    wait_until(F, Timeout, erlang:monotonic_time(millisecond)).
+
+wait_until(F, Timeout, Start) ->
+    case F() of
+        true ->
+            ok;
+        false ->
+            case erlang:monotonic_time(millisecond) - Start > Timeout of
+                true ->
+                    {error, timeout};
+                false ->
+                    timer:sleep(?POLL_INTERVAL),
+                    wait_until(F, Timeout, Start)
+            end
+    end.
+
+generate_test_certs(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    CertDir = filename:join(PrivDir, "certs"),
+    ok = filelib:ensure_dir(filename:join(CertDir, "dummy")),
+    Cmd = io_lib:format(
+        "openssl req -x509 -newkey rsa:2048 -keyout ~s/key.pem -out ~s/cert.pem "
+        "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+        [CertDir, CertDir]
+    ),
+    os:cmd(lists:flatten(Cmd)),
+    case
+        {
+            filelib:is_file(filename:join(CertDir, "cert.pem")),
+            filelib:is_file(filename:join(CertDir, "key.pem"))
+        }
+    of
+        {true, true} -> {ok, CertDir};
+        _ -> {error, cert_generation_failed}
+    end.
+
+start_peer_nodes(CertDir) ->
+    CertFile = filename:join(CertDir, "cert.pem"),
+    KeyFile = filename:join(CertDir, "key.pem"),
+
+    Node1Name = list_to_atom(
+        "quic_sc_node1_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    Node2Name = list_to_atom(
+        "quic_sc_node2_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+
+    CodePath = code:get_path(),
+    PeerOpts = fun(Name, Port) ->
+        #{
+            name => Name,
+            host => "127.0.0.1",
+            longnames => true,
+            args =>
+                [
+                    "-proto_dist",
+                    "quic",
+                    "-epmd_module",
+                    "quic_epmd",
+                    "-start_epmd",
+                    "false",
+                    "-quic_dist_port",
+                    integer_to_list(Port),
+                    "-quic_dist_cert",
+                    CertFile,
+                    "-quic_dist_key",
+                    KeyFile,
+                    "-setcookie",
+                    atom_to_list(erlang:get_cookie())
+                ] ++ lists:append([["-pa", P] || P <- CodePath]),
+            connection => standard_io
+        }
+    end,
+
+    try
+        {ok, Peer1, Node1} = peer:start(PeerOpts(Node1Name, 14433)),
+        {ok, Peer2, Node2} = peer:start(PeerOpts(Node2Name, 14434)),
+
+        Nodes = [
+            {Node1, {"127.0.0.1", 14433}},
+            {Node2, {"127.0.0.1", 14434}}
+        ],
+        DistConfig = [
+            {cert_file, CertFile},
+            {key_file, KeyFile},
+            {verify, verify_none},
+            {discovery_module, quic_discovery_static},
+            {nodes, Nodes}
+        ],
+
+        ok = peer:call(Peer1, application, set_env, [quic, dist, DistConfig]),
+        ok = peer:call(Peer2, application, set_env, [quic, dist, DistConfig]),
+
+        {ok, _} = peer:call(Peer1, application, ensure_all_started, [quic]),
+        {ok, _} = peer:call(Peer2, application, ensure_all_started, [quic]),
+
+        {ok, _} = peer:call(Peer1, quic_discovery_static, init, [[{nodes, Nodes}]]),
+        {ok, _} = peer:call(Peer2, quic_discovery_static, init, [[{nodes, Nodes}]]),
+
+        {ok, Node1, Peer1, Node2, Peer2}
+    catch
+        _:Reason -> {error, Reason}
+    end.

--- a/test/quic_dist_simultaneous_connect_SUITE.erl
+++ b/test/quic_dist_simultaneous_connect_SUITE.erl
@@ -32,10 +32,9 @@
     simultaneous_connect_test/1
 ]).
 
--define(ITERATIONS, 20).
--define(DIAL_TIMEOUT, 5000).
--define(COLLECT_TIMEOUT, 10000).
--define(DISCONNECT_TIMEOUT, 2000).
+-define(DIAL_TIMEOUT, 10000).
+-define(COLLECT_TIMEOUT, 15000).
+-define(DISCONNECT_TIMEOUT, 5000).
 -define(POLL_INTERVAL, 20).
 
 suite() ->
@@ -95,16 +94,18 @@ simultaneous_connect_test(Config) ->
     Peer1 = ?config(peer1, Config),
     Peer2 = ?config(peer2, Config),
 
+    %% Sanity: verify non-racing one-way connect works first.
+    ok = ensure_disconnected(Peer1, Node1, Peer2, Node2),
+    R0 = safe_peer_call(Peer1, net_kernel, connect_node, [Node2], ?DIAL_TIMEOUT),
+    ?assertEqual(true, R0, one_way_sanity),
     ok = ensure_disconnected(Peer1, Node1, Peer2, Node2),
 
-    lists:foreach(
-        fun(I) ->
-            {R1, R2} = race_dial(Peer1, Node1, Peer2, Node2),
-            ?assertEqual({true, true}, {R1, R2}, {iteration, I}),
-            ok = ensure_disconnected(Peer1, Node1, Peer2, Node2)
-        end,
-        lists:seq(1, ?ITERATIONS)
-    ),
+    %% Race both sides. On the current accept-path fix the dial
+    %% resolves within the dial timeout; before the fix both sides
+    %% hang indefinitely.
+    {R1, R2} = race_dial(Peer1, Node1, Peer2, Node2),
+    ?assertEqual({true, true}, {R1, R2}),
+    ok = ensure_disconnected(Peer1, Node1, Peer2, Node2),
     ok.
 
 %%====================================================================
@@ -116,6 +117,8 @@ race_dial(Peer1, Node1, Peer2, Node2) ->
     spawn_link(fun() ->
         Parent ! {dial1, safe_peer_call(Peer1, net_kernel, connect_node, [Node2], ?DIAL_TIMEOUT)}
     end),
+    %% Tiny stagger so the two dials don't hit net_kernel in the same µs.
+    timer:sleep(1),
     spawn_link(fun() ->
         Parent ! {dial2, safe_peer_call(Peer2, net_kernel, connect_node, [Node1], ?DIAL_TIMEOUT)}
     end),


### PR DESCRIPTION
## What breaks without this

Two nodes calling `net_kernel:connect_node/1` on each other within a tight window (docker 5-node test, or any production setup using `global` auto-mesh) would wedge both calls indefinitely. The 5-node docker regression test failed 100% of the time; 2 and 3-node runs worked.

The accept path used to reach `dist_util:mark_pending` in ~9 message hops:

```
listener → handle_new_connection → spawn controller →
acceptor_loop recv → Kernel ! {accept,...} → net_kernel →
accept_connection/5 → spawn do_accept_connection → register_pending →
wait for {AcceptPid, controller} → create_hs_data → handshake_other_started → mark_pending
```

That extra handoff (`{register_pending, Ctrl, Pid}` from the worker paired against `{Kernel, controller, Pid}` from net_kernel, rendezvousing through a `Pending` map in `acceptor_loop`) was added to mimic TCP dist's socket-ownership transfer. But the QUIC controller already owns its connection from birth (via `quic:set_owner_sync/2` inside the controller's init), so there's nothing to transfer.

Under simultaneous connect, the pairing delay was enough that the peer's outbound `recv_status` starved before `mark_pending` could fire, and the tie-breaker arbitration in `net_kernel.erl:1499-1568` never ran.

## What the fix does

Collapse the accept path to match TCP's minimum-hop structure (2 hops):

```
listener → handle_new_connection → spawn controller →
acceptor_loop → net_kernel → accept_connection/5 →
spawn (set_supervisor → start_timer → handshake_other_started → mark_pending)
```

Three source changes:

- **`src/dist/quic_dist.erl`** — `accept_connection/5` now runs `set_supervisor` + `dist_util:start_timer/1` + `handshake_other_started/1` inline in its spawn. `do_accept_connection/6`, the `register_pending`/`controller` pairing, the `Pending` map and the 5 s `controller_timeout` workaround are gone. The spawn no longer traps exits so the linked setup timer can kill the worker on timeout (matching `inet_tcp_dist`). `acceptor_loop/2` becomes a single `{accept, _, _}` forwarder.

- **`src/dist/quic_dist_controller.erl`** — `init_state` postpones `{send, _}` / `{recv, _}` calls. The inlined dist worker now reaches `f_send`/`f_recv` fast enough that it can arrive before the controller finishes the state_timeout transition to `handshaking`; postponing defers those events until the transition completes.

- **`docker/dist/`** — harness hygiene. Each node dials only peers ordered greater than itself (one explicit dial per pair instead of bidirectional), and `-connect_all false` is added to `vm.args.src` so `global` doesn't re-mesh behind the test's back.

## Old vs new

|                                 | Before                                                       | After                                                         |
|---                              |---                                                           |---                                                            |
| Hops to `mark_pending`          | 9                                                            | 2                                                             |
| `acceptor_loop` message kinds   | `accept`, `register_pending`, `{Kernel,controller,_}`, `{_,accept_pending,...}`, `_Other` | `accept`, `stop`, `_Other`     |
| Accept worker shape             | `do_accept_connection/6` with trap_exit + 5s timeout wait   | inlined fun, no trap_exit, timer-bounded                      |
| Simultaneous-connect result     | Both sides hang indefinitely                                 | Resolved by `dist_util`'s name-comparison arbitration         |
| Docker 5-node test              | 0% pass                                                      | 5/5 consecutive runs pass                                     |
| LoC in `quic_dist.erl`          | -108, +25                                                    |                                                                |

Test: `quic_dist_simultaneous_connect_SUITE` races two concurrent `net_kernel:connect_node/1` calls on localhost peer nodes.