### PR TITLE
chore: include README sponsor logo in hex package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,12 @@
     {erlfmt, "~> 1.7"}
 ]}.
 
-{hex, [{doc, ex_doc}]}.
+{hex, [
+    {doc, ex_doc},
+    %% Ship README-referenced assets so the rendered Hex.pm page does
+    %% not show a broken image.
+    {include_files, ["docs/images/enki-multimedia.svg"]}
+]}.
 
 {ex_doc, [
     {source_url, <<"https://github.com/benoitc/erlang_quic">>},


### PR DESCRIPTION
Adds `docs/images/enki-multimedia.svg` to the Hex `include_files` list so the README image ships with the package and renders correctly on Hex.pm.