### PR TITLE
fix(dist): drop @doc tag before -callback to unbreak ex_doc

### DIFF
--- a/src/dist/quic_dist_auth.erl
+++ b/src/dist/quic_dist_auth.erl
@@ -26,7 +26,7 @@
 
 -module(quic_dist_auth).
 
-%% @doc Implementations validate the freshly-established QUIC connection
+%% Implementations validate the freshly-established QUIC connection
 %% (e.g. inspect peer certificates, run a challenge/response on a user
 %% stream) and return `{ok, Info}' on success or `{error, Reason}' to
 %% refuse it. `Timeout' is the deadline configured via


### PR DESCRIPTION
ex_doc/edoc rejects `@doc` placed before a `-callback` declaration with: `tag @doc not allowed here`. Demote to a plain comment; no behaviour change.