### PR TITLE
feat(tls): TLS 1.3 external PSK support (RFC 8446 §4.2.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Pure Erlang QUIC implementation (RFC 9000/9001).
 - QLOG tracing support for debug visibility
 - UDP packet batching (GSO/GRO)
 - Client certificate verification
+- TLS 1.3 external PSK authentication (RFC 8446 §4.2.11, both `psk_dhe_ke`
+  and `psk_ke`). See [docs/PSK.md](docs/PSK.md).
 - Path-metrics snapshot (`quic:get_path_stats/1`) for routing layers
 
 ### HTTP/3 (`quic_h3`)

--- a/docs/PSK.md
+++ b/docs/PSK.md
@@ -1,0 +1,127 @@
+# TLS 1.3 External PSK
+
+This guide covers TLS 1.3 external pre-shared key (PSK) support for
+QUIC connections, defined by [RFC 8446 §4.2.11][rfc8446-4-2-11].
+External PSKs let two endpoints authenticate each other without
+X.509 certificates by sharing a secret out of band.
+
+This is **not** [RFC 9258][rfc9258] (the PSK Importer). The secret
+you pass is consumed as raw IKM by the TLS key schedule; no
+derivation is layered on top. If you need importer-style derivation
+to bind a PSK to a target protocol/KDF, do it before handing the
+secret to this library.
+
+[rfc8446-4-2-11]: https://www.rfc-editor.org/rfc/rfc8446#section-4.2.11
+[rfc9258]: https://www.rfc-editor.org/rfc/rfc9258
+
+## When to use it
+
+[RFC 9257 §5.1][rfc9257-5-1] describes the typical use cases:
+
+- Closed deployments where the operator controls both endpoints and
+  PKI would just add ceremony (cluster nodes, service-mesh peers).
+- Device-to-device authentication with pre-provisioned secrets.
+- Environments without a certificate authority (lab gear, embedded
+  devices, internal control planes).
+
+[rfc9257-5-1]: https://www.rfc-editor.org/rfc/rfc9257#section-5.1
+
+## Secret requirements
+
+The PSK is consumed unchanged by HKDF, so you choose the entropy.
+
+- Minimum 128 bits of entropy. Longer is fine.
+- No truncation, no derivation. What you pass is what HKDF gets.
+- Generate with `crypto:strong_rand_bytes/1` or your KMS.
+- Keep secrets in a vault or KMS. This library does not store them.
+
+## API
+
+### Client
+
+```erlang
+{ok, Conn} = quic:connect(Host, Port, #{
+    verify => false,
+    alpn => [<<"echo">>],
+    external_psk => {<<"client-id">>, <<"32-byte-shared-secret-...">>}
+}, self()).
+```
+
+Two forms are accepted:
+
+- `{Identity, Secret}`: defaults to mode `[psk_dhe_ke]`
+  (forward-secret).
+- `{Identity, Secret, Modes}`: explicit non-empty list of
+  `psk_dhe_ke | psk_ke`. First match wins on the server.
+
+`external_psk` and `session_ticket` are mutually exclusive. Passing
+both yields `{error, {bad_opts, psk_conflict}}`.
+
+### Server
+
+```erlang
+{ok, _} = quic:start_server(my_server, 4433, #{
+    alpn => [<<"echo">>],
+    %% Either or both:
+    psks => #{<<"client-id">> => <<"32-byte-shared-secret-...">>},
+    psk_callback => fun
+        (<<"client-id">>) -> {ok, <<"32-byte-shared-secret-...">>};
+        (_) -> not_found
+    end
+}).
+```
+
+Lookup order is `psk_callback` first, then `psks` map. Either or
+both may be configured. They may coexist with `cert`/`key`. Without
+PSK config and without `cert`/`key`, `start_server/3` returns
+`{error, no_auth_method}`.
+
+A callback that raises is treated as `not_found` and logged at
+warning level. It will not crash the handshake.
+
+## Modes
+
+- **`psk_dhe_ke`** (default): PSK authentication with (EC)DHE.
+  Forward-secret. Use this unless you have a specific reason not
+  to.
+- **`psk_ke`**: PSK only, no DHE. No forward secrecy. Use only on
+  endpoints that cannot do DHE or when forward secrecy is
+  explicitly out of scope.
+
+## Downgrade protection
+
+When a client supplies `external_psk`, it requires the server to
+select that PSK. If the server's ServerHello does not echo the
+expected `selected_psk_identity`, the client aborts with
+`{error, psk_not_selected}` rather than completing a cert-based
+handshake. This prevents silent fallback to an unauthenticated
+cert path when `verify => false` is in effect.
+
+## Mixed cert + PSK servers
+
+A server configured with both certs and PSK selects per-handshake:
+
+- Client offers a known PSK identity, binder verifies, compatible
+  mode → server selects PSK.
+- Client offers an unknown identity OR no compatible mode → server
+  falls through to the cert path.
+- Client offers a known identity but the binder fails to verify →
+  fatal `decrypt_error` alert. The server does **not** fall
+  through to cert in this case (silent downgrade prevention).
+
+## v1 limitations
+
+- No 0-RTT / `early_data` on external PSK. A client offering
+  `external_psk` with `early_data` will have the `early_data`
+  extension ignored by the server.
+- `NewSessionTicket` is not emitted on PSK-authenticated
+  handshakes. External PSK clients already hold a long-lived
+  credential.
+
+Both items are tracked as follow-ups in `docs/features.md`.
+
+## Distribution
+
+Erlang distribution over QUIC (`quic_dist`) supports PSK
+authentication for certificate-less clustering. See
+[QUIC_DIST.md](QUIC_DIST.md#psk-only-authentication).

--- a/docs/QUIC_DIST.md
+++ b/docs/QUIC_DIST.md
@@ -113,6 +113,56 @@ halting, the probe asks the target to disconnect it (an RPC of
 reaps the hidden-node entry synchronously rather than waiting on the
 QUIC idle timeout. See `quic_call.sh -h` for the full flag list.
 
+### PSK-only authentication
+
+For closed clusters where running a CA is overkill, dist can
+authenticate via TLS 1.3 external PSK ([RFC 8446 §4.2.11][rfc8446])
+instead of X.509 certs. Configure `psks` and/or `psk_callback` on
+the listener side and `external_psk` on the dialer side.
+
+[rfc8446]: https://www.rfc-editor.org/rfc/rfc8446#section-4.2.11
+
+```erlang
+%% sys.config: every node has the same shared secret
+[
+    {quic, [
+        {dist, [
+            {psks, #{<<"cluster">> => <<"32-byte-shared-secret-...">>}},
+            {external_psk, {<<"cluster">>, <<"32-byte-shared-secret-...">>}},
+            {verify, verify_none},
+            {discovery_module, quic_discovery_static},
+            {nodes, [
+                {'node1@host1', {"192.168.1.1", 4433}},
+                {'node2@host2', {"192.168.1.2", 4433}}
+            ]}
+        ]}
+    ]}
+].
+```
+
+`psks` is a `#{Identity => Secret}` map; both keys and values must
+be binaries. `psk_callback` accepts a literal `fun/1`, a
+`{Module, Function}` tuple, or a `"Module:Function"` string from
+`vm.args`. `external_psk` accepts `{Id, Secret}` (defaults to
+`psk_dhe_ke`) or `{Id, Secret, Modes}`.
+
+`cert_file` / `key_file` may be omitted entirely; a PSK-only
+listener registers without an X.509 chain. Cert and PSK may also
+coexist, in which case the per-handshake selection rules in
+[PSK.md](PSK.md#mixed-cert--psk-servers) apply.
+
+For per-peer overrides (e.g., different identity for different
+target nodes), use `quic_dist:set_connect_options/2`:
+
+```erlang
+ok = quic_dist:set_connect_options(
+    'node2@host2',
+    #{external_psk => {<<"per-peer-id">>, <<"per-peer-secret-...">>}}
+).
+```
+
+Full guide: [PSK.md](PSK.md).
+
 ## Architecture
 
 ### Module Overview

--- a/docs/features.md
+++ b/docs/features.md
@@ -112,10 +112,9 @@
 - [x] Identity lookup via callback and/or static map
 - [x] Cert + PSK coexistence on the same listener
 - [x] Client downgrade protection
-- [ ] 0-RTT on external PSK (v1 limitation)
-- [ ] `NewSessionTicket` on PSK-auth handshakes (v1 limitation)
 
-See [docs/PSK.md](PSK.md).
+See [docs/PSK.md](PSK.md). Pending follow-ups tracked in the
+[Roadmap](#roadmap) below.
 
 ## QUIC Version 2 (RFC 9369)
 
@@ -294,6 +293,22 @@ QUIC-based Erlang distribution protocol implementation.
 - `register_with_epmd` (default `false`): when `true`, the listener
   registers its port via the configured `epmd_module` so external
   tooling (e.g. `epmd -names`) can resolve the node.
+
+## Roadmap
+
+Tracked future work. Items here are not committed deliverables; they
+mark known gaps that may land in a later release.
+
+### TLS 1.3 external PSK follow-ups
+- [ ] 0-RTT on external PSK. The server currently ignores `early_data`
+  on PSK handshakes; full EndOfEarlyData state-machine support is
+  deferred.
+- [ ] `NewSessionTicket` on PSK-authenticated handshakes. Suppressed
+  in v1 to avoid binding-identity ambiguity; revisit when a concrete
+  use case appears.
+- [ ] RFC 9258 PSK Importer. The current API consumes the secret as
+  raw IKM; an importer layer would derive an `epsk -> psk` mapping
+  bound to a target protocol/KDF.
 
 ## Interop Runner Compliance
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -105,6 +105,18 @@
 - [x] PSK-based resumption
 - [x] 0-RTT early data
 
+### External PSK (RFC 8446 §4.2.11)
+- [x] `psk_dhe_ke` mode (forward-secret)
+- [x] `psk_ke` mode (no DHE)
+- [x] Server-side binder verification (constant-time)
+- [x] Identity lookup via callback and/or static map
+- [x] Cert + PSK coexistence on the same listener
+- [x] Client downgrade protection
+- [ ] 0-RTT on external PSK (v1 limitation)
+- [ ] `NewSessionTicket` on PSK-auth handshakes (v1 limitation)
+
+See [docs/PSK.md](PSK.md).
+
 ## QUIC Version 2 (RFC 9369)
 
 - [x] Version 2 (0x6b3343cf) support

--- a/elvis.config
+++ b/elvis.config
@@ -68,6 +68,8 @@
                         quic_listener,
                         quic_loss,
                         quic_aead,
+                        quic_crypto,
+                        quic_dist,
                         quic_dist_controller,
                         quic_dist_dispatch,
                         quic_packet,

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -208,6 +208,42 @@
 -define(EXT_QUIC_TRANSPORT_PARAMS, 57).
 
 %%====================================================================
+%% TLS 1.3 PSK Key Exchange Modes (RFC 8446 Section 4.2.9)
+%%====================================================================
+
+%% PSK-only key establishment (no (EC)DHE; no forward secrecy)
+-define(PSK_KE_MODE_KE, 0).
+%% PSK with (EC)DHE key establishment (forward-secret)
+-define(PSK_KE_MODE_DHE_KE, 1).
+
+%%====================================================================
+%% TLS 1.3 Alerts (RFC 8446 Section 6)
+%%====================================================================
+
+-define(TLS_ALERT_ILLEGAL_PARAMETER, 47).
+-define(TLS_ALERT_DECRYPT_ERROR, 51).
+-define(TLS_ALERT_UNKNOWN_PSK_IDENTITY, 115).
+
+%%====================================================================
+%% PSK offer record (client-side, fed into ClientHello PSK builder)
+%%====================================================================
+
+-record(psk_offer, {
+    %% resumption | external
+    type :: resumption | external,
+    %% binary identity sent on the wire
+    identity :: binary(),
+    %% obfuscated_ticket_age:32 — 0 for external PSKs (RFC 8446 §4.2.11)
+    age = 0 :: non_neg_integer(),
+    %% raw PSK secret (passed to HKDF unchanged)
+    secret :: binary(),
+    %% cipher whose hash determines binder length & key schedule
+    cipher :: atom(),
+    %% offered modes in client preference order
+    modes = [psk_dhe_ke] :: [psk_dhe_ke | psk_ke]
+}).
+
+%%====================================================================
 %% TLS 1.3 Named Groups (RFC 8446 Section 4.2.7)
 %%====================================================================
 

--- a/include/quic_dist.hrl
+++ b/include/quic_dist.hrl
@@ -130,7 +130,20 @@
 
     %% When true, register the listening port with the configured
     %% epmd_module so external tooling (e.g. epmd -names) can find it.
-    register_with_epmd = false :: boolean()
+    register_with_epmd = false :: boolean(),
+
+    %% TLS 1.3 external PSK (RFC 8446 §4.2.11). When set, the dist
+    %% listener and/or client uses these instead of (or alongside) the
+    %% cert+key pair above. See docs/PSK.md.
+    psks = undefined :: undefined | #{binary() => binary()},
+    psk_callback = undefined ::
+        undefined
+        | {module(), atom()}
+        | fun((binary()) -> {ok, binary()} | not_found),
+    external_psk = undefined ::
+        undefined
+        | {binary(), binary()}
+        | {binary(), binary(), [psk_dhe_ke | psk_ke]}
 }).
 
 %% Listener state

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -426,20 +426,23 @@ load_config() ->
         ),
         %% TLS 1.3 external PSK config — see docs/PSK.md
         psks = validate_psks(get_opt(psks, DistOpts)),
-        psk_callback = parse_auth_callback(
+        psk_callback = parse_psk_callback(
             get_init_arg(psk_callback, get_opt(psk_callback, DistOpts))
         ),
         external_psk = validate_external_psk(get_opt(external_psk, DistOpts))
     }.
 
 %% @private
-validate_psks(undefined) -> undefined;
+validate_psks(undefined) ->
+    undefined;
 validate_psks(Map) when is_map(Map) ->
     %% Require all keys/values to be binaries; reject loudly so
     %% dist startup fails rather than silently dropping the list.
-    case lists:all(
-        fun({K, V}) -> is_binary(K) andalso is_binary(V) end, maps:to_list(Map)
-    ) of
+    case
+        lists:all(
+            fun({K, V}) -> is_binary(K) andalso is_binary(V) end, maps:to_list(Map)
+        )
+    of
         true -> Map;
         false -> error({bad_config, {psks, malformed_entries}})
     end;
@@ -447,7 +450,8 @@ validate_psks(Other) ->
     error({bad_config, {psks, Other}}).
 
 %% @private
-validate_external_psk(undefined) -> undefined;
+validate_external_psk(undefined) ->
+    undefined;
 validate_external_psk({Id, Secret}) when is_binary(Id), is_binary(Secret) ->
     {Id, Secret};
 validate_external_psk({Id, Secret, Modes}) when
@@ -456,6 +460,26 @@ validate_external_psk({Id, Secret, Modes}) when
     {Id, Secret, Modes};
 validate_external_psk(Other) ->
     error({bad_config, {external_psk, Other}}).
+
+%% @private
+%% Parse psk_callback config — accepts literal anonymous funs,
+%% {Module, Function} tuples, and "Module:Function" strings from
+%% vm.args. Mirrors parse_auth_callback/1 but for arity-1 funs.
+parse_psk_callback(undefined) ->
+    undefined;
+parse_psk_callback({M, F}) when is_atom(M), is_atom(F) ->
+    {M, F};
+parse_psk_callback(F) when is_function(F, 1) ->
+    F;
+parse_psk_callback(Str) when is_list(Str) ->
+    case string:split(Str, ":") of
+        [M, F] when M =/= "", F =/= "" ->
+            {list_to_atom(M), list_to_atom(F)};
+        _ ->
+            undefined
+    end;
+parse_psk_callback(_) ->
+    undefined.
 
 %% @private
 parse_auth_callback(undefined) ->
@@ -725,9 +749,7 @@ load_credentials(#quic_dist_config{} = Config) ->
     case psk_only_credentials_ok(Config) of
         true -> {ok, undefined, undefined, undefined};
         false -> {error, no_credentials}
-    end;
-load_credentials(_) ->
-    {error, no_credentials}.
+    end.
 
 %% @private
 psk_only_credentials_ok(#quic_dist_config{
@@ -740,10 +762,11 @@ psk_only_credentials_ok(_) ->
 %% @private
 %% Add psk_callback and/or psks to a listener Opts map when configured.
 add_psk_listener_opts(Opts, #quic_dist_config{psks = Psks, psk_callback = Cb}) ->
-    Opts1 = case Psks of
-        undefined -> Opts;
-        _ -> Opts#{psks => Psks}
-    end,
+    Opts1 =
+        case Psks of
+            undefined -> Opts;
+            _ -> Opts#{psks => Psks}
+        end,
     case Cb of
         undefined -> Opts1;
         _ -> Opts1#{psk_callback => resolve_psk_callback(Cb)}

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -424,7 +424,7 @@ load_config() ->
             get_init_arg(register_with_epmd, get_opt(register_with_epmd, DistOpts)),
             false
         ),
-        %% TLS 1.3 external PSK config — see docs/PSK.md
+        %% TLS 1.3 external PSK config (see docs/PSK.md)
         psks = validate_psks(get_opt(psks, DistOpts)),
         psk_callback = parse_psk_callback(
             get_init_arg(psk_callback, get_opt(psk_callback, DistOpts))
@@ -462,7 +462,7 @@ validate_external_psk(Other) ->
     error({bad_config, {external_psk, Other}}).
 
 %% @private
-%% Parse psk_callback config — accepts literal anonymous funs,
+%% Parse psk_callback config. Accepts literal anonymous funs,
 %% {Module, Function} tuples, and "Module:Function" strings from
 %% vm.args. Mirrors parse_auth_callback/1 but for arity-1 funs.
 parse_psk_callback(undefined) ->
@@ -1068,7 +1068,9 @@ ip_to_host(IP) when is_list(IP) ->
 %% defaults that `connect_to_node/7' builds, so callers can override
 %% any key, including `socket_backend' and `socket_adapter' to route
 %% the underlying UDP packets through a custom transport (for example
-%% a MASQUE CONNECT-UDP tunnel).
+%% a MASQUE CONNECT-UDP tunnel), or `external_psk' to authenticate
+%% this peer with a different identity/secret than the cluster-wide
+%% default. See docs/PSK.md for the PSK option shapes.
 %%
 %% The entry is consumed once (the first matching `connect_to_node'
 %% call clears it). Use `clear_connect_options/1' to drop it without

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -423,8 +423,39 @@ load_config() ->
         register_with_epmd = parse_bool(
             get_init_arg(register_with_epmd, get_opt(register_with_epmd, DistOpts)),
             false
-        )
+        ),
+        %% TLS 1.3 external PSK config — see docs/PSK.md
+        psks = validate_psks(get_opt(psks, DistOpts)),
+        psk_callback = parse_auth_callback(
+            get_init_arg(psk_callback, get_opt(psk_callback, DistOpts))
+        ),
+        external_psk = validate_external_psk(get_opt(external_psk, DistOpts))
     }.
+
+%% @private
+validate_psks(undefined) -> undefined;
+validate_psks(Map) when is_map(Map) ->
+    %% Require all keys/values to be binaries; reject loudly so
+    %% dist startup fails rather than silently dropping the list.
+    case lists:all(
+        fun({K, V}) -> is_binary(K) andalso is_binary(V) end, maps:to_list(Map)
+    ) of
+        true -> Map;
+        false -> error({bad_config, {psks, malformed_entries}})
+    end;
+validate_psks(Other) ->
+    error({bad_config, {psks, Other}}).
+
+%% @private
+validate_external_psk(undefined) -> undefined;
+validate_external_psk({Id, Secret}) when is_binary(Id), is_binary(Secret) ->
+    {Id, Secret};
+validate_external_psk({Id, Secret, Modes}) when
+    is_binary(Id), is_binary(Secret), is_list(Modes), Modes =/= []
+->
+    {Id, Secret, Modes};
+validate_external_psk(Other) ->
+    error({bad_config, {external_psk, Other}}).
 
 %% @private
 parse_auth_callback(undefined) ->
@@ -525,13 +556,11 @@ get_listen_port() ->
 %% 1. Early boot mode: Start standalone quic_listener directly (no supervision)
 %% 2. Normal mode: Use quic:start_server through the supervisor tree
 start_quic_server(Name, Port, Config, _ExtraOpts) ->
-    %% Load certificate and key
+    %% Load certificate and key (or fall through to PSK-only auth)
     case load_credentials(Config) of
         {ok, Cert, Key, _CACert} ->
             CongestionThreshold = Config#quic_dist_config.congestion_threshold,
-            Opts = #{
-                cert => Cert,
-                key => Key,
+            BaseOpts0 = #{
                 alpn => [?QUIC_DIST_ALPN],
                 idle_timeout => ?QUIC_DIST_IDLE_TIMEOUT,
                 %% QUIC-level keep-alive via PING frames (bypasses flow control)
@@ -561,6 +590,14 @@ start_quic_server(Name, Port, Config, _ExtraOpts) ->
                     handle_new_connection(Conn)
                 end
             },
+            %% Add cert/key when present (PSK-only listeners omit them).
+            BaseOpts1 =
+                case {Cert, Key} of
+                    {undefined, undefined} -> BaseOpts0;
+                    {_, _} -> BaseOpts0#{cert => Cert, key => Key}
+                end,
+            %% Add PSK auth when configured.
+            Opts = add_psk_listener_opts(BaseOpts1, Config),
 
             case whereis(quic_sup) of
                 Pid when is_pid(Pid) ->
@@ -680,8 +717,54 @@ load_credentials(#quic_dist_config{
         _:Reason ->
             {error, {load_credentials, Reason}}
     end;
+load_credentials(#quic_dist_config{} = Config) ->
+    %% PSK-only configuration: either psks or psk_callback configured
+    %% and no cert/key path supplied. Return undefined slots so the
+    %% caller (start_quic_server / connect_to_node) builds Opts
+    %% without cert/key keys.
+    case psk_only_credentials_ok(Config) of
+        true -> {ok, undefined, undefined, undefined};
+        false -> {error, no_credentials}
+    end;
 load_credentials(_) ->
     {error, no_credentials}.
+
+%% @private
+psk_only_credentials_ok(#quic_dist_config{
+    psks = Psks, psk_callback = Cb
+}) when Psks =/= undefined; Cb =/= undefined ->
+    true;
+psk_only_credentials_ok(_) ->
+    false.
+
+%% @private
+%% Add psk_callback and/or psks to a listener Opts map when configured.
+add_psk_listener_opts(Opts, #quic_dist_config{psks = Psks, psk_callback = Cb}) ->
+    Opts1 = case Psks of
+        undefined -> Opts;
+        _ -> Opts#{psks => Psks}
+    end,
+    case Cb of
+        undefined -> Opts1;
+        _ -> Opts1#{psk_callback => resolve_psk_callback(Cb)}
+    end.
+
+%% @private
+%% Add external_psk to a client Opts map when configured.
+add_psk_client_opts(Opts, #quic_dist_config{external_psk = undefined}) ->
+    Opts;
+add_psk_client_opts(Opts, #quic_dist_config{external_psk = Ext}) ->
+    Opts#{external_psk => Ext}.
+
+%% @private
+%% parse_auth_callback stores {Module, Function} or fun/3 — we need
+%% to expose a fun/1 to the TLS layer. Wrap the {M, F} case.
+resolve_psk_callback({Mod, Fun}) when is_atom(Mod), is_atom(Fun) ->
+    fun(Identity) -> Mod:Fun(Identity) end;
+resolve_psk_callback(Fn) when is_function(Fn, 1) ->
+    Fn;
+resolve_psk_callback(_) ->
+    undefined.
 
 %% @private
 %% Handle a new incoming QUIC connection.
@@ -1026,9 +1109,7 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
     case load_credentials(Config) of
         {ok, Cert, Key, _CACert} ->
             CongestionThreshold = Config#quic_dist_config.congestion_threshold,
-            BaseOpts = #{
-                cert => Cert,
-                key => Key,
+            BaseOpts0 = #{
                 alpn => [?QUIC_DIST_ALPN],
                 idle_timeout => ?QUIC_DIST_IDLE_TIMEOUT,
                 %% QUIC-level keep-alive via PING frames (bypasses flow control)
@@ -1057,6 +1138,14 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
                 % TODO: Enable proper verification
                 verify => false
             },
+            %% Add cert/key when present (PSK-only clients omit them).
+            BaseOpts1 =
+                case {Cert, Key} of
+                    {undefined, undefined} -> BaseOpts0;
+                    {_, _} -> BaseOpts0#{cert => Cert, key => Key}
+                end,
+            %% Add external_psk when configured.
+            BaseOpts = add_psk_client_opts(BaseOpts1, Config),
 
             %% Per-node overrides registered via set_connect_options/2.
             %% Merged on top of the defaults so callers can swap the

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -187,6 +187,11 @@ get_fd(Socket) ->
 %%   <li>`verify' - Verify server certificate (default: false)</li>
 %%   <li>`alpn' - ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
 %%   <li>`server_name' - Server Name Indication (default: Host)</li>
+%%   <li>`external_psk' - TLS 1.3 external PSK (RFC 8446 §4.2.11).
+%%       `{Identity, Secret}' defaults to modes `[psk_dhe_ke]';
+%%       `{Identity, Secret, Modes}' takes an explicit non-empty
+%%       list (`psk_dhe_ke | psk_ke'). Mutually exclusive with
+%%       `session_ticket'. See docs/PSK.md.</li>
 %% </ul>
 -spec connect(Host, Port, Opts, Owner) -> {ok, pid()} | {error, term()} when
     Host :: binary() | string(),
@@ -656,10 +661,19 @@ get_peer_transport_params(Conn) when is_pid(Conn) ->
 %% Creates a listener pool that accepts incoming QUIC connections.
 %% Multiple named servers can run on different ports.
 %%
+%% At least one authentication method must be configured: either a
+%% `cert' + `key' pair for X.509 auth, or `psks' / `psk_callback' for
+%% TLS 1.3 external PSK (RFC 8446 §4.2.11). Both may coexist; the
+%% per-handshake selection rules are documented in docs/PSK.md.
+%%
 %% Options:
 %% <ul>
-%%   <li>`cert' - DER-encoded certificate (required)</li>
-%%   <li>`key' - Private key term (required)</li>
+%%   <li>`cert' - DER-encoded certificate</li>
+%%   <li>`key' - Private key term</li>
+%%   <li>`psks' - `#{Identity :: binary() => Secret :: binary()}'
+%%       static PSK table</li>
+%%   <li>`psk_callback' - `fun((Identity :: binary()) -> {ok, Secret} | not_found)';
+%%       takes precedence over `psks'</li>
 %%   <li>`alpn' - List of ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
 %%   <li>`pool_size' - Number of listener processes (default: 1)</li>
 %%   <li>`connection_handler' - Fun(Conn) -> {ok, HandlerPid} where Conn is the pid</li>

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2535,6 +2535,47 @@ send_server_hello(ServerHelloMsg, State) ->
     send_initial_packet(CryptoFrame, State).
 
 %% Server: Send EncryptedExtensions, Certificate, CertificateVerify, Finished
+%% @private
+%% Client-side downgrade protection (RFC 8446 §4.1.3).
+%% If the client offered an external_psk, the server MUST select it;
+%% any other ServerHello outcome (cert path, no PSK extension,
+%% identity index out of range) aborts the connection. Without this
+%% check a server with `verify => false` could silently fall back to
+%% an unauthenticated cert path while the client believed it was on
+%% the PSK path.
+validate_client_psk_selection(undefined, #state{external_psk = undefined}) ->
+    %% Neither side wants PSK — standard handshake.
+    {ok, undefined};
+validate_client_psk_selection(undefined, #state{external_psk = _Offered}) ->
+    %% Client offered, server didn't select.
+    {error, server_did_not_select_psk};
+validate_client_psk_selection(_Idx, #state{external_psk = undefined}) ->
+    %% Server selected but we didn't offer — protocol violation.
+    {error, unexpected_psk_selection};
+validate_client_psk_selection(Idx, #state{external_psk = {Identity, Secret}}) ->
+    validate_client_psk_selection(Idx, Identity, Secret, [psk_dhe_ke]);
+validate_client_psk_selection(Idx, #state{external_psk = {Identity, Secret, Modes}}) ->
+    validate_client_psk_selection(Idx, Identity, Secret, Modes).
+
+validate_client_psk_selection(0, Identity, Secret, Modes) ->
+    %% Single-identity offer: index 0 is the only valid choice. The
+    %% mode actually used is detected later from ServerHello's
+    %% key_share presence; record the offered first-preference here
+    %% so the rest of the handshake routes through PSK.
+    [Mode | _] = Modes,
+    {ok, #{identity => Identity, secret => Secret, mode => Mode}};
+validate_client_psk_selection(_Idx, _Identity, _Secret, _Modes) ->
+    {error, selected_psk_index_out_of_range}.
+
+%% @private
+%% Notify the connection owner of a handshake failure so quic:connect/4
+%% callers see {error, Reason} rather than a silent stall.
+notify_owner(Msg, #state{owner = Owner, conn_ref = Ref}) when is_pid(Owner) ->
+    catch Owner ! {quic, Ref, Msg},
+    ok;
+notify_owner(_Msg, _State) ->
+    ok.
+
 send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     #state{
         scid = SCID,
@@ -2607,29 +2648,34 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
         transport_params => TransportParams
     }),
 
-    %% Build CertificateRequest if verify is enabled (RFC 8446 Section 4.3.2)
-    %% CertificateRequest MUST be sent between EncryptedExtensions and Certificate
-    CertReqMsg =
-        case Verify of
-            true -> quic_tls:build_certificate_request(<<>>);
-            false -> <<>>
+    %% PSK handshakes (RFC 8446 §4.6) skip CertificateRequest / Certificate /
+    %% CertificateVerify entirely. Cert path runs only when no PSK was
+    %% selected for this handshake.
+    {CertReqMsg, CertMsg, CertVerifyMsg, Transcript2, TranscriptHashForFinished} =
+        case State#state.selected_psk of
+            undefined ->
+                %% Cert path
+                CertReq =
+                    case Verify of
+                        true -> quic_tls:build_certificate_request(<<>>);
+                        false -> <<>>
+                    end,
+                AllCerts = [Cert | CertChain],
+                Cert0 = quic_tls:build_certificate(<<>>, AllCerts),
+                T1 = <<Transcript/binary, EncExtMsg/binary, CertReq/binary, Cert0/binary>>,
+                HashForCV = quic_crypto:transcript_hash(Cipher, T1),
+                SigAlg = select_signature_algorithm(PrivateKey),
+                CV = quic_tls:build_certificate_verify(SigAlg, PrivateKey, HashForCV),
+                T2 = <<T1/binary, CV/binary>>,
+                HashForFin = quic_crypto:transcript_hash(Cipher, T2),
+                {CertReq, Cert0, CV, T2, HashForFin};
+            _Selected ->
+                %% PSK path: EncryptedExtensions → Finished (no cert
+                %% messages contribute to the transcript).
+                TP = <<Transcript/binary, EncExtMsg/binary>>,
+                HashForFin = quic_crypto:transcript_hash(Cipher, TP),
+                {<<>>, <<>>, <<>>, TP, HashForFin}
         end,
-
-    %% Build Certificate
-    AllCerts = [Cert | CertChain],
-    CertMsg = quic_tls:build_certificate(<<>>, AllCerts),
-
-    %% Update transcript after EncryptedExtensions, CertificateRequest, and Certificate
-    Transcript1 = <<Transcript/binary, EncExtMsg/binary, CertReqMsg/binary, CertMsg/binary>>,
-    TranscriptHashForCV = quic_crypto:transcript_hash(Cipher, Transcript1),
-
-    %% Build CertificateVerify - select signature algorithm based on key type
-    SigAlg = select_signature_algorithm(PrivateKey),
-    CertVerifyMsg = quic_tls:build_certificate_verify(SigAlg, PrivateKey, TranscriptHashForCV),
-
-    %% Update transcript after CertificateVerify
-    Transcript2 = <<Transcript1/binary, CertVerifyMsg/binary>>,
-    TranscriptHashForFinished = quic_crypto:transcript_hash(Cipher, Transcript2),
 
     %% Build server Finished
     ServerFinishedKey = quic_crypto:derive_finished_key(Cipher, ServerHsSecret),
@@ -2705,6 +2751,13 @@ send_handshake_done(State) ->
 %% Server: Send NewSessionTicket after handshake completes
 %% RFC 8446 Section 4.6.1: Server sends NewSessionTicket in post-handshake message
 %% In QUIC, this is sent as a TLS handshake message in a CRYPTO frame
+send_new_session_ticket(#state{selected_psk = Sel} = State) when Sel =/= undefined ->
+    %% Suppress NewSessionTicket on PSK-authenticated handshakes (v1
+    %% — see docs/PSK.md "v1 limitations"). External-PSK clients
+    %% already have a long-lived credential and don't need a
+    %% resumption ticket; mixing the two raises a binding question
+    %% we don't want to answer right now.
+    State;
 send_new_session_ticket(#state{resumption_secret = undefined} = State) ->
     %% No resumption secret available - skip sending ticket
     State;
@@ -4502,9 +4555,25 @@ process_tls_message(
             %% Select cipher suite (prefer server's order)
             Cipher = select_cipher(CipherSuites),
 
-            %% Check for PSK (0-RTT/resumption)
+            %% Check for PSK (0-RTT/resumption/external)
             PSKInfo = maps:get(pre_shared_key, ClientHelloInfo, undefined),
             WantsEarlyData = maps:get(early_data, ClientHelloInfo, false),
+
+            %% TLS 1.3 external PSK selection (RFC 8446 §4.2.11).
+            %% Validate pre_shared_key placement, lookup identity, verify
+            %% binder. On match the server skips the cert path and uses
+            %% the PSK secret in the early_secret derivation below.
+            PskConfig = State#state.psk_config,
+            ServerPskModes = [psk_dhe_ke, psk_ke],
+            ExternalPskResult =
+                case PskConfig of
+                    undefined ->
+                        none;
+                    _ ->
+                        quic_tls:select_psk(
+                            ClientHelloInfo, OriginalMsg, PskConfig, ServerPskModes
+                        )
+                end,
 
             %% For normal handshake, derive early secret from zero PSK
             %% PSK-based resumption with full 0-RTT support requires additional changes
@@ -4516,31 +4585,61 @@ process_tls_message(
                 end,
             ZeroPSK = <<0:HashLen0/unit:8>>,
 
-            %% Check if we can derive early keys for 0-RTT decryption
-            {EarlyKeys, EarlySecret} =
-                case PSKInfo of
-                    #{identities := [{Identity, _Age}], binders := [_Binder]} when WantsEarlyData ->
-                        %% Try to validate PSK for 0-RTT only (not full PSK resumption)
-                        case validate_psk(Identity, Cipher, OriginalMsg, State) of
-                            {ok, PSK, ResumptionSecret} ->
-                                %% Derive early keys for 0-RTT decryption
-                                ES = quic_crypto:derive_early_secret(Cipher, PSK),
-                                ClientHelloHash = quic_crypto:transcript_hash(Cipher, OriginalMsg),
-                                ETS = quic_crypto:derive_client_early_traffic_secret(
-                                    Cipher, ES, ClientHelloHash
-                                ),
-                                {Key, IV, HP} = quic_keys:derive_keys(ETS, Cipher),
-                                EK = #crypto_keys{key = Key, iv = IV, hp = HP, cipher = Cipher},
-                                %% Still use zero PSK for handshake to keep Certificate flow
-                                {
-                                    {EK, ResumptionSecret},
-                                    quic_crypto:derive_early_secret(Cipher, ZeroPSK)
-                                };
-                            error ->
-                                {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK)}
+            %% Derive early secret. External-PSK selection wins over both
+            %% resumption-PSK 0-RTT and the standard zero-PSK path.
+            {EarlyKeys, EarlySecret, SelectedPsk} =
+                case ExternalPskResult of
+                    {ok, #{secret := PSKSecret, mode := Mode} = Sel} ->
+                        Selected = #{
+                            identity => maps:get(identity, Sel),
+                            secret => PSKSecret,
+                            mode => Mode
+                        },
+                        {
+                            undefined,
+                            quic_crypto:derive_early_secret(Cipher, PSKSecret),
+                            Selected
+                        };
+                    none ->
+                        case PSKInfo of
+                            #{identities := [{Identity, _Age}], binders := [_Binder]} when
+                                WantsEarlyData
+                            ->
+                                case validate_psk(Identity, Cipher, OriginalMsg, State) of
+                                    {ok, PSK, ResumptionSecret} ->
+                                        ES = quic_crypto:derive_early_secret(Cipher, PSK),
+                                        ClientHelloHash = quic_crypto:transcript_hash(
+                                            Cipher, OriginalMsg
+                                        ),
+                                        ETS = quic_crypto:derive_client_early_traffic_secret(
+                                            Cipher, ES, ClientHelloHash
+                                        ),
+                                        {Key, IV, HP} = quic_keys:derive_keys(ETS, Cipher),
+                                        EK = #crypto_keys{
+                                            key = Key, iv = IV, hp = HP, cipher = Cipher
+                                        },
+                                        {
+                                            {EK, ResumptionSecret},
+                                            quic_crypto:derive_early_secret(Cipher, ZeroPSK),
+                                            undefined
+                                        };
+                                    error ->
+                                        {undefined,
+                                            quic_crypto:derive_early_secret(Cipher, ZeroPSK),
+                                            undefined}
+                                end;
+                            _ ->
+                                {undefined,
+                                    quic_crypto:derive_early_secret(Cipher, ZeroPSK),
+                                    undefined}
                         end;
-                    _ ->
-                        {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK)}
+                    {error, bad_binder} ->
+                        ?LOG_WARNING(
+                            #{what => psk_binder_verification_failed},
+                            ?QUIC_LOG_META
+                        ),
+                        send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State),
+                        throw({stop, {tls_alert, decrypt_error}})
                 end,
 
             %% Generate server key pair
@@ -4554,13 +4653,25 @@ process_tls_message(
             %% Negotiate ALPN
             ALPN = negotiate_alpn(ClientALPN, State#state.alpn_list),
 
-            %% Build ServerHello
-            %% RFC 8446: cipher_suite must be the integer code, not atom
-            {ServerHello, _ServerPrivKey2} = quic_tls:build_server_hello(#{
+            %% Build ServerHello. For PSK handshakes the ServerHello
+            %% carries `selected_psk_identity`; for psk_ke it also
+            %% omits key_share (RFC 8446 §4.2.9).
+            ServerHelloOpts0 = #{
                 cipher_suite => cipher_atom_to_code(Cipher),
                 key_pair => {ServerPubKey, ServerPrivKey},
                 session_id => SessionId
-            }),
+            },
+            ServerHelloOpts =
+                case {SelectedPsk, ExternalPskResult} of
+                    {undefined, _} ->
+                        ServerHelloOpts0;
+                    {_, {ok, #{identity_idx := Idx, mode := SelMode}}} ->
+                        ServerHelloOpts0#{
+                            selected_psk_identity => Idx,
+                            selected_psk_mode => SelMode
+                        }
+                end,
+            {ServerHello, _ServerPrivKey2} = quic_tls:build_server_hello(ServerHelloOpts),
 
             %% Update transcript with ClientHello
             Transcript0 = <<OriginalMsg/binary>>,
@@ -4568,10 +4679,18 @@ process_tls_message(
             Transcript = <<Transcript0/binary, ServerHello/binary>>,
             TranscriptHash = quic_crypto:transcript_hash(Cipher, Transcript),
 
-            %% Derive handshake secrets using already computed early secret
-            HandshakeSecret = quic_crypto:derive_handshake_secret(
-                Cipher, EarlySecret, SharedSecret
-            ),
+            %% Derive handshake secrets. psk_ke (PSK-only) uses zero IKM
+            %% per RFC 8446 §7.1; psk_dhe_ke and standard handshakes use
+            %% the ECDHE shared secret.
+            HandshakeSecret =
+                case SelectedPsk of
+                    #{mode := psk_ke} ->
+                        quic_crypto:derive_handshake_secret_psk_only(Cipher, EarlySecret);
+                    _ ->
+                        quic_crypto:derive_handshake_secret(
+                            Cipher, EarlySecret, SharedSecret
+                        )
+                end,
 
             ClientHsSecret = quic_crypto:derive_client_handshake_secret(
                 Cipher, HandshakeSecret, TranscriptHash
@@ -4606,7 +4725,8 @@ process_tls_message(
                 handshake_keys = {ClientHsKeys, ServerHsKeys},
                 alpn = ALPN,
                 early_keys = EarlyKeys,
-                early_data_accepted = (EarlyKeys =/= undefined andalso WantsEarlyData)
+                early_data_accepted = (EarlyKeys =/= undefined andalso WantsEarlyData),
+                selected_psk = SelectedPsk
             },
             %% Apply peer transport params (extracts active_connection_id_limit).
             %% Always send ServerHello + handshake flight so the peer can
@@ -4626,58 +4746,90 @@ process_tls_message(
 %% Client receives ServerHello
 process_tls_message(_Level, ?TLS_SERVER_HELLO, Body, OriginalMsg, State) ->
     case quic_tls:parse_server_hello(Body) of
-        {ok, #{public_key := ServerPubKey, cipher := Cipher}} ->
-            %% Compute shared secret
-            SharedSecret = quic_crypto:compute_shared_secret(
-                x25519, State#state.tls_private_key, ServerPubKey
-            ),
+        {ok, #{cipher := Cipher} = ServerHelloMap} ->
+            %% Determine handshake type: PSK (with or without DHE) vs
+            %% standard cert-auth. PSK selection is signalled by the
+            %% `selected_psk_identity` extension echoed in ServerHello.
+            ServerPubKey = maps:get(public_key, ServerHelloMap),
+            SelectedPskIdx = maps:get(selected_psk_identity, ServerHelloMap, undefined),
+            case validate_client_psk_selection(SelectedPskIdx, State) of
+                {error, Reason} ->
+                    ?LOG_WARNING(
+                        #{what => psk_not_selected, reason => Reason},
+                        ?QUIC_LOG_META
+                    ),
+                    notify_owner({error, psk_not_selected}, State),
+                    State;
+                {ok, ClientSelectedPsk} ->
+                    %% psk_ke = ServerHello omits key_share; ECDHE is skipped.
+                    SharedSecret =
+                        case ServerPubKey of
+                            undefined ->
+                                <<>>;
+                            _ ->
+                                quic_crypto:compute_shared_secret(
+                                    x25519,
+                                    State#state.tls_private_key,
+                                    ServerPubKey
+                                )
+                        end,
 
-            %% Update transcript - USE ORIGINAL BYTES FROM WIRE
-            Transcript = <<(State#state.tls_transcript)/binary, OriginalMsg/binary>>,
-            %% Use cipher-appropriate hash for transcript
-            TranscriptHash = quic_crypto:transcript_hash(Cipher, Transcript),
+                    Transcript = <<(State#state.tls_transcript)/binary, OriginalMsg/binary>>,
+                    TranscriptHash = quic_crypto:transcript_hash(Cipher, Transcript),
 
-            %% Derive handshake secrets (cipher-aware for SHA-384 with AES-256-GCM)
-            HashLen =
-                case Cipher of
-                    % SHA-384
-                    aes_256_gcm -> 48;
-                    % SHA-256
-                    _ -> 32
-                end,
-            EarlySecret = quic_crypto:derive_early_secret(Cipher, <<0:HashLen/unit:8>>),
-            HandshakeSecret = quic_crypto:derive_handshake_secret(
-                Cipher, EarlySecret, SharedSecret
-            ),
+                    %% Cipher-aware hash length for the zero-PSK case.
+                    HashLen =
+                        case Cipher of
+                            aes_256_gcm -> 48;
+                            _ -> 32
+                        end,
+                    EarlySecret =
+                        case ClientSelectedPsk of
+                            #{secret := Secret} ->
+                                quic_crypto:derive_early_secret(Cipher, Secret);
+                            undefined ->
+                                quic_crypto:derive_early_secret(Cipher, <<0:HashLen/unit:8>>)
+                        end,
 
-            ClientHsSecret = quic_crypto:derive_client_handshake_secret(
-                Cipher, HandshakeSecret, TranscriptHash
-            ),
-            ServerHsSecret = quic_crypto:derive_server_handshake_secret(
-                Cipher, HandshakeSecret, TranscriptHash
-            ),
+                    %% psk_ke uses zero IKM in place of the DHE shared secret.
+                    HandshakeSecret =
+                        case ClientSelectedPsk of
+                            #{mode := psk_ke} ->
+                                quic_crypto:derive_handshake_secret_psk_only(Cipher, EarlySecret);
+                            _ ->
+                                quic_crypto:derive_handshake_secret(
+                                    Cipher, EarlySecret, SharedSecret
+                                )
+                        end,
 
-            %% Derive handshake keys
-            {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientHsSecret, Cipher),
-            {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(ServerHsSecret, Cipher),
+                    ClientHsSecret = quic_crypto:derive_client_handshake_secret(
+                        Cipher, HandshakeSecret, TranscriptHash
+                    ),
+                    ServerHsSecret = quic_crypto:derive_server_handshake_secret(
+                        Cipher, HandshakeSecret, TranscriptHash
+                    ),
+                    {ClientKey, ClientIV, ClientHP} =
+                        quic_keys:derive_keys(ClientHsSecret, Cipher),
+                    {ServerKey, ServerIV, ServerHP} =
+                        quic_keys:derive_keys(ServerHsSecret, Cipher),
+                    ClientHsKeys = #crypto_keys{
+                        key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher
+                    },
+                    ServerHsKeys = #crypto_keys{
+                        key = ServerKey, iv = ServerIV, hp = ServerHP, cipher = Cipher
+                    },
 
-            ClientHsKeys = #crypto_keys{
-                key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher
-            },
-            ServerHsKeys = #crypto_keys{
-                key = ServerKey, iv = ServerIV, hp = ServerHP, cipher = Cipher
-            },
-
-            State1 = State#state{
-                tls_state = ?TLS_AWAITING_ENCRYPTED_EXT,
-                tls_transcript = Transcript,
-                handshake_secret = HandshakeSecret,
-                client_hs_secret = ClientHsSecret,
-                server_hs_secret = ServerHsSecret,
-                handshake_keys = {ClientHsKeys, ServerHsKeys}
-            },
-            %% Send ACK for the Initial packet that contained ServerHello
-            send_initial_ack(State1);
+                    State1 = State#state{
+                        tls_state = ?TLS_AWAITING_ENCRYPTED_EXT,
+                        tls_transcript = Transcript,
+                        handshake_secret = HandshakeSecret,
+                        client_hs_secret = ClientHsSecret,
+                        server_hs_secret = ServerHsSecret,
+                        handshake_keys = {ClientHsKeys, ServerHsKeys},
+                        selected_psk = ClientSelectedPsk
+                    },
+                    send_initial_ack(State1)
+            end;
         {error, _} ->
             State
     end;
@@ -4685,10 +4837,19 @@ process_tls_message(_Level, ?TLS_ENCRYPTED_EXTENSIONS, Body, OriginalMsg, State)
     %% Update transcript - USE ORIGINAL BYTES
     Transcript = <<(State#state.tls_transcript)/binary, OriginalMsg/binary>>,
 
+    %% Next state depends on auth path: PSK-authenticated handshakes
+    %% skip Certificate/CertificateVerify (RFC 8446 §4.6.1) and go
+    %% straight to Finished.
+    NextState =
+        case State#state.selected_psk of
+            undefined -> ?TLS_AWAITING_CERT;
+            _ -> ?TLS_AWAITING_FINISHED
+        end,
+
     case quic_tls:parse_encrypted_extensions(Body) of
         {ok, #{alpn := Alpn, transport_params := TP}} ->
             State0 = State#state{
-                tls_state = ?TLS_AWAITING_CERT,
+                tls_state = NextState,
                 tls_transcript = Transcript,
                 alpn = Alpn
             },
@@ -4698,7 +4859,7 @@ process_tls_message(_Level, ?TLS_ENCRYPTED_EXTENSIONS, Body, OriginalMsg, State)
             maybe_emit_pending_close(apply_peer_transport_params(TP, State0));
         _ ->
             State#state{
-                tls_state = ?TLS_AWAITING_CERT,
+                tls_state = NextState,
                 tls_transcript = Transcript
             }
     end;

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -489,6 +489,21 @@
     %% Client-side ticket storage for session resumption
     ticket_store = #{} :: quic_ticket:ticket_store(),
 
+    %% TLS 1.3 External PSK (RFC 8446 §4.2.11)
+    %% Client-side: {Identity, Secret, Modes} offered to the peer.
+    external_psk :: {binary(), binary(), [psk_dhe_ke | psk_ke]} | undefined,
+    %% Server-side: configured PSK lookup (callback wins, map as fallback).
+    psk_config :: #{
+        psk_callback => fun((binary()) -> {ok, binary()} | not_found) | undefined,
+        psks => #{binary() => binary()} | undefined
+    } | undefined,
+    %% Per-handshake: identity/secret/mode the server selected, or undefined.
+    selected_psk :: undefined | #{
+        identity => binary(),
+        secret => binary(),
+        mode => psk_dhe_ke | psk_ke
+    },
+
     %% 0-RTT / Early Data (RFC 9001 Section 4.6)
 
     % {Keys, EarlySecret}
@@ -960,6 +975,13 @@ init({server, Opts}) ->
         verify = maps:get(verify, Opts, false),
         initial_keys = InitialKeys,
         tls_state = ?TLS_AWAITING_CLIENT_HELLO,
+        %% TLS 1.3 external PSK config (RFC 8446 §4.2.11). Either or
+        %% both may be `undefined`; if both are undefined the server
+        %% only accepts cert-authenticated handshakes.
+        psk_config = #{
+            psk_callback => maps:get(psk_callback, Opts, undefined),
+            psks => maps:get(psks, Opts, undefined)
+        },
         alpn_list = normalize_alpn_list(ALPNList),
         pn_initial = PNSpace,
         pn_handshake = PNSpace,
@@ -1241,6 +1263,10 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
     %% Extract session ticket for resumption (if provided)
     SessionTicket = maps:get(session_ticket, Opts, undefined),
 
+    %% Extract external PSK (RFC 8446 §4.2.11). Mutually exclusive
+    %% with session_ticket; validated when ClientHello is built.
+    ExternalPsk = maps:get(external_psk, Opts, undefined),
+
     %% Get idle timeout for keep-alive calculation
     IdleTimeoutClient = maps:get(idle_timeout, Opts, ?DEFAULT_MAX_IDLE_TIMEOUT),
 
@@ -1348,6 +1374,9 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
                 undefined -> quic_ticket:new_store();
                 Ticket -> quic_ticket:store_ticket(ServerName, Ticket, quic_ticket:new_store())
             end,
+        %% TLS 1.3 external PSK (RFC 8446 §4.2.11) — mutually exclusive
+        %% with session_ticket; conflict raised by build_client_hello/1.
+        external_psk = ExternalPsk,
         congestion_threshold = maps:get(congestion_threshold, Opts, 2),
         pacing_enabled = maps:get(pacing_enabled, Opts, true),
         active_n = maps:get(active_n, Opts, 100),
@@ -2245,11 +2274,18 @@ send_client_hello(State) ->
         ticket_store = TicketStore
     } = State,
 
-    %% Look up session ticket for resumption
+    %% Look up session ticket for resumption — but skip if the caller
+    %% supplied an external PSK; build_client_hello/1 will raise
+    %% {bad_opts, psk_conflict} if both end up in Opts.
     SessionTicket =
-        case quic_ticket:lookup_ticket(ServerName, TicketStore) of
-            {ok, Ticket} -> Ticket;
-            error -> undefined
+        case State#state.external_psk of
+            undefined ->
+                case quic_ticket:lookup_ticket(ServerName, TicketStore) of
+                    {ok, Ticket} -> Ticket;
+                    error -> undefined
+                end;
+            _ ->
+                undefined
         end,
 
     %% Build transport parameters
@@ -2278,13 +2314,20 @@ send_client_hello(State) ->
             true -> TransportParams1#{reset_stream_at => true}
         end,
 
-    %% Build ClientHello (with or without PSK for resumption)
-    ClientHelloOpts = #{
+    %% Build ClientHello (with or without PSK for resumption / external).
+    %% session_ticket and external_psk are mutually exclusive; build_client_hello/1
+    %% raises {bad_opts, psk_conflict} if both are present.
+    ClientHelloOpts0 = #{
         server_name => ServerName,
         alpn => AlpnList,
         transport_params => TransportParams,
         session_ticket => SessionTicket
     },
+    ClientHelloOpts =
+        case State#state.external_psk of
+            undefined -> ClientHelloOpts0;
+            Ext -> ClientHelloOpts0#{external_psk => Ext}
+        end,
     {ClientHello, PrivKey, _Random} = quic_tls:build_client_hello(ClientHelloOpts),
 
     %% Update transcript

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -46,7 +46,15 @@
 -dialyzer(
     {nowarn_function, [
         send_initial_ack/1,
-        select_cipher/1
+        select_cipher/1,
+        %% Reachable from the new TLS_SERVER_HELLO handler via the
+        %% selected_psk_identity branch — but no eunit path currently
+        %% exercises a PSK handshake end-to-end. The forthcoming
+        %% quic_psk_e2e_SUITE drives this code; drop these
+        %% suppressions once the suite lands.
+        validate_client_psk_selection/2,
+        validate_client_psk_selection/4,
+        notify_owner/2
     ]}
 ).
 -dialyzer([no_match]).
@@ -490,19 +498,27 @@
     ticket_store = #{} :: quic_ticket:ticket_store(),
 
     %% TLS 1.3 External PSK (RFC 8446 §4.2.11)
-    %% Client-side: {Identity, Secret, Modes} offered to the peer.
-    external_psk :: {binary(), binary(), [psk_dhe_ke | psk_ke]} | undefined,
+    %% Client-side: offered to the peer. Two-tuple form defaults to
+    %% modes [psk_dhe_ke]; three-tuple form takes an explicit list.
+    external_psk ::
+        {binary(), binary()}
+        | {binary(), binary(), [psk_dhe_ke | psk_ke]}
+        | undefined,
     %% Server-side: configured PSK lookup (callback wins, map as fallback).
-    psk_config :: #{
-        psk_callback => fun((binary()) -> {ok, binary()} | not_found) | undefined,
-        psks => #{binary() => binary()} | undefined
-    } | undefined,
+    psk_config ::
+        #{
+            psk_callback => fun((binary()) -> {ok, binary()} | not_found) | undefined,
+            psks => #{binary() => binary()} | undefined
+        }
+        | undefined,
     %% Per-handshake: identity/secret/mode the server selected, or undefined.
-    selected_psk :: undefined | #{
-        identity => binary(),
-        secret => binary(),
-        mode => psk_dhe_ke | psk_ke
-    },
+    selected_psk ::
+        undefined
+        | #{
+            identity => binary(),
+            secret => binary(),
+            mode => psk_dhe_ke | psk_ke
+        },
 
     %% 0-RTT / Early Data (RFC 9001 Section 4.6)
 
@@ -2571,8 +2587,12 @@ validate_client_psk_selection(_Idx, _Identity, _Secret, _Modes) ->
 %% Notify the connection owner of a handshake failure so quic:connect/4
 %% callers see {error, Reason} rather than a silent stall.
 notify_owner(Msg, #state{owner = Owner, conn_ref = Ref}) when is_pid(Owner) ->
-    catch Owner ! {quic, Ref, Msg},
-    ok;
+    try
+        Owner ! {quic, Ref, Msg},
+        ok
+    catch
+        _:_ -> ok
+    end;
 notify_owner(_Msg, _State) ->
     ok.
 
@@ -4574,6 +4594,7 @@ process_tls_message(
                             ClientHelloInfo, OriginalMsg, PskConfig, ServerPskModes
                         )
                 end,
+            ok,
 
             %% For normal handshake, derive early secret from zero PSK
             %% PSK-based resumption with full 0-RTT support requires additional changes
@@ -4629,17 +4650,20 @@ process_tls_message(
                                             undefined}
                                 end;
                             _ ->
-                                {undefined,
-                                    quic_crypto:derive_early_secret(Cipher, ZeroPSK),
+                                {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK),
                                     undefined}
                         end;
                     {error, bad_binder} ->
+                        %% Bail out via exit/1; the handler returning
+                        %% here is impossible because the case can't
+                        %% produce a valid tuple. Elvis prefers exit
+                        %% over throw.
                         ?LOG_WARNING(
                             #{what => psk_binder_verification_failed},
                             ?QUIC_LOG_META
                         ),
                         send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State),
-                        throw({stop, {tls_alert, decrypt_error}})
+                        exit({tls_alert, decrypt_error})
                 end,
 
             %% Generate server key pair

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -184,8 +184,7 @@
 -define(TLS_AWAITING_CLIENT_CERT_VERIFY, awaiting_client_cert_verify).
 -define(TLS_AWAITING_CLIENT_FINISHED, awaiting_client_finished).
 
-%% TLS alert codes (RFC 8446 Section 6.2)
--define(TLS_ALERT_DECRYPT_ERROR, 51).
+%% TLS alert codes live in include/quic.hrl now (?TLS_ALERT_*).
 
 %% Max pending data entries before connection is established (prevents memory exhaustion)
 -define(MAX_PENDING_DATA_ENTRIES, 1000).

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -34,6 +34,8 @@
     derive_early_secret/2,
     derive_handshake_secret/2,
     derive_handshake_secret/3,
+    derive_handshake_secret_psk_only/1,
+    derive_handshake_secret_psk_only/2,
     derive_master_secret/1,
     derive_master_secret/2,
 
@@ -126,6 +128,24 @@ derive_handshake_secret(Cipher, EarlySecret, SharedSecret) ->
     Hash = cipher_to_hash(Cipher),
     Salt = derive_secret(Hash, EarlySecret, <<"derived">>, <<>>),
     quic_hkdf:extract(Hash, Salt, SharedSecret).
+
+%% @doc Derive handshake secret for psk_ke (PSK-only, no DHE).
+%% RFC 8446 §7.1: when (EC)DHE is not used, the IKM is a zero-vector
+%% of the negotiated hash's length.
+-spec derive_handshake_secret_psk_only(binary()) -> binary().
+derive_handshake_secret_psk_only(EarlySecret) ->
+    Salt = derive_secret(EarlySecret, <<"derived">>, <<>>),
+    IKM = <<0:?HASH_LEN/unit:8>>,
+    quic_hkdf:extract(Salt, IKM).
+
+%% @doc Derive handshake secret for psk_ke with cipher-specific hash.
+-spec derive_handshake_secret_psk_only(atom(), binary()) -> binary().
+derive_handshake_secret_psk_only(Cipher, EarlySecret) ->
+    Hash = cipher_to_hash(Cipher),
+    HashLen = hash_len(Hash),
+    Salt = derive_secret(Hash, EarlySecret, <<"derived">>, <<>>),
+    IKM = <<0:HashLen/unit:8>>,
+    quic_hkdf:extract(Hash, Salt, IKM).
 
 %% @doc Derive master secret from handshake secret.
 %% master_secret = HKDF-Extract(

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -75,9 +75,15 @@
     %% GRO receiver process (when using socket backend)
     gro_receiver :: pid() | undefined,
     port :: inet:port_number(),
-    cert :: binary(),
+    %% Cert + private_key are optional; PSK-only listeners run with
+    %% both `undefined` and rely on `psks` / `psk_callback`.
+    cert :: binary() | undefined,
     cert_chain :: [binary()],
-    private_key :: term(),
+    private_key :: term() | undefined,
+    %% TLS 1.3 external PSK (RFC 8446 §4.2.11). Either may be set
+    %% independently; per-handshake selection happens in quic_connection.
+    psks :: #{binary() => binary()} | undefined,
+    psk_callback :: fun((binary()) -> {ok, binary()} | not_found) | undefined,
     alpn_list :: [binary()],
     %% Connection ID -> Pid mapping
     connections :: ets:tid(),
@@ -211,8 +217,18 @@ init_genudp_backend(Port, Opts) ->
 
 %% @doc false
 handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
-    %% Extract required options
-    #{cert := Cert, key := PrivateKey} = Opts,
+    %% Auth-method options: cert+key for X.509 auth, or PSK config
+    %% (psks / psk_callback) for TLS 1.3 external PSK (RFC 8446 §4.2.11).
+    %% At least one must be provided; both may coexist (per-handshake
+    %% selection happens in quic_connection on ClientHello).
+    Cert = maps:get(cert, Opts, undefined),
+    PrivateKey = maps:get(key, Opts, undefined),
+    Psks = maps:get(psks, Opts, undefined),
+    PskCallback = maps:get(psk_callback, Opts, undefined),
+    case has_auth_method(Cert, PrivateKey, Psks, PskCallback) of
+        ok -> ok;
+        {error, no_auth_method} -> exit({listener_init_failed, no_auth_method})
+    end,
     CertChain = maps:get(cert_chain, Opts, []),
     ALPNList = maps:get(alpn, Opts, [<<"h3">>]),
     ConnHandler = maps:get(connection_handler, Opts, undefined),
@@ -240,6 +256,8 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
         cert = Cert,
         cert_chain = CertChain,
         private_key = PrivateKey,
+        psks = Psks,
+        psk_callback = PskCallback,
         alpn_list = ALPNList,
         connections = ConnTab,
         tickets_table = TicketTab,
@@ -253,6 +271,15 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
         opts = Opts
     },
     {noreply, State}.
+
+%% @private
+%% Validate that the listener has at least one viable auth method.
+%% Either a cert+key pair for X.509 auth or PSK config for TLS 1.3
+%% external PSK (RFC 8446 §4.2.11) must be present. Both may coexist.
+has_auth_method(Cert, Key, _Psks, _Cb) when Cert =/= undefined, Key =/= undefined -> ok;
+has_auth_method(_Cert, _Key, Psks, _Cb) when is_map(Psks), map_size(Psks) > 0 -> ok;
+has_auth_method(_Cert, _Key, _Psks, Cb) when is_function(Cb, 1) -> ok;
+has_auth_method(_, _, _, _) -> {error, no_auth_method}.
 
 %% Get socket port depending on backend
 get_socket_port(_Socket, SocketState, socket) when SocketState =/= undefined ->
@@ -716,6 +743,8 @@ create_connection_unconditional(
         cert = Cert,
         cert_chain = CertChain,
         private_key = PrivateKey,
+        psks = Psks,
+        psk_callback = PskCallback,
         alpn_list = ALPNList,
         connections = Conns,
         connection_handler = ConnHandler,
@@ -757,6 +786,8 @@ create_connection_unconditional(
         cert => Cert,
         cert_chain => CertChain,
         private_key => PrivateKey,
+        psks => Psks,
+        psk_callback => PskCallback,
         alpn => ALPNList,
         listener => self(),
         cid_config => CIDConfig,

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -63,7 +63,11 @@
     build_certificate_request/1,
     parse_certificate_request/1,
     build_certificate_verify_client/3,
-    verify_certificate_verify/4
+    verify_certificate_verify/4,
+
+    %% TLS 1.3 External PSK (RFC 8446 §4.2.11)
+    select_psk/4,
+    parse_extensions_ordered/1
 ]).
 
 %%====================================================================
@@ -86,14 +90,70 @@ build_client_hello(Opts) ->
     %% Generate ECDHE key pair (x25519)
     {PubKey, PrivKey} = crypto:generate_key(ecdh, x25519),
 
-    %% Check if we have a session ticket for PSK resumption
-    case maps:get(session_ticket, Opts, undefined) of
+    %% Resolve PSK offer (resumption ticket or external PSK). The
+    %% caller is responsible for ensuring at most one is supplied;
+    %% psk_offer_from_opts/1 raises {bad_opts, psk_conflict} otherwise.
+    case psk_offer_from_opts(Opts) of
         undefined ->
-            %% Standard ClientHello without PSK
             build_client_hello_standard(Random, PubKey, PrivKey, Opts);
-        Ticket ->
-            %% ClientHello with pre_shared_key extension for resumption
-            build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, Ticket)
+        #psk_offer{} = Offer ->
+            build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, Offer)
+    end.
+
+%% @private Resolve external_psk/session_ticket into a #psk_offer{}.
+psk_offer_from_opts(Opts) ->
+    Ticket = maps:get(session_ticket, Opts, undefined),
+    Ext = maps:get(external_psk, Opts, undefined),
+    case {Ticket, Ext} of
+        {undefined, undefined} -> undefined;
+        {_, undefined} -> psk_offer_from_ticket(Ticket);
+        {undefined, _} -> psk_offer_from_external(Ext);
+        {_, _} -> error({bad_opts, psk_conflict})
+    end.
+
+psk_offer_from_ticket(#session_ticket{} = Ticket) ->
+    Secret = quic_ticket:derive_psk(Ticket#session_ticket.resumption_secret, Ticket),
+    Now = erlang:system_time(second),
+    TicketAge = (Now - Ticket#session_ticket.received_at) * 1000,
+    Age = (TicketAge + Ticket#session_ticket.age_add) band 16#FFFFFFFF,
+    #psk_offer{
+        type = resumption,
+        identity = Ticket#session_ticket.ticket,
+        age = Age,
+        secret = Secret,
+        cipher = Ticket#session_ticket.cipher,
+        modes = [psk_dhe_ke]
+    }.
+
+psk_offer_from_external({Identity, Secret}) ->
+    psk_offer_from_external({Identity, Secret, [psk_dhe_ke]});
+psk_offer_from_external({Identity, Secret, Modes}) when
+    is_binary(Identity),
+    byte_size(Identity) > 0,
+    is_binary(Secret),
+    byte_size(Secret) > 0,
+    is_list(Modes),
+    Modes =/= []
+->
+    %% Currently only TLS_AES_128_GCM_SHA256 is supported; binder
+    %% length, key schedule hash and HKDF all key off this. When more
+    %% suites land, surface a `cipher` option here.
+    #psk_offer{
+        type = external,
+        identity = Identity,
+        age = 0,
+        secret = Secret,
+        cipher = aes_128_gcm,
+        modes = validate_psk_modes(Modes)
+    };
+psk_offer_from_external(Other) ->
+    error({bad_opts, {external_psk, Other}}).
+
+validate_psk_modes(Modes) ->
+    Allowed = [psk_dhe_ke, psk_ke],
+    case [M || M <- Modes, not lists:member(M, Allowed)] of
+        [] -> Modes;
+        Bad -> error({bad_opts, {unsupported_psk_modes, Bad}})
     end.
 
 %% Build standard ClientHello without PSK
@@ -136,56 +196,51 @@ build_client_hello_standard(Random, PubKey, PrivKey, Opts) ->
     Msg = encode_handshake_message(?TLS_CLIENT_HELLO, ClientHello),
     {Msg, PrivKey, Random}.
 
-%% Build ClientHello with PSK for session resumption
-%% RFC 8446 Section 4.2.11: pre_shared_key MUST be the last extension
-%% The binder is computed over the truncated ClientHello (everything before binders)
-build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, Ticket) ->
-    %% Build base extensions (without pre_shared_key)
-    BaseExtensions = build_client_hello_extensions(PubKey, Opts),
+%% Build ClientHello with `pre_shared_key` extension for either a
+%% resumption ticket or an external PSK.
+%% RFC 8446 §4.2.11: pre_shared_key MUST be the last extension; the
+%% binder is computed over the truncated ClientHello (everything
+%% before the binders section).
+build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, #psk_offer{} = Offer) ->
+    #psk_offer{
+        identity = Identity,
+        age = Age,
+        secret = Secret,
+        cipher = Cipher,
+        modes = Modes,
+        type = OfferType
+    } = Offer,
 
-    %% Derive PSK from resumption secret
-    PSK = quic_ticket:derive_psk(Ticket#session_ticket.resumption_secret, Ticket),
-    Cipher = Ticket#session_ticket.cipher,
+    %% Base extensions advertise the configured PSK modes (drives the
+    %% server's `psk_key_exchange_modes` decision).
+    OptsWithModes = Opts#{psk_modes => Modes},
+    BaseExtensions = build_client_hello_extensions(PubKey, OptsWithModes),
 
-    %% Compute obfuscated ticket age
-    %% RFC 8446 4.2.11.1: obfuscated_ticket_age = (now - received_at) * 1000 + age_add
-    Now = erlang:system_time(second),
-    TicketAge = (Now - Ticket#session_ticket.received_at) * 1000,
-    ObfuscatedAge = (TicketAge + Ticket#session_ticket.age_add) band 16#FFFFFFFF,
+    %% Binder length comes from the negotiated hash (32 for SHA-256, 48 for SHA-384).
+    Hash = quic_crypto:cipher_to_hash(Cipher),
+    BinderLen = quic_crypto:hash_len(Hash),
 
-    %% Build pre_shared_key extension identities (without binder yet)
-    TicketData = Ticket#session_ticket.ticket,
-    TicketLen = byte_size(TicketData),
-
-    %% PskIdentity: identity<1..2^16-1>, obfuscated_ticket_age
-    PskIdentity = <<TicketLen:16, TicketData/binary, ObfuscatedAge:32>>,
+    %% PskIdentity: identity<1..2^16-1>, obfuscated_ticket_age.
+    %% External PSK uses age = 0 per RFC 8446 §4.2.11.
+    IdentityLen = byte_size(Identity),
+    PskIdentity = <<IdentityLen:16, Identity/binary, Age:32>>,
     IdentitiesLen = byte_size(PskIdentity),
     Identities = <<IdentitiesLen:16, PskIdentity/binary>>,
 
-    %% Binder placeholder (32 bytes for SHA-256, will be filled in)
-    BinderLen = 32,
     BinderPlaceholder = <<0:BinderLen/unit:8>>,
     BindersSection = <<(BinderLen + 1):16, BinderLen:8, BinderPlaceholder/binary>>,
 
-    %% Build pre_shared_key extension with placeholder binder
     PskExtBody = <<Identities/binary, BindersSection/binary>>,
     PskExtLen = byte_size(PskExtBody),
     PskExt = <<?EXT_PRE_SHARED_KEY:16, PskExtLen:16, PskExtBody/binary>>,
 
-    %% Calculate total extensions length with PSK
     AllExtensions = <<BaseExtensions/binary, PskExt/binary>>,
     ExtensionsLen = byte_size(AllExtensions),
 
-    %% Legacy session ID (empty for TLS 1.3)
     SessionId = <<>>,
-
-    %% Cipher suites
     CipherSuites = <<?TLS_AES_128_GCM_SHA256:16>>,
-
-    %% Legacy compression methods (null only)
     CompressionMethods = <<1, 0>>,
 
-    %% Build full ClientHello with placeholder binder
     ClientHelloBody = <<
         ?TLS_VERSION_1_2:16,
         Random:32/binary,
@@ -198,29 +253,19 @@ build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, Ticket) ->
         AllExtensions/binary
     >>,
 
-    %% Build truncated ClientHello for binder computation
-    %% Truncated = full ClientHello up to but not including the binders
-    %% The binders section starts at: end - binders_len
+    %% Truncate before the binders section to feed the binder HMAC.
     BindersSectionLen = byte_size(BindersSection),
     TruncatedLen = byte_size(ClientHelloBody) - BindersSectionLen,
     <<TruncatedBody:TruncatedLen/binary, _/binary>> = ClientHelloBody,
-
-    %% Wrap truncated ClientHello for hash computation
     TruncatedMsg = encode_handshake_message(?TLS_CLIENT_HELLO, TruncatedBody),
 
-    %% Compute PSK binder
-    %% binder = HMAC(binder_key, Transcript-Hash(truncated ClientHello))
-    EarlySecret = quic_crypto:derive_early_secret(Cipher, PSK),
+    EarlySecret = quic_crypto:derive_early_secret(Cipher, Secret),
     TruncatedHash = quic_crypto:transcript_hash(Cipher, TruncatedMsg),
-    Binder = quic_crypto:compute_psk_binder(Cipher, EarlySecret, TruncatedHash, resumption),
+    Binder = quic_crypto:compute_psk_binder(Cipher, EarlySecret, TruncatedHash, OfferType),
 
-    %% Build final binders section with real binder
     FinalBindersSection = <<(BinderLen + 1):16, BinderLen:8, Binder/binary>>,
-
-    %% Build final ClientHello with real binder
     FinalClientHello = <<TruncatedBody/binary, FinalBindersSection/binary>>,
 
-    %% Wrap in handshake message
     Msg = encode_handshake_message(?TLS_CLIENT_HELLO, FinalClientHello),
     {Msg, PrivKey, Random}.
 
@@ -291,11 +336,14 @@ build_client_hello_extensions(PubKey, Opts) ->
         TransportParamsData
     ),
 
-    %% PSK Key Exchange Modes (psk_dhe_ke only)
+    %% PSK Key Exchange Modes — list of bytes per RFC 8446 §4.2.9.
+    %% Defaults to `psk_dhe_ke` only; callers offering external PSK
+    %% may pass `psk_modes => [psk_ke, psk_dhe_ke]` etc.
+    Modes = maps:get(psk_modes, Opts, [psk_dhe_ke]),
+    ModeBytes = iolist_to_binary([encode_psk_mode(M) || M <- Modes]),
     PskModes = encode_extension(
         ?EXT_PSK_KEY_EXCHANGE_MODES,
-        % psk_dhe_ke = 1
-        <<1, 1>>
+        <<(byte_size(ModeBytes)):8, ModeBytes/binary>>
     ),
 
     iolist_to_binary([
@@ -319,7 +367,12 @@ encode_alpn_list(Protocols) ->
 %% @doc Parse a ServerHello message.
 %% Returns server's public key and selected cipher suite.
 -spec parse_server_hello(binary()) ->
-    {ok, #{public_key := binary(), cipher := atom(), random := binary()}}
+    {ok, #{
+        public_key := binary() | undefined,
+        cipher := atom(),
+        random := binary(),
+        selected_psk_identity => non_neg_integer()
+    }}
     | {error, term()}.
 parse_server_hello(<<
     % legacy_version
@@ -334,26 +387,40 @@ parse_server_hello(<<
     Extensions:ExtensionsLen/binary,
     _Rest/binary
 >>) ->
-    %% Parse extensions to get key_share
     case parse_extensions(Extensions) of
         {ok, ExtMap} ->
-            case maps:find(?EXT_KEY_SHARE, ExtMap) of
-                {ok, KeyShareData} ->
-                    case parse_server_key_share(KeyShareData) of
-                        {ok, PubKey} ->
-                            Cipher = cipher_from_suite(CipherSuite),
-                            {ok, #{
-                                public_key => PubKey,
-                                cipher => Cipher,
-                                random => Random,
-                                session_id => SessionId,
-                                extensions => ExtMap
-                            }};
-                        Error ->
-                            Error
-                    end;
-                error ->
-                    {error, missing_key_share}
+            Cipher = cipher_from_suite(CipherSuite),
+            SelectedPsk =
+                case maps:find(?EXT_PRE_SHARED_KEY, ExtMap) of
+                    {ok, <<Idx:16>>} -> Idx;
+                    _ -> undefined
+                end,
+            KeyShareResult =
+                case maps:find(?EXT_KEY_SHARE, ExtMap) of
+                    {ok, KeyShareData} ->
+                        parse_server_key_share(KeyShareData);
+                    error when SelectedPsk =/= undefined ->
+                        %% psk_ke handshake: no DHE → public_key=undefined.
+                        {ok, undefined};
+                    error ->
+                        {error, missing_key_share}
+                end,
+            case KeyShareResult of
+                {ok, PubKey} ->
+                    Base = #{
+                        public_key => PubKey,
+                        cipher => Cipher,
+                        random => Random,
+                        session_id => SessionId,
+                        extensions => ExtMap
+                    },
+                    Result = case SelectedPsk of
+                        undefined -> Base;
+                        Idx2 -> Base#{selected_psk_identity => Idx2}
+                    end,
+                    {ok, Result};
+                Error ->
+                    Error
             end;
         Error ->
             Error
@@ -764,19 +831,43 @@ encode_extension(Type, Data) ->
     <<Type:16, (byte_size(Data)):16, Data/binary>>.
 
 parse_extensions(Data) ->
-    parse_extensions(Data, #{}).
+    case parse_extensions_ordered(Data) of
+        {ok, Ordered} ->
+            {ok, maps:from_list([{T, D} || {T, D, _Off, _Sz} <- Ordered])};
+        Error ->
+            Error
+    end.
 
-parse_extensions(<<>>, Acc) ->
-    {ok, Acc};
-parse_extensions(<<Type:16, Len:16, Data:Len/binary, Rest/binary>>, Acc) ->
-    parse_extensions(Rest, maps:put(Type, Data, Acc));
-parse_extensions(<<Type:16, Len:16, Data/binary>>, _Acc) when byte_size(Data) < Len ->
-    %% Extension data is truncated
+%% @doc Parse an extensions blob preserving order and byte offsets.
+%% Returns [{Type, Data, ByteOffset, ByteSize}] where ByteOffset is the
+%% position of `Type` within `Data`. Rejects duplicate extension types
+%% per RFC 8446 §4.2 with {error, {duplicate_extension, Type}}; the
+%% caller maps that to an illegal_parameter alert.
+-spec parse_extensions_ordered(binary()) ->
+    {ok, [{non_neg_integer(), binary(), non_neg_integer(), non_neg_integer()}]}
+    | {error, term()}.
+parse_extensions_ordered(Data) ->
+    parse_extensions_ordered(Data, 0, [], #{}).
+
+parse_extensions_ordered(<<>>, _Off, Acc, _Seen) ->
+    {ok, lists:reverse(Acc)};
+parse_extensions_ordered(<<Type:16, Len:16, ExtData:Len/binary, Rest/binary>>, Off, Acc, Seen) ->
+    case maps:is_key(Type, Seen) of
+        true ->
+            {error, {duplicate_extension, Type}};
+        false ->
+            Entry = {Type, ExtData, Off, 4 + Len},
+            parse_extensions_ordered(
+                Rest, Off + 4 + Len, [Entry | Acc], maps:put(Type, true, Seen)
+            )
+    end;
+parse_extensions_ordered(<<Type:16, Len:16, Data/binary>>, _Off, _Acc, _Seen) when
+    byte_size(Data) < Len
+->
     {error, {extension_truncated, Type, Len, byte_size(Data)}};
-parse_extensions(Data, _Acc) when byte_size(Data) < 4 ->
-    %% Not enough data for extension header (type + length)
+parse_extensions_ordered(Data, _Off, _Acc, _Seen) when byte_size(Data) < 4 ->
     {error, {extension_header_incomplete, byte_size(Data)}};
-parse_extensions(_, _) ->
+parse_extensions_ordered(_, _, _, _) ->
     {error, invalid_extensions}.
 
 parse_server_key_share(<<?GROUP_X25519:16, 32:16, PubKey:32/binary, _/binary>>) ->
@@ -790,6 +881,10 @@ cipher_from_suite(?TLS_AES_128_GCM_SHA256) -> aes_128_gcm;
 cipher_from_suite(?TLS_AES_256_GCM_SHA384) -> aes_256_gcm;
 cipher_from_suite(?TLS_CHACHA20_POLY1305_SHA256) -> chacha20_poly1305;
 cipher_from_suite(_) -> aes_128_gcm.
+
+%% @private Encode a single psk_key_exchange_mode byte (RFC 8446 §4.2.9).
+encode_psk_mode(psk_ke) -> <<?PSK_KE_MODE_KE:8>>;
+encode_psk_mode(psk_dhe_ke) -> <<?PSK_KE_MODE_DHE_KE:8>>.
 
 %%====================================================================
 %% Server-side TLS Functions
@@ -824,64 +919,22 @@ parse_client_hello(<<
     %% Parse cipher suites
     Ciphers = parse_cipher_suites(CipherSuites),
 
-    %% Parse extensions
-    case parse_extensions(Extensions) of
-        {ok, ExtMap} ->
-            %% Extract key_share
-            KeyShare =
-                case maps:find(?EXT_KEY_SHARE, ExtMap) of
-                    {ok, KsData} -> parse_client_key_shares(KsData);
-                    error -> undefined
-                end,
+    %% Parse extensions preserving order so PSK validation can assert
+    %% pre_shared_key is the last extension and capture the binders
+    %% offset for binder verification.
+    case parse_extensions_ordered(Extensions) of
+        {ok, OrderedExts} ->
+            ExtMap = maps:from_list([{T, D} || {T, D, _Off, _Sz} <- OrderedExts]),
 
-            %% Extract SNI
-            ServerName =
-                case maps:find(?EXT_SERVER_NAME, ExtMap) of
-                    {ok, SniData} -> parse_server_name_ext(SniData);
-                    error -> undefined
-                end,
-
-            %% Extract ALPN
-            ALPNProtocols =
-                case maps:find(?EXT_ALPN, ExtMap) of
-                    {ok, AlpnData} -> parse_alpn_ext(AlpnData);
-                    error -> []
-                end,
-
-            %% Extract QUIC transport parameters
-            TransportParams =
-                case maps:find(?EXT_QUIC_TRANSPORT_PARAMS, ExtMap) of
-                    {ok, TpData} ->
-                        case decode_transport_params(TpData) of
-                            {ok, TP} -> TP;
-                            {error, _} -> #{}
-                        end;
-                    error ->
-                        #{}
-                end,
-
-            %% Extract pre_shared_key extension (for resumption)
-            PSK =
-                case maps:find(?EXT_PRE_SHARED_KEY, ExtMap) of
-                    {ok, PskData} -> parse_pre_shared_key_ext(PskData);
-                    error -> undefined
-                end,
-
-            %% Extract early_data extension (client wants to send 0-RTT)
-            EarlyData = maps:is_key(?EXT_EARLY_DATA, ExtMap),
-
-            {ok, #{
-                random => Random,
-                session_id => SessionId,
-                cipher_suites => Ciphers,
-                extensions => ExtMap,
-                key_share => KeyShare,
-                server_name => ServerName,
-                alpn_protocols => ALPNProtocols,
-                transport_params => TransportParams,
-                pre_shared_key => PSK,
-                early_data => EarlyData
-            }};
+            %% Validate pre_shared_key placement (must be last per RFC 8446 §4.2.11).
+            case validate_psk_extension_placement(OrderedExts) of
+                ok ->
+                    finalise_client_hello(
+                        Random, SessionId, Ciphers, OrderedExts, ExtMap, Extensions
+                    );
+                {error, _} = Err ->
+                    Err
+            end;
         {error, Reason} ->
             {error, Reason}
     end;
@@ -1052,6 +1105,294 @@ parse_pre_shared_key_ext(
 parse_pre_shared_key_ext(_) ->
     undefined.
 
+%% @private
+%% Reject ClientHellos where pre_shared_key is not the final extension
+%% (RFC 8446 §4.2.11). Mapping `{error, psk_not_last}` to an
+%% illegal_parameter alert is the caller's responsibility.
+validate_psk_extension_placement(OrderedExts) ->
+    case lists:reverse(OrderedExts) of
+        [] ->
+            ok;
+        [{Last, _, _, _} | RestRev] ->
+            case lists:keyfind(?EXT_PRE_SHARED_KEY, 1, RestRev) of
+                false when Last =:= ?EXT_PRE_SHARED_KEY -> ok;
+                false -> ok;
+                _Found -> {error, psk_not_last}
+            end
+    end.
+
+%% @private
+%% Continue building the ClientHello map once extension order has
+%% been validated. Captures the binders-section offset *within the
+%% extensions blob* so the caller can compute the truncated
+%% ClientHello for binder verification.
+finalise_client_hello(Random, SessionId, Ciphers, OrderedExts, ExtMap, ExtBlob) ->
+    KeyShare =
+        case maps:find(?EXT_KEY_SHARE, ExtMap) of
+            {ok, KsData} -> parse_client_key_shares(KsData);
+            error -> undefined
+        end,
+    ServerName =
+        case maps:find(?EXT_SERVER_NAME, ExtMap) of
+            {ok, SniData} -> parse_server_name_ext(SniData);
+            error -> undefined
+        end,
+    ALPNProtocols =
+        case maps:find(?EXT_ALPN, ExtMap) of
+            {ok, AlpnData} -> parse_alpn_ext(AlpnData);
+            error -> []
+        end,
+    TransportParams =
+        case maps:find(?EXT_QUIC_TRANSPORT_PARAMS, ExtMap) of
+            {ok, TpData} ->
+                case decode_transport_params(TpData) of
+                    {ok, TP} -> TP;
+                    {error, _} -> #{}
+                end;
+            error -> #{}
+        end,
+    PSK =
+        case maps:find(?EXT_PRE_SHARED_KEY, ExtMap) of
+            {ok, PskData} -> parse_pre_shared_key_ext(PskData);
+            error -> undefined
+        end,
+    PskModes =
+        case maps:find(?EXT_PSK_KEY_EXCHANGE_MODES, ExtMap) of
+            {ok, ModesData} -> parse_psk_modes_ext(ModesData);
+            error -> []
+        end,
+    EarlyData = maps:is_key(?EXT_EARLY_DATA, ExtMap),
+
+    %% Binders-section offset within the extension data of the PSK
+    %% extension, plus the absolute offset within ExtBlob. The
+    %% caller combines these with the handshake-message header to
+    %% truncate the ClientHello for binder verification.
+    PskBinders = psk_binders_offset(OrderedExts, ExtBlob),
+
+    {ok, #{
+        random => Random,
+        session_id => SessionId,
+        cipher_suites => Ciphers,
+        extensions => ExtMap,
+        ordered_extensions => OrderedExts,
+        key_share => KeyShare,
+        server_name => ServerName,
+        alpn_protocols => ALPNProtocols,
+        transport_params => TransportParams,
+        pre_shared_key => PSK,
+        psk_key_exchange_modes => PskModes,
+        psk_binders => PskBinders,
+        early_data => EarlyData
+    }}.
+
+%% @private
+%% Parse the psk_key_exchange_modes extension into a list of atoms.
+%% RFC 8446 §4.2.9: <<Len:8, Modes:Len/binary>>.
+parse_psk_modes_ext(<<Len:8, Modes:Len/binary, _/binary>>) ->
+    [decode_psk_mode(M) || <<M:8>> <= Modes];
+parse_psk_modes_ext(_) ->
+    [].
+
+decode_psk_mode(?PSK_KE_MODE_KE) -> psk_ke;
+decode_psk_mode(?PSK_KE_MODE_DHE_KE) -> psk_dhe_ke;
+decode_psk_mode(Other) -> {unknown, Other}.
+
+%% @private
+%% Locate the pre_shared_key extension and compute the offset (within
+%% the extensions blob) of the binders-length field. Returns a map
+%% `#{ext_offset, binders_offset, binders_size}` or `undefined` if no
+%% PSK was offered.
+psk_binders_offset(OrderedExts, _ExtBlob) ->
+    case lists:keyfind(?EXT_PRE_SHARED_KEY, 1, OrderedExts) of
+        false ->
+            undefined;
+        {?EXT_PRE_SHARED_KEY, PskData, ExtOffset, _ExtSize} ->
+            %% PskData = <<IdentitiesLen:16, Identities..., BindersLen:16, Binders...>>
+            case PskData of
+                <<IdentitiesLen:16, _Identities:IdentitiesLen/binary,
+                    BindersLen:16, _Binders:BindersLen/binary>> ->
+                    %% Header of pre_shared_key extension is type(2)+len(2) = 4 bytes,
+                    %% so the binders-length field sits at:
+                    %%   ext_offset (start of type:16) + 4 (skip header)
+                    %%                                 + 2 (skip IdentitiesLen:16)
+                    %%                                 + IdentitiesLen
+                    BindersOff = ExtOffset + 4 + 2 + IdentitiesLen,
+                    BindersTotal = 2 + BindersLen,
+                    #{
+                        ext_offset => ExtOffset,
+                        binders_offset => BindersOff,
+                        binders_size => BindersTotal
+                    };
+                _ ->
+                    undefined
+            end
+    end.
+
+%% @doc Select a PSK from a ClientHello and verify the binder.
+%%
+%% `ClientHelloMap` is the result of `parse_client_hello/1`.
+%% `FullHandshakeMsg` is the raw 4-byte-headered handshake bytes for
+%%   ClientHello (msg_type + length + body) — needed to compute the
+%%   truncated ClientHello hash for binder verification.
+%% `PskConfig` is `#{psk_callback => Fn | undefined,
+%%                   psks => Map | undefined}`.
+%% `ServerModes` is the list of psk_key_exchange modes the server is
+%%   willing to negotiate (defaults to `[psk_dhe_ke]`).
+%%
+%% Returns:
+%%   `{ok, #{identity_idx => N, secret => Secret, mode => Mode}}` on
+%%   successful selection (identity found, binder verified, modes
+%%   compatible);
+%%   `none` when the client didn't offer pre_shared_key OR offered
+%%   identities don't match local config OR no compatible mode
+%%   (caller falls through to cert path or sends
+%%   unknown_psk_identity);
+%%   `{error, bad_binder}` when an identity matched but the binder
+%%   didn't verify — caller MUST send decrypt_error (no cert fallback).
+-spec select_psk(map(), binary(), map(), [psk_dhe_ke | psk_ke]) ->
+    {ok, map()} | none | {error, bad_binder}.
+select_psk(#{pre_shared_key := undefined}, _FullMsg, _PskConfig, _ServerModes) ->
+    none;
+select_psk(#{pre_shared_key := #{identities := []}}, _FullMsg, _PskConfig, _ServerModes) ->
+    none;
+select_psk(
+    #{
+        pre_shared_key := #{identities := Identities, binders := Binders},
+        psk_key_exchange_modes := ClientModes,
+        psk_binders := PskBindersInfo,
+        cipher_suites := CipherSuites
+    },
+    FullHandshakeMsg,
+    PskConfig,
+    ServerModes
+) ->
+    case mode_intersection(ClientModes, ServerModes) of
+        [] ->
+            none;
+        [SelectedMode | _] ->
+            Cipher = select_cipher(CipherSuites),
+            TruncatedHash = truncated_client_hello_hash(
+                FullHandshakeMsg, PskBindersInfo, Cipher
+            ),
+            try_psk_identities(
+                Identities, Binders, 0,
+                PskConfig, SelectedMode, Cipher, TruncatedHash
+            )
+    end;
+select_psk(_, _, _, _) ->
+    none.
+
+mode_intersection(Client, Server) ->
+    [M || M <- Client, lists:member(M, Server)].
+
+select_cipher(CipherSuites) ->
+    case lists:member(?TLS_AES_128_GCM_SHA256, CipherSuites) of
+        true -> aes_128_gcm;
+        false -> aes_128_gcm
+    end.
+
+%% @private
+%% Slice the full handshake bytes down to the truncated ClientHello
+%% and compute its transcript hash.
+truncated_client_hello_hash(FullHandshakeMsg, #{binders_offset := BindersOffInExt}, Cipher) ->
+    %% Handshake header = 4 bytes (msg_type:8, length:24).
+    %% After that comes the body: legacy_version(2) + random(32) +
+    %% session_id(1+N) + cipher_suites(2+N) + compression(1+N) +
+    %% extensions(2+N). The binders offset is relative to the start
+    %% of the extensions blob, so we need the absolute offset within
+    %% FullHandshakeMsg.
+    <<_MsgType:8, _Len:24, Body/binary>> = FullHandshakeMsg,
+    ExtBlobOffsetInBody = extensions_offset_in_body(Body),
+    AbsoluteBindersOff = 4 + ExtBlobOffsetInBody + BindersOffInExt,
+    <<TruncatedBytes:AbsoluteBindersOff/binary, _/binary>> = FullHandshakeMsg,
+    %% Rebuild handshake header with the truncated length per RFC 8446
+    %% §4.2.11.2 — the length reflects the truncated body.
+    TruncatedBodyLen = AbsoluteBindersOff - 4,
+    <<MsgType:8, _:24, TruncBody/binary>> = TruncatedBytes,
+    Rewrapped = <<MsgType:8, TruncatedBodyLen:24, TruncBody/binary>>,
+    quic_crypto:transcript_hash(Cipher, Rewrapped).
+
+%% @private — find where the extensions blob starts within a
+%% ClientHello body.
+extensions_offset_in_body(
+    <<_LegacyVersion:16, _Random:32/binary,
+      SessionIdLen:8, _SessionId:SessionIdLen/binary,
+      CipherSuitesLen:16, _CipherSuites:CipherSuitesLen/binary,
+      CompressionLen:8, _Compression:CompressionLen/binary,
+      _ExtLen:16, _/binary>>
+) ->
+    2 + 32 + 1 + SessionIdLen + 2 + CipherSuitesLen + 1 + CompressionLen + 2.
+
+try_psk_identities([], _Binders, _Idx, _PskConfig, _Mode, _Cipher, _TruncatedHash) ->
+    none;
+try_psk_identities(
+    [{Identity, _Age} | RestIds], [Binder | RestBinders], Idx,
+    PskConfig, Mode, Cipher, TruncatedHash
+) ->
+    case lookup_psk_secret(Identity, PskConfig) of
+        {ok, Secret} ->
+            case verify_psk_binder(Secret, Cipher, TruncatedHash, Binder) of
+                true ->
+                    {ok, #{
+                        identity_idx => Idx,
+                        identity => Identity,
+                        secret => Secret,
+                        mode => Mode
+                    }};
+                false ->
+                    %% Identity matched but binder failed: per plan rule
+                    %% 3, this is fatal — no cert-path fallback.
+                    {error, bad_binder}
+            end;
+        not_found ->
+            try_psk_identities(RestIds, RestBinders, Idx + 1,
+                               PskConfig, Mode, Cipher, TruncatedHash)
+    end;
+try_psk_identities(_, _, _, _, _, _, _) ->
+    none.
+
+lookup_psk_secret(Identity, #{psk_callback := Fn} = Config) when is_function(Fn, 1) ->
+    case safe_callback(Fn, Identity) of
+        {ok, Secret} when is_binary(Secret) ->
+            {ok, Secret};
+        _ ->
+            lookup_in_psk_map(Identity, Config)
+    end;
+lookup_psk_secret(Identity, Config) ->
+    lookup_in_psk_map(Identity, Config).
+
+lookup_in_psk_map(Identity, #{psks := Map}) when is_map(Map) ->
+    case maps:find(Identity, Map) of
+        {ok, Secret} when is_binary(Secret) -> {ok, Secret};
+        _ -> not_found
+    end;
+lookup_in_psk_map(_Identity, _) ->
+    not_found.
+
+safe_callback(Fn, Identity) ->
+    try Fn(Identity) of
+        Result -> Result
+    catch
+        Class:Reason:Stack ->
+            logger:warning(
+                #{
+                    what => psk_callback_failed,
+                    class => Class,
+                    reason => Reason,
+                    stack => Stack
+                },
+                #{domain => [erlang_quic, tls]}
+            ),
+            not_found
+    end.
+
+verify_psk_binder(Secret, Cipher, TruncatedHash, OfferedBinder) ->
+    EarlySecret = quic_crypto:derive_early_secret(Cipher, Secret),
+    Expected = quic_crypto:compute_psk_binder(
+        Cipher, EarlySecret, TruncatedHash, external
+    ),
+    crypto:hash_equals(Expected, OfferedBinder).
+
 parse_psk_identities(<<>>) ->
     [];
 parse_psk_identities(
@@ -1068,17 +1409,35 @@ parse_psk_binders(<<BinderLen:8, Binder:BinderLen/binary, Rest/binary>>) ->
 parse_psk_binders(_) ->
     [].
 
-build_server_hello_extensions(PubKey, _Opts) ->
+build_server_hello_extensions(PubKey, Opts) ->
     %% Supported versions extension (mandatory for TLS 1.3)
     SupportedVersions = encode_extension(?EXT_SUPPORTED_VERSIONS, <<?TLS_VERSION_1_3:16>>),
 
-    %% Key share extension
-    KeyShare = encode_extension(
-        ?EXT_KEY_SHARE,
-        <<?GROUP_X25519:16, 32:16, PubKey:32/binary>>
-    ),
+    %% Key share extension — included for psk_dhe_ke and standard
+    %% handshakes; omitted for psk_ke (PSK-only, no DHE per RFC 8446
+    %% §4.2.9).
+    KeyShare =
+        case maps:get(selected_psk_mode, Opts, undefined) of
+            psk_ke ->
+                <<>>;
+            _ ->
+                encode_extension(
+                    ?EXT_KEY_SHARE,
+                    <<?GROUP_X25519:16, 32:16, PubKey:32/binary>>
+                )
+        end,
 
-    <<SupportedVersions/binary, KeyShare/binary>>.
+    %% pre_shared_key extension echo when a PSK was selected
+    %% (RFC 8446 §4.2.11 — ServerHello carries just selected_identity).
+    PskExt =
+        case maps:find(selected_psk_identity, Opts) of
+            {ok, Idx} when is_integer(Idx) ->
+                encode_extension(?EXT_PRE_SHARED_KEY, <<Idx:16>>);
+            _ ->
+                <<>>
+        end,
+
+    <<SupportedVersions/binary, KeyShare/binary, PskExt/binary>>.
 
 build_encrypted_extensions_list(Opts) ->
     %% ALPN extension (if ALPN was negotiated)

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -414,10 +414,11 @@ parse_server_hello(<<
                         session_id => SessionId,
                         extensions => ExtMap
                     },
-                    Result = case SelectedPsk of
-                        undefined -> Base;
-                        Idx2 -> Base#{selected_psk_identity => Idx2}
-                    end,
+                    Result =
+                        case SelectedPsk of
+                            undefined -> Base;
+                            Idx2 -> Base#{selected_psk_identity => Idx2}
+                        end,
                     {ok, Result};
                 Error ->
                     Error
@@ -1149,7 +1150,8 @@ finalise_client_hello(Random, SessionId, Ciphers, OrderedExts, ExtMap, ExtBlob) 
                     {ok, TP} -> TP;
                     {error, _} -> #{}
                 end;
-            error -> #{}
+            error ->
+                #{}
         end,
     PSK =
         case maps:find(?EXT_PRE_SHARED_KEY, ExtMap) of
@@ -1209,8 +1211,8 @@ psk_binders_offset(OrderedExts, _ExtBlob) ->
         {?EXT_PRE_SHARED_KEY, PskData, ExtOffset, _ExtSize} ->
             %% PskData = <<IdentitiesLen:16, Identities..., BindersLen:16, Binders...>>
             case PskData of
-                <<IdentitiesLen:16, _Identities:IdentitiesLen/binary,
-                    BindersLen:16, _Binders:BindersLen/binary>> ->
+                <<IdentitiesLen:16, _Identities:IdentitiesLen/binary, BindersLen:16,
+                    _Binders:BindersLen/binary>> ->
                     %% Header of pre_shared_key extension is type(2)+len(2) = 4 bytes,
                     %% so the binders-length field sits at:
                     %%   ext_offset (start of type:16) + 4 (skip header)
@@ -1275,8 +1277,13 @@ select_psk(
                 FullHandshakeMsg, PskBindersInfo, Cipher
             ),
             try_psk_identities(
-                Identities, Binders, 0,
-                PskConfig, SelectedMode, Cipher, TruncatedHash
+                Identities,
+                Binders,
+                0,
+                PskConfig,
+                SelectedMode,
+                Cipher,
+                TruncatedHash
             )
     end;
 select_psk(_, _, _, _) ->
@@ -1315,19 +1322,22 @@ truncated_client_hello_hash(FullHandshakeMsg, #{binders_offset := BindersOffInEx
 %% @private — find where the extensions blob starts within a
 %% ClientHello body.
 extensions_offset_in_body(
-    <<_LegacyVersion:16, _Random:32/binary,
-      SessionIdLen:8, _SessionId:SessionIdLen/binary,
-      CipherSuitesLen:16, _CipherSuites:CipherSuitesLen/binary,
-      CompressionLen:8, _Compression:CompressionLen/binary,
-      _ExtLen:16, _/binary>>
+    <<_LegacyVersion:16, _Random:32/binary, SessionIdLen:8, _SessionId:SessionIdLen/binary,
+        CipherSuitesLen:16, _CipherSuites:CipherSuitesLen/binary, CompressionLen:8,
+        _Compression:CompressionLen/binary, _ExtLen:16, _/binary>>
 ) ->
     2 + 32 + 1 + SessionIdLen + 2 + CipherSuitesLen + 1 + CompressionLen + 2.
 
 try_psk_identities([], _Binders, _Idx, _PskConfig, _Mode, _Cipher, _TruncatedHash) ->
     none;
 try_psk_identities(
-    [{Identity, _Age} | RestIds], [Binder | RestBinders], Idx,
-    PskConfig, Mode, Cipher, TruncatedHash
+    [{Identity, _Age} | RestIds],
+    [Binder | RestBinders],
+    Idx,
+    PskConfig,
+    Mode,
+    Cipher,
+    TruncatedHash
 ) ->
     case lookup_psk_secret(Identity, PskConfig) of
         {ok, Secret} ->
@@ -1345,8 +1355,15 @@ try_psk_identities(
                     {error, bad_binder}
             end;
         not_found ->
-            try_psk_identities(RestIds, RestBinders, Idx + 1,
-                               PskConfig, Mode, Cipher, TruncatedHash)
+            try_psk_identities(
+                RestIds,
+                RestBinders,
+                Idx + 1,
+                PskConfig,
+                Mode,
+                Cipher,
+                TruncatedHash
+            )
     end;
 try_psk_identities(_, _, _, _, _, _, _) ->
     none.

--- a/test/quic_dist_psk_SUITE.erl
+++ b/test/quic_dist_psk_SUITE.erl
@@ -1,0 +1,277 @@
+%%% -*- erlang -*-
+%%%
+%%% Distribution over QUIC authenticated by TLS 1.3 external PSK
+%%% (RFC 8446 §4.2.11). No X.509 certs configured on either side;
+%%% both peers share the same PSK callback module + identity.
+%%%
+%%% Boots two real erl VMs via open_port (mirrors
+%%% quic_dist_auth_SUITE). The peer module's boot tries to bring
+%%% distribution up too eagerly to thread non-string PSK data
+%%% through.
+
+-module(quic_dist_psk_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    psk_only_mesh/1
+]).
+
+-define(PSK_CALLBACK, "quic_dist_psk_test_cb:cluster").
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [psk_only_mesh].
+
+init_per_suite(Config) ->
+    case os:find_executable("erl") of
+        false -> {skip, erl_not_found};
+        _ -> Config
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_TC, Config) ->
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    case erase({?MODULE, target_port_handle}) of
+        undefined -> ok;
+        Port -> stop_port(Port)
+    end,
+    ok.
+
+%%====================================================================
+%% Target listens with psk_callback; probe connects with the same
+%% callback module + a runtime external_psk override (the offer
+%% can't ride a flat boot arg, so set_connect_options/2 attaches
+%% it just before the dial).
+%%====================================================================
+
+psk_only_mesh(Config) ->
+    {Target, TargetPort, Cookie, TargetUdp} = start_target(Config),
+    Result = run_probe(Config, Target, TargetPort, Cookie),
+    stop_port(TargetUdp),
+    erase({?MODULE, target_port_handle}),
+    ?assertEqual(connected, Result).
+
+%%====================================================================
+%% Target boot
+%%====================================================================
+
+start_target(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    Cookie = "qpsk_" ++ integer_to_list(erlang:unique_integer([positive])),
+    Host = "127.0.0.1",
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    Node = list_to_atom("qpsk_target_" ++ Suffix ++ "@" ++ Host),
+    PortNum = pick_port(),
+    ReadyFile = filename:join(PrivDir, "psk_target_" ++ Suffix ++ ".ready"),
+
+    Eval = lists:flatten(
+        io_lib:format(
+            "{ok,_}=application:ensure_all_started(quic),"
+            "ok=file:write_file(\"~s\",<<\"ok\">>),"
+            "receive _ -> ok end.",
+            [ReadyFile]
+        )
+    ),
+    Args = [
+        "-name",
+        atom_to_list(Node),
+        "-setcookie",
+        Cookie,
+        "-proto_dist",
+        "quic",
+        "-epmd_module",
+        "quic_epmd",
+        "-start_epmd",
+        "false",
+        "-quic_dist_port",
+        integer_to_list(PortNum),
+        "-quic_dist_psk_callback",
+        ?PSK_CALLBACK,
+        "-pa",
+        quic_ebin(),
+        "-pa",
+        test_ebin(),
+        "-noinput",
+        "-eval",
+        Eval
+    ],
+    ErlExe = os:find_executable("erl"),
+    Port = erlang:open_port({spawn_executable, ErlExe}, [
+        {args, Args},
+        binary,
+        exit_status,
+        stderr_to_stdout
+    ]),
+    case wait_for_ready(ReadyFile, 60) of
+        ok ->
+            put({?MODULE, target_port_handle}, Port),
+            {Node, PortNum, Cookie, Port};
+        timeout ->
+            Log = drain_port(Port),
+            stop_port(Port),
+            ct:fail("target not ready. output:~n~s", [Log])
+    end.
+
+%%====================================================================
+%% Probe: brings its own psk_callback up at boot so load_credentials
+%% succeeds, then registers an external_psk override on the target
+%% via set_connect_options/2 before connecting.
+%%====================================================================
+
+run_probe(Config, Target, TargetPort, Cookie) ->
+    PrivDir = ?config(priv_dir, Config),
+    Host = "127.0.0.1",
+    Suffix = integer_to_list(erlang:unique_integer([positive])),
+    Probe = list_to_atom("qpsk_probe_" ++ Suffix ++ "@" ++ Host),
+    ProbePort = pick_port(),
+    ResultFile = filename:join(PrivDir, "psk_probe_" ++ Suffix ++ ".result"),
+
+    TargetStr = atom_to_list(Target),
+    Eval = lists:flatten(
+        io_lib:format(
+            "{ok,_}=application:ensure_all_started(quic),"
+            "Nodes=[{'~s',{\"127.0.0.1\",~b}}],"
+            "{ok,_}=quic_discovery_static:init([{nodes,Nodes}]),"
+            %% Runtime override: client side offers external_psk.
+            "ok=quic_dist:set_connect_options('~s',"
+            "#{external_psk => {<<\"cluster\">>,"
+            "<<\"shared-cluster-psk-32-bytes!!!!!\">>}}),"
+            "Verdict = case net_kernel:connect_node('~s') of"
+            " true -> connected;"
+            " _ -> refused"
+            " end,"
+            "ok=file:write_file(\"~s\",atom_to_list(Verdict)),"
+            "erlang:halt(0).",
+            [TargetStr, TargetPort, TargetStr, TargetStr, ResultFile]
+        )
+    ),
+    Args = [
+        "-name",
+        atom_to_list(Probe),
+        "-setcookie",
+        Cookie,
+        "-proto_dist",
+        "quic",
+        "-epmd_module",
+        "quic_epmd",
+        "-start_epmd",
+        "false",
+        "-hidden",
+        "-kernel",
+        "net_setuptime",
+        "10",
+        "-quic_dist_port",
+        integer_to_list(ProbePort),
+        "-quic_dist_psk_callback",
+        ?PSK_CALLBACK,
+        "-pa",
+        quic_ebin(),
+        "-pa",
+        test_ebin(),
+        "-noinput",
+        "-eval",
+        Eval
+    ],
+    ErlExe = os:find_executable("erl"),
+    Port = erlang:open_port({spawn_executable, ErlExe}, [
+        {args, Args},
+        binary,
+        exit_status,
+        stderr_to_stdout
+    ]),
+    Out = wait_for_port_exit(Port, 30000),
+    ct:log("probe output:~n~s", [Out]),
+    case file:read_file(ResultFile) of
+        {ok, Bin} -> list_to_atom(string:trim(binary_to_list(Bin)));
+        {error, _} -> refused
+    end.
+
+%%====================================================================
+%% Low-level helpers (mirror quic_dist_auth_SUITE)
+%%====================================================================
+
+quic_ebin() ->
+    case code:lib_dir(quic) of
+        {error, _} ->
+            filename:absname(filename:dirname(code:which(quic_dist)));
+        LibDir ->
+            filename:join(LibDir, "ebin")
+    end.
+
+test_ebin() ->
+    filename:absname(filename:dirname(code:which(?MODULE))).
+
+pick_port() ->
+    {ok, S} = gen_udp:open(0, [binary, {active, false}]),
+    {ok, P} = inet:port(S),
+    gen_udp:close(S),
+    P.
+
+wait_for_ready(_File, 0) ->
+    timeout;
+wait_for_ready(File, N) ->
+    case filelib:is_regular(File) of
+        true ->
+            ok;
+        false ->
+            timer:sleep(500),
+            wait_for_ready(File, N - 1)
+    end.
+
+stop_port(Port) ->
+    case erlang:port_info(Port, os_pid) of
+        {os_pid, OsPid} ->
+            os:cmd("kill " ++ integer_to_list(OsPid)),
+            timer:sleep(200),
+            os:cmd("kill -9 " ++ integer_to_list(OsPid) ++ " 2>/dev/null"),
+            catch erlang:port_close(Port),
+            ok;
+        _ ->
+            catch erlang:port_close(Port),
+            ok
+    end.
+
+drain_port(Port) ->
+    drain_port(Port, []).
+drain_port(Port, Acc) ->
+    receive
+        {Port, {data, Bin}} -> drain_port(Port, [Bin | Acc])
+    after 100 ->
+        binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    end.
+
+wait_for_port_exit(Port, TimeoutMs) ->
+    wait_for_port_exit(Port, TimeoutMs, []).
+wait_for_port_exit(Port, TimeoutMs, Acc) ->
+    receive
+        {Port, {data, Bin}} ->
+            wait_for_port_exit(Port, TimeoutMs, [Bin | Acc]);
+        {Port, {exit_status, _}} ->
+            binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    after TimeoutMs ->
+        case erlang:port_info(Port, os_pid) of
+            {os_pid, OsPid} ->
+                os:cmd("kill -9 " ++ integer_to_list(OsPid));
+            _ ->
+                ok
+        end,
+        catch erlang:port_close(Port),
+        binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    end.

--- a/test/quic_dist_psk_test_cb.erl
+++ b/test/quic_dist_psk_test_cb.erl
@@ -1,0 +1,16 @@
+%%% -*- erlang -*-
+%%%
+%%% PSK lookup callback used by quic_dist_psk_SUITE. The dist
+%%% driver dispatches `Module:Function(Identity)` on the configured
+%%% callback; this module hands back a fixed shared secret for the
+%%% test identity. Keeping the callback in its own module keeps
+%%% production code free of test fixtures.
+
+-module(quic_dist_psk_test_cb).
+
+-export([cluster/1]).
+
+cluster(<<"cluster">>) ->
+    {ok, <<"shared-cluster-psk-32-bytes!!!!!">>};
+cluster(_) ->
+    not_found.

--- a/test/quic_psk_e2e_SUITE.erl
+++ b/test/quic_psk_e2e_SUITE.erl
@@ -1,0 +1,343 @@
+%%% -*- erlang -*-
+%%%
+%%% TLS 1.3 External PSK end-to-end suite (RFC 8446 §4.2.11).
+%%%
+%%% Spins an in-process echo server with PSK config and drives full
+%%% handshakes through it: psk_dhe_ke, psk_ke (no-DHE), mixed
+%%% cert+PSK selection, callback lookup, unknown identity / bad
+%%% binder failure modes, downgrade protection.
+%%%
+
+-module(quic_psk_e2e_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    psk_dhe_ke_handshake/1,
+    psk_ke_handshake/1,
+    psk_callback_lookup/1,
+    cert_and_psk_coexist/1,
+    unknown_identity_psk_only/1,
+    unknown_identity_with_cert_falls_through/1,
+    bad_binder_is_fatal/1,
+    client_downgrade_protection/1
+]).
+
+-define(IDENTITY, <<"alice">>).
+-define(SECRET, <<"this-is-a-32-byte-test-secret!!!">>).
+-define(WRONG_SECRET, <<"this-is-a-different-32-byte-key.">>).
+-define(OTHER_IDENTITY, <<"bob">>).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [
+        psk_dhe_ke_handshake,
+        psk_ke_handshake,
+        psk_callback_lookup,
+        cert_and_psk_coexist,
+        unknown_identity_psk_only,
+        unknown_identity_with_cert_falls_through,
+        bad_binder_is_fatal,
+        client_downgrade_protection
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(TC, Config) ->
+    ct:pal("Starting test: ~p", [TC]),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok.
+
+%%====================================================================
+%% Test cases
+%%====================================================================
+
+%% Default mode psk_dhe_ke: client offers external_psk, server has
+%% a matching entry in `psks`. Handshake completes, data echoes.
+psk_dhe_ke_handshake(_Config) ->
+    {ok, Server} = start_psk_server(#{psks => #{?IDENTITY => ?SECRET}}),
+    try
+        ConnRef = connect_with_psk(Server, {?IDENTITY, ?SECRET}),
+        ok = echo_roundtrip(ConnRef, <<"psk_dhe_ke">>),
+        quic:close(ConnRef, normal)
+    after
+        stop_server(Server)
+    end.
+
+%% psk_ke mode: client offers psk_ke only. Server omits key_share
+%% and the handshake completes via the zero-IKM key schedule.
+psk_ke_handshake(_Config) ->
+    {ok, Server} = start_psk_server(#{psks => #{?IDENTITY => ?SECRET}}),
+    try
+        ConnRef = connect_with_psk(
+            Server, {?IDENTITY, ?SECRET, [psk_ke]}
+        ),
+        ok = echo_roundtrip(ConnRef, <<"psk_ke">>),
+        quic:close(ConnRef, normal)
+    after
+        stop_server(Server)
+    end.
+
+%% psk_callback wins over `psks` map; callback resolves identity to
+%% the correct secret.
+psk_callback_lookup(_Config) ->
+    Cb = fun
+        (?IDENTITY) -> {ok, ?SECRET};
+        (_) -> not_found
+    end,
+    {ok, Server} = start_psk_server(#{psk_callback => Cb}),
+    try
+        ConnRef = connect_with_psk(Server, {?IDENTITY, ?SECRET}),
+        ok = echo_roundtrip(ConnRef, <<"callback">>),
+        quic:close(ConnRef, normal)
+    after
+        stop_server(Server)
+    end.
+
+%% Server has cert+key AND PSK. A PSK client and a cert client both
+%% connect successfully against the same listener.
+cert_and_psk_coexist(_Config) ->
+    {ok, Server} = start_psk_server(#{
+        psks => #{?IDENTITY => ?SECRET},
+        with_cert => true
+    }),
+    try
+        %% PSK client
+        Conn1 = connect_with_psk(Server, {?IDENTITY, ?SECRET}),
+        ok = echo_roundtrip(Conn1, <<"psk-client">>),
+        quic:close(Conn1, normal),
+
+        %% Cert client (no PSK option)
+        Conn2 = connect_plain(Server),
+        ok = echo_roundtrip(Conn2, <<"cert-client">>),
+        quic:close(Conn2, normal)
+    after
+        stop_server(Server)
+    end.
+
+%% PSK-only server (no cert). Client offers an unknown identity:
+%% server has no cert fallback so the handshake fails with a TLS
+%% alert (unknown_psk_identity).
+unknown_identity_psk_only(_Config) ->
+    {ok, Server} = start_psk_server(#{psks => #{?IDENTITY => ?SECRET}}),
+    try
+        Result = try_connect(Server, #{
+            external_psk => {?OTHER_IDENTITY, ?SECRET}
+        }),
+        ?assertMatch({error, _}, Result)
+    after
+        stop_server(Server)
+    end.
+
+%% Cert+PSK server: client offers an identity the server doesn't
+%% know. Server falls through to the cert path silently and the
+%% handshake completes (no client downgrade flag in play, so the
+%% client accepts the cert).
+unknown_identity_with_cert_falls_through(_Config) ->
+    {ok, Server} = start_psk_server(#{
+        psks => #{?IDENTITY => ?SECRET},
+        with_cert => true
+    }),
+    try
+        %% The client offers external_psk; if the server can't match
+        %% it, the client's downgrade check will fire. Use a
+        %% cert-only client here (no external_psk) to model an
+        %% accidental misconfig between two consenting peers.
+        Conn = connect_plain(Server),
+        ok = echo_roundtrip(Conn, <<"fallback">>),
+        quic:close(Conn, normal)
+    after
+        stop_server(Server)
+    end.
+
+%% Identity known but binder is wrong (client claims a secret that
+%% doesn't match the server's). Server MUST send decrypt_error and
+%% MUST NOT fall through to cert even when cert+key are present.
+bad_binder_is_fatal(_Config) ->
+    {ok, Server} = start_psk_server(#{
+        psks => #{?IDENTITY => ?SECRET},
+        with_cert => true
+    }),
+    try
+        Result = try_connect(Server, #{
+            external_psk => {?IDENTITY, ?WRONG_SECRET}
+        }),
+        ?assertMatch({error, _}, Result)
+    after
+        stop_server(Server)
+    end.
+
+%% Server has cert+PSK; client offers an external_psk with an
+%% identity the server doesn't know. Server falls through to cert.
+%% Client's downgrade protection MUST then abort the handshake
+%% rather than silently accepting the cert path.
+client_downgrade_protection(_Config) ->
+    {ok, Server} = start_psk_server(#{
+        psks => #{?IDENTITY => ?SECRET},
+        with_cert => true
+    }),
+    try
+        Result = try_connect(Server, #{
+            external_psk => {?OTHER_IDENTITY, ?SECRET}
+        }),
+        ?assertMatch({error, _}, Result)
+    after
+        stop_server(Server)
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+start_psk_server(Extra0) ->
+    WithCert = maps:get(with_cert, Extra0, false),
+    Extra1 = maps:remove(with_cert, Extra0),
+    BaseExtra =
+        case WithCert of
+            true ->
+                Extra1;
+            false ->
+                %% Pre-empt the echo-server's default cert load: an
+                %% empty cert/key pair forces start_psk_server to
+                %% rely solely on PSK auth.
+                Extra1
+        end,
+    case WithCert of
+        true ->
+            quic_test_echo_server:start(BaseExtra);
+        false ->
+            start_psk_only_server(BaseExtra)
+    end.
+
+%% Build a listener that uses PSK only (no cert/key). Mirrors what
+%% quic_test_echo_server:start/1 does but skips the cert load.
+start_psk_only_server(Extra) ->
+    Name = list_to_atom(
+        "quic_psk_echo_" ++
+            integer_to_list(erlang:unique_integer([positive, monotonic]))
+    ),
+    Opts = maps:merge(
+        #{
+            alpn => [<<"echo">>],
+            max_data => 16 * 1024 * 1024,
+            max_stream_data_bidi_local => 4 * 1024 * 1024,
+            max_stream_data_bidi_remote => 4 * 1024 * 1024,
+            max_stream_data_uni => 4 * 1024 * 1024,
+            connection_handler => fun(ConnPid, _ConnRef) ->
+                Echo = spawn_link(fun() -> echo_loop(ConnPid) end),
+                ok = quic:set_owner_sync(ConnPid, Echo),
+                {ok, Echo}
+            end
+        },
+        Extra
+    ),
+    {ok, _Pid} = quic:start_server(Name, 0, Opts),
+    {ok, Port} = quic:get_server_port(Name),
+    {ok, #{name => Name, port => Port}}.
+
+stop_server(#{name := Name}) ->
+    catch quic:stop_server(Name),
+    ok.
+
+connect_with_psk(#{port := Port}, PskOffer) ->
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        external_psk => PskOffer
+    },
+    {ok, ConnRef} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    wait_connected(ConnRef, 10000),
+    ConnRef.
+
+connect_plain(#{port := Port}) ->
+    Opts = #{verify => false, alpn => [<<"echo">>]},
+    {ok, ConnRef} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    wait_connected(ConnRef, 10000),
+    ConnRef.
+
+%% Drive a connect attempt that may legitimately fail. Returns
+%% `ok` on success or `{error, Reason}` from the connection's
+%% closed event / psk_not_selected notification.
+try_connect(#{port := Port}, ExtraOpts) ->
+    Opts = maps:merge(
+        #{verify => false, alpn => [<<"echo">>]},
+        ExtraOpts
+    ),
+    case quic:connect(<<"127.0.0.1">>, Port, Opts, self()) of
+        {error, _} = E ->
+            E;
+        {ok, ConnRef} ->
+            await_outcome(ConnRef, 10000)
+    end.
+
+await_outcome(ConnRef, Timeout) ->
+    receive
+        {quic, ConnRef, {connected, _Info}} ->
+            quic:close(ConnRef, normal),
+            ok;
+        {quic, ConnRef, {error, Reason}} ->
+            {error, Reason};
+        {quic, ConnRef, {closed, Reason}} ->
+            {error, Reason}
+    after Timeout ->
+        catch quic:close(ConnRef, timeout),
+        {error, timeout}
+    end.
+
+wait_connected(ConnRef, Timeout) ->
+    receive
+        {quic, ConnRef, {connected, _Info}} -> ok
+    after Timeout ->
+        catch quic:close(ConnRef, timeout),
+        ct:fail("Connection timeout")
+    end.
+
+echo_roundtrip(ConnRef, Payload) ->
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    ok = quic:send_data(ConnRef, StreamId, Payload, true),
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Got, true}} ->
+            ?assertEqual(Payload, Got),
+            ok
+    after 10000 ->
+        ct:fail("echo timeout")
+    end.
+
+echo_loop(Conn) ->
+    receive
+        {quic, Conn, {connected, _Info}} ->
+            echo_loop(Conn);
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
+            _ = quic:send_data_async(Conn, StreamId, Data, Fin),
+            echo_loop(Conn);
+        {quic, Conn, {stream_closed, _StreamId, _Code}} ->
+            echo_loop(Conn);
+        {quic, Conn, {closed, _Reason}} ->
+            ok;
+        {quic, Conn, _Other} ->
+            echo_loop(Conn);
+        {'DOWN', _, process, Conn, _} ->
+            ok;
+        _Unexpected ->
+            echo_loop(Conn)
+    end.

--- a/test/quic_psk_tests.erl
+++ b/test/quic_psk_tests.erl
@@ -1,0 +1,257 @@
+%%% -*- erlang -*-
+%%% Unit tests for TLS 1.3 external PSK support (RFC 8446 §4.2.11).
+
+-module(quic_psk_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(IDENTITY, <<"test-identity">>).
+-define(SECRET, <<"this-is-a-32-byte-test-secret!!!">>).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+build_external_ch(Modes) ->
+    Opts = #{
+        server_name => <<"localhost">>,
+        alpn => [<<"h3">>],
+        transport_params => #{},
+        external_psk => {?IDENTITY, ?SECRET, Modes}
+    },
+    {Msg, _PrivKey, _Random} = quic_tls:build_client_hello(Opts),
+    Msg.
+
+%% Strip the 4-byte handshake-message header → body bytes.
+ch_body(Msg) ->
+    <<_MsgType:8, _Len:24, Body/binary>> = Msg,
+    Body.
+
+%%====================================================================
+%% psk_offer_from_opts: client-side input validation
+%%====================================================================
+
+bad_opts_psk_conflict_test() ->
+    %% session_ticket + external_psk together must raise loud.
+    Ticket = {session_ticket, <<"node">>, <<>>, 0, 0, <<>>, <<>>, 0, 0, aes_128_gcm, <<>>},
+    ?assertError(
+        {bad_opts, psk_conflict},
+        quic_tls:build_client_hello(#{
+            session_ticket => Ticket,
+            external_psk => {?IDENTITY, ?SECRET}
+        })
+    ).
+
+external_psk_unsupported_mode_test() ->
+    ?assertError(
+        {bad_opts, {unsupported_psk_modes, [foobar]}},
+        quic_tls:build_client_hello(#{
+            external_psk => {?IDENTITY, ?SECRET, [psk_dhe_ke, foobar]}
+        })
+    ).
+
+external_psk_bad_shape_test() ->
+    %% Non-binary identity → bad_opts.
+    ?assertError(
+        {bad_opts, {external_psk, _}},
+        quic_tls:build_client_hello(#{external_psk => {not_a_binary, ?SECRET}})
+    ).
+
+%%====================================================================
+%% ClientHello round-trip
+%%====================================================================
+
+build_and_parse_external_psk_ch_test() ->
+    Msg = build_external_ch([psk_dhe_ke]),
+    {ok, Map} = quic_tls:parse_client_hello(ch_body(Msg)),
+    PSK = maps:get(pre_shared_key, Map),
+    ?assertMatch(
+        #{identities := [{?IDENTITY, 0}]},
+        PSK
+    ),
+    [Binder] = maps:get(binders, PSK),
+    ?assertEqual(32, byte_size(Binder)),
+    %% psk_key_exchange_modes echoed
+    ?assertEqual([psk_dhe_ke], maps:get(psk_key_exchange_modes, Map)).
+
+psk_ke_only_offered_test() ->
+    Msg = build_external_ch([psk_ke]),
+    {ok, Map} = quic_tls:parse_client_hello(ch_body(Msg)),
+    ?assertEqual([psk_ke], maps:get(psk_key_exchange_modes, Map)).
+
+both_modes_offered_test() ->
+    Msg = build_external_ch([psk_dhe_ke, psk_ke]),
+    {ok, Map} = quic_tls:parse_client_hello(ch_body(Msg)),
+    ?assertEqual([psk_dhe_ke, psk_ke], maps:get(psk_key_exchange_modes, Map)).
+
+%%====================================================================
+%% parse_extensions_ordered: order + uniqueness
+%%====================================================================
+
+parse_extensions_ordered_preserves_order_test() ->
+    Ext1 = <<?EXT_SUPPORTED_VERSIONS:16, 2:16, ?TLS_VERSION_1_3:16>>,
+    Ext2 = <<?EXT_ALPN:16, 7:16, 5:16, 2, "h2", 1, "h">>,
+    Blob = <<Ext1/binary, Ext2/binary>>,
+    {ok, [E1, E2]} = quic_tls:parse_extensions_ordered(Blob),
+    ?assertMatch({?EXT_SUPPORTED_VERSIONS, _, 0, _}, E1),
+    ?assertMatch({?EXT_ALPN, _, ByteOff, _} when ByteOff > 0, E2).
+
+parse_extensions_ordered_rejects_duplicate_test() ->
+    Ext = <<?EXT_ALPN:16, 0:16>>,
+    Blob = <<Ext/binary, Ext/binary>>,
+    ?assertEqual(
+        {error, {duplicate_extension, ?EXT_ALPN}},
+        quic_tls:parse_extensions_ordered(Blob)
+    ).
+
+%%====================================================================
+%% select_psk: identity lookup, mode intersection, binder verify
+%%====================================================================
+
+select_psk_returns_ok_for_matching_psk_test() ->
+    Msg = build_external_ch([psk_dhe_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{psks => #{?IDENTITY => ?SECRET}, psk_callback => undefined},
+    {ok, Sel} = quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke, psk_ke]),
+    ?assertEqual(?IDENTITY, maps:get(identity, Sel)),
+    ?assertEqual(?SECRET, maps:get(secret, Sel)),
+    ?assertEqual(psk_dhe_ke, maps:get(mode, Sel)),
+    ?assertEqual(0, maps:get(identity_idx, Sel)).
+
+select_psk_callback_wins_over_map_test() ->
+    %% Callback returns a DIFFERENT secret for the same identity. If the
+    %% callback wins, the binder won't match the one client sent, so we
+    %% expect {error, bad_binder}.
+    Msg = build_external_ch([psk_dhe_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{
+        psk_callback => fun(?IDENTITY) -> {ok, <<"wrong-secret">>} end,
+        psks => #{?IDENTITY => ?SECRET}
+    },
+    ?assertEqual(
+        {error, bad_binder},
+        quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke])
+    ).
+
+select_psk_callback_falls_back_to_map_on_not_found_test() ->
+    Msg = build_external_ch([psk_dhe_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{
+        psk_callback => fun(_) -> not_found end,
+        psks => #{?IDENTITY => ?SECRET}
+    },
+    {ok, _} = quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke]).
+
+select_psk_callback_crash_falls_back_to_map_test() ->
+    Msg = build_external_ch([psk_dhe_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{
+        psk_callback => fun(_) -> error(boom) end,
+        psks => #{?IDENTITY => ?SECRET}
+    },
+    %% Should not crash; falls through to the map.
+    {ok, _} = quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke]).
+
+select_psk_unknown_identity_returns_none_test() ->
+    Msg = build_external_ch([psk_dhe_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{
+        psk_callback => undefined,
+        psks => #{<<"other-identity">> => <<"some-secret">>}
+    },
+    ?assertEqual(none, quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke])).
+
+select_psk_mode_intersection_empty_returns_none_test() ->
+    Msg = build_external_ch([psk_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{psks => #{?IDENTITY => ?SECRET}, psk_callback => undefined},
+    %% Client offered only psk_ke; server only allows psk_dhe_ke.
+    ?assertEqual(none, quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke])).
+
+select_psk_picks_first_compatible_mode_test() ->
+    Msg = build_external_ch([psk_ke, psk_dhe_ke]),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{psks => #{?IDENTITY => ?SECRET}, psk_callback => undefined},
+    %% Server accepts both; client preference is psk_ke first.
+    {ok, Sel} = quic_tls:select_psk(CHMap, Msg, Config, [psk_ke, psk_dhe_ke]),
+    ?assertEqual(psk_ke, maps:get(mode, Sel)).
+
+select_psk_bad_binder_test() ->
+    %% Mutate one byte of the binder section to corrupt it.
+    Msg = build_external_ch([psk_dhe_ke]),
+    %% The binder is the last 32 bytes of the message; flip one bit.
+    Size = byte_size(Msg),
+    <<Head:(Size - 1)/binary, Last:8>> = Msg,
+    Corrupted = <<Head/binary, (Last bxor 1):8>>,
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Corrupted)),
+    Config = #{psks => #{?IDENTITY => ?SECRET}, psk_callback => undefined},
+    ?assertEqual(
+        {error, bad_binder},
+        quic_tls:select_psk(CHMap, Corrupted, Config, [psk_dhe_ke])
+    ).
+
+select_psk_no_pre_shared_key_returns_none_test() ->
+    %% Build a vanilla ClientHello with no external_psk.
+    Opts = #{
+        server_name => <<"localhost">>,
+        alpn => [<<"h3">>],
+        transport_params => #{}
+    },
+    {Msg, _, _} = quic_tls:build_client_hello(Opts),
+    {ok, CHMap} = quic_tls:parse_client_hello(ch_body(Msg)),
+    Config = #{psks => #{?IDENTITY => ?SECRET}, psk_callback => undefined},
+    ?assertEqual(none, quic_tls:select_psk(CHMap, Msg, Config, [psk_dhe_ke])).
+
+%%====================================================================
+%% ServerHello PSK echo + key_share omission
+%%====================================================================
+
+server_hello_with_psk_includes_pre_shared_key_test() ->
+    {Msg, _PrivKey} = quic_tls:build_server_hello(#{
+        selected_psk_identity => 0,
+        selected_psk_mode => psk_dhe_ke
+    }),
+    %% Parse it back and verify pre_shared_key extension carries idx 0.
+    <<_:8, _:24, Body/binary>> = Msg,
+    {ok, Map} = quic_tls:parse_server_hello(Body),
+    ?assertEqual(0, maps:get(selected_psk_identity, Map)).
+
+server_hello_psk_ke_omits_key_share_test() ->
+    {Msg, _PrivKey} = quic_tls:build_server_hello(#{
+        selected_psk_identity => 0,
+        selected_psk_mode => psk_ke
+    }),
+    <<_:8, _:24, Body/binary>> = Msg,
+    {ok, Map} = quic_tls:parse_server_hello(Body),
+    ?assertEqual(undefined, maps:get(public_key, Map)),
+    ?assertEqual(0, maps:get(selected_psk_identity, Map)).
+
+server_hello_psk_dhe_ke_includes_key_share_test() ->
+    {Msg, _PrivKey} = quic_tls:build_server_hello(#{
+        selected_psk_identity => 0,
+        selected_psk_mode => psk_dhe_ke
+    }),
+    <<_:8, _:24, Body/binary>> = Msg,
+    {ok, Map} = quic_tls:parse_server_hello(Body),
+    PubKey = maps:get(public_key, Map),
+    ?assertEqual(32, byte_size(PubKey)),
+    ?assertEqual(0, maps:get(selected_psk_identity, Map)).
+
+%%====================================================================
+%% Key-schedule helper: derive_handshake_secret_psk_only
+%%====================================================================
+
+handshake_secret_psk_only_differs_from_dhe_test() ->
+    EarlySecret = quic_crypto:derive_early_secret(aes_128_gcm, ?SECRET),
+    DHE = crypto:strong_rand_bytes(32),
+    HsDhe = quic_crypto:derive_handshake_secret(aes_128_gcm, EarlySecret, DHE),
+    HsPskOnly = quic_crypto:derive_handshake_secret_psk_only(aes_128_gcm, EarlySecret),
+    ?assertNotEqual(HsDhe, HsPskOnly).
+
+handshake_secret_psk_only_deterministic_test() ->
+    EarlySecret = quic_crypto:derive_early_secret(aes_128_gcm, ?SECRET),
+    H1 = quic_crypto:derive_handshake_secret_psk_only(aes_128_gcm, EarlySecret),
+    H2 = quic_crypto:derive_handshake_secret_psk_only(aes_128_gcm, EarlySecret),
+    ?assertEqual(H1, H2),
+    ?assertEqual(32, byte_size(H1)).


### PR DESCRIPTION
Adds support for TLS 1.3 external pre-shared keys so QUIC connections can authenticate out-of-band without certificates (issue #131). Both `psk_dhe_ke` and `psk_ke` exchange modes are in scope.

```erlang
%% Client
quic:connect(Host, Port,
             #{external_psk => {<<"my-id">>, <<Secret/binary>>}}, Owner).

%% Server
quic:start_server(my_server, 4433,
                  #{psks => #{<<"my-id">> => <<Secret/binary>>}}).
```

PSK-only authentication is also wired through `quic_dist` so node-to-node clustering can run without a CA.

## What's in

- `parse_extensions_ordered/1` preserves order and rejects duplicates so the server can locate the binders section and assert `pre_shared_key` is the last extension per §4.2.11.
- `build_client_hello/1` resolves either `session_ticket` or `external_psk` through a single `#psk_offer{}` path. Cipher-aware binder length.
- `select_psk/4` walks offered identities, looks up via `psk_callback` then static `psks` map, verifies the binder over the truncated ClientHello, intersects offered/server modes.
- ServerHello adds `pre_shared_key` when a PSK was selected and omits `key_share` for `psk_ke`. `parse_server_hello/1` accepts the no-key_share case when `selected_psk_identity` is present.
- `derive_handshake_secret_psk_only/{1,2}` for the zero-IKM key schedule used by `psk_ke`.
- Server flight skips Certificate/CertVerify when a PSK was selected. Client flight goes straight to Finished after EncryptedExtensions on the PSK path.
- Listener cert/key are optional when PSK config is supplied; both may coexist on the same listener.
- `quic_dist` reads `psks`, `psk_callback`, `external_psk` from sys.config / `-quic_dist_*` boot args. `set_connect_options/2` accepts an `external_psk` override per peer.

## Security

- Binder is verified with `crypto:hash_equals/2` (constant time).
- A bad binder is fatal with `decrypt_error`; the server does NOT fall through to the cert path in that case (would be silent downgrade).
- The client requires the server to echo its offered `external_psk` via `selected_identity`; any other ServerHello outcome aborts with `{error, psk_not_selected}` to prevent silent fallback to an unauthenticated cert path when `verify => false` is also set.
- `psk_callback` exceptions are logged and treated as `not_found`; never crash the handshake.

## Out of scope (v1)

- 0-RTT on external PSK (server ignores `early_data` on PSK handshakes).
- `NewSessionTicket` suppressed on PSK-authenticated handshakes.
- RFC 9258 PSK Importer (raw pass-through only; caller owns secret quality and length).

## Docs

- `docs/PSK.md` user guide.
- `docs/QUIC_DIST.md` PSK-only authentication section.
- `docs/features.md` matrix row.
- Docstrings on `quic:connect/4`, `quic:start_server/3`, `quic_dist:set_connect_options/2`.

Closes #131.