### PR TITLE
chore: release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-05-03
+
 ### Added
-- `priv/bin/quic_call.sh`, an `erl_call`-style one-shot RPC helper for `quic_dist` clusters. Boots a hidden probe node with `-proto_dist quic`, runs `rpc:call/5` against the target, prints the result, and exits. Reuses the cluster's `sys.config` (`-C`) for credentials and discovery; cert/key can also be passed via `--cert`/`--key`.
+- `priv/bin/quic_call.sh`, an `erl_call`-style one-shot RPC helper for `quic_dist` clusters. Boots a hidden probe node with `-proto_dist quic`, runs `rpc:call/5` against the target, asks the target to disconnect so the hidden-node entry is reaped immediately, and halts. Reuses the cluster's `sys.config` (`-C`) for credentials and discovery; cert/key can also be passed via `--cert`/`--key`. (#123, #124)
 
 ## [1.3.1] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Pure Erlang QUIC implementation (RFC 9000/9001).
 - Session-ticket cache for 0-RTT reconnection
 - User-accessible streams API on top of dist connections
 - Stream prioritization (control vs data) and connection-level backpressure
+- `priv/bin/quic_call.sh`: `erl_call`-style one-shot RPC against a `-proto_dist quic` node
 - See [docs/QUIC_DIST.md](docs/QUIC_DIST.md) for setup
 
 ## Requirements

--- a/src/quic.app.src
+++ b/src/quic.app.src
@@ -1,6 +1,6 @@
 {application, quic, [
     {description, "Pure Erlang QUIC implementation (RFC 9000)"},
-    {vsn, "1.3.1"},
+    {vsn, "1.3.2"},
     {registered, [
         quic_sup,
         quic_server_registry,


### PR DESCRIPTION
## Summary

Cuts 1.3.2. The release bundles the new `quic_call.sh` helper (#123) and the target-side disconnect fix (#124).

- `src/quic.app.src`: `vsn` → `1.3.2`
- `CHANGELOG.md`: new `[1.3.2] - 2026-05-03` section
- `README.md`: mention `quic_call.sh` under the `quic_dist` features