### PR TITLE
fix(dist): quic_call.sh asks target to disconnect on exit

### DIFF
--- a/docs/QUIC_DIST.md
+++ b/docs/QUIC_DIST.md
@@ -107,8 +107,11 @@ SCRIPT="$(erl -noshell -eval \
 
 The script auto-parses `cert_file` and `key_file` from the `sys.config`
 you pass via `-C`; pass `--cert` / `--key` directly to override. Output
-is the Erlang term as printed by `io:format("~p~n", [Result])`. See
-`quic_call.sh -h` for the full flag list.
+is the Erlang term as printed by `io:format("~p~n", [Result])`. Before
+halting, the probe asks the target to disconnect it (an RPC of
+`erlang:disconnect_node/1` against the probe's own name) so the target
+reaps the hidden-node entry synchronously rather than waiting on the
+QUIC idle timeout. See `quic_call.sh -h` for the full flag list.
 
 ## Architecture
 

--- a/priv/bin/quic_call.sh
+++ b/priv/bin/quic_call.sh
@@ -159,7 +159,12 @@ case net_kernel:connect_node('${NODE}') of
         io:format(standard_error, "connect failed: ~p~n", [ConnErr]),
         erlang:halt(4)
 end,
-case rpc:call('${NODE}', '${MOD}', '${FUN}', ${ARGS}, ${TIMEOUT}) of
+RpcResult = rpc:call('${NODE}', '${MOD}', '${FUN}', ${ARGS}, ${TIMEOUT}),
+%% Local disconnect_node + halt races the CONNECTION_CLOSE; have the
+%% target drop us instead so the hidden-node entry is reaped now.
+Self = node(),
+_ = (catch rpc:call('${NODE}', erlang, disconnect_node, [Self], 2000)),
+case RpcResult of
     {badrpc, BadRpc} ->
         io:format(standard_error, "badrpc: ~p~n", [BadRpc]),
         erlang:halt(5);

--- a/test/quic_call_SUITE.erl
+++ b/test/quic_call_SUITE.erl
@@ -29,7 +29,8 @@
     rpc_with_args/1,
     rpc_badrpc/1,
     rpc_bad_cookie/1,
-    rpc_hidden/1
+    rpc_hidden/1,
+    target_drops_probe/1
 ]).
 
 -define(TARGET_PORT, 14530).
@@ -48,6 +49,7 @@ groups() ->
             rpc_with_args,
             rpc_badrpc,
             rpc_hidden,
+            target_drops_probe,
             rpc_bad_cookie
         ]}
     ].
@@ -185,9 +187,56 @@ rpc_hidden(Config) ->
     ?assertNotEqual(nomatch, string:find(Hidden, "quic_call_")),
     ok.
 
+target_drops_probe(Config) ->
+    %% After the probe halts, the target must reap the hidden-node entry
+    %% promptly. Without erlang:disconnect_node/1 in the script, the entry
+    %% lingers for ~5 minutes (QUIC_DIST_IDLE_TIMEOUT).
+    {_, _, 0} = run_call(Config, "erlang node '[]'"),
+    ?assertEqual(ok, wait_until_no_probe_hidden(Config, 5000)).
+
 %%====================================================================
 %% Helpers
 %%====================================================================
+
+wait_until_no_probe_hidden(Config, MaxMs) ->
+    wait_until_no_probe_hidden(Config, MaxMs, 0).
+
+wait_until_no_probe_hidden(_Config, MaxMs, Elapsed) when Elapsed >= MaxMs ->
+    {error, timeout};
+wait_until_no_probe_hidden(Config, MaxMs, Elapsed) ->
+    case run_call(Config, "erlang nodes '[hidden]'") of
+        {Stdout, _, 0} ->
+            %% The polling probe itself appears in its own snapshot; that
+            %% probe will then disconnect cleanly on its way out. We're
+            %% checking that no *prior* probe is still listed. The output
+            %% contains the polling probe's name; everything else means
+            %% an earlier connection was not reaped.
+            Trimmed = string:trim(Stdout),
+            Names = parse_node_names(Trimmed),
+            Self =
+                case Names of
+                    [Only] -> Only;
+                    _ -> none
+                end,
+            Lingering = [N || N <- Names, N =/= Self],
+            case Lingering of
+                [] ->
+                    ok;
+                _ ->
+                    timer:sleep(200),
+                    wait_until_no_probe_hidden(Config, MaxMs, Elapsed + 200)
+            end;
+        _ ->
+            timer:sleep(200),
+            wait_until_no_probe_hidden(Config, MaxMs, Elapsed + 200)
+    end.
+
+parse_node_names(Str) ->
+    %% Strip leading "[" and trailing "]", split on commas/whitespace,
+    %% drop empties.
+    Inner = string:trim(Str, both, "[]\n\r "),
+    Parts = string:split(Inner, ",", all),
+    [string:trim(P) || P <- Parts, string:trim(P) =/= ""].
 
 locate_script() ->
     case code:priv_dir(quic) of


### PR DESCRIPTION
## Summary

Probes left stale entries in `nodes(hidden)` on the target for the full QUIC idle timeout (5 minutes); each invocation piled another one on. Reproducer:

```
$ for i in 1 2 3 4; do $SCRIPT ... target erlang node '[]'; done
$ $SCRIPT ... target erlang nodes '[hidden]'
[quic_call_79418@..., quic_call_79460@..., quic_call_79501@..., quic_call_79536@...]
```

`erlang:disconnect_node/1` from the local side casts close to `quic_connection` and then `halt/1` kills the VM before the cast is processed, so the CONNECTION_CLOSE never makes it on the wire. Doing it via rpc on the target side has the target tear the dist link down synchronously, then the probe halts.

Adds `target_drops_probe` to `quic_call_SUITE` to lock in the new behaviour. Test fails on the prior tip.