### PR TITLE
feat(dist): auth_callback and register_with_epmd hooks

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -506,3 +506,42 @@ The `quic:migrate/1` API triggers active connection migration:
 - Network handover (WiFi to cellular)
 - NAT rebinding recovery
 - Load balancing
+
+## Distribution Extension Hooks
+
+`quic_dist` exposes two optional hooks for embedding custom behaviour
+in the distribution layer.
+
+### `auth_callback`
+
+A `{Mod, Fun}` pair (or `fun/3`) invoked on both sides between TLS
+completion (the `{quic, Conn, {connected, _}}` event) and the
+`dist_util` handshake. The callback can run any application-level
+challenge / response on the freshly secured QUIC connection — open a
+user stream, send a token, validate certificates — and return `{ok, _}`
+to admit the connection or `{error, Reason}` to refuse it.
+
+On the server side, the callback is hosted by a short-lived
+*gatekeeper* process. The listener installs the gatekeeper as the
+QUIC connection owner via the existing `connection_handler` contract,
+so it receives the `{connected, _}` event and any subsequent stream
+data. After a successful callback, the gatekeeper starts the dist
+controller (which takes ownership atomically via
+`quic:set_owner_sync/2`) and *drains its mailbox* of any QUIC events
+that arrived before the ownership swap, forwarding them to the
+controller. This guarantees the first stream-data event sent by the
+peer cannot be lost between the callback returning and the controller
+becoming the owner. On failure the gatekeeper closes the connection
+and exits; the listener is unaffected.
+
+On the client side, the callback runs inline in the setup process
+that already owns the connection — no gatekeeper is needed.
+
+### `register_with_epmd`
+
+Boolean. When `false` (default), `quic_dist` keeps the historical
+behaviour of synthesising its own creation number and skipping
+`epmd` entirely. When `true`, `listen/1` calls
+`(net_kernel:epmd_module()):register_node/3` so the listening port
+appears in the configured registry. Useful for mixed-protocol
+clusters and external tooling.

--- a/docs/QUIC_DIST.md
+++ b/docs/QUIC_DIST.md
@@ -441,6 +441,46 @@ The input handler:
 | `max_data` | integer | 10485760 | Connection flow control limit (bytes) |
 | `max_stream_data` | integer | 1048576 | Stream flow control limit (bytes) |
 
+### Extension Hooks
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `auth_callback` | `{Mod,Fun}` \| `fun/3` | `undefined` | Optional auth handshake run after the QUIC handshake but before `dist_util` |
+| `auth_handshake_timeout` | integer | 10000 | Deadline (ms) passed to the callback; gatekeeper aborts at expiry |
+| `register_with_epmd` | boolean | `false` | When `true`, register the listening port via the configured `epmd_module` so external tooling (e.g. `epmd -names`) can resolve it |
+
+#### `auth_callback`
+
+The callback runs on both sides with the freshly-established QUIC
+connection pid:
+
+```erlang
+authenticate(Conn, Side :: client | server, Timeout) ->
+    {ok, Info :: term()} | {error, Reason :: term()}.
+```
+
+`{error, Reason}` closes the QUIC connection without ever starting
+the dist controller; the peer's `net_kernel:connect_node/1` returns
+`false`. Implementations typically open a user stream
+(`quic_dist:open_stream/2`) for a challenge/response. See the
+`quic_dist_auth` behaviour module.
+
+On the server, the callback is hosted by a short-lived gatekeeper
+process that owns the connection until the callback resolves. Any
+QUIC events buffered in its mailbox (e.g. the first stream-data) are
+forwarded to the dist controller after a successful handoff.
+
+Boot-arg form: `-quic_dist auth_callback Mod:Fun`.
+
+#### `register_with_epmd`
+
+By default, `quic_dist` skips `epmd` registration entirely and uses
+its own discovery. With `register_with_epmd = true`, the listener
+calls `EpmdMod:register_node/3` (where `EpmdMod` is whatever
+`net_kernel:epmd_module/0` returns) so the node appears in the
+configured registry. Useful in mixed-protocol clusters and for
+tools that scrape `epmd` directly.
+
 ## Discovery Backends
 
 ### Static Discovery (`quic_discovery_static`)

--- a/docs/features.md
+++ b/docs/features.md
@@ -262,6 +262,7 @@ QUIC-based Erlang distribution protocol implementation.
 - `quic_dist_sup` - Distribution supervisor
 - `quic_dist_tickets` - Session ticket storage
 - `quic_epmd` - EPMD replacement module
+- `quic_dist_auth` - Optional auth-handshake behaviour
 
 ### Discovery Backends
 - `quic_discovery_static` - Static node configuration
@@ -271,6 +272,16 @@ QUIC-based Erlang distribution protocol implementation.
 ### Distribution API
 - `quic:get_stats/1` - Get packet counts for liveness detection
 - `quic:send_ping/1` - Send transport-level PING frame
+
+### Extension Hooks
+- `auth_callback` (default `undefined`): `{Mod, Fun}` or `fun/3` invoked
+  on both sides after the QUIC handshake but before the dist_util
+  handshake. Returning `{error, _}` closes the connection without ever
+  starting the dist controller. See `quic_dist_auth` and the
+  Configuration Reference in `docs/QUIC_DIST.md`.
+- `register_with_epmd` (default `false`): when `true`, the listener
+  registers its port via the configured `epmd_module` so external
+  tooling (e.g. `epmd -names`) can resolve the node.
 
 ## Interop Runner Compliance
 

--- a/include/quic_dist.hrl
+++ b/include/quic_dist.hrl
@@ -115,7 +115,20 @@
     backpressure_retry_ms = ?DEFAULT_BACKPRESSURE_RETRY_MS :: pos_integer(),
 
     %% Pacing
-    pacing_enabled = true :: boolean()
+    pacing_enabled = true :: boolean(),
+
+    %% Authentication callback invoked after the QUIC handshake but
+    %% before the dist_util handshake. Either side may refuse the
+    %% connection. Default undefined preserves the existing behaviour.
+    auth_callback = undefined ::
+        undefined
+        | {module(), atom()}
+        | fun((pid(), client | server, timeout()) -> {ok, term()} | {error, term()}),
+    auth_handshake_timeout = 10000 :: timeout(),
+
+    %% When true, register the listening port with the configured
+    %% epmd_module so external tooling (e.g. epmd -names) can find it.
+    register_with_epmd = false :: boolean()
 }).
 
 %% Listener state

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -184,30 +184,54 @@ listen(Name, ExtraOpts) ->
             Port = get_listen_port(),
             case start_quic_server(Name, Port, Config, ExtraOpts) of
                 {ok, ServerName, ActualPort} ->
-                    %% Create listener record
                     Listener = #quic_dist_listener{
                         server_name = ServerName,
                         port = ActualPort,
                         config = Config
                     },
-
-                    %% Build net_address record
                     Address = #net_address{
                         address = {{0, 0, 0, 0}, ActualPort},
                         host = localhost,
                         family = inet,
                         protocol = quic
                     },
-
-                    %% Creation number (1-3, different for each instance)
-                    Creation = get_creation(Name),
-
-                    {ok, {Listener, Address, Creation}};
+                    case resolve_creation(Name, ActualPort, Config) of
+                        {ok, Creation} ->
+                            {ok, {Listener, Address, Creation}};
+                        {error, EpmdReason} ->
+                            close(Listener),
+                            {error, EpmdReason}
+                    end;
                 {error, Reason} ->
                     {error, Reason}
             end;
         {error, Reason} ->
             {error, Reason}
+    end.
+
+%% @private
+%% Resolve the creation number. Either a synthetic one (default), or the
+%% one returned by registering with the configured epmd_module so that
+%% external tooling (e.g. `epmd -names') can find this node.
+resolve_creation(Name, _Port, #quic_dist_config{register_with_epmd = false}) ->
+    {ok, get_creation(Name)};
+resolve_creation(Name, Port, #quic_dist_config{
+    register_with_epmd = true,
+    discovery_module = DiscoveryModule
+}) ->
+    %% quic_discovery dispatches via erlang:function_exported/3, which
+    %% only sees exports of *loaded* modules. listen/1 runs before the
+    %% normal application boot, so force the discovery backend in now.
+    _ = code:ensure_loaded(DiscoveryModule),
+    NameStr =
+        case Name of
+            N when is_atom(N) -> atom_to_list(N);
+            N when is_list(N) -> N
+        end,
+    EpmdMod = net_kernel:epmd_module(),
+    case EpmdMod:register_node(NameStr, Port, inet) of
+        {ok, Creation} -> {ok, Creation};
+        {error, _} = Err -> Err
     end.
 
 %% @doc Accept a connection from the distribution listener.
@@ -386,8 +410,65 @@ load_config() ->
             backpressure_retry_ms, DistOpts, ?DEFAULT_BACKPRESSURE_RETRY_MS
         ),
         %% Pacing
-        pacing_enabled = get_opt(pacing_enabled, DistOpts, true)
+        pacing_enabled = get_opt(pacing_enabled, DistOpts, true),
+        %% Optional post-QUIC, pre-dist auth handshake
+        auth_callback = parse_auth_callback(
+            get_init_arg(auth_callback, get_opt(auth_callback, DistOpts))
+        ),
+        auth_handshake_timeout = parse_timeout(
+            get_init_arg(auth_handshake_timeout, get_opt(auth_handshake_timeout, DistOpts)),
+            10000
+        ),
+        %% Stock-EPMD registration of the listener port
+        register_with_epmd = parse_bool(
+            get_init_arg(register_with_epmd, get_opt(register_with_epmd, DistOpts)),
+            false
+        )
     }.
+
+%% @private
+parse_auth_callback(undefined) ->
+    undefined;
+parse_auth_callback({M, F}) when is_atom(M), is_atom(F) ->
+    {M, F};
+parse_auth_callback(F) when is_function(F, 3) ->
+    F;
+parse_auth_callback(Str) when is_list(Str) ->
+    case string:split(Str, ":") of
+        [M, F] when M =/= "", F =/= "" ->
+            {list_to_atom(M), list_to_atom(F)};
+        _ ->
+            undefined
+    end;
+parse_auth_callback(_) ->
+    undefined.
+
+%% @private
+parse_timeout(undefined, Default) ->
+    Default;
+parse_timeout(N, _Default) when is_integer(N), N > 0 ->
+    N;
+parse_timeout(infinity, _Default) ->
+    infinity;
+parse_timeout("infinity", _Default) ->
+    infinity;
+parse_timeout(Str, Default) when is_list(Str) ->
+    try list_to_integer(Str) of
+        N when N > 0 -> N;
+        _ -> Default
+    catch
+        _:_ -> Default
+    end;
+parse_timeout(_, Default) ->
+    Default.
+
+%% @private
+parse_bool(undefined, Default) -> Default;
+parse_bool(true, _) -> true;
+parse_bool(false, _) -> false;
+parse_bool("true", _) -> true;
+parse_bool("false", _) -> false;
+parse_bool(_, Default) -> Default.
 
 %% @private
 %% Get value from init argument -quic_dist_Key Value
@@ -604,43 +685,138 @@ load_credentials(_) ->
 
 %% @private
 %% Handle a new incoming QUIC connection.
+%%
+%% Two paths:
+%% - No auth_callback configured (default): start the dist controller
+%%   immediately, hand it ownership of the QUIC connection, and notify
+%%   the acceptor.
+%% - auth_callback configured: spawn a short-lived gatekeeper process
+%%   that takes ownership, waits for `{quic, Conn, {connected, _}}',
+%%   runs the callback, and only on `{ok, _}' starts the dist
+%%   controller. Any QUIC events the gatekeeper buffered between the
+%%   `connected' event and the ownership swap are forwarded to the
+%%   controller so the first stream-data event is not lost.
 handle_new_connection(Conn) ->
-    logger:info(
-        "quic_dist: handle_new_connection called, Conn=~p~n",
-        [Conn]
-    ),
-    %% Start distribution controller for this connection
+    Config = load_config(),
+    case Config#quic_dist_config.auth_callback of
+        undefined ->
+            handle_new_connection_direct(Conn);
+        Callback ->
+            handle_new_connection_with_auth(
+                Conn, Callback, Config#quic_dist_config.auth_handshake_timeout
+            )
+    end.
+
+%% @private
+handle_new_connection_direct(Conn) ->
     case quic_dist_controller:start_link(Conn, server) of
         {ok, ControllerPid} ->
-            logger:info("quic_dist: server controller started: ~p~n", [ControllerPid]),
-            %% Notify the acceptor about the new connection
-            %% The server name is based on the short node name (before @)
-            NodeName = node(),
-            ShortName =
-                case NodeName of
-                    nonode@nohost ->
-                        nonode;
-                    _ ->
-                        NodeStr = atom_to_list(NodeName),
-                        case string:split(NodeStr, "@") of
-                            [Name, _Host] -> list_to_atom(Name);
-                            [Name] -> list_to_atom(Name)
-                        end
-                end,
-            ServerName = dist_server_name(ShortName),
-            case persistent_term:get({quic_dist_acceptor, ServerName}, undefined) of
-                undefined ->
-                    %% No acceptor registered yet, this is normal during early boot
-                    %% The kernel will eventually call accept/1
-                    ok;
-                AcceptorPid when is_pid(AcceptorPid) ->
-                    %% Notify acceptor - NodeName will be extracted during handshake
-                    AcceptorPid ! {accept, ControllerPid, undefined}
-            end,
+            notify_acceptor(ControllerPid),
             {ok, ControllerPid};
         Error ->
-            logger:error("quic_dist: Failed to start controller: ~p~n", [Error]),
+            logger:error("quic_dist: failed to start controller: ~p~n", [Error]),
             Error
+    end.
+
+%% @private
+%% Spawn the gatekeeper unlinked: a crash here must not propagate to
+%% the listener. It owns the connection, so if it dies the QUIC
+%% connection process will clean up on owner DOWN.
+handle_new_connection_with_auth(Conn, Callback, Timeout) ->
+    Gatekeeper = spawn(fun() ->
+        gatekeeper(Conn, Callback, Timeout)
+    end),
+    {ok, Gatekeeper}.
+
+%% @private
+gatekeeper(Conn, Callback, Timeout) ->
+    receive
+        {quic, Conn, {connected, _Info}} ->
+            case run_auth_callback(Callback, Conn, server, Timeout) of
+                {ok, _} ->
+                    finalize_server_handoff(Conn);
+                {error, Reason} ->
+                    catch quic:close(Conn, normal),
+                    exit({auth_failed, Reason})
+            end;
+        {quic, Conn, {closed, Reason}} ->
+            exit({connection_closed, Reason});
+        {quic, Conn, {transport_error, Code, Reason}} ->
+            exit({transport_error, Code, Reason})
+    after Timeout ->
+        catch quic:close(Conn, normal),
+        exit({auth_failed, handshake_timeout})
+    end.
+
+%% @private
+%% Start the dist controller (which takes ownership of the connection),
+%% drain any QUIC events that arrived in our mailbox before the
+%% ownership swap and forward them to the controller, then notify the
+%% acceptor and exit normally.
+finalize_server_handoff(Conn) ->
+    case quic_dist_controller:start_link(Conn, server) of
+        {ok, ControllerPid} ->
+            drain_quic_events(Conn, ControllerPid),
+            notify_acceptor(ControllerPid);
+        {error, Reason} ->
+            catch quic:close(Conn, normal),
+            exit({controller_failed, Reason})
+    end.
+
+%% @private
+drain_quic_events(Conn, Target) ->
+    receive
+        {quic, Conn, _} = Msg ->
+            Target ! Msg,
+            drain_quic_events(Conn, Target)
+    after 0 ->
+        ok
+    end.
+
+%% @private
+notify_acceptor(ControllerPid) ->
+    NodeName = node(),
+    ShortName =
+        case NodeName of
+            nonode@nohost ->
+                nonode;
+            _ ->
+                NodeStr = atom_to_list(NodeName),
+                case string:split(NodeStr, "@") of
+                    [Name, _Host] -> list_to_atom(Name);
+                    [Name] -> list_to_atom(Name)
+                end
+        end,
+    ServerName = dist_server_name(ShortName),
+    case persistent_term:get({quic_dist_acceptor, ServerName}, undefined) of
+        undefined ->
+            %% No acceptor registered yet (early boot). net_kernel will
+            %% eventually call accept/1.
+            ok;
+        AcceptorPid when is_pid(AcceptorPid) ->
+            AcceptorPid ! {accept, ControllerPid, undefined},
+            ok
+    end.
+
+%% @private
+%% Invoke the configured auth callback. Crashes are turned into
+%% `{error, {crash, _}}' so a buggy callback cannot bring down the
+%% process running it. Callers must filter out `undefined' before
+%% calling.
+run_auth_callback({Mod, Fun}, Conn, Side, Timeout) when is_atom(Mod), is_atom(Fun) ->
+    safe_call(fun() -> Mod:Fun(Conn, Side, Timeout) end);
+run_auth_callback(F, Conn, Side, Timeout) when is_function(F, 3) ->
+    safe_call(fun() -> F(Conn, Side, Timeout) end).
+
+%% @private
+safe_call(Thunk) ->
+    try Thunk() of
+        {ok, _} = Ok -> Ok;
+        {error, _} = Err -> Err;
+        Other -> {error, {auth_callback_bad_return, Other}}
+    catch
+        Class:Reason:Stack ->
+            {error, {auth_callback_crash, Class, Reason, Stack}}
     end.
 
 %%====================================================================
@@ -895,7 +1071,7 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
             case quic:connect(Host, Port, Opts, self()) of
                 {ok, Conn} ->
                     %% Wait for connection to be established
-                    wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer);
+                    wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer, Config);
                 {error, Reason} ->
                     ?shutdown2(Node, {connect_failed, Reason})
             end;
@@ -904,21 +1080,17 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
     end.
 
 %% @private
-wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer) ->
+wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer, Config) ->
     receive
         {quic, Conn, {connected, _Info}} ->
-            %% Start distribution controller
-            case quic_dist_controller:start_link(Conn, client) of
-                {ok, DistCtrl} ->
-                    %% Set kernel on controller and store node
-                    quic_dist_controller:set_supervisor(DistCtrl, Kernel),
-                    quic_dist_controller:set_node(DistCtrl, Node),
-                    %% Perform distribution handshake
-                    HSData = create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer),
-                    dist_util:handshake_we_started(HSData);
-                {error, Reason} ->
-                    quic:close(Conn, normal),
-                    ?shutdown2(Node, {controller_failed, Reason})
+            %% Optional auth handshake before the dist controller
+            %% takes ownership.
+            case maybe_run_client_auth(Conn, Config) of
+                ok ->
+                    start_client_controller(Kernel, Node, Conn, MyNode, Type, Timer);
+                {error, AuthReason} ->
+                    catch quic:close(Conn, normal),
+                    ?shutdown2(Node, {auth_failed, AuthReason})
             end;
         {quic, Conn, {closed, Reason}} ->
             ?shutdown2(Node, {closed, Reason});
@@ -927,6 +1099,31 @@ wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer) ->
         {'EXIT', Timer, setup_timer_timeout} ->
             quic:close(Conn, timeout),
             ?shutdown2(Node, connect_timeout)
+    end.
+
+%% @private
+maybe_run_client_auth(_Conn, #quic_dist_config{auth_callback = undefined}) ->
+    ok;
+maybe_run_client_auth(Conn, #quic_dist_config{
+    auth_callback = Callback,
+    auth_handshake_timeout = Timeout
+}) ->
+    case run_auth_callback(Callback, Conn, client, Timeout) of
+        {ok, _} -> ok;
+        {error, _} = Err -> Err
+    end.
+
+%% @private
+start_client_controller(Kernel, Node, Conn, MyNode, Type, Timer) ->
+    case quic_dist_controller:start_link(Conn, client) of
+        {ok, DistCtrl} ->
+            quic_dist_controller:set_supervisor(DistCtrl, Kernel),
+            quic_dist_controller:set_node(DistCtrl, Node),
+            HSData = create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer),
+            dist_util:handshake_we_started(HSData);
+        {error, Reason} ->
+            quic:close(Conn, normal),
+            ?shutdown2(Node, {controller_failed, Reason})
     end.
 
 %%====================================================================

--- a/src/dist/quic_dist_auth.erl
+++ b/src/dist/quic_dist_auth.erl
@@ -1,0 +1,39 @@
+%%% -*- erlang -*-
+%%%
+%%% QUIC Distribution Authentication Behaviour
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+%%% @doc Optional authentication callback invoked between the QUIC
+%%% handshake and the Erlang distribution handshake.
+%%%
+%%% Configure via the `auth_callback' option (sys.config or
+%%% `-quic_dist auth_callback Mod:Fun'):
+%%%
+%%% ```
+%%% {quic, [{dist, [
+%%%   {auth_callback, {my_app_auth, authenticate}},
+%%%   {auth_handshake_timeout, 10000}
+%%% ]}]}.
+%%% '''
+%%%
+%%% The callback runs on both sides. It can refuse the connection by
+%%% returning `{error, Reason}'; the connection is then closed and the
+%%% dist controller is never started.
+%%%
+%%% @end
+
+-module(quic_dist_auth).
+
+%% @doc Implementations validate the freshly-established QUIC connection
+%% (e.g. inspect peer certificates, run a challenge/response on a user
+%% stream) and return `{ok, Info}' on success or `{error, Reason}' to
+%% refuse it. `Timeout' is the deadline configured via
+%% `auth_handshake_timeout'.
+-callback authenticate(
+    Conn :: pid(),
+    Side :: client | server,
+    Timeout :: timeout()
+) ->
+    {ok, Info :: term()} | {error, Reason :: term()}.

--- a/test/quic_dist_auth_SUITE.erl
+++ b/test/quic_dist_auth_SUITE.erl
@@ -1,0 +1,422 @@
+%%% -*- erlang -*-
+%%%
+%%% E2E coverage for quic_dist auth_callback and register_with_epmd.
+%%%
+%%% Copyright (c) 2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+
+-module(quic_dist_auth_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    default_no_callback/1,
+    auth_ok_both_sides/1,
+    auth_server_denies/1,
+    auth_timeout/1,
+    register_with_epmd_visible/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [
+        default_no_callback,
+        auth_ok_both_sides,
+        auth_server_denies,
+        auth_timeout,
+        register_with_epmd_visible
+    ].
+
+%%====================================================================
+%% Suite setup
+%%====================================================================
+
+init_per_suite(Config) ->
+    case os:find_executable("erl") of
+        false ->
+            {skip, erl_not_found};
+        _ ->
+            case generate_certs(Config) of
+                {ok, CertDir} ->
+                    [{cert_dir, CertDir} | Config];
+                {error, R} ->
+                    {skip, {cert_generation_failed, R}}
+            end
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    case erase({?MODULE, target_port_handle}) of
+        undefined -> ok;
+        Port -> stop_port(Port)
+    end,
+    ok.
+
+%%====================================================================
+%% Test cases
+%%====================================================================
+
+default_no_callback(Config) ->
+    Spec = #{tag => "default", auth_cb => undefined},
+    {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
+    Result = run_probe(Config, "default_probe", Target, TargetUdp, Cookie, undefined, 10000),
+    ?assertEqual(connected, Result).
+
+auth_ok_both_sides(Config) ->
+    Cb = "quic_dist_auth_test_cb:always_ok",
+    Spec = #{tag => "ok", auth_cb => Cb},
+    {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
+    Result = run_probe(Config, "ok_probe", Target, TargetUdp, Cookie, Cb, 10000),
+    ?assertEqual(connected, Result).
+
+auth_server_denies(Config) ->
+    Cb = "quic_dist_auth_test_cb:server_denies",
+    Spec = #{tag => "deny", auth_cb => Cb},
+    {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
+    Result = run_probe(Config, "deny_probe", Target, TargetUdp, Cookie, Cb, 10000),
+    ?assertEqual(refused, Result).
+
+auth_timeout(Config) ->
+    %% Both sides hang in the callback. The configured timeout fires
+    %% on the server gatekeeper; the client setup process eventually
+    %% sees the connection close.
+    Cb = "quic_dist_auth_test_cb:hangs_forever",
+    Spec = #{tag => "tmo", auth_cb => Cb, auth_timeout => 1500},
+    {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
+    Result = run_probe(Config, "tmo_probe", Target, TargetUdp, Cookie, Cb, 1500),
+    ?assertEqual(refused, Result).
+
+register_with_epmd_visible(Config) ->
+    %% Boot a target with register_with_epmd=true and have it write its
+    %% own quic_epmd:names/1 result to a file. Verify the short name is
+    %% present.
+    PrivDir = ?config(priv_dir, Config),
+    NamesFile = filename:join(PrivDir, "epmd_names.txt"),
+    Spec = #{
+        tag => "epmd",
+        auth_cb => undefined,
+        register_with_epmd => true,
+        %% Bypass quic_epmd:names/1 (its function_exported check is
+        %% load-order sensitive); query the static backend directly.
+        extra_eval =>
+            "{ok, RegisteredNodes} = quic_discovery_static:list_nodes(\"127.0.0.1\"),"
+            "ok = file:write_file(\"" ++ NamesFile ++
+            "\", io_lib:format(\"~p\", [RegisteredNodes])),"
+    },
+    {Target, _Port, _Cookie, TargetUdp} = start_target(Config, Spec),
+    %% Cleanup the target promptly; the file is already written.
+    stop_port(TargetUdp),
+    erase({?MODULE, target_port_handle}),
+    {ok, Bin} = file:read_file(NamesFile),
+    NamesStr = binary_to_list(Bin),
+    ct:log("quic_epmd:names result:~n~s", [NamesStr]),
+    ShortName = short_name(Target),
+    ?assertNotEqual(nomatch, string:find(NamesStr, ShortName)).
+
+%%====================================================================
+%% Boot helpers
+%%====================================================================
+
+start_target(Config, Spec) ->
+    CertDir = ?config(cert_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    CertFile = filename:join(CertDir, "cert.pem"),
+    KeyFile = filename:join(CertDir, "key.pem"),
+    Cookie = "qauth_" ++ integer_to_list(erlang:unique_integer([positive])),
+    Host = "127.0.0.1",
+    Tag = maps:get(tag, Spec),
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    Node = list_to_atom(
+        "qauth_target_" ++ Tag ++ "_" ++ Suffix ++ "@" ++ Host
+    ),
+    PortNum = pick_port(),
+    ReadyFile = filename:join(PrivDir, "target_" ++ Tag ++ ".ready"),
+
+    AuthCb = maps:get(auth_cb, Spec, undefined),
+    AuthTimeout = maps:get(auth_timeout, Spec, 10000),
+    RegisterEpmd = maps:get(register_with_epmd, Spec, false),
+    ExtraEval = maps:get(extra_eval, Spec, ""),
+
+    AuthArgs =
+        case AuthCb of
+            undefined ->
+                [];
+            CbStr ->
+                [
+                    "-quic_dist_auth_callback",
+                    CbStr,
+                    "-quic_dist_auth_handshake_timeout",
+                    integer_to_list(AuthTimeout)
+                ]
+        end,
+    EpmdArgs =
+        case RegisterEpmd of
+            true -> ["-quic_dist_register_with_epmd", "true"];
+            false -> []
+        end,
+
+    Eval = lists:flatten(
+        io_lib:format(
+            "{ok,_}=application:ensure_all_started(quic),"
+            "~s"
+            "ok=file:write_file(\"~s\",<<\"ok\">>),"
+            "receive _ -> ok end.",
+            [ExtraEval, ReadyFile]
+        )
+    ),
+    Args =
+        [
+            "-name",
+            atom_to_list(Node),
+            "-setcookie",
+            Cookie,
+            "-proto_dist",
+            "quic",
+            "-epmd_module",
+            "quic_epmd",
+            "-start_epmd",
+            "false",
+            "-quic_dist_port",
+            integer_to_list(PortNum),
+            "-quic_dist_cert",
+            CertFile,
+            "-quic_dist_key",
+            KeyFile,
+            "-quic_dist_verify",
+            "verify_none",
+            "-pa",
+            quic_ebin(),
+            "-pa",
+            test_ebin(),
+            "-noinput",
+            "-eval",
+            Eval
+        ] ++ AuthArgs ++ EpmdArgs,
+
+    ErlExe = os:find_executable("erl"),
+    Port = erlang:open_port({spawn_executable, ErlExe}, [
+        {args, Args},
+        binary,
+        exit_status,
+        stderr_to_stdout
+    ]),
+    case wait_for_ready(ReadyFile, 60) of
+        ok ->
+            put({?MODULE, target_port_handle}, Port),
+            put({?MODULE, target_port_for, atom_to_list(Node)}, PortNum),
+            {Node, PortNum, Cookie, Port};
+        timeout ->
+            Log = drain_port(Port),
+            stop_port(Port),
+            ct:fail("target ~s not ready. output:~n~s", [Tag, Log])
+    end.
+
+run_probe(Config, Tag, Target, _TargetUdp, Cookie, AuthCb, AuthTimeout) ->
+    CertDir = ?config(cert_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    CertFile = filename:join(CertDir, "cert.pem"),
+    KeyFile = filename:join(CertDir, "key.pem"),
+    Host = "127.0.0.1",
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    Probe = list_to_atom(
+        "qauth_probe_" ++ Tag ++ "_" ++ Suffix ++ "@" ++ Host
+    ),
+    ProbePort = pick_port(),
+    ResultFile = filename:join(PrivDir, "probe_result_" ++ Tag),
+
+    AuthArgs =
+        case AuthCb of
+            undefined ->
+                [];
+            CbStr ->
+                [
+                    "-quic_dist_auth_callback",
+                    CbStr,
+                    "-quic_dist_auth_handshake_timeout",
+                    integer_to_list(AuthTimeout)
+                ]
+        end,
+
+    TargetStr = atom_to_list(Target),
+    TargetPort = get({?MODULE, target_port_for, TargetStr}),
+
+    Eval = lists:flatten(
+        io_lib:format(
+            "{ok,_}=application:ensure_all_started(quic),"
+            "Nodes=[{'~s',{\"127.0.0.1\",~b}}],"
+            "{ok,_}=quic_discovery_static:init([{nodes,Nodes}]),"
+            "Verdict = case net_kernel:connect_node('~s') of"
+            " true -> connected;"
+            " _ -> refused"
+            " end,"
+            "ok=file:write_file(\"~s\",atom_to_list(Verdict)),"
+            "erlang:halt(0).",
+            [TargetStr, TargetPort, TargetStr, ResultFile]
+        )
+    ),
+    Args =
+        [
+            "-name",
+            atom_to_list(Probe),
+            "-setcookie",
+            Cookie,
+            "-proto_dist",
+            "quic",
+            "-epmd_module",
+            "quic_epmd",
+            "-start_epmd",
+            "false",
+            "-hidden",
+            "-kernel",
+            "net_setuptime",
+            "10",
+            "-quic_dist_port",
+            integer_to_list(ProbePort),
+            "-quic_dist_cert",
+            CertFile,
+            "-quic_dist_key",
+            KeyFile,
+            "-quic_dist_verify",
+            "verify_none",
+            "-pa",
+            quic_ebin(),
+            "-pa",
+            test_ebin(),
+            "-noinput",
+            "-eval",
+            Eval
+        ] ++ AuthArgs,
+
+    ErlExe = os:find_executable("erl"),
+    Port = erlang:open_port({spawn_executable, ErlExe}, [
+        {args, Args},
+        binary,
+        exit_status,
+        stderr_to_stdout
+    ]),
+    Out = wait_for_port_exit(Port, 30000),
+    ct:log("probe ~s output:~n~s", [Tag, Out]),
+    case file:read_file(ResultFile) of
+        {ok, Bin} ->
+            list_to_atom(string:trim(binary_to_list(Bin)));
+        {error, _} ->
+            refused
+    end.
+
+%%====================================================================
+%% Low-level helpers
+%%====================================================================
+
+quic_ebin() ->
+    case code:lib_dir(quic) of
+        {error, _} ->
+            filename:absname(filename:dirname(code:which(quic_dist)));
+        LibDir ->
+            filename:join(LibDir, "ebin")
+    end.
+
+test_ebin() ->
+    filename:absname(filename:dirname(code:which(?MODULE))).
+
+generate_certs(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    CertDir = filename:join(PrivDir, "certs"),
+    ok = filelib:ensure_dir(filename:join(CertDir, "dummy")),
+    Cmd = io_lib:format(
+        "openssl req -x509 -newkey rsa:2048 -keyout ~s/key.pem -out ~s/cert.pem "
+        "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+        [CertDir, CertDir]
+    ),
+    os:cmd(lists:flatten(Cmd)),
+    case
+        {
+            filelib:is_file(filename:join(CertDir, "cert.pem")),
+            filelib:is_file(filename:join(CertDir, "key.pem"))
+        }
+    of
+        {true, true} -> {ok, CertDir};
+        _ -> {error, openssl_failed}
+    end.
+
+pick_port() ->
+    {ok, S} = gen_udp:open(0, [binary, {active, false}]),
+    {ok, P} = inet:port(S),
+    gen_udp:close(S),
+    P.
+
+wait_for_ready(_File, 0) ->
+    timeout;
+wait_for_ready(File, N) ->
+    case filelib:is_regular(File) of
+        true ->
+            ok;
+        false ->
+            timer:sleep(500),
+            wait_for_ready(File, N - 1)
+    end.
+
+stop_port(Port) ->
+    case erlang:port_info(Port, os_pid) of
+        {os_pid, OsPid} ->
+            os:cmd("kill " ++ integer_to_list(OsPid)),
+            timer:sleep(200),
+            os:cmd("kill -9 " ++ integer_to_list(OsPid) ++ " 2>/dev/null"),
+            catch erlang:port_close(Port),
+            ok;
+        _ ->
+            catch erlang:port_close(Port),
+            ok
+    end.
+
+drain_port(Port) ->
+    drain_port(Port, []).
+drain_port(Port, Acc) ->
+    receive
+        {Port, {data, Bin}} -> drain_port(Port, [Bin | Acc])
+    after 100 ->
+        binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    end.
+
+wait_for_port_exit(Port, TimeoutMs) ->
+    wait_for_port_exit(Port, TimeoutMs, []).
+wait_for_port_exit(Port, TimeoutMs, Acc) ->
+    receive
+        {Port, {data, Bin}} ->
+            wait_for_port_exit(Port, TimeoutMs, [Bin | Acc]);
+        {Port, {exit_status, _}} ->
+            binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    after TimeoutMs ->
+        case erlang:port_info(Port, os_pid) of
+            {os_pid, OsPid} ->
+                os:cmd("kill -9 " ++ integer_to_list(OsPid));
+            _ ->
+                ok
+        end,
+        catch erlang:port_close(Port),
+        binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    end.
+
+short_name(Node) ->
+    NodeStr = atom_to_list(Node),
+    case string:split(NodeStr, "@") of
+        [N, _Host] -> N;
+        [N] -> N
+    end.

--- a/test/quic_dist_auth_test_cb.erl
+++ b/test/quic_dist_auth_test_cb.erl
@@ -1,0 +1,35 @@
+%%% -*- erlang -*-
+%%%
+%%% Test callbacks for quic_dist_auth_SUITE.
+%%%
+
+-module(quic_dist_auth_test_cb).
+
+%% Each exported function matches the quic_dist_auth callback signature
+%% `(Conn, Side, Timeout) -> {ok, _} | {error, _}'. The suite picks one
+%% per test via the `auth_callback' Mod:Fun option.
+
+-export([
+    always_ok/3,
+    server_denies/3,
+    client_denies/3,
+    hangs_forever/3
+]).
+
+always_ok(_Conn, _Side, _Timeout) ->
+    {ok, ok}.
+
+server_denies(_Conn, server, _Timeout) ->
+    {error, denied};
+server_denies(_Conn, client, _Timeout) ->
+    {ok, ok}.
+
+client_denies(_Conn, client, _Timeout) ->
+    {error, denied};
+client_denies(_Conn, server, _Timeout) ->
+    {ok, ok}.
+
+hangs_forever(_Conn, _Side, _Timeout) ->
+    receive
+        never -> ok
+    end.


### PR DESCRIPTION
## Summary

Two optional `quic_dist` extension points, both defaulting to today's behaviour.

**`auth_callback`** — `{Mod, Fun}` (or `fun/3`) invoked on both sides between TLS completion and the `dist_util` handshake. `{error, _}` closes the connection without ever starting the dist controller. On the server side a short-lived gatekeeper hosts the call, drains its mailbox after handing the connection to the controller, and forwards any buffered QUIC events so the first stream-data is not lost.

```erlang
{auth_callback, {my_app_auth, authenticate}},
{auth_handshake_timeout, 10000}
```

**`register_with_epmd`** — boolean. When `true`, `listen/1` registers the listening port via `(net_kernel:epmd_module()):register_node/3` so external tooling (`epmd -names`, mixed-protocol clusters) can resolve the node. Default `false` keeps the historical synthetic creation.

Boot-arg form mirrors the sys.config form: `-quic_dist_auth_callback Mod:Fun`, `-quic_dist_auth_handshake_timeout`, `-quic_dist_register_with_epmd true`.