### PR TITLE
chore: release 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-05-03
+
+### Added
+- `quic:get_path_stats/1` returns a snapshot of the connection's path metrics (srtt / latest_rtt / min_rtt / rtt_var in microseconds, plus cwnd, bytes_in_flight, in_recovery, congested) for downstream routing layers. Backward-compatible; off the packet-processing path. (#127)
+- `quic_dist` `auth_callback` option runs a custom `{Mod,Fun}` (or `fun/3`) on both sides between the QUIC handshake and the dist_util handshake. `{error, _}` closes the connection without ever starting the dist controller. New `quic_dist_auth` behaviour. (#126)
+- `quic_dist` `register_with_epmd` option (default `false`) registers the listening port via the configured `epmd_module` so external tooling (e.g. `epmd -names`) can resolve the node. (#126)
+
 ## [1.3.2] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Pure Erlang QUIC implementation (RFC 9000/9001).
 - QLOG tracing support for debug visibility
 - UDP packet batching (GSO/GRO)
 - Client certificate verification
+- Path-metrics snapshot (`quic:get_path_stats/1`) for routing layers
 
 ### HTTP/3 (`quic_h3`)
 - Full HTTP/3 client and server (RFC 9114) with QPACK header compression (RFC 9204)
@@ -48,6 +49,7 @@ Pure Erlang QUIC implementation (RFC 9000/9001).
 - User-accessible streams API on top of dist connections
 - Stream prioritization (control vs data) and connection-level backpressure
 - `priv/bin/quic_call.sh`: `erl_call`-style one-shot RPC against a `-proto_dist quic` node
+- Optional `auth_callback` for an app-level handshake between TLS and `dist_util`, plus `register_with_epmd` for stock-EPMD discoverability
 - See [docs/QUIC_DIST.md](docs/QUIC_DIST.md) for setup
 
 ## Requirements

--- a/src/quic.app.src
+++ b/src/quic.app.src
@@ -1,6 +1,6 @@
 {application, quic, [
     {description, "Pure Erlang QUIC implementation (RFC 9000)"},
-    {vsn, "1.3.2"},
+    {vsn, "1.3.3"},
     {registered, [
         quic_sup,
         quic_server_registry,


### PR DESCRIPTION
Bumps to 1.3.3. Two additive features merged since 1.3.2: `quic:get_path_stats/1` (#127) and `quic_dist` auth/EPMD hooks (#126).