### PR TITLE
fix(stream): RESET_STREAM keeps recv side open (#113)

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -6995,21 +6995,27 @@ send_pending_data([{StreamId, Data, Fin} | Rest], State) ->
             send_pending_data(Rest, State)
     end.
 
-%% Close a stream
+%% Send RESET_STREAM (RFC 9000 §3.2): closes the SEND direction only.
+%% The recv side stays alive so the caller can still issue
+%% stop_sending and receive frames from the peer until the peer
+%% closes its own send side. Drop the stream from the map only when
+%% both directions are terminated.
 do_close_stream(StreamId, ErrorCode, #state{streams = Streams} = State) ->
     case maps:find(StreamId, Streams) of
         {ok, StreamState} ->
-            %% Cancel deadline timer if any
             case StreamState#stream_state.deadline_timer of
                 undefined -> ok;
                 Timer -> erlang:cancel_timer(Timer)
             end,
-            %% Send RESET_STREAM frame
             FinalSize = StreamState#stream_state.send_offset,
             ResetFrame = {reset_stream, StreamId, ErrorCode, FinalSize},
             NewState = send_frame(ResetFrame, State),
+            UpdatedStream = StreamState#stream_state{
+                state = reset,
+                deadline_timer = undefined
+            },
             {ok, NewState#state{
-                streams = maps:remove(StreamId, Streams)
+                streams = maps:put(StreamId, UpdatedStream, Streams)
             }};
         error ->
             {error, unknown_stream}

--- a/test/quic_reset_stream_tests.erl
+++ b/test/quic_reset_stream_tests.erl
@@ -1,0 +1,66 @@
+%%% -*- erlang -*-
+%%%
+%%% Regression test for issue #113.
+%%%
+%%% RFC 9000 §3.2 / §19.4: RESET_STREAM closes the SEND direction
+%%% only. The recv side stays alive until the peer sends FIN or our
+%%% local end issues STOP_SENDING. Calling
+%%% `quic:reset_stream/3` followed by `quic:stop_sending/3' must
+%%% therefore still emit STOP_SENDING — the stream entry must not be
+%%% dropped after RESET_STREAM.
+
+-module(quic_reset_stream_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+reset_then_stop_sending_both_succeed_test_() ->
+    %% This is an integration test against the in-process echo server,
+    %% so wrap in a fixture to bound runtime.
+    {timeout, 10, fun reset_then_stop_sending_both_succeed/0}.
+
+reset_then_stop_sending_both_succeed() ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    Port = maps:get(port, Echo),
+    try
+        Opts = maps:merge(quic_test_echo_server:client_opts(), #{alpn => [<<"echo">>]}),
+        {ok, ConnRef} = quic:connect("127.0.0.1", Port, Opts, self()),
+        ok = wait_connected(ConnRef, 5000),
+        {ok, StreamId} = quic:open_stream(ConnRef),
+        ok = quic:send_data(ConnRef, StreamId, <<"hi">>, false),
+        %% Issue #113: reset_stream must not drop the stream entry.
+        %% stop_sending called after reset_stream MUST succeed (return
+        %% `ok`), not `{error, unknown_stream}'.
+        ok = quic:reset_stream(ConnRef, StreamId, 16#10),
+        ?assertEqual(ok, quic:stop_sending(ConnRef, StreamId, 16#10)),
+        quic:close(ConnRef, normal)
+    after
+        quic_test_echo_server:stop(Echo)
+    end.
+
+%% Reverse order — STOP_SENDING then RESET_STREAM — works on the
+%% existing code; assert it stays green.
+stop_sending_then_reset_both_succeed_test_() ->
+    {timeout, 10, fun stop_sending_then_reset_both_succeed/0}.
+
+stop_sending_then_reset_both_succeed() ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    Port = maps:get(port, Echo),
+    try
+        Opts = maps:merge(quic_test_echo_server:client_opts(), #{alpn => [<<"echo">>]}),
+        {ok, ConnRef} = quic:connect("127.0.0.1", Port, Opts, self()),
+        ok = wait_connected(ConnRef, 5000),
+        {ok, StreamId} = quic:open_stream(ConnRef),
+        ok = quic:send_data(ConnRef, StreamId, <<"hi">>, false),
+        ok = quic:stop_sending(ConnRef, StreamId, 16#10),
+        ?assertEqual(ok, quic:reset_stream(ConnRef, StreamId, 16#10)),
+        quic:close(ConnRef, normal)
+    after
+        quic_test_echo_server:stop(Echo)
+    end.
+
+wait_connected(ConnRef, Timeout) ->
+    receive
+        {quic, ConnRef, {connected, _}} -> ok
+    after Timeout ->
+        {error, timeout}
+    end.


### PR DESCRIPTION
RFC 9000 §3.2: RESET_STREAM closes only the SEND direction. The
outbound path was removing the stream from the streams map after
sending the frame, so a subsequent \`quic:stop_sending/3' returned
\`{error, unknown_stream}' and never emitted STOP_SENDING.

Mirror what we already do on the inbound RESET_STREAM path: keep the
stream entry and transition its state to \`reset'. STOP_SENDING (and
any other recv-side operation) can then run normally.

Regression test in \`quic_reset_stream_tests' reproduces the bug
against the in-process echo server: pre-fix the second call returns
\`{error, unknown_stream}'; post-fix it returns \`ok'. The reverse
order (\`stop_sending' then \`reset_stream') already worked and stays
green.

Closes #113.