### PR TITLE
feat(dist): add quic_call.sh, an erl_call replacement for quic_dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `priv/bin/quic_call.sh`, an `erl_call`-style one-shot RPC helper for `quic_dist` clusters. Boots a hidden probe node with `-proto_dist quic`, runs `rpc:call/5` against the target, prints the result, and exits. Reuses the cluster's `sys.config` (`-C`) for credentials and discovery; cert/key can also be passed via `--cert`/`--key`.
+
 ## [1.3.1] - 2026-04-30
 
 ### Added

--- a/docs/QUIC_DIST.md
+++ b/docs/QUIC_DIST.md
@@ -76,6 +76,40 @@ nodes().
 %% => ['node2@host2']
 ```
 
+### Debugging a Running Node
+
+`erl_call` only speaks `inet_tcp_dist`, so it cannot attach to a node
+running with `-proto_dist quic`. Two replacements work over QUIC:
+
+**Interactive remote shell** — same as `erl_call -i`:
+
+```bash
+erl -name debug@host \
+    -proto_dist quic -epmd_module quic_epmd -start_epmd false \
+    -quic_dist_cert /path/to/cert.pem \
+    -quic_dist_key  /path/to/key.pem \
+    -setcookie <cookie> \
+    -config sys.config \
+    -pa _build/default/lib/quic/ebin \
+    -remsh node1@host1
+```
+
+**One-shot RPC** — same role as `erl_call -a`. The hex package ships
+`priv/bin/quic_call.sh`:
+
+```bash
+SCRIPT="$(erl -noshell -eval \
+    'io:format("~s",[filename:join([code:priv_dir(quic),"bin","quic_call.sh"])]),halt().')"
+
+"$SCRIPT" -c <cookie> -C sys.config \
+    node1@host1 erlang memory '[]'
+```
+
+The script auto-parses `cert_file` and `key_file` from the `sys.config`
+you pass via `-C`; pass `--cert` / `--key` directly to override. Output
+is the Erlang term as printed by `io:format("~p~n", [Result])`. See
+`quic_call.sh -h` for the full flag list.
+
 ## Architecture
 
 ### Module Overview

--- a/priv/bin/quic_call.sh
+++ b/priv/bin/quic_call.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# quic_call.sh - erl_call-style one-shot RPC over quic_dist.
+#
+# erl_call only speaks inet_tcp_dist; this wrapper boots a hidden probe
+# node with -proto_dist quic, connects to the target, runs an rpc:call/5,
+# prints the result, and exits.
+#
+# Usage:
+#   quic_call.sh [options] <Node> <Module> <Function> [ArgsTerm]
+#
+# ArgsTerm defaults to "[]". Must be a literal Erlang list term.
+#
+# Options (env var fallback in parentheses):
+#   -c, --cookie COOKIE    dist cookie (COOKIE) - required
+#   -C, --config FILE      sys.config with {quic, [{dist, [...]}]} (QUIC_SYS_CONFIG)
+#       --cert FILE        TLS cert (QUIC_CERT) - required, auto-parsed from --config
+#       --key FILE         TLS key  (QUIC_KEY)  - required, auto-parsed from --config
+#       --verify MODE      verify_none | verify_peer (default verify_none)
+#   -p, --port PORT        probe local listen port (QUIC_DIST_PORT, default 0)
+#   -n, --name NAME        probe node name (default quic_call_$$@<host>)
+#   -s, --sname            use -sname instead of -name
+#   -t, --timeout MS       rpc:call timeout (default 10000)
+#   -h, --help             show this help
+#
+# Exit codes:
+#   0 on success, 2 on usage error,
+#   3 if the probe node fails to start the quic application,
+#   4 if it cannot connect to the target,
+#   5 if rpc:call returns {badrpc, _}.
+
+set -euo pipefail
+
+usage() {
+    sed -n '3,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+COOKIE="${COOKIE:-}"
+CONFIG="${QUIC_SYS_CONFIG:-}"
+CERT="${QUIC_CERT:-}"
+KEY="${QUIC_KEY:-}"
+VERIFY="verify_none"
+PORT="${QUIC_DIST_PORT:-0}"
+NAME=""
+NAME_FLAG="-name"
+TIMEOUT="10000"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c|--cookie)  COOKIE="$2"; shift 2 ;;
+        -C|--config)  CONFIG="$2"; shift 2 ;;
+        --cert)       CERT="$2"; shift 2 ;;
+        --key)        KEY="$2"; shift 2 ;;
+        --verify)     VERIFY="$2"; shift 2 ;;
+        -p|--port)    PORT="$2"; shift 2 ;;
+        -n|--name)    NAME="$2"; shift 2 ;;
+        -s|--sname)   NAME_FLAG="-sname"; shift ;;
+        -t|--timeout) TIMEOUT="$2"; shift 2 ;;
+        -h|--help)    usage; exit 0 ;;
+        --)           shift; break ;;
+        -*)           echo "quic_call: unknown option $1" >&2; exit 2 ;;
+        *)            break ;;
+    esac
+done
+
+if [[ $# -lt 3 ]]; then
+    usage >&2
+    exit 2
+fi
+
+NODE="$1"
+MOD="$2"
+FUN="$3"
+ARGS="${4:-[]}"
+
+if [[ -z "$COOKIE" ]]; then
+    echo "quic_call: cookie is required (-c, --cookie or \$COOKIE)" >&2
+    exit 2
+fi
+
+# Auto-parse cert_file/key_file from sys.config when not given on CLI.
+# The probe boots with -proto_dist quic, and quic_dist:listen/1 runs before
+# the kernel finishes loading sys.config-defined app envs, so the credentials
+# must come through -quic_dist_cert / -quic_dist_key init args.
+if [[ -n "$CONFIG" && -z "$CERT" ]]; then
+    CERT="$(awk -F'"' '/cert_file/{print $2; exit}' "$CONFIG" 2>/dev/null || true)"
+fi
+if [[ -n "$CONFIG" && -z "$KEY" ]]; then
+    KEY="$(awk -F'"' '/key_file/{print $2; exit}' "$CONFIG" 2>/dev/null || true)"
+fi
+
+if [[ -z "$CERT" || -z "$KEY" ]]; then
+    echo "quic_call: --cert and --key are required (or set them in --config)" >&2
+    exit 2
+fi
+if [[ ! -r "$CERT" ]]; then
+    echo "quic_call: cert file not readable: $CERT" >&2
+    exit 2
+fi
+if [[ ! -r "$KEY" ]]; then
+    echo "quic_call: key file not readable: $KEY" >&2
+    exit 2
+fi
+
+# Resolve the script's own absolute path without relying on realpath
+# (not on every BSD/macOS by default).
+SCRIPT_PATH="$0"
+case "$SCRIPT_PATH" in
+    /*) ;;
+    *)  SCRIPT_PATH="$PWD/$SCRIPT_PATH" ;;
+esac
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+QUIC_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+EBIN="${QUIC_EBIN:-$QUIC_DIR/ebin}"
+
+if [[ ! -d "$EBIN" ]]; then
+    echo "quic_call: quic ebin not found at $EBIN" >&2
+    echo "  run 'rebar3 compile' or set QUIC_EBIN" >&2
+    exit 2
+fi
+
+if [[ "$NAME_FLAG" == "-sname" ]]; then
+    : "${NAME:=quic_call_$$}"
+else
+    HOST="$(hostname -s)"
+    : "${NAME:=quic_call_$$@${HOST}}"
+fi
+
+ERL_ARGS=(
+    "$NAME_FLAG" "$NAME"
+    -setcookie "$COOKIE"
+    -hidden
+    -kernel net_setuptime 10
+    -proto_dist quic
+    -epmd_module quic_epmd
+    -start_epmd false
+    -quic_dist_port "$PORT"
+    -quic_dist_cert "$CERT"
+    -quic_dist_key "$KEY"
+    -quic_dist_verify "$VERIFY"
+    -pa "$EBIN"
+    -noinput
+)
+
+if [[ -n "$CONFIG" ]]; then
+    ERL_ARGS+=( -config "$CONFIG" )
+fi
+
+EVAL=$(cat <<ERL
+case application:ensure_all_started(quic) of
+    {ok, _} -> ok;
+    {error, StartErr} ->
+        io:format(standard_error, "quic start failed: ~p~n", [StartErr]),
+        erlang:halt(3)
+end,
+case net_kernel:connect_node('${NODE}') of
+    true -> ok;
+    ConnErr ->
+        io:format(standard_error, "connect failed: ~p~n", [ConnErr]),
+        erlang:halt(4)
+end,
+case rpc:call('${NODE}', '${MOD}', '${FUN}', ${ARGS}, ${TIMEOUT}) of
+    {badrpc, BadRpc} ->
+        io:format(standard_error, "badrpc: ~p~n", [BadRpc]),
+        erlang:halt(5);
+    Result ->
+        io:format("~p~n", [Result]),
+        erlang:halt(0)
+end.
+ERL
+)
+
+exec erl "${ERL_ARGS[@]}" -eval "$EVAL"

--- a/test/quic_call_SUITE.erl
+++ b/test/quic_call_SUITE.erl
@@ -1,0 +1,393 @@
+%%% -*- erlang -*-
+%%%
+%%% E2E coverage for priv/bin/quic_call.sh against a live quic_dist target.
+%%%
+%%% Copyright (c) 2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+
+-module(quic_call_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_group/2,
+    end_per_group/2,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    rpc_help/1,
+    rpc_node/1,
+    rpc_with_args/1,
+    rpc_badrpc/1,
+    rpc_bad_cookie/1,
+    rpc_hidden/1
+]).
+
+-define(TARGET_PORT, 14530).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [{group, script}].
+
+groups() ->
+    [
+        {script, [sequence], [
+            rpc_help,
+            rpc_node,
+            rpc_with_args,
+            rpc_badrpc,
+            rpc_hidden,
+            rpc_bad_cookie
+        ]}
+    ].
+
+%%====================================================================
+%% Suite setup
+%%====================================================================
+
+init_per_suite(Config) ->
+    case locate_script() of
+        {error, Reason} ->
+            {skip, Reason};
+        {ok, Script} ->
+            case code:which(peer) of
+                non_existing ->
+                    {skip, peer_not_available};
+                _ ->
+                    case os:find_executable("bash") of
+                        false ->
+                            {skip, bash_not_found};
+                        _ ->
+                            case generate_certs(Config) of
+                                {ok, CertDir} ->
+                                    [{script, Script}, {cert_dir, CertDir} | Config];
+                                {error, R} ->
+                                    {skip, {cert_generation_failed, R}}
+                            end
+                    end
+            end
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(script, Config) ->
+    case start_target(Config) of
+        {ok, Port, Node, Cookie, ProbeConfig} ->
+            [
+                {target_port_handle, Port},
+                {target_node, Node},
+                {cookie, Cookie},
+                {probe_config, ProbeConfig}
+                | Config
+            ];
+        {error, Reason} ->
+            {skip, {target_start_failed, Reason}}
+    end;
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(script, Config) ->
+    case ?config(target_port_handle, Config) of
+        undefined -> ok;
+        Port -> stop_port(Port)
+    end,
+    ok;
+end_per_group(_Group, _Config) ->
+    ok.
+
+stop_port(Port) ->
+    case erlang:port_info(Port, os_pid) of
+        {os_pid, OsPid} ->
+            os:cmd("kill " ++ integer_to_list(OsPid)),
+            timer:sleep(200),
+            os:cmd("kill -9 " ++ integer_to_list(OsPid) ++ " 2>/dev/null"),
+            catch erlang:port_close(Port),
+            ok;
+        _ ->
+            catch erlang:port_close(Port),
+            ok
+    end.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%====================================================================
+%% Test cases
+%%====================================================================
+
+rpc_help(Config) ->
+    Script = ?config(script, Config),
+    {Stdout, _Stderr, Exit} = run(Script ++ " -h"),
+    ?assertEqual(0, Exit),
+    ?assertNotEqual(nomatch, string:find(Stdout, "Usage:")),
+    ok.
+
+rpc_node(Config) ->
+    {Stdout, _Stderr, Exit} = run_call(Config, "erlang node '[]'"),
+    ?assertEqual(0, Exit),
+    NodeStr = atom_to_list(?config(target_node, Config)),
+    ?assertNotEqual(nomatch, string:find(Stdout, NodeStr)),
+    ok.
+
+rpc_with_args(Config) ->
+    {Stdout, _Stderr, Exit} = run_call(Config, "erlang '+' '[2,3]'"),
+    ?assertEqual(0, Exit),
+    ?assertEqual("5", string:trim(Stdout)),
+    ok.
+
+rpc_badrpc(Config) ->
+    {_Stdout, Stderr, Exit} = run_call(Config, "erlang nope_function '[]'"),
+    ?assertNotEqual(0, Exit),
+    ?assertNotEqual(nomatch, string:find(Stderr, "badrpc")),
+    ok.
+
+rpc_bad_cookie(Config) ->
+    Script = ?config(script, Config),
+    Probe = ?config(probe_config, Config),
+    Node = atom_to_list(?config(target_node, Config)),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "~s -c wrong_cookie_value -C ~s ~s erlang node '[]'",
+            [Script, Probe, Node]
+        )
+    ),
+    %% A wrong cookie causes the target to reject at challenge-reply time;
+    %% the probe's net_kernel may take a while to give up. We just need to
+    %% see a non-zero exit (or a forced kill) to confirm it didn't succeed.
+    {_Stdout, _Stderr, Exit} = run(Cmd, 30000),
+    ?assertNotEqual(0, Exit),
+    ok.
+
+rpc_hidden(Config) ->
+    %% From the target's POV during the call, the probe must appear in
+    %% nodes(hidden) but NOT in nodes().
+    {Visible, _, Exit0} = run_call(Config, "erlang nodes '[]'"),
+    ?assertEqual(0, Exit0),
+    ?assertEqual(nomatch, string:find(Visible, "quic_call_")),
+
+    {Hidden, _, Exit1} = run_call(Config, "erlang nodes '[hidden]'"),
+    ?assertEqual(0, Exit1),
+    ?assertNotEqual(nomatch, string:find(Hidden, "quic_call_")),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+locate_script() ->
+    case code:priv_dir(quic) of
+        {error, _} = E ->
+            E;
+        Priv ->
+            Path = filename:join([Priv, "bin", "quic_call.sh"]),
+            case filelib:is_regular(Path) of
+                true -> {ok, Path};
+                false -> {error, {script_missing, Path}}
+            end
+    end.
+
+generate_certs(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    CertDir = filename:join(PrivDir, "certs"),
+    ok = filelib:ensure_dir(filename:join(CertDir, "dummy")),
+    Cmd = io_lib:format(
+        "openssl req -x509 -newkey rsa:2048 -keyout ~s/key.pem -out ~s/cert.pem "
+        "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+        [CertDir, CertDir]
+    ),
+    os:cmd(lists:flatten(Cmd)),
+    case
+        {
+            filelib:is_file(filename:join(CertDir, "cert.pem")),
+            filelib:is_file(filename:join(CertDir, "key.pem"))
+        }
+    of
+        {true, true} -> {ok, CertDir};
+        _ -> {error, openssl_failed}
+    end.
+
+start_target(Config) ->
+    CertDir = ?config(cert_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    CertFile = filename:join(CertDir, "cert.pem"),
+    KeyFile = filename:join(CertDir, "key.pem"),
+    Cookie = "quiccall_" ++ integer_to_list(erlang:unique_integer([positive])),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    Host = "127.0.0.1",
+    Node = list_to_atom("quic_call_target_" ++ Suffix ++ "@" ++ Host),
+    ReadyFile = filename:join(PrivDir, "target.ready"),
+
+    EbinDir =
+        case code:lib_dir(quic) of
+            {error, _} ->
+                filename:absname(filename:dirname(code:which(quic_dist)));
+            LibDir ->
+                filename:join(LibDir, "ebin")
+        end,
+
+    Eval = lists:flatten(
+        io_lib:format(
+            "{ok,_}=application:ensure_all_started(quic),"
+            "Nodes=[{'~s',{\"~s\",~b}}],"
+            "application:set_env(quic,dist,"
+            "[{cert_file,\"~s\"},{key_file,\"~s\"},{verify,verify_none},"
+            "{discovery_module,quic_discovery_static},{nodes,Nodes}]),"
+            "{ok,_}=quic_discovery_static:init([{nodes,Nodes}]),"
+            "ok=file:write_file(\"~s\",<<\"ok\">>),"
+            "receive _ -> ok end.",
+            [atom_to_list(Node), Host, ?TARGET_PORT, CertFile, KeyFile, ReadyFile]
+        )
+    ),
+    Args = [
+        "-name",
+        atom_to_list(Node),
+        "-setcookie",
+        Cookie,
+        "-proto_dist",
+        "quic",
+        "-epmd_module",
+        "quic_epmd",
+        "-start_epmd",
+        "false",
+        "-quic_dist_port",
+        integer_to_list(?TARGET_PORT),
+        "-quic_dist_cert",
+        CertFile,
+        "-quic_dist_key",
+        KeyFile,
+        "-quic_dist_verify",
+        "verify_none",
+        "-pa",
+        EbinDir,
+        "-noinput",
+        "-eval",
+        Eval
+    ],
+    ErlExe = os:find_executable("erl"),
+    Port = erlang:open_port({spawn_executable, ErlExe}, [
+        {args, Args},
+        binary,
+        exit_status,
+        stderr_to_stdout
+    ]),
+
+    case wait_for_ready(ReadyFile, 60) of
+        ok ->
+            ProbeConfig = write_dist_config(
+                filename:join(PrivDir, "probe.config"),
+                CertDir,
+                [{Node, {Host, ?TARGET_PORT}}]
+            ),
+            {ok, Port, Node, Cookie, ProbeConfig};
+        timeout ->
+            Log = drain_port(Port, []),
+            stop_port(Port),
+            ct:log("target failed to become ready. output:~n~s", [Log]),
+            {error, target_not_ready}
+    end.
+
+drain_port(Port, Acc) ->
+    receive
+        {Port, {data, Bin}} -> drain_port(Port, [Bin | Acc])
+    after 100 ->
+        lists:reverse(Acc)
+    end.
+
+wait_for_ready(_File, 0) ->
+    timeout;
+wait_for_ready(File, N) ->
+    case filelib:is_regular(File) of
+        true ->
+            ok;
+        false ->
+            timer:sleep(500),
+            wait_for_ready(File, N - 1)
+    end.
+
+write_dist_config(Path, CertDir, Nodes) ->
+    NodesIO = [
+        io_lib:format("{'~s', {\"~s\", ~b}}", [atom_to_list(N), Host, Port])
+     || {N, {Host, Port}} <- Nodes
+    ],
+    NodesStr = lists:join(", ", NodesIO),
+    Body = io_lib:format(
+        "[{quic, [{dist, [{cert_file, \"~s\"},"
+        " {key_file, \"~s\"},"
+        " {verify, verify_none},"
+        " {discovery_module, quic_discovery_static},"
+        " {nodes, [~s]}]}]}].~n",
+        [
+            filename:join(CertDir, "cert.pem"),
+            filename:join(CertDir, "key.pem"),
+            NodesStr
+        ]
+    ),
+    ok = file:write_file(Path, iolist_to_binary(Body)),
+    Path.
+
+run_call(Config, MFAStr) ->
+    Script = ?config(script, Config),
+    Probe = ?config(probe_config, Config),
+    Cookie = ?config(cookie, Config),
+    Node = atom_to_list(?config(target_node, Config)),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "~s -c ~s -C ~s ~s ~s",
+            [Script, Cookie, Probe, Node, MFAStr]
+        )
+    ),
+    run(Cmd).
+
+run(Cmd) ->
+    run(Cmd, 20000).
+
+run(Cmd, TimeoutMs) ->
+    StderrFile =
+        "/tmp/quic_call_stderr_" ++ integer_to_list(erlang:unique_integer([positive])),
+    Bash = os:find_executable("bash"),
+    Wrapped = lists:flatten(io_lib:format("exec ~s 2>~s", [Cmd, StderrFile])),
+    Port = erlang:open_port(
+        {spawn_executable, Bash},
+        [{args, ["-c", Wrapped]}, exit_status, binary, stream]
+    ),
+    {Stdout, Exit} = collect(Port, [], TimeoutMs),
+    Stderr =
+        case file:read_file(StderrFile) of
+            {ok, Bin} -> binary_to_list(Bin);
+            _ -> ""
+        end,
+    file:delete(StderrFile),
+    ct:log("cmd: ~s~nstdout:~n~s~nstderr:~n~s~nexit: ~p", [Cmd, Stdout, Stderr, Exit]),
+    {Stdout, Stderr, Exit}.
+
+collect(Port, Acc, TimeoutMs) ->
+    receive
+        {Port, {data, Bin}} ->
+            collect(Port, [Bin | Acc], TimeoutMs);
+        {Port, {exit_status, Status}} ->
+            {binary_to_list(iolist_to_binary(lists:reverse(Acc))), Status}
+    after TimeoutMs ->
+        case erlang:port_info(Port, os_pid) of
+            {os_pid, OsPid} ->
+                os:cmd("kill -9 " ++ integer_to_list(OsPid));
+            _ ->
+                ok
+        end,
+        catch erlang:port_close(Port),
+        {binary_to_list(iolist_to_binary(lists:reverse(Acc))), 124}
+    end.


### PR DESCRIPTION
## Summary

`erl_call` only speaks `inet_tcp_dist`, so it cannot attach to a node running with `-proto_dist quic`. This PR ships a one-shot RPC helper that does the equivalent over QUIC.

The script lives in `priv/bin/` so it travels in the hex package and is reachable from downstream apps via `code:priv_dir(quic)`:

```bash
priv/bin/quic_call.sh -c <cookie> -C sys.config node1@host1 erlang memory '[]'
```

It boots a hidden probe node with `-proto_dist quic`, calls `net_kernel:connect_node/1` plus `rpc:call/5` against the target, prints the result, and exits. Cert/key are auto-parsed from the `sys.config` passed via `-C`; `--cert`/`--key`/`--verify` flags override.

For interactive sessions, the docs section also points at `erl ... -remsh`, which is the natural `-i` analogue.