### PR TITLE
chore(docs): unblock ex_doc and refresh 1.2.0 pins

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@ Add to your `rebar.config`:
 
 ```erlang
 {deps, [
-    {quic, {git, "https://github.com/benoitc/erlang_quic.git", {tag, "0.11.0"}}}
+    {quic, {git, "https://github.com/benoitc/erlang_quic.git", {tag, "1.2.0"}}}
 ]}.
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -13,7 +13,7 @@ Add erlang_quic to your `rebar.config` dependencies:
 
 ```erlang
 {deps, [
-    {quic, {git, "https://github.com/benoitc/erlang_quic.git", {tag, "0.11.0"}}}
+    {quic, {git, "https://github.com/benoitc/erlang_quic.git", {tag, "1.2.0"}}}
 ]}.
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -127,7 +127,8 @@
         {<<"QPACK">>, [
             quic_qpack,
             quic_qpack_huffman
-        ]}
+        ]},
+        {<<"Load Balancer">>, [quic_lb]}
     ]}
 ]}.
 

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -1335,23 +1335,20 @@ input_handler_loop(DHandle, Controller, Conn, ControlStream, Buffer, Deliver) ->
 
 %% @private
 %% Deliver complete messages to the VM with batch limiting.
-%% We use 4-byte length-prefixed framing: <<Length:32/big, Payload:Length/binary>>
-%% The payload (WITHOUT length header) is passed to dist_ctrl_put_data.
+%% 4-byte length-prefixed framing: <<Length:32/big, Payload:Length/binary>>.
+%% The payload (without the length header) is passed to the Deliver fn.
 %% Empty frames (Length=0) are tick signals - no payload to deliver.
-%% Returns {ok, RemainingBuffer} or {error, Reason}
+%% The unprocessed remnant comes back via `{ok, RemainingBuffer}'; the
+%% yield signal is a tag-only `continue_delivery' atom so the buffer
+%% cannot race against an incoming `{dist_data, _}' message.
 -ifdef(TEST).
-%% Test-only convenience: exercised by
+%% Test-only /3 convenience, exercised by
 %% `quic_dist_controller_tests:deliver_yield_returns_remainder_test/0'.
 %% Production code calls the /4 arity directly.
 deliver_complete_messages(DHandle, Buffer, Remaining) ->
     deliver_complete_messages(DHandle, Buffer, Remaining, fun erlang:dist_ctrl_put_data/2).
 -endif.
 
-%% @private
-%% Deliver complete messages with batch limit to prevent blocking.
-%% The unprocessed remnant comes back via `{ok, RemainingBuffer}`; the
-%% yield signal is a tag-only `continue_delivery' atom so the buffer
-%% cannot race against an incoming `{dist_data, _}' message.
 deliver_complete_messages(_DHandle, Buffer, 0, _Deliver) ->
     self() ! continue_delivery,
     {ok, Buffer};


### PR DESCRIPTION
- `rebar3 ex_doc` was exiting non-zero on a duplicate `@private` tag around `deliver_complete_messages/3` vs `/4` in `quic_dist_controller`. Collapsed the two `%% @private` blocks into one above the `-ifdef(TEST)` so edoc attaches a single tag. Build now exits clean with no warnings.
- Bumped the dep snippet in GETTING_STARTED and DEVELOPER_GUIDE from `0.11.0` to `1.2.0`.
- Added `quic_lb` to the ex_doc `groups_for_modules` under a new "Load Balancer" group so it no longer lands in the catch-all sidebar.