### PR TITLE
feat: add quic:get_path_stats/1

### DIFF
--- a/src/quic.erl
+++ b/src/quic.erl
@@ -55,6 +55,24 @@
 %% Export the send_queue_info type for external use
 -export_type([send_queue_info/0]).
 
+%% Path metrics snapshot for routing decisions (e.g. multipath
+%% selection). All RTT values are in microseconds. `min_rtt' is `0'
+%% before any RTT sample has been taken (i.e. before the handshake
+%% provides one); callers should treat `min_rtt =:= 0' as "no sample
+%% yet".
+-type path_stats() :: #{
+    srtt := non_neg_integer(),
+    latest_rtt := non_neg_integer(),
+    min_rtt := non_neg_integer(),
+    rtt_var := non_neg_integer(),
+    cwnd := non_neg_integer(),
+    bytes_in_flight := non_neg_integer(),
+    in_recovery := boolean(),
+    congested := boolean()
+}.
+
+-export_type([path_stats/0]).
+
 -export([
     connect/4,
     close/1,
@@ -93,6 +111,8 @@
     get_stream_deadline/2,
     %% Congestion/backpressure status
     get_send_queue_info/1,
+    %% Path metrics (RTT + congestion control snapshot)
+    get_path_stats/1,
     %% Connection statistics for liveness detection
     get_stats/1,
     %% Transport-level PING (bypasses congestion control)
@@ -556,6 +576,20 @@ get_stream_deadline(Conn, StreamId) when is_pid(Conn) ->
     Conn :: pid().
 get_send_queue_info(Conn) when is_pid(Conn) ->
     quic_connection:get_send_queue_info(Conn).
+
+%% @doc Return a snapshot of the connection's path metrics.
+%%
+%% The map combines RTT estimates from `quic_loss' with congestion
+%% control state from `quic_cc'. Intended for routing layers that need
+%% per-connection path quality without poking at internal records via
+%% `sys:get_state/1'.
+%%
+%% Returns `{error, not_connected}' if the connection has not yet
+%% completed the handshake.
+-spec get_path_stats(Conn) -> {ok, path_stats()} | {error, term()} when
+    Conn :: pid().
+get_path_stats(Conn) when is_pid(Conn) ->
+    quic_connection:get_path_stats(Conn).
 
 %% @doc Get connection statistics for liveness detection.
 %%

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -79,6 +79,7 @@
     set_owner_sync/2,
     setopts/2,
     get_send_queue_info/1,
+    get_path_stats/1,
     %% Connection statistics (for liveness detection)
     get_stats/1,
     %% Peer transport parameters
@@ -733,6 +734,11 @@ setopts(Conn, Opts) ->
 -spec get_send_queue_info(pid()) -> {ok, quic:send_queue_info()} | {error, term()}.
 get_send_queue_info(Conn) ->
     gen_statem:call(Conn, get_send_queue_info).
+
+%% @doc Path metrics snapshot. See `quic:get_path_stats/1'.
+-spec get_path_stats(pid()) -> {ok, quic:path_stats()} | {error, term()}.
+get_path_stats(Conn) ->
+    gen_statem:call(Conn, get_path_stats).
 
 %% @doc Get connection statistics for liveness detection.
 %% Returns packet counts that can be used by net_kernel for tick checking.
@@ -1818,6 +1824,40 @@ connected(
     {keep_state, State, [{reply, From, {ok, Info}}]};
 connected(
     {call, From},
+    get_path_stats,
+    #state{
+        send_queue_bytes = Bytes,
+        cc_state = CCState,
+        loss_state = LossState,
+        congestion_threshold = Threshold
+    } = State
+) ->
+    Cwnd = quic_cc:cwnd(CCState),
+    InFlight = quic_cc:bytes_in_flight(CCState),
+    InRecovery = quic_cc:in_recovery(CCState),
+    Congested = (Bytes > Cwnd * Threshold) orelse (InRecovery andalso Bytes > Cwnd),
+    %% quic_loss tracks RTT in milliseconds; the public contract is
+    %% microseconds. Convert at read time so the underlying state
+    %% stays untouched. min_rtt is `infinity' before the first sample
+    %% lands; surface it as 0 so callers can rely on non_neg_integer.
+    MinRttMs =
+        case quic_loss:min_rtt(LossState) of
+            infinity -> 0;
+            M -> M
+        end,
+    Stats = #{
+        srtt => quic_loss:smoothed_rtt(LossState) * 1000,
+        latest_rtt => quic_loss:latest_rtt(LossState) * 1000,
+        min_rtt => MinRttMs * 1000,
+        rtt_var => quic_loss:rtt_var(LossState) * 1000,
+        cwnd => Cwnd,
+        bytes_in_flight => InFlight,
+        in_recovery => InRecovery,
+        congested => Congested
+    },
+    {keep_state, State, [{reply, From, {ok, Stats}}]};
+connected(
+    {call, From},
     get_stats,
     #state{
         packets_received = PacketsRecv,
@@ -2099,6 +2139,8 @@ closed(_EventType, _EventContent, State) ->
 
 handle_common_event({call, From}, get_ref, _StateName, #state{conn_ref = Ref} = State) ->
     {keep_state, State, [{reply, From, Ref}]};
+handle_common_event({call, From}, get_path_stats, _StateName, State) ->
+    {keep_state, State, [{reply, From, {error, not_connected}}]};
 handle_common_event(cast, handle_timeout, _StateName, State) ->
     %% Handle loss detection / idle timeout
     NewState = check_timeouts(State),

--- a/test/quic_path_stats_tests.erl
+++ b/test/quic_path_stats_tests.erl
@@ -1,0 +1,253 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for quic:get_path_stats/1.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+
+-module(quic_path_stats_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Test Generators
+%%====================================================================
+
+post_handshake_test_() ->
+    {timeout, 30, fun test_post_handshake/0}.
+
+not_connected_test_() ->
+    {timeout, 15, fun test_not_connected/0}.
+
+concurrent_calls_test_() ->
+    {timeout, 30, fun test_concurrent_calls/0}.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+%% After handshake + a round-trip of data, the snapshot has positive
+%% srtt + min_rtt and a positive cwnd, plus all the documented keys.
+test_post_handshake() ->
+    ensure_started(),
+    case generate_certs() of
+        {error, _} ->
+            ok;
+        {ok, TmpDir, Cert, Key} ->
+            ServerName = unique_name("path_stats"),
+            try
+                {ok, _} = quic:start_server(ServerName, 0, #{
+                    cert => Cert, key => Key, alpn => [<<"test">>]
+                }),
+                {ok, Port} = quic:get_server_port(ServerName),
+                {ok, Conn} = quic:connect(
+                    "127.0.0.1",
+                    Port,
+                    #{
+                        alpn => [<<"test">>], verify => false
+                    },
+                    self()
+                ),
+                ok = wait_connected(Conn, 5000),
+
+                %% Drive at least one round-trip so RTT samples land.
+                {ok, StreamId} = quic:open_stream(Conn),
+                ok = quic:send_data(Conn, StreamId, <<"hello path">>, true),
+                timer:sleep(150),
+
+                {ok, Stats} = quic:get_path_stats(Conn),
+                ?assert(is_map(Stats)),
+                lists:foreach(
+                    fun(K) -> ?assert(maps:is_key(K, Stats)) end,
+                    [
+                        srtt,
+                        latest_rtt,
+                        min_rtt,
+                        rtt_var,
+                        cwnd,
+                        bytes_in_flight,
+                        in_recovery,
+                        congested
+                    ]
+                ),
+                ?assert(is_integer(maps:get(srtt, Stats))),
+                ?assert(is_integer(maps:get(min_rtt, Stats))),
+                ?assert(is_integer(maps:get(cwnd, Stats))),
+                ?assert(is_boolean(maps:get(in_recovery, Stats))),
+                ?assert(is_boolean(maps:get(congested, Stats))),
+                %% RTT samples are non-negative; loopback round-trips
+                %% can round to 0 ms, so don't require strictly > 0.
+                ?assert(maps:get(srtt, Stats) >= 0),
+                ?assert(maps:get(min_rtt, Stats) >= 0),
+                ?assert(maps:get(cwnd, Stats) > 0),
+
+                cleanup(TmpDir, ServerName, Conn)
+            catch
+                Class:Reason:Stack ->
+                    cleanup(TmpDir, ServerName, undefined),
+                    erlang:raise(Class, Reason, Stack)
+            end
+    end.
+
+%% A connection that has not finished the handshake must return
+%% {error, not_connected} cleanly without crashing the connection
+%% process or the caller.
+test_not_connected() ->
+    ensure_started(),
+    %% Connect to a port nothing is listening on; the connection
+    %% process exists in handshaking state until it times out.
+    DeadPort = pick_dead_port(),
+    case
+        quic:connect(
+            "127.0.0.1",
+            DeadPort,
+            #{
+                alpn => [<<"test">>], verify => false
+            },
+            self()
+        )
+    of
+        {ok, Conn} ->
+            try
+                ?assertEqual({error, not_connected}, quic:get_path_stats(Conn)),
+                %% Process must still be alive (no crash).
+                ?assert(is_process_alive(Conn))
+            after
+                catch quic:close(Conn, normal)
+            end;
+        {error, _} ->
+            %% Connect failed synchronously; the {error, _} guarantee
+            %% in get_path_stats is moot. Treat as skipped.
+            ok
+    end.
+
+%% Many concurrent callers must all complete within a reasonable
+%% deadline. gen_statem:call serialises against the connection's own
+%% mailbox, but the call is O(1) so 64 in-flight calls finish quickly.
+test_concurrent_calls() ->
+    ensure_started(),
+    case generate_certs() of
+        {error, _} ->
+            ok;
+        {ok, TmpDir, Cert, Key} ->
+            ServerName = unique_name("path_stats_conc"),
+            try
+                {ok, _} = quic:start_server(ServerName, 0, #{
+                    cert => Cert, key => Key, alpn => [<<"test">>]
+                }),
+                {ok, Port} = quic:get_server_port(ServerName),
+                {ok, Conn} = quic:connect(
+                    "127.0.0.1",
+                    Port,
+                    #{
+                        alpn => [<<"test">>], verify => false
+                    },
+                    self()
+                ),
+                ok = wait_connected(Conn, 5000),
+
+                Parent = self(),
+                Refs = [
+                    begin
+                        Ref = make_ref(),
+                        spawn_link(fun() ->
+                            Result = quic:get_path_stats(Conn),
+                            Parent ! {Ref, Result}
+                        end),
+                        Ref
+                    end
+                 || _ <- lists:seq(1, 64)
+                ],
+                ok = collect(Refs, 5000),
+
+                cleanup(TmpDir, ServerName, Conn)
+            catch
+                Class:Reason:Stack ->
+                    cleanup(TmpDir, ServerName, undefined),
+                    erlang:raise(Class, Reason, Stack)
+            end
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+ensure_started() ->
+    application:ensure_all_started(crypto),
+    application:ensure_all_started(quic).
+
+unique_name(Prefix) ->
+    list_to_atom(Prefix ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+generate_certs() ->
+    TmpDir = filename:join([
+        "/tmp", "quic_path_stats_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ]),
+    ok = filelib:ensure_dir(filename:join(TmpDir, "dummy")),
+    CertFile = filename:join(TmpDir, "cert.pem"),
+    KeyFile = filename:join(TmpDir, "key.pem"),
+    Cmd = io_lib:format(
+        "openssl req -x509 -newkey rsa:2048 -keyout ~s -out ~s "
+        "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+        [KeyFile, CertFile]
+    ),
+    os:cmd(lists:flatten(Cmd)),
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            {ok, CertPem} = file:read_file(CertFile),
+            {ok, KeyPem} = file:read_file(KeyFile),
+            [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+            KeyDer = decode_key(KeyPem),
+            {ok, TmpDir, CertDer, KeyDer};
+        _ ->
+            os:cmd("rm -rf " ++ TmpDir),
+            {error, cert_generation_failed}
+    end.
+
+decode_key(KeyPem) ->
+    case public_key:pem_decode(KeyPem) of
+        [{'RSAPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('RSAPrivateKey', Der);
+        [{'ECPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('ECPrivateKey', Der);
+        [{'PrivateKeyInfo', Der, not_encrypted}] ->
+            public_key:der_decode('PrivateKeyInfo', Der);
+        [{_Type, Der, not_encrypted}] ->
+            Der
+    end.
+
+wait_connected(Conn, Timeout) ->
+    receive
+        {quic, Conn, {connected, _}} -> ok
+    after Timeout ->
+        throw(connection_timeout)
+    end.
+
+pick_dead_port() ->
+    {ok, S} = gen_udp:open(0, [binary]),
+    {ok, P} = inet:port(S),
+    gen_udp:close(S),
+    P.
+
+collect([], _Timeout) ->
+    ok;
+collect([Ref | Rest], Timeout) ->
+    receive
+        {Ref, {ok, Stats}} when is_map(Stats) ->
+            collect(Rest, Timeout);
+        {Ref, Other} ->
+            erlang:error({unexpected_path_stats_result, Other})
+    after Timeout ->
+        erlang:error({path_stats_timeout, length(Rest) + 1})
+    end.
+
+cleanup(TmpDir, ServerName, ConnRef) ->
+    case ConnRef of
+        undefined -> ok;
+        _ -> catch quic:close(ConnRef, normal)
+    end,
+    timer:sleep(50),
+    catch quic:stop_server(ServerName),
+    catch os:cmd("rm -rf " ++ TmpDir),
+    ok.


### PR DESCRIPTION
Add `quic:get_path_stats/1` reading existing RTT/CC state. Used by downstream routing layers (mycelium) for path selection without resorting to `sys:get_state` on internal records. Backward-compatible. No changes to packet processing.

Snapshot returns srtt / latest_rtt / min_rtt / rtt_var (microseconds), cwnd, bytes_in_flight, in_recovery, congested. Returns `{error, not_connected}` from any non-connected state.