### PR TITLE
feat: add adapter socket backend for callback-based datagram transport

### DIFF
--- a/src/quic.erl
+++ b/src/quic.erl
@@ -157,6 +157,13 @@ get_fd(Socket) ->
 %% <ul>
 %%   <li>`socket' - Use an existing UDP socket (gen_udp:socket())</li>
 %%   <li>`extra_socket_opts' - Options for socket creation (e.g., [{ip, Addr}])</li>
+%%   <li>`socket_backend' - `gen_udp' (default), `socket' (OTP NIF) or
+%%       `adapter' (caller-supplied datagram callbacks)</li>
+%%   <li>`socket_adapter' - Required when `socket_backend = adapter'.
+%%       Map with `send_fun => fun((IP, Port, Packet) -> ok | {error,_})'
+%%       and optional `close_fun', `local'. Inbound packets must be
+%%       delivered to the owning connection as `{udp, Socket, IP, Port,
+%%       Data}' messages.</li>
 %%   <li>`verify' - Verify server certificate (default: false)</li>
 %%   <li>`alpn' - ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
 %%   <li>`server_name' - Server Name Indication (default: Host)</li>
@@ -191,14 +198,31 @@ connect(_Host, _Port, _Opts, _Owner) ->
     {error, badarg}.
 
 %% A pre-opened `socket' is always a gen_udp handle; requesting the
-%% OTP socket NIF backend at the same time cannot be honoured.
+%% OTP socket NIF backend or the callback adapter at the same time
+%% cannot be honoured.
 validate_connect_opts(Socket, Opts) when Socket =/= undefined ->
     case maps:get(socket_backend, Opts, gen_udp) of
-        socket -> {error, {incompatible_options, [socket, {socket_backend, socket}]}};
-        _ -> ok
+        socket  -> {error, {incompatible_options, [socket, {socket_backend, socket}]}};
+        adapter -> {error, {incompatible_options, [socket, {socket_backend, adapter}]}};
+        _       -> ok
     end;
-validate_connect_opts(undefined, _Opts) ->
-    ok.
+validate_connect_opts(undefined, Opts) ->
+    case maps:get(socket_backend, Opts, gen_udp) of
+        adapter ->
+            validate_adapter_opts(maps:get(socket_adapter, Opts, undefined));
+        _ ->
+            ok
+    end.
+
+validate_adapter_opts(undefined) ->
+    {error, missing_socket_adapter};
+validate_adapter_opts(A) when is_map(A) ->
+    case maps:get(send_fun, A, undefined) of
+        F when is_function(F, 3) -> ok;
+        _ -> {error, badarg_socket_adapter}
+    end;
+validate_adapter_opts(_) ->
+    {error, badarg_socket_adapter}.
 
 %% @doc Close a QUIC connection with normal reason.
 -spec close(Conn) -> ok when

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -202,9 +202,9 @@ connect(_Host, _Port, _Opts, _Owner) ->
 %% cannot be honoured.
 validate_connect_opts(Socket, Opts) when Socket =/= undefined ->
     case maps:get(socket_backend, Opts, gen_udp) of
-        socket  -> {error, {incompatible_options, [socket, {socket_backend, socket}]}};
+        socket -> {error, {incompatible_options, [socket, {socket_backend, socket}]}};
         adapter -> {error, {incompatible_options, [socket, {socket_backend, adapter}]}};
-        _       -> ok
+        _ -> ok
     end;
 validate_connect_opts(undefined, Opts) ->
     case maps:get(socket_backend, Opts, gen_udp) of

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -244,7 +244,7 @@
     %% the client uses the OTP socket NIF via open_for_send/2 and a
     %% dedicated receiver process forwards {udp, ...} messages to this
     %% connection. Ignored for server connections (the listener picks).
-    client_socket_backend = gen_udp :: gen_udp | socket,
+    client_socket_backend = gen_udp :: gen_udp | socket | adapter,
     %% Pid of the client-side receiver process when
     %% client_socket_backend = socket; undefined otherwise.
     client_receiver :: pid() | undefined,
@@ -1094,6 +1094,8 @@ open_client_socket(undefined, {IP, _Port} = RemoteAddr, Opts, ExtraOpts) ->
     case maps:get(socket_backend, Opts, gen_udp) of
         socket ->
             open_client_socket_backend(RemoteAddr, Opts);
+        adapter ->
+            open_client_socket_adapter(Opts);
         _ ->
             open_client_socket_genudp(IP, Opts, ExtraOpts)
     end;
@@ -1149,6 +1151,30 @@ open_client_socket_genudp(IP, Opts, ExtraOpts) ->
 %% cmsg on uniform batches. The wrapping `#socket_state{}' is stashed
 %% in the process dictionary for `init_client_state/8' to adopt without
 %% widening the tuple shape returned by `open_client_socket/4'.
+%% Caller-supplied datagram adapter. The connection delegates outbound
+%% sends to `send_fun' inside the adapter map; inbound packets must be
+%% delivered to the connection owner as `{udp, Socket, IP, Port, Data}'
+%% by the caller's recv loop, where `Socket' is the reference returned
+%% in the socket_state. Stash the socket_state via the process dict so
+%% `init_client_state/8' adopts it without changing return shapes.
+open_client_socket_adapter(Opts) ->
+    AdapterOpts = maps:get(socket_adapter, Opts, undefined),
+    case AdapterOpts of
+        undefined ->
+            {error, missing_socket_adapter};
+        _ when is_map(AdapterOpts) ->
+            case quic_socket:open_adapter(AdapterOpts) of
+                {ok, SocketState} ->
+                    {ok, LA} = quic_socket:sockname(SocketState),
+                    put(client_socket_state, SocketState),
+                    {ok, quic_socket:get_socket(SocketState), LA, true};
+                {error, _} = Err ->
+                    Err
+            end;
+        _ ->
+            {error, badarg_socket_adapter}
+    end.
+
 open_client_socket_backend({IP, _Port}, Opts) ->
     OpenOpts = Opts#{backend => socket},
     case quic_socket:open_for_send(IP, OpenOpts) of
@@ -5428,6 +5454,10 @@ send_packet_to_addr(IP, Port, Packet, #state{socket = Socket}) ->
 %% `quic_socket:start_client_receiver/2'.
 client_rearm_active(#state{client_socket_backend = socket}, _N) ->
     ok;
+client_rearm_active(#state{client_socket_backend = adapter}, _N) ->
+    %% Adapter callers manage their own delivery; there is no UDP
+    %% socket whose active counter we could rearm.
+    ok;
 client_rearm_active(#state{socket = Socket}, N) ->
     inet:setopts(Socket, [{active, N}]).
 
@@ -5438,6 +5468,11 @@ client_rearm_active(#state{socket = Socket}, N) ->
 %% `gen_udp:socket()' — nothing else owns it.
 close_client_socket(#state{client_socket_backend = socket, client_receiver = Receiver}) ->
     quic_socket:stop_client_receiver(Receiver);
+close_client_socket(#state{client_socket_backend = adapter, socket_state = SocketState}) ->
+    case SocketState of
+        undefined -> ok;
+        _ -> quic_socket:close(SocketState)
+    end;
 close_client_socket(#state{socket = undefined}) ->
     ok;
 close_client_socket(#state{socket = Socket}) ->
@@ -5457,6 +5492,9 @@ close_raw_client_socket(Opts, Socket) ->
             catch
                 _:_ -> ok
             end;
+        adapter ->
+            %% Adapter holds its own callbacks; nothing native to close.
+            ok;
         _ ->
             try gen_udp:close(Socket) of
                 _ -> ok
@@ -7664,6 +7702,9 @@ set_idle_timer(#state{idle_timeout = Timeout, idle_timer = OldTimer} = State) ->
 %% socket handle ({'$socket', Ref}). inet:sockname/1 only accepts
 %% the gen_udp port shape, socket:sockname/1 the other. Returns
 %% undefined if neither succeeds.
+query_local_addr(Ref) when is_reference(Ref) ->
+    %% Adapter backend: no real socket, no kernel-known sockname.
+    undefined;
 query_local_addr({'$socket', _} = Socket) ->
     case socket:sockname(Socket) of
         {ok, #{addr := IP, port := Port}} -> {IP, Port};
@@ -8181,6 +8222,10 @@ rebind_socket(OldSocket) ->
 -spec rebind_client_socket(#state{}) -> {ok, #state{}} | {error, term()}.
 rebind_client_socket(#state{client_socket_backend = socket} = State) ->
     rebind_client_socket_otp(State);
+rebind_client_socket(#state{client_socket_backend = adapter}) ->
+    %% Connection migration via fresh local UDP port has no analogue
+    %% when the transport is a caller-supplied adapter.
+    {error, not_supported_on_adapter};
 rebind_client_socket(#state{socket = OldSocket, socket_state = OldSocketState} = State) ->
     %% Flush any pending batch to the old socket before rebinding so
     %% already-sequenced packets reach the server under the pre-migrate

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -82,9 +82,9 @@
     %% Inbound packets must be delivered as
     %%   `{udp, Socket, IP, Port, Data}' to the connection owner pid,
     %% same shape as the gen_udp backend.
-    adapter_send_fun :: undefined |
-                        fun((inet:ip_address(), inet:port_number(), iodata()) ->
-                            ok | {error, term()}),
+    adapter_send_fun ::
+        undefined
+        | fun((inet:ip_address(), inet:port_number(), iodata()) -> ok | {error, term()}),
     adapter_close_fun :: undefined | fun(() -> ok),
     %% Adapter-only: cached local address (sockname has no real socket).
     adapter_local :: undefined | {inet:ip_address(), inet:port_number()},
@@ -376,15 +376,15 @@ info(#socket_state{
 -spec open_adapter(map()) -> {ok, socket_state()} | {error, term()}.
 open_adapter(#{send_fun := SendFun} = Opts) when is_function(SendFun, 3) ->
     State = #socket_state{
-        socket             = maps:get(socket_ref, Opts, make_ref()),
-        backend            = adapter,
-        owns_socket        = true,
-        gso_supported      = false,
-        gro_enabled        = false,
-        batching_enabled   = false,
-        adapter_send_fun   = SendFun,
-        adapter_close_fun  = maps:get(close_fun, Opts, undefined),
-        adapter_local      = maps:get(local, Opts, undefined)
+        socket = maps:get(socket_ref, Opts, make_ref()),
+        backend = adapter,
+        owns_socket = true,
+        gso_supported = false,
+        gro_enabled = false,
+        batching_enabled = false,
+        adapter_send_fun = SendFun,
+        adapter_close_fun = maps:get(close_fun, Opts, undefined),
+        adapter_local = maps:get(local, Opts, undefined)
     },
     {ok, State};
 open_adapter(_) ->
@@ -446,8 +446,11 @@ new_sender(Socket, Opts) ->
 -spec close(socket_state()) -> ok.
 close(#socket_state{backend = adapter, adapter_close_fun = Fun}) ->
     case Fun of
-        undefined -> ok;
-        F when is_function(F, 0) -> _ = catch F(), ok
+        undefined ->
+            ok;
+        F when is_function(F, 0) ->
+            _ = catch F(),
+            ok
     end;
 close(#socket_state{owns_socket = false}) ->
     %% Don't close wrapped sockets - caller owns them
@@ -1046,7 +1049,9 @@ send_segments(Socket, Dest, [Packet | Rest], State) ->
         {error, Reason} -> {error, Reason, State}
     end.
 
-do_send_immediate(#socket_state{backend = adapter, adapter_send_fun = Fun} = State, IP, Port, Packet) ->
+do_send_immediate(
+    #socket_state{backend = adapter, adapter_send_fun = Fun} = State, IP, Port, Packet
+) ->
     Bin = normalize_packet(Packet),
     case Fun(IP, Port, Bin) of
         ok -> {ok, State};

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -41,6 +41,7 @@
     open/2,
     open_for_send/2,
     open_server_send/2,
+    open_adapter/1,
     wrap/2,
     new_sender/2,
     close/1,
@@ -71,10 +72,22 @@
 -define(UDP_GRO, 104).
 
 -record(socket_state, {
-    %% The underlying socket
-    socket :: socket:socket() | gen_udp:socket(),
+    %% The underlying socket. For the `adapter' backend this is an
+    %% opaque reference() used only for pattern matching against the
+    %% owning connection's #state.socket field.
+    socket :: socket:socket() | gen_udp:socket() | reference(),
     %% Which backend we're using
-    backend :: socket | gen_udp,
+    backend :: socket | gen_udp | adapter,
+    %% Adapter backend: caller-supplied datagram send and close callbacks.
+    %% Inbound packets must be delivered as
+    %%   `{udp, Socket, IP, Port, Data}' to the connection owner pid,
+    %% same shape as the gen_udp backend.
+    adapter_send_fun :: undefined |
+                        fun((inet:ip_address(), inet:port_number(), iodata()) ->
+                            ok | {error, term()}),
+    adapter_close_fun :: undefined | fun(() -> ok),
+    %% Adapter-only: cached local address (sockname has no real socket).
+    adapter_local :: undefined | {inet:ip_address(), inet:port_number()},
     %% Whether this socket_state owns the socket (true = close on cleanup)
     %% When wrapping an existing socket, this is false to avoid closing caller's socket
     owns_socket = true :: boolean(),
@@ -336,6 +349,47 @@ info(#socket_state{
         packets_coalesced => Coalesced
     }.
 
+%% @doc Build a socket_state backed by caller-supplied callbacks instead
+%% of a real UDP socket. Useful for tunnelling QUIC packets over an
+%% alternate transport (for example a MASQUE CONNECT-UDP session).
+%%
+%% Required options:
+%% <ul>
+%%   <li>`send_fun' - `fun((IP, Port, Packet) -> ok | {error, _})'.
+%%       Called for every outbound packet. The caller is responsible
+%%       for delivering inbound packets to the connection owner as
+%%       `{udp, Socket, IP, Port, Data}' messages, where `Socket' is
+%%       the reference returned in the `socket_state'.</li>
+%% </ul>
+%% Optional options:
+%% <ul>
+%%   <li>`close_fun' - `fun(() -> ok)' invoked on socket close.</li>
+%%   <li>`local' - `{IP, Port}' returned by `sockname/1'.</li>
+%%   <li>`socket_ref' - `reference()' to use as the opaque socket
+%%       handle. Defaults to a fresh `make_ref/0'. Callers that need
+%%       to forward inbound packets as `{udp, Ref, IP, Port, Data}'
+%%       should supply their own ref so they know which value to use
+%%       before the connection starts.</li>
+%% </ul>
+%% Batching, GSO and GRO are unconditionally disabled for this backend
+%% because the underlying transport handles its own framing.
+-spec open_adapter(map()) -> {ok, socket_state()} | {error, term()}.
+open_adapter(#{send_fun := SendFun} = Opts) when is_function(SendFun, 3) ->
+    State = #socket_state{
+        socket             = maps:get(socket_ref, Opts, make_ref()),
+        backend            = adapter,
+        owns_socket        = true,
+        gso_supported      = false,
+        gro_enabled        = false,
+        batching_enabled   = false,
+        adapter_send_fun   = SendFun,
+        adapter_close_fun  = maps:get(close_fun, Opts, undefined),
+        adapter_local      = maps:get(local, Opts, undefined)
+    },
+    {ok, State};
+open_adapter(_) ->
+    {error, {missing, send_fun}}.
+
 %% @doc Wrap an existing gen_udp socket with batching support.
 %% This allows adding batching to connections that already have a socket.
 %% Note: GSO/GRO are not available when wrapping existing gen_udp sockets.
@@ -390,6 +444,11 @@ new_sender(Socket, Opts) ->
 %% @doc Close the socket and flush any pending packets.
 %% Only closes the socket if owns_socket is true (i.e., socket was created by us).
 -spec close(socket_state()) -> ok.
+close(#socket_state{backend = adapter, adapter_close_fun = Fun}) ->
+    case Fun of
+        undefined -> ok;
+        F when is_function(F, 0) -> _ = catch F(), ok
+    end;
 close(#socket_state{owns_socket = false}) ->
     %% Don't close wrapped sockets - caller owns them
     ok;
@@ -498,6 +557,14 @@ recv(#socket_state{socket = Socket, backend = gen_udp}, Timeout) ->
             {ok, {IP, Port}, [Data]}
     after Timeout ->
         {error, timeout}
+    end;
+recv(#socket_state{socket = Socket, backend = adapter}, Timeout) ->
+    %% Adapter backend: caller delivers gen_udp-shaped messages.
+    receive
+        {udp, Socket, IP, Port, Data} ->
+            {ok, {IP, Port}, [Data]}
+    after Timeout ->
+        {error, timeout}
     end.
 
 %% @doc Get the local address and port.
@@ -511,7 +578,12 @@ sockname(#socket_state{socket = Socket, backend = socket}) ->
             Error
     end;
 sockname(#socket_state{socket = Socket, backend = gen_udp}) ->
-    inet:sockname(Socket).
+    inet:sockname(Socket);
+sockname(#socket_state{backend = adapter, adapter_local = Local}) ->
+    case Local of
+        undefined -> {ok, {{0, 0, 0, 0}, 0}};
+        {_, _} -> {ok, Local}
+    end.
 
 %% @doc Set the controlling process.
 -spec controlling_process(socket_state(), pid()) -> ok | {error, term()}.
@@ -519,6 +591,9 @@ controlling_process(#socket_state{socket = Socket, backend = gen_udp}, Pid) ->
     gen_udp:controlling_process(Socket, Pid);
 controlling_process(#socket_state{backend = socket}, _Pid) ->
     %% socket module doesn't have controlling_process concept
+    ok;
+controlling_process(#socket_state{backend = adapter}, _Pid) ->
+    %% Caller manages its own delivery pid.
     ok.
 
 %% @doc Set socket options.
@@ -527,7 +602,10 @@ setopts(#socket_state{socket = Socket, backend = gen_udp}, Opts) ->
     inet:setopts(Socket, Opts);
 setopts(#socket_state{socket = Socket, backend = socket}, Opts) ->
     %% Convert gen_udp style opts to socket module
-    set_socket_opts(Socket, Opts).
+    set_socket_opts(Socket, Opts);
+setopts(#socket_state{backend = adapter}, _Opts) ->
+    %% No socket options to configure on a callback-based adapter.
+    ok.
 
 %% @doc Get the underlying file descriptor.
 -spec get_fd(socket_state()) -> {ok, integer()} | {error, term()}.
@@ -546,7 +624,9 @@ get_fd(#socket_state{socket = Socket, backend = socket}) ->
         end
     catch
         _:_ -> {error, not_supported}
-    end.
+    end;
+get_fd(#socket_state{backend = adapter}) ->
+    {error, not_supported}.
 
 %% @doc Spawn a client-side receiver process for the `socket' backend.
 %%
@@ -565,7 +645,10 @@ start_client_receiver(#socket_state{backend = socket} = SocketState, Owner) when
     Pid = spawn_link(fun() -> client_recv_loop(SocketState, Owner) end),
     {ok, Pid};
 start_client_receiver(#socket_state{backend = gen_udp}, _Owner) ->
-    {error, not_supported_on_gen_udp}.
+    {error, not_supported_on_gen_udp};
+start_client_receiver(#socket_state{backend = adapter}, _Owner) ->
+    %% Adapter callers deliver `{udp, ...}' messages themselves.
+    {error, not_supported_on_adapter}.
 
 %% @doc Stop a client receiver process previously returned by
 %% `start_client_receiver/2'. Safe to call with `undefined'.
@@ -963,6 +1046,12 @@ send_segments(Socket, Dest, [Packet | Rest], State) ->
         {error, Reason} -> {error, Reason, State}
     end.
 
+do_send_immediate(#socket_state{backend = adapter, adapter_send_fun = Fun} = State, IP, Port, Packet) ->
+    Bin = normalize_packet(Packet),
+    case Fun(IP, Port, Bin) of
+        ok -> {ok, State};
+        {error, _} = Error -> Error
+    end;
 do_send_immediate(#socket_state{socket = Socket, backend = socket} = State, IP, Port, Packet) ->
     %% Use sendmsg with iov - no flattening needed
     Msg = #{

--- a/test/quic_adapter_SUITE.erl
+++ b/test/quic_adapter_SUITE.erl
@@ -1,0 +1,166 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for the `socket_backend => adapter' option of quic:connect/4.
+%%%
+%%% The adapter backend lets a caller plug in custom datagram send/recv
+%%% callbacks instead of opening a UDP socket. The test bridges the
+%%% callbacks to a private gen_udp socket that talks to the in-process
+%%% echo server, exercising a full handshake + bidi stream round-trip.
+
+-module(quic_adapter_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    connect_via_adapter/1,
+    rejects_missing_adapter/1,
+    rejects_bad_adapter/1,
+    rejects_socket_with_adapter/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 1}}].
+
+all() ->
+    [
+        connect_via_adapter,
+        rejects_missing_adapter,
+        rejects_bad_adapter,
+        rejects_socket_with_adapter
+    ].
+
+init_per_suite(Config) ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    [{echo_server, Echo} | Config].
+
+end_per_suite(Config) ->
+    case ?config(echo_server, Config) of
+        undefined -> ok;
+        Echo -> quic_test_echo_server:stop(Echo)
+    end,
+    ok.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+connect_via_adapter(Config) ->
+    Echo = ?config(echo_server, Config),
+    Port = maps:get(port, Echo),
+    ServerIP = {127, 0, 0, 1},
+    %% Pre-allocate the opaque socket handle so the bridge knows what
+    %% reference to put in the `{udp, Ref, ...}' forwards.
+    SocketRef = make_ref(),
+
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef) end),
+
+    SendFun =
+        fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+    CloseFun = fun() -> Bridge ! stop, ok end,
+
+    Adapter = #{
+        send_fun   => SendFun,
+        close_fun  => CloseFun,
+        local      => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+
+    Opts = (quic_test_echo_server:client_opts())#{
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter
+    },
+
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+
+    receive
+        {quic, Conn, {connected, _Info}} -> ok
+    after 10000 ->
+        ct:fail("connect timeout")
+    end,
+
+    {ok, StreamId} = quic:open_stream(Conn),
+    Payload = <<"hello via adapter">>,
+    ok = quic:send_data(Conn, StreamId, Payload, false),
+
+    receive
+        {quic, Conn, {stream_data, StreamId, Echoed, _Fin}} ->
+            ?assertEqual(Payload, Echoed)
+    after 10000 ->
+        ct:fail("echo timeout")
+    end,
+
+    quic:close(Conn, normal),
+    ok.
+
+rejects_missing_adapter(_Config) ->
+    Opts = #{socket_backend => adapter},
+    ?assertEqual(
+        {error, missing_socket_adapter},
+        quic:connect(<<"127.0.0.1">>, 12345, Opts, self())
+    ).
+
+rejects_bad_adapter(_Config) ->
+    Opts = #{socket_backend => adapter, socket_adapter => #{}},
+    ?assertEqual(
+        {error, badarg_socket_adapter},
+        quic:connect(<<"127.0.0.1">>, 12345, Opts, self())
+    ).
+
+rejects_socket_with_adapter(_Config) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        Opts = #{
+            socket => Sock,
+            socket_backend => adapter,
+            socket_adapter => #{send_fun => fun(_, _, _) -> ok end}
+        },
+        ?assertEqual(
+            {error, {incompatible_options, [socket, {socket_backend, adapter}]}},
+            quic:connect(<<"127.0.0.1">>, 12345, Opts, self())
+        )
+    after
+        gen_udp:close(Sock)
+    end.
+
+%%====================================================================
+%% Bridge: gen_udp <-> adapter callbacks
+%%====================================================================
+
+%% Owns one gen_udp socket and shuttles datagrams between the QUIC
+%% client (via the adapter `send_fun' and `{udp, SocketRef, ...}'
+%% forwards) and the echo server.
+bridge_init(ServerIP, ServerPort, SocketRef) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(Sock, undefined, ServerIP, ServerPort, SocketRef).
+
+bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef) ->
+    receive
+        {set_conn, NewConn} ->
+            bridge_loop(Sock, NewConn, ServerIP, ServerPort, SocketRef);
+        {send, _IP, _Port, Pkt} ->
+            ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef);
+        {udp, Sock, _IP, _Port, Data} when is_pid(Conn) ->
+            Conn ! {udp, SocketRef, ServerIP, ServerPort, Data},
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef);
+        {udp, Sock, _IP, _Port, _Data} ->
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef);
+        stop ->
+            gen_udp:close(Sock),
+            ok;
+        _ ->
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef)
+    end.

--- a/test/quic_adapter_SUITE.erl
+++ b/test/quic_adapter_SUITE.erl
@@ -67,12 +67,15 @@ connect_via_adapter(Config) ->
             Bridge ! {send, IP, P, Pkt},
             ok
         end,
-    CloseFun = fun() -> Bridge ! stop, ok end,
+    CloseFun = fun() ->
+        Bridge ! stop,
+        ok
+    end,
 
     Adapter = #{
-        send_fun   => SendFun,
-        close_fun  => CloseFun,
-        local      => {{127, 0, 0, 1}, 0},
+        send_fun => SendFun,
+        close_fun => CloseFun,
+        local => {{127, 0, 0, 1}, 0},
         socket_ref => SocketRef
     },
 


### PR DESCRIPTION
## Summary

Introduces a third `socket_backend` option, `adapter`, alongside the existing `gen_udp` and `socket` backends. With `socket_backend => adapter` and a `socket_adapter` map carrying a `send_fun`, callers can plug their own datagram transport (for example a MASQUE CONNECT-UDP session) under a QUIC connection without opening a real UDP socket.

## Design

- `quic_socket` gets `open_adapter/1` and `adapter` branches in send/close/sockname/recv/controlling_process/setopts/get_fd/start_client_receiver. Batching, GSO and GRO are forced off because the underlying transport handles its own framing.
- The opaque socket handle is a `reference()`, so `Socket =:= #state.socket` guards in `quic_connection` keep working unchanged. Callers can supply their own ref via `socket_ref` so they know which value to put in the `{udp, Ref, IP, Port, Data}` messages they forward to the connection.
- `quic_connection` learns to skip `gen_udp:open` and adopt the caller's adapter `socket_state` in `open_client_socket`, treats `client_rearm_active` as a no-op for the adapter, closes via `quic_socket:close` so the adapter's `close_fun` runs, and rejects connection migration on the adapter path.
- `quic:connect/4` validates the new options. Combining a pre-opened `socket` with `socket_backend => adapter` is rejected; missing or malformed `socket_adapter` returns `{error, missing_socket_adapter}` or `{error, badarg_socket_adapter}`.

## Example usage

```erlang
SocketRef = make_ref(),
Bridge = spawn_link(fun() -> bridge_loop(...) end),
Adapter = #{
    send_fun   => fun(IP, Port, Pkt) -> Bridge ! {send, IP, Port, Pkt}, ok end,
    close_fun  => fun() -> Bridge ! stop, ok end,
    socket_ref => SocketRef
},
{ok, Conn} = quic:connect(Host, Port, #{
    socket_backend => adapter,
    socket_adapter => Adapter,
    %% ... other QUIC opts
}, self()),
%% Bridge forwards inbound UDP datagrams as
%%   {udp, SocketRef, IP, Port, Data}
%% messages to Conn.
```

## Notes

- `quic_dist` is not modified in this PR. The adapter is exposed only through `quic:connect/4`. Plumbing dist through the adapter (so `proto_dist quic_dist` connections can ride a tunnel) is intended as a separate, smaller follow-up.
- Tests: `quic_adapter_SUITE` does a full handshake + bidi stream round-trip against the in-process echo server via a `gen_udp` loopback bridge, plus three validation cases. `xref`, `dialyzer`, and `quic_e2e_SUITE` all stay green.