### PR TITLE
test(h3): vendor h3spec runner image locally

### DIFF
--- a/docker/h3spec/Dockerfile
+++ b/docker/h3spec/Dockerfile
@@ -1,0 +1,27 @@
+# h3spec runner image
+#
+# Packages the prebuilt h3spec-linux-x86_64 binary from
+# https://github.com/kazu-yamamoto/h3spec/releases into a minimal
+# Debian image so the HTTP/3 conformance CT suite can run without
+# depending on an external registry.
+#
+# Build locally:
+#   docker build -t erlang_quic/h3spec:local docker/h3spec
+#
+FROM --platform=linux/amd64 debian:bookworm-slim
+
+ARG H3SPEC_VERSION=v0.1.13
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libgmp10 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL \
+        "https://github.com/kazu-yamamoto/h3spec/releases/download/${H3SPEC_VERSION}/h3spec-linux-x86_64" \
+        -o /usr/local/bin/h3spec \
+ && chmod +x /usr/local/bin/h3spec
+
+ENTRYPOINT ["/usr/local/bin/h3spec"]

--- a/test/quic_h3_h3spec_SUITE.erl
+++ b/test/quic_h3_h3spec_SUITE.erl
@@ -209,62 +209,59 @@ echo_handler(Conn, StreamId, Method, Path, Headers) ->
 
 %% @doc Run h3spec via Docker
 run_h3spec(Port, _Config) ->
-    %% Build docker command
-    %% h3spec tests against localhost with insecure mode
+    ok = ensure_h3spec_image(),
     Cmd = lists:flatten(
         io_lib:format(
             "docker run --rm --network host "
-            "ghcr.io/kazu-yamamoto/h3spec:latest "
-            "h3spec -h 127.0.0.1 -p ~p --insecure 2>&1",
+            "erlang_quic/h3spec:local "
+            "127.0.0.1 ~p -n 2>&1",
             [Port]
         )
     ),
-
     ct:pal("Running: ~s", [Cmd]),
-
-    %% Execute with timeout
     Output = os:cmd(Cmd),
     ct:pal("h3spec output:~n~s", [Output]),
-
-    %% Parse output for results
-    %% h3spec outputs: "X examples, Y failures"
     case parse_h3spec_output(Output) of
         {ok, Examples, 0} ->
             ct:pal("h3spec passed: ~p examples, 0 failures", [Examples]),
             ok;
         {ok, Examples, Failures} ->
-            %% For now, log failures but don't fail the test
-            %% as we may not implement all h3spec requirements yet
             ct:pal("h3spec: ~p examples, ~p failures", [Examples, Failures]),
             case Failures > Examples div 2 of
-                true ->
-                    %% Fail if more than 50% failures
-                    ct:fail({h3spec_failures, Failures, Examples});
-                false ->
-                    %% Log warning but continue
-                    ct:pal("WARNING: ~p h3spec failures (acceptable for now)", [Failures]),
-                    ok
-            end;
-        {error, docker_not_found} ->
-            %% Docker image not found, try to pull it
-            ct:pal("h3spec image not found, attempting to pull..."),
-            os:cmd("docker pull ghcr.io/kazu-yamamoto/h3spec:latest"),
-            %% Retry once
-            Output2 = os:cmd(Cmd),
-            ct:pal("h3spec output (retry):~n~s", [Output2]),
-            case parse_h3spec_output(Output2) of
-                {ok, Ex, 0} ->
-                    ct:pal("h3spec passed: ~p examples, 0 failures", [Ex]),
-                    ok;
-                {ok, Ex, Fail} ->
-                    ct:pal("h3spec: ~p examples, ~p failures", [Ex, Fail]),
-                    % Don't fail on retry
-                    ok;
-                {error, Reason} ->
-                    ct:fail({h3spec_error, Reason})
+                true -> ct:fail({h3spec_failures, Failures, Examples});
+                false -> ok
             end;
         {error, Reason} ->
             ct:fail({h3spec_error, Reason})
+    end.
+
+%% @doc Build erlang_quic/h3spec:local from docker/h3spec if it is not
+%% already present. The h3spec binary is vendored via the Dockerfile so
+%% this is a one-time build per host.
+ensure_h3spec_image() ->
+    case os:cmd("docker image inspect erlang_quic/h3spec:local > /dev/null 2>&1; echo $?") of
+        "0\n" ->
+            ok;
+        _ ->
+            ct:pal("Building erlang_quic/h3spec:local ..."),
+            Out = os:cmd(
+                "docker build --platform linux/amd64 "
+                "-t erlang_quic/h3spec:local docker/h3spec 2>&1"
+            ),
+            ct:pal("h3spec build output:~n~s", [Out]),
+            case re:run(Out, "^Successfully tagged|writing image", [multiline]) of
+                {match, _} ->
+                    ok;
+                nomatch ->
+                    case
+                        os:cmd(
+                            "docker image inspect erlang_quic/h3spec:local > /dev/null 2>&1; echo $?"
+                        )
+                    of
+                        "0\n" -> ok;
+                        _ -> ct:fail({h3spec_build_failed, Out})
+                    end
+            end
     end.
 
 %% @doc Parse h3spec output to extract results


### PR DESCRIPTION
The external \`ghcr.io/kazu-yamamoto/h3spec:latest\` image is access-denied, which silently skipped \`quic_h3_h3spec_SUITE\`. This vendors a local Dockerfile that packages the prebuilt \`h3spec-linux-x86_64\` v0.1.13 binary so the suite can build its own runner on first run and no longer depends on an external registry.

Also fixes the suite's CLI invocation - the current h3spec binary takes \`<host> <port> -n\` (no-validate), not the older \`-h/-p/--insecure\` flags.

With the image available the suite now runs end-to-end and reports a real conformance score (49 examples). This PR does not change the pass/fail threshold; actual h3spec conformance work is a separate track.