### PR TITLE
feat(tls): HelloRetryRequest, multi-group key exchange, expanded signature algorithms

### DIFF
--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -45,6 +45,25 @@ quic:close(Conn, normal).
 | `server_name` | binary | Host | Server Name Indication |
 | `cert` | binary | - | Client certificate (for mTLS) |
 | `key` | term | - | Client private key (for mTLS) |
+| `groups` | [atom()] | `[x25519]` | Key-exchange groups in preference order (`x25519`, `secp256r1`, `secp384r1`). The head gets a `key_share`; the rest are HelloRetryRequest-eligible. |
+| `signature_algs` | [atom()] | historical list | Advertised signature schemes (`ecdsa_secp256r1_sha256`, `ecdsa_secp384r1_sha384`, `rsa_pss_rsae_sha256\|384\|512`, `ed25519`, `rsa_pkcs1_sha256`). |
+| `external_psk` | tuple | - | TLS 1.3 external PSK; see [PSK.md](PSK.md). |
+
+The `connected` event's `Info` map reports `negotiated_group` and
+`negotiated_scheme` for the chosen group and the server's
+CertificateVerify scheme.
+
+Mixed-group fleet example: a client that prefers `x25519` but can
+also speak NIST curves offers all three; a server pinned to
+`secp256r1` triggers a HelloRetryRequest and the client retries
+transparently.
+
+```erlang
+{ok, Conn} = quic:connect(Host, Port, #{
+    verify => false,
+    groups => [x25519, secp256r1, secp384r1]
+}, self()).
+```
 
 ### Connection Options
 

--- a/docs/SERVER_GUIDE.md
+++ b/docs/SERVER_GUIDE.md
@@ -34,6 +34,15 @@ application:ensure_all_started(quic).
 |--------|------|---------|-------------|
 | `alpn` | [binary()] | `[<<"h3">>]` | ALPN protocols to advertise |
 | `cert_chain` | [binary()] | `[]` | Additional certificate chain |
+| `groups` | [atom()] | `[x25519]` | Accepted key-exchange groups in preference order (`x25519`, `secp256r1`, `secp384r1`). A client whose `key_share` matches none of these but whose `supported_groups` does triggers a HelloRetryRequest. |
+| `signature_algs` | [atom()] | historical list | Accepted/advertised signature schemes. The CertificateVerify scheme is the server's first choice the client also offered (`rsa_pkcs1_*` is never used for CertificateVerify). |
+| `psks` / `psk_callback` | map / fun | - | TLS 1.3 external PSK; see [PSK.md](PSK.md). |
+
+The signature scheme is derived from the server's key type by
+default; `signature_algs` only needs setting to restrict or reorder
+the advertised set. A server pinned to `groups => [secp256r1]`
+exercises the HelloRetryRequest path for x25519-only clients that
+also advertise `secp256r1`.
 
 ### Connection Options
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,6 +86,20 @@
 - [x] ALPN negotiation
 - [x] Transport parameters exchange
 - [x] Certificate verification
+- [x] HelloRetryRequest (RFC 8446 §4.1.4)
+
+### Key-exchange groups
+- [x] x25519 (default)
+- [x] secp256r1, secp384r1 (opt-in via `groups`)
+- [x] Multi-group `key_share` + `supported_groups` negotiation
+- [ ] secp521r1, x448 (constants only; see Roadmap)
+
+### Signature algorithms
+- [x] ECDSA secp256r1-SHA256, secp384r1-SHA384
+- [x] RSA-PSS-RSAE SHA256/384/512
+- [x] Ed25519
+- [x] Per-handshake `signature_algorithms` negotiation (`signature_algs`)
+- [ ] Ed448, ECDSA secp521r1-SHA512 (constants only; see Roadmap)
 
 ### Encryption
 - [x] AES-128-GCM cipher suite
@@ -309,6 +323,15 @@ mark known gaps that may land in a later release.
 - [ ] RFC 9258 PSK Importer. The current API consumes the secret as
   raw IKM; an importer layer would derive an `epsk -> psk` mapping
   bound to a target protocol/KDF.
+
+### TLS 1.3 negotiation follow-ups
+- [ ] secp521r1 / x448 key-exchange groups (constants defined; key
+  generation and key_share wiring deferred).
+- [ ] Ed448 / ECDSA secp521r1-SHA512 signature schemes (constants
+  defined; sign/verify branches deferred).
+- [ ] PSK + HelloRetryRequest in one handshake. Currently the client
+  aborts if HRR follows a PSK ClientHello (binder recompute over the
+  synthetic transcript is not implemented).
 
 ## Interop Runner Compliance
 

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -220,6 +220,8 @@
 %% TLS 1.3 Alerts (RFC 8446 Section 6)
 %%====================================================================
 
+-define(TLS_ALERT_UNEXPECTED_MESSAGE, 10).
+-define(TLS_ALERT_HANDSHAKE_FAILURE, 40).
 -define(TLS_ALERT_ILLEGAL_PARAMETER, 47).
 -define(TLS_ALERT_DECRYPT_ERROR, 51).
 -define(TLS_ALERT_UNKNOWN_PSK_IDENTITY, 115).
@@ -242,6 +244,43 @@
     %% offered modes in client preference order
     modes = [psk_dhe_ke] :: [psk_dhe_ke | psk_ke]
 }).
+
+%% HelloRetryRequest sentinel random (RFC 8446 §4.1.3): SHA-256 of
+%% "HelloRetryRequest". A ServerHello carrying this random IS an HRR.
+-define(TLS_HRR_RANDOM, <<
+    16#CF,
+    16#21,
+    16#AD,
+    16#74,
+    16#E5,
+    16#9A,
+    16#61,
+    16#11,
+    16#BE,
+    16#1D,
+    16#8C,
+    16#02,
+    16#1E,
+    16#65,
+    16#B8,
+    16#91,
+    16#C2,
+    16#A2,
+    16#11,
+    16#16,
+    16#7A,
+    16#BB,
+    16#8C,
+    16#5E,
+    16#07,
+    16#9E,
+    16#09,
+    16#E2,
+    16#C8,
+    16#A8,
+    16#33,
+    16#9C
+>>).
 
 %%====================================================================
 %% TLS 1.3 Named Groups (RFC 8446 Section 4.2.7)

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -192,6 +192,14 @@ get_fd(Socket) ->
 %%       `{Identity, Secret, Modes}' takes an explicit non-empty
 %%       list (`psk_dhe_ke | psk_ke'). Mutually exclusive with
 %%       `session_ticket'. See docs/PSK.md.</li>
+%%   <li>`groups' - key-exchange groups in preference order
+%%       (`x25519 | secp256r1 | secp384r1'; default `[x25519]').
+%%       The head gets a `key_share'; the rest are HelloRetryRequest
+%%       eligible.</li>
+%%   <li>`signature_algs' - advertised signature schemes
+%%       (`ecdsa_secp256r1_sha256 | ecdsa_secp384r1_sha384 |
+%%       rsa_pss_rsae_sha256|384|512 | ed25519 | rsa_pkcs1_sha256').
+%%       Defaults to the historical wire list.</li>
 %% </ul>
 -spec connect(Host, Port, Opts, Owner) -> {ok, pid()} | {error, term()} when
     Host :: binary() | string(),
@@ -675,6 +683,15 @@ get_peer_transport_params(Conn) when is_pid(Conn) ->
 %%   <li>`psk_callback' - `fun((Identity :: binary()) -> {ok, Secret} | not_found)';
 %%       takes precedence over `psks'</li>
 %%   <li>`alpn' - List of ALPN protocols (default: [&lt;&lt;"h3"&gt;&gt;])</li>
+%%   <li>`groups' - accepted key-exchange groups in preference order
+%%       (`x25519 | secp256r1 | secp384r1'; default `[x25519]'). When
+%%       the client's `key_share' matches none of these but a
+%%       `supported_groups' entry does, the server sends a
+%%       HelloRetryRequest.</li>
+%%   <li>`signature_algs' - accepted/advertised signature schemes; the
+%%       CertificateVerify scheme is the server's first choice the
+%%       client also offered. `rsa_pkcs1_*' is never selected for
+%%       CertificateVerify (RFC 8446 §4.4.3).</li>
 %%   <li>`pool_size' - Number of listener processes (default: 1)</li>
 %%   <li>`connection_handler' - Fun(Conn) -> {ok, HandlerPid} where Conn is the pid</li>
 %% </ul>

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -285,6 +285,30 @@
     server_hs_secret :: binary() | undefined,
     client_hs_secret :: binary() | undefined,
 
+    %% Key-exchange + signature negotiation (RFC 8446 §4.1.4 / §4.2.3)
+    tls_groups = [x25519] :: [atom()],
+    tls_sig_algs :: [atom()] | undefined,
+    %% Peer's offered signature_algorithms (wire codes), set on the
+    %% server when the ClientHello is parsed.
+    peer_sig_algs = [] :: [non_neg_integer()],
+    %% CertificateVerify scheme chosen for this handshake (wire code).
+    cert_verify_code :: non_neg_integer() | undefined,
+    %% Group of the key_share we sent (client) / selected (server)
+    tls_group = x25519 :: atom(),
+    %% HelloRetryRequest bookkeeping
+    hrr_sent = false :: boolean(),
+    hrr_group :: atom() | undefined,
+    %% Outgoing Initial-level CRYPTO stream offset. Stays 0 for a
+    %% one-shot flight; bumps after HRR so CH2 / ServerHello continue
+    %% the stream (RFC 9001 §4.1.3).
+    initial_tx_off = 0 :: non_neg_integer(),
+    %% Client-side: CH1 random + build opts, needed to rebuild CH2
+    tls_ch1_random :: binary() | undefined,
+    tls_ch1_opts :: map() | undefined,
+    %% Negotiated values surfaced in the connected event
+    negotiated_group :: atom() | undefined,
+    negotiated_scheme :: atom() | undefined,
+
     %% CRYPTO frame buffer (per level: initial, handshake, app)
     crypto_buffer = #{initial => #{}, handshake => #{}, app => #{}} :: map(),
     crypto_offset = #{initial => 0, handshake => 0, app => 0} :: map(),
@@ -998,6 +1022,8 @@ init({server, Opts}) ->
             psk_callback => maps:get(psk_callback, Opts, undefined),
             psks => maps:get(psks, Opts, undefined)
         },
+        tls_groups = maps:get(groups, Opts, [x25519]),
+        tls_sig_algs = maps:get(signature_algs, Opts, undefined),
         alpn_list = normalize_alpn_list(ALPNList),
         pn_initial = PNSpace,
         pn_handshake = PNSpace,
@@ -1349,6 +1375,9 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         initial_keys = InitialKeys,
         retry_token = InitialRetryToken,
         tls_state = ?TLS_AWAITING_SERVER_HELLO,
+        tls_groups = maps:get(groups, Opts, [x25519]),
+        tls_sig_algs = maps:get(signature_algs, Opts, undefined),
+        tls_group = hd(maps:get(groups, Opts, [x25519])),
         alpn_list = AlpnList,
         pn_initial = PNSpace,
         pn_handshake = PNSpace,
@@ -1668,6 +1697,8 @@ connected(
         role = Role,
         pending_data = Pending,
         transport_params = TransportParams,
+        negotiated_group = NegGroup,
+        negotiated_scheme = NegScheme,
         active_n = ActiveN
     } = State
 ) when
@@ -1677,7 +1708,9 @@ connected(
     Info = #{
         alpn => Alpn,
         alpn_protocol => Alpn,
-        transport_params => TransportParams
+        transport_params => TransportParams,
+        negotiated_group => NegGroup,
+        negotiated_scheme => NegScheme
     },
     Owner ! {quic, self(), {connected, Info}},
     %% For client connections, ensure socket is active for receiving
@@ -2337,14 +2370,20 @@ send_client_hello(State) ->
         server_name => ServerName,
         alpn => AlpnList,
         transport_params => TransportParams,
-        session_ticket => SessionTicket
+        session_ticket => SessionTicket,
+        groups => State#state.tls_groups
     },
+    ClientHelloOpts1 =
+        case State#state.tls_sig_algs of
+            undefined -> ClientHelloOpts0;
+            SigAlgs -> ClientHelloOpts0#{signature_algs => SigAlgs}
+        end,
     ClientHelloOpts =
         case State#state.external_psk of
-            undefined -> ClientHelloOpts0;
-            Ext -> ClientHelloOpts0#{external_psk => Ext}
+            undefined -> ClientHelloOpts1;
+            Ext -> ClientHelloOpts1#{external_psk => Ext}
         end,
-    {ClientHello, PrivKey, _Random} = quic_tls:build_client_hello(ClientHelloOpts),
+    {ClientHello, PrivKey, ClientRandom} = quic_tls:build_client_hello(ClientHelloOpts),
 
     %% Update transcript
     Transcript = ClientHello,
@@ -2376,6 +2415,9 @@ send_client_hello(State) ->
     NewState = send_initial_packet(CryptoFrame, State#state{
         tls_private_key = PrivKey,
         tls_transcript = Transcript,
+        tls_ch1_random = ClientRandom,
+        tls_ch1_opts = ClientHelloOpts,
+        initial_tx_off = byte_size(ClientHello),
         early_keys = EarlyKeys,
         max_early_data =
             case SessionTicket of
@@ -2431,11 +2473,50 @@ negotiate_alpn(ClientALPN, ServerALPN) ->
         [] -> undefined
     end.
 
-%% Extract x25519 public key from key share entries list
-extract_x25519_key(undefined) -> undefined;
-extract_x25519_key([]) -> undefined;
-extract_x25519_key([{?GROUP_X25519, PubKey} | _]) -> PubKey;
-extract_x25519_key([_ | Rest]) -> extract_x25519_key(Rest).
+%% Extract the client's key_share public key for a given group atom.
+extract_group_key(_Group, undefined) ->
+    undefined;
+extract_group_key(_Group, []) ->
+    undefined;
+extract_group_key(Group, [{Code, PubKey} | Rest]) ->
+    case group_atom(Code) of
+        Group -> PubKey;
+        _ -> extract_group_key(Group, Rest)
+    end.
+
+%% Named-group wire code -> atom (unknown stays as the integer).
+group_atom(?GROUP_X25519) -> x25519;
+group_atom(?GROUP_SECP256R1) -> secp256r1;
+group_atom(?GROUP_SECP384R1) -> secp384r1;
+group_atom(Other) -> Other.
+
+%% Decide the key-exchange group for a ClientHello (RFC 8446 §4.1.4).
+%% Returns {direct, Group} when the client already sent a usable
+%% key_share, {hrr, Group} when a HelloRetryRequest is needed, or
+%% none when there is no group both sides support.
+select_key_share_group(ServerGroups, KeyShareEntries, SupportedGroups) ->
+    Offered = [group_atom(C) || {C, _} <- entries_or_empty(KeyShareEntries)],
+    case first_in(ServerGroups, Offered) of
+        {ok, G} ->
+            {direct, G};
+        none ->
+            case first_in(ServerGroups, SupportedGroups) of
+                {ok, G} -> {hrr, G};
+                none -> none
+            end
+    end.
+
+entries_or_empty(undefined) -> [];
+entries_or_empty(L) when is_list(L) -> L.
+
+%% First element of Prefs that also appears in Avail.
+first_in([], _Avail) ->
+    none;
+first_in([P | Rest], Avail) ->
+    case lists:member(P, Avail) of
+        true -> {ok, P};
+        false -> first_in(Rest, Avail)
+    end.
 
 %% Validate PSK from client's pre_shared_key extension
 %% Returns {ok, PSK, ResumptionSecret} if valid, error otherwise
@@ -2545,10 +2626,13 @@ ensure_ticket_table() ->
             ok
     end.
 
-%% Server: Send ServerHello in Initial packet
+%% Server: Send ServerHello in Initial packet. Uses the tracked
+%% Initial CRYPTO offset (non-zero only after a HelloRetryRequest).
 send_server_hello(ServerHelloMsg, State) ->
-    CryptoFrame = quic_frame:encode({crypto, 0, ServerHelloMsg}),
-    send_initial_packet(CryptoFrame, State).
+    Off = State#state.initial_tx_off,
+    CryptoFrame = quic_frame:encode({crypto, Off, ServerHelloMsg}),
+    State1 = State#state{initial_tx_off = Off + byte_size(ServerHelloMsg)},
+    send_initial_packet(CryptoFrame, State1).
 
 %% Server: Send EncryptedExtensions, Certificate, CertificateVerify, Finished
 %% @private
@@ -2677,14 +2761,15 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
                 %% Cert path
                 CertReq =
                     case Verify of
-                        true -> quic_tls:build_certificate_request(<<>>);
+                        true -> build_cert_request(State);
                         false -> <<>>
                     end,
                 AllCerts = [Cert | CertChain],
                 Cert0 = quic_tls:build_certificate(<<>>, AllCerts),
                 T1 = <<Transcript/binary, EncExtMsg/binary, CertReq/binary, Cert0/binary>>,
                 HashForCV = quic_crypto:transcript_hash(Cipher, T1),
-                SigAlg = select_signature_algorithm(PrivateKey),
+                %% Scheme negotiated in do_server_client_hello.
+                SigAlg = State#state.cert_verify_code,
                 CV = quic_tls:build_certificate_verify(SigAlg, PrivateKey, HashForCV),
                 T2 = <<T1/binary, CV/binary>>,
                 HashForFin = quic_crypto:transcript_hash(Cipher, T2),
@@ -4566,203 +4651,34 @@ process_tls_message(
                 random := _ClientRandom,
                 key_share := KeyShareEntries,
                 cipher_suites := CipherSuites,
-                alpn_protocols := ClientALPN,
-                transport_params := TP,
                 session_id := SessionId
             } = ClientHelloInfo} ->
-            %% Extract x25519 public key from key share entries
-            ClientPubKey = extract_x25519_key(KeyShareEntries),
             %% Select cipher suite (prefer server's order)
             Cipher = select_cipher(CipherSuites),
-
-            %% Check for PSK (0-RTT/resumption/external)
-            PSKInfo = maps:get(pre_shared_key, ClientHelloInfo, undefined),
-            WantsEarlyData = maps:get(early_data, ClientHelloInfo, false),
-
-            %% TLS 1.3 external PSK selection (RFC 8446 §4.2.11).
-            %% Validate pre_shared_key placement, lookup identity, verify
-            %% binder. On match the server skips the cert path and uses
-            %% the PSK secret in the early_secret derivation below.
-            PskConfig = State#state.psk_config,
-            ServerPskModes = [psk_dhe_ke, psk_ke],
-            ExternalPskResult =
-                case PskConfig of
-                    undefined ->
-                        none;
-                    _ ->
-                        quic_tls:select_psk(
-                            ClientHelloInfo, OriginalMsg, PskConfig, ServerPskModes
-                        )
-                end,
-            ok,
-
-            %% For normal handshake, derive early secret from zero PSK
-            %% PSK-based resumption with full 0-RTT support requires additional changes
-            %% to skip Certificate/CertificateVerify - implementing basic 0-RTT decryption only
-            HashLen0 =
-                case Cipher of
-                    aes_256_gcm -> 48;
-                    _ -> 32
-                end,
-            ZeroPSK = <<0:HashLen0/unit:8>>,
-
-            %% Derive early secret. External-PSK selection wins over both
-            %% resumption-PSK 0-RTT and the standard zero-PSK path.
-            {EarlyKeys, EarlySecret, SelectedPsk} =
-                case ExternalPskResult of
-                    {ok, #{secret := PSKSecret, mode := Mode} = Sel} ->
-                        Selected = #{
-                            identity => maps:get(identity, Sel),
-                            secret => PSKSecret,
-                            mode => Mode
-                        },
-                        {
-                            undefined,
-                            quic_crypto:derive_early_secret(Cipher, PSKSecret),
-                            Selected
-                        };
-                    none ->
-                        case PSKInfo of
-                            #{identities := [{Identity, _Age}], binders := [_Binder]} when
-                                WantsEarlyData
-                            ->
-                                case validate_psk(Identity, Cipher, OriginalMsg, State) of
-                                    {ok, PSK, ResumptionSecret} ->
-                                        ES = quic_crypto:derive_early_secret(Cipher, PSK),
-                                        ClientHelloHash = quic_crypto:transcript_hash(
-                                            Cipher, OriginalMsg
-                                        ),
-                                        ETS = quic_crypto:derive_client_early_traffic_secret(
-                                            Cipher, ES, ClientHelloHash
-                                        ),
-                                        {Key, IV, HP} = quic_keys:derive_keys(ETS, Cipher),
-                                        EK = #crypto_keys{
-                                            key = Key, iv = IV, hp = HP, cipher = Cipher
-                                        },
-                                        {
-                                            {EK, ResumptionSecret},
-                                            quic_crypto:derive_early_secret(Cipher, ZeroPSK),
-                                            undefined
-                                        };
-                                    error ->
-                                        {undefined,
-                                            quic_crypto:derive_early_secret(Cipher, ZeroPSK),
-                                            undefined}
-                                end;
-                            _ ->
-                                {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK),
-                                    undefined}
-                        end;
-                    {error, bad_binder} ->
-                        %% Bail out via exit/1; the handler returning
-                        %% here is impossible because the case can't
-                        %% produce a valid tuple. Elvis prefers exit
-                        %% over throw.
-                        ?LOG_WARNING(
-                            #{what => psk_binder_verification_failed},
-                            ?QUIC_LOG_META
-                        ),
-                        send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State),
-                        exit({tls_alert, decrypt_error})
-                end,
-
-            %% Generate server key pair
-            {ServerPubKey, ServerPrivKey} = quic_crypto:generate_key_pair(x25519),
-
-            %% Compute shared secret
-            SharedSecret = quic_crypto:compute_shared_secret(
-                x25519, ServerPrivKey, ClientPubKey
-            ),
-
-            %% Negotiate ALPN
-            ALPN = negotiate_alpn(ClientALPN, State#state.alpn_list),
-
-            %% Build ServerHello. For PSK handshakes the ServerHello
-            %% carries `selected_psk_identity`; for psk_ke it also
-            %% omits key_share (RFC 8446 §4.2.9).
-            ServerHelloOpts0 = #{
-                cipher_suite => cipher_atom_to_code(Cipher),
-                key_pair => {ServerPubKey, ServerPrivKey},
-                session_id => SessionId
-            },
-            ServerHelloOpts =
-                case {SelectedPsk, ExternalPskResult} of
-                    {undefined, _} ->
-                        ServerHelloOpts0;
-                    {_, {ok, #{identity_idx := Idx, mode := SelMode}}} ->
-                        ServerHelloOpts0#{
-                            selected_psk_identity => Idx,
-                            selected_psk_mode => SelMode
-                        }
-                end,
-            {ServerHello, _ServerPrivKey2} = quic_tls:build_server_hello(ServerHelloOpts),
-
-            %% Update transcript with ClientHello
-            Transcript0 = <<OriginalMsg/binary>>,
-            %% Add ServerHello to transcript
-            Transcript = <<Transcript0/binary, ServerHello/binary>>,
-            TranscriptHash = quic_crypto:transcript_hash(Cipher, Transcript),
-
-            %% Derive handshake secrets. psk_ke (PSK-only) uses zero IKM
-            %% per RFC 8446 §7.1; psk_dhe_ke and standard handshakes use
-            %% the ECDHE shared secret.
-            HandshakeSecret =
-                case SelectedPsk of
-                    #{mode := psk_ke} ->
-                        quic_crypto:derive_handshake_secret_psk_only(Cipher, EarlySecret);
-                    _ ->
-                        quic_crypto:derive_handshake_secret(
-                            Cipher, EarlySecret, SharedSecret
-                        )
-                end,
-
-            ClientHsSecret = quic_crypto:derive_client_handshake_secret(
-                Cipher, HandshakeSecret, TranscriptHash
-            ),
-            ServerHsSecret = quic_crypto:derive_server_handshake_secret(
-                Cipher, HandshakeSecret, TranscriptHash
-            ),
-
-            %% Derive handshake keys
-            {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientHsSecret, Cipher),
-            {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(ServerHsSecret, Cipher),
-
-            ClientHsKeys = #crypto_keys{
-                key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher
-            },
-            ServerHsKeys = #crypto_keys{
-                key = ServerKey, iv = ServerIV, hp = ServerHP, cipher = Cipher
-            },
-
-            %% Update DCID from ClientHello SCID
-            %% quic_tls decodes the initial_source_connection_id param as initial_scid
-            ClientSCID = maps:get(initial_scid, TP, <<>>),
-
-            State0 = State#state{
-                dcid = ClientSCID,
-                tls_state = ?TLS_AWAITING_CLIENT_FINISHED,
-                tls_transcript = Transcript,
-                tls_private_key = ServerPrivKey,
-                handshake_secret = HandshakeSecret,
-                client_hs_secret = ClientHsSecret,
-                server_hs_secret = ServerHsSecret,
-                handshake_keys = {ClientHsKeys, ServerHsKeys},
-                alpn = ALPN,
-                early_keys = EarlyKeys,
-                early_data_accepted = (EarlyKeys =/= undefined andalso WantsEarlyData),
-                selected_psk = SelectedPsk
-            },
-            %% Apply peer transport params (extracts active_connection_id_limit).
-            %% Always send ServerHello + handshake flight so the peer can
-            %% derive handshake keys; if a TP violation was flagged,
-            %% maybe_emit_pending_close/1 emits CONNECTION_CLOSE afterward.
-            %% Always send ServerHello + handshake flight so the peer can
-            %% derive handshake keys; if a TP violation was flagged,
-            %% maybe_emit_pending_close/1 emits CONNECTION_CLOSE afterward.
-            State1 = apply_peer_transport_params(TP, State0),
-            State2 = send_server_hello(ServerHello, State1),
-            State3 = send_server_handshake_flight(Cipher, TranscriptHash, State2),
-            maybe_emit_pending_close(State3);
+            %% RFC 8446 §4.1.4 group negotiation: use the client's
+            %% key_share directly when possible, otherwise send a
+            %% HelloRetryRequest for a mutually-supported group.
+            SupportedGroups = maps:get(supported_groups, ClientHelloInfo, []),
+            case
+                select_key_share_group(
+                    State#state.tls_groups, KeyShareEntries, SupportedGroups
+                )
+            of
+                {direct, SelGroup} ->
+                    ClientPubKey = extract_group_key(SelGroup, KeyShareEntries),
+                    do_server_client_hello(
+                        SelGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
+                    );
+                {hrr, HrrGroup} when not State#state.hrr_sent ->
+                    send_hello_retry_request(HrrGroup, Cipher, SessionId, OriginalMsg, State);
+                {hrr, _} ->
+                    %% Client ignored our HRR group selection.
+                    send_tls_alert(
+                        ?TLS_ALERT_ILLEGAL_PARAMETER, <<"bad retry key_share">>, State
+                    );
+                none ->
+                    send_tls_alert(?TLS_ALERT_HANDSHAKE_FAILURE, <<"no common group">>, State)
+            end;
         {error, Reason} ->
             ?LOG_ERROR(#{what => client_hello_parse_failed, reason => Reason}, ?QUIC_LOG_META),
             State
@@ -4770,6 +4686,8 @@ process_tls_message(
 %% Client receives ServerHello
 process_tls_message(_Level, ?TLS_SERVER_HELLO, Body, OriginalMsg, State) ->
     case quic_tls:parse_server_hello(Body) of
+        {hrr, HrrInfo} ->
+            handle_hello_retry_request(HrrInfo, OriginalMsg, State);
         {ok, #{cipher := Cipher} = ServerHelloMap} ->
             %% Determine handshake type: PSK (with or without DHE) vs
             %% standard cert-auth. PSK selection is signalled by the
@@ -4792,7 +4710,7 @@ process_tls_message(_Level, ?TLS_SERVER_HELLO, Body, OriginalMsg, State) ->
                                 <<>>;
                             _ ->
                                 quic_crypto:compute_shared_secret(
-                                    x25519,
+                                    State#state.tls_group,
                                     State#state.tls_private_key,
                                     ServerPubKey
                                 )
@@ -4850,6 +4768,7 @@ process_tls_message(_Level, ?TLS_SERVER_HELLO, Body, OriginalMsg, State) ->
                         client_hs_secret = ClientHsSecret,
                         server_hs_secret = ServerHsSecret,
                         handshake_keys = {ClientHsKeys, ServerHsKeys},
+                        negotiated_group = State#state.tls_group,
                         selected_psk = ClientSelectedPsk
                     },
                     send_initial_ack(State1)
@@ -4917,15 +4836,22 @@ process_tls_message(
 process_tls_message(
     _Level,
     ?TLS_CERTIFICATE_VERIFY,
-    _Body,
+    Body,
     OriginalMsg,
     #state{role = client, tls_state = ?TLS_AWAITING_CERT_VERIFY} = State
 ) ->
-    %% Update transcript
+    %% Update transcript and record the server's CertificateVerify
+    %% scheme for the connected event.
     Transcript = <<(State#state.tls_transcript)/binary, OriginalMsg/binary>>,
+    Scheme =
+        case quic_tls:parse_certificate_verify(Body) of
+            {ok, #{algorithm := Alg}} -> code_to_sig_alg(Alg);
+            _ -> undefined
+        end,
     State#state{
         tls_state = ?TLS_AWAITING_FINISHED,
-        tls_transcript = Transcript
+        tls_transcript = Transcript,
+        negotiated_scheme = Scheme
     };
 %% Client receives server's Finished
 process_tls_message(
@@ -5010,9 +4936,10 @@ process_tls_message(
                                         ),
                                         T1 = <<Transcript/binary, ClientCertMsg/binary>>,
                                         TranscriptHashCV = quic_crypto:transcript_hash(Cipher, T1),
-                                        SigAlg = select_signature_algorithm(
-                                            State#state.client_private_key
-                                        ),
+                                        %% Pick a scheme the server offered and our
+                                        %% key can produce; fall back to the key's
+                                        %% natural scheme if the offer is empty.
+                                        SigAlg = client_cert_verify_code(State),
                                         ClientCertVerifyMsg = quic_tls:build_certificate_verify_client(
                                             SigAlg, State#state.client_private_key, TranscriptHashCV
                                         ),
@@ -5185,15 +5112,23 @@ process_tls_message(
 process_tls_message(
     _Level,
     ?TLS_CERTIFICATE_REQUEST,
-    _Body,
+    Body,
     OriginalMsg,
     #state{role = client} = State
 ) ->
-    %% Update transcript and mark that server wants client certificate
+    %% Update transcript and mark that server wants client certificate.
+    %% Capture the advertised signature_algorithms so the client can
+    %% pick a compatible CertificateVerify scheme.
     Transcript = <<(State#state.tls_transcript)/binary, OriginalMsg/binary>>,
+    PeerSigAlgs =
+        case quic_tls:parse_certificate_request(Body) of
+            {ok, #{signature_algorithms := SA}} -> SA;
+            _ -> []
+        end,
     State#state{
         tls_transcript = Transcript,
-        cert_request_received = true
+        cert_request_received = true,
+        peer_sig_algs = PeerSigAlgs
     };
 %% Server receives client Certificate (when verify=true)
 process_tls_message(
@@ -5263,6 +5198,316 @@ process_tls_message(
     end;
 process_tls_message(_Level, _Type, _Body, _OriginalMsg, State) ->
     State.
+
+%% @private Continue a server-side ClientHello once the key-exchange
+%% group is settled (direct or post-HRR). SelectedGroup is the agreed
+%% named group; ClientPubKey is the client's key_share for it.
+do_server_client_hello(SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State0In) ->
+    ClientALPN = maps:get(alpn_protocols, ClientHelloInfo, []),
+    TP = maps:get(transport_params, ClientHelloInfo, #{}),
+    SessionId = maps:get(session_id, ClientHelloInfo, <<>>),
+    %% Remember the client's offered signature schemes for the
+    %% server's CertificateVerify negotiation.
+    State = State0In#state{
+        peer_sig_algs = maps:get(signature_algorithms, ClientHelloInfo, [])
+    },
+    %% Check for PSK (0-RTT/resumption/external)
+    PSKInfo = maps:get(pre_shared_key, ClientHelloInfo, undefined),
+    WantsEarlyData = maps:get(early_data, ClientHelloInfo, false),
+
+    %% TLS 1.3 external PSK selection (RFC 8446 §4.2.11).
+    %% Validate pre_shared_key placement, lookup identity, verify
+    %% binder. On match the server skips the cert path and uses
+    %% the PSK secret in the early_secret derivation below.
+    PskConfig = State#state.psk_config,
+    ServerPskModes = [psk_dhe_ke, psk_ke],
+    ExternalPskResult =
+        case PskConfig of
+            undefined ->
+                none;
+            _ ->
+                quic_tls:select_psk(
+                    ClientHelloInfo, OriginalMsg, PskConfig, ServerPskModes
+                )
+        end,
+    ok,
+
+    %% For normal handshake, derive early secret from zero PSK
+    %% PSK-based resumption with full 0-RTT support requires additional changes
+    %% to skip Certificate/CertificateVerify - implementing basic 0-RTT decryption only
+    HashLen0 =
+        case Cipher of
+            aes_256_gcm -> 48;
+            _ -> 32
+        end,
+    ZeroPSK = <<0:HashLen0/unit:8>>,
+
+    %% Derive early secret. External-PSK selection wins over both
+    %% resumption-PSK 0-RTT and the standard zero-PSK path.
+    {EarlyKeys, EarlySecret, SelectedPsk} =
+        case ExternalPskResult of
+            {ok, #{secret := PSKSecret, mode := Mode} = Sel} ->
+                Selected = #{
+                    identity => maps:get(identity, Sel),
+                    secret => PSKSecret,
+                    mode => Mode
+                },
+                {
+                    undefined,
+                    quic_crypto:derive_early_secret(Cipher, PSKSecret),
+                    Selected
+                };
+            none ->
+                case PSKInfo of
+                    #{identities := [{Identity, _Age}], binders := [_Binder]} when
+                        WantsEarlyData
+                    ->
+                        case validate_psk(Identity, Cipher, OriginalMsg, State) of
+                            {ok, PSK, ResumptionSecret} ->
+                                ES = quic_crypto:derive_early_secret(Cipher, PSK),
+                                ClientHelloHash = quic_crypto:transcript_hash(
+                                    Cipher, OriginalMsg
+                                ),
+                                ETS = quic_crypto:derive_client_early_traffic_secret(
+                                    Cipher, ES, ClientHelloHash
+                                ),
+                                {Key, IV, HP} = quic_keys:derive_keys(ETS, Cipher),
+                                EK = #crypto_keys{
+                                    key = Key, iv = IV, hp = HP, cipher = Cipher
+                                },
+                                {
+                                    {EK, ResumptionSecret},
+                                    quic_crypto:derive_early_secret(Cipher, ZeroPSK),
+                                    undefined
+                                };
+                            error ->
+                                {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK),
+                                    undefined}
+                        end;
+                    _ ->
+                        {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK), undefined}
+                end;
+            {error, bad_binder} ->
+                %% Bail out via exit/1; the handler returning
+                %% here is impossible because the case can't
+                %% produce a valid tuple. Elvis prefers exit
+                %% over throw.
+                ?LOG_WARNING(
+                    #{what => psk_binder_verification_failed},
+                    ?QUIC_LOG_META
+                ),
+                send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State),
+                exit({tls_alert, decrypt_error})
+        end,
+
+    %% Generate server key pair for the negotiated group
+    {ServerPubKey, ServerPrivKey} = quic_crypto:generate_key_pair(SelectedGroup),
+
+    %% Compute shared secret
+    SharedSecret = quic_crypto:compute_shared_secret(
+        SelectedGroup, ServerPrivKey, ClientPubKey
+    ),
+
+    %% Negotiate ALPN
+    ALPN = negotiate_alpn(ClientALPN, State#state.alpn_list),
+
+    %% Build ServerHello. For PSK handshakes the ServerHello
+    %% carries `selected_psk_identity`; for psk_ke it also
+    %% omits key_share (RFC 8446 §4.2.9).
+    ServerHelloOpts0 = #{
+        cipher_suite => cipher_atom_to_code(Cipher),
+        key_pair => {ServerPubKey, ServerPrivKey},
+        key_share_group => SelectedGroup,
+        session_id => SessionId
+    },
+    ServerHelloOpts =
+        case {SelectedPsk, ExternalPskResult} of
+            {undefined, _} ->
+                ServerHelloOpts0;
+            {_, {ok, #{identity_idx := Idx, mode := SelMode}}} ->
+                ServerHelloOpts0#{
+                    selected_psk_identity => Idx,
+                    selected_psk_mode => SelMode
+                }
+        end,
+    {ServerHello, _ServerPrivKey2} = quic_tls:build_server_hello(ServerHelloOpts),
+
+    %% Transcript base: empty for a first ClientHello, or the
+    %% synthetic-message_hash + HRR prefix on a post-HRR retry
+    %% (already stored in tls_transcript when the HRR was sent).
+    Transcript0 =
+        case State#state.hrr_sent of
+            true -> State#state.tls_transcript;
+            false -> <<>>
+        end,
+    Transcript = <<Transcript0/binary, OriginalMsg/binary, ServerHello/binary>>,
+    TranscriptHash = quic_crypto:transcript_hash(Cipher, Transcript),
+
+    %% Derive handshake secrets. psk_ke (PSK-only) uses zero IKM
+    %% per RFC 8446 §7.1; psk_dhe_ke and standard handshakes use
+    %% the ECDHE shared secret.
+    HandshakeSecret =
+        case SelectedPsk of
+            #{mode := psk_ke} ->
+                quic_crypto:derive_handshake_secret_psk_only(Cipher, EarlySecret);
+            _ ->
+                quic_crypto:derive_handshake_secret(
+                    Cipher, EarlySecret, SharedSecret
+                )
+        end,
+
+    ClientHsSecret = quic_crypto:derive_client_handshake_secret(
+        Cipher, HandshakeSecret, TranscriptHash
+    ),
+    ServerHsSecret = quic_crypto:derive_server_handshake_secret(
+        Cipher, HandshakeSecret, TranscriptHash
+    ),
+
+    %% Derive handshake keys
+    {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientHsSecret, Cipher),
+    {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(ServerHsSecret, Cipher),
+
+    ClientHsKeys = #crypto_keys{
+        key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher
+    },
+    ServerHsKeys = #crypto_keys{
+        key = ServerKey, iv = ServerIV, hp = ServerHP, cipher = Cipher
+    },
+
+    %% Update DCID from ClientHello SCID
+    %% quic_tls decodes the initial_source_connection_id param as initial_scid
+    ClientSCID = maps:get(initial_scid, TP, <<>>),
+
+    State0 = State#state{
+        dcid = ClientSCID,
+        tls_state = ?TLS_AWAITING_CLIENT_FINISHED,
+        tls_transcript = Transcript,
+        tls_private_key = ServerPrivKey,
+        tls_group = SelectedGroup,
+        negotiated_group = SelectedGroup,
+        handshake_secret = HandshakeSecret,
+        client_hs_secret = ClientHsSecret,
+        server_hs_secret = ServerHsSecret,
+        handshake_keys = {ClientHsKeys, ServerHsKeys},
+        alpn = ALPN,
+        early_keys = EarlyKeys,
+        early_data_accepted = (EarlyKeys =/= undefined andalso WantsEarlyData),
+        selected_psk = SelectedPsk
+    },
+    %% Negotiate the CertificateVerify scheme up front (cert
+    %% path only). No common scheme is fatal (RFC 8446 §4.4.3).
+    case negotiate_cert_verify(SelectedPsk, State0) of
+        {error, no_common_sig_alg} ->
+            send_tls_alert(
+                ?TLS_ALERT_HANDSHAKE_FAILURE,
+                <<"no common signature algorithm">>,
+                State0
+            );
+        {ok, CVCode, CVScheme} ->
+            State0b = State0#state{
+                cert_verify_code = CVCode,
+                negotiated_scheme = CVScheme
+            },
+            State1 = apply_peer_transport_params(TP, State0b),
+            State2 = send_server_hello(ServerHello, State1),
+            State3 = send_server_handshake_flight(Cipher, TranscriptHash, State2),
+            maybe_emit_pending_close(State3)
+    end.
+
+%% @private Choose the server's CertificateVerify scheme. PSK
+%% handshakes need none. Cert handshakes intersect the key's schemes
+%% with the client's offer; no overlap is fatal.
+negotiate_cert_verify(SelectedPsk, _State) when SelectedPsk =/= undefined ->
+    {ok, undefined, undefined};
+negotiate_cert_verify(_None, #state{server_private_key = undefined}) ->
+    {ok, undefined, undefined};
+negotiate_cert_verify(_None, State) ->
+    case
+        select_signature_algorithm(
+            State#state.server_private_key,
+            State#state.tls_sig_algs,
+            State#state.peer_sig_algs
+        )
+    of
+        error -> {error, no_common_sig_alg};
+        Code -> {ok, Code, code_to_sig_alg(Code)}
+    end.
+
+%% @private Send a HelloRetryRequest for SelectedGroup and arm the
+%% server to receive the client's second ClientHello. The transcript
+%% is reset to the synthetic message_hash(CH1) + HRR per RFC 8446
+%% §4.4.1. No handshake keys exist yet, so HRR ships at Initial level.
+send_hello_retry_request(SelectedGroup, Cipher, SessionId, OriginalMsg, State) ->
+    CH1Hash = quic_crypto:transcript_hash(Cipher, OriginalMsg),
+    Prefix = quic_crypto:hrr_transcript_prefix(Cipher, CH1Hash),
+    HRR = quic_tls:build_hello_retry_request(
+        SessionId, cipher_atom_to_code(Cipher), SelectedGroup
+    ),
+    Transcript = <<Prefix/binary, HRR/binary>>,
+    State1 = State#state{
+        hrr_sent = true,
+        hrr_group = SelectedGroup,
+        tls_transcript = Transcript,
+        initial_tx_off = byte_size(HRR)
+    },
+    send_initial_packet(quic_frame:encode({crypto, 0, HRR}), State1).
+
+%% @private Client-side HelloRetryRequest handling (RFC 8446 §4.1.4).
+%% Validates the one-HRR and group rules, rebuilds CH2 reusing CH1's
+%% random + session_id, and rewrites the transcript to the synthetic
+%% message_hash(CH1) + HRR prefix.
+handle_hello_retry_request(
+    #{cipher := Cipher, selected_group := SelGroup}, HrrMsg, State
+) ->
+    Ch1Opts = State#state.tls_ch1_opts,
+    PskOffered =
+        Ch1Opts =/= undefined andalso
+            (maps:get(external_psk, Ch1Opts, undefined) =/= undefined orelse
+                maps:get(session_ticket, Ch1Opts, undefined) =/= undefined),
+    GroupOffered = lists:member(SelGroup, State#state.tls_groups),
+    case {State#state.hrr_sent, PskOffered, GroupOffered} of
+        {true, _, _} ->
+            %% A second HRR is illegal (RFC 8446 §4.1.4).
+            notify_owner({error, {tls_alert, unexpected_message}}, State),
+            send_tls_alert(?TLS_ALERT_UNEXPECTED_MESSAGE, State);
+        {_, true, _} ->
+            %% PSK + HRR is out of scope for v1; aborting avoids a
+            %% silent binder-recompute gap.
+            notify_owner({error, {tls_alert, unexpected_message}}, State),
+            send_tls_alert(?TLS_ALERT_UNEXPECTED_MESSAGE, State);
+        {_, _, false} ->
+            %% Server picked a group we never offered.
+            notify_owner({error, {tls_alert, illegal_parameter}}, State),
+            send_tls_alert(?TLS_ALERT_ILLEGAL_PARAMETER, State);
+        {false, false, true} ->
+            %% Synthetic transcript: message_hash(CH1) || HRR. The
+            %% current transcript holds exactly CH1.
+            CH1Hash = quic_crypto:transcript_hash(Cipher, State#state.tls_transcript),
+            Prefix = quic_crypto:hrr_transcript_prefix(Cipher, CH1Hash),
+            BaseTranscript = <<Prefix/binary, HrrMsg/binary>>,
+
+            %% Rebuild CH2: same random + session_id, key_share moved
+            %% to the server-selected group. supported_groups stays.
+            Ch2Opts = Ch1Opts#{
+                key_share_group => SelGroup,
+                retry_random => State#state.tls_ch1_random,
+                retry_session_id => <<>>
+            },
+            {CH2, PrivKey, _Random} = quic_tls:build_client_hello(Ch2Opts),
+            Transcript = <<BaseTranscript/binary, CH2/binary>>,
+
+            Off = State#state.initial_tx_off,
+            CryptoFrame = quic_frame:encode({crypto, Off, CH2}),
+            State1 = State#state{
+                hrr_sent = true,
+                hrr_group = SelGroup,
+                tls_group = SelGroup,
+                tls_private_key = PrivKey,
+                tls_transcript = Transcript,
+                initial_tx_off = Off + byte_size(CH2)
+            },
+            send_initial_packet(CryptoFrame, State1)
+    end.
 
 %%====================================================================
 %% Internal Functions - Stream Processing
@@ -5962,21 +6207,87 @@ derive_initial_keys(DCID, Version) ->
     },
     {ClientKeys, ServerKeys}.
 
-%% Select signature algorithm based on private key type
-select_signature_algorithm({'ECPrivateKey', _, _, {namedCurve, {1, 2, 840, 10045, 3, 1, 7}}, _, _}) ->
-    %% secp256r1 / P-256
-    ?SIG_ECDSA_SECP256R1_SHA256;
-select_signature_algorithm({'ECPrivateKey', _, _, {namedCurve, {1, 3, 132, 0, 34}}, _, _}) ->
-    %% secp384r1 / P-384
-    ?SIG_ECDSA_SECP384R1_SHA384;
-select_signature_algorithm({'ECPrivateKey', _, _, _, _, _}) ->
-    %% Default EC to P-256
-    ?SIG_ECDSA_SECP256R1_SHA256;
-select_signature_algorithm({'RSAPrivateKey', _, _, _, _, _, _, _, _, _, _}) ->
-    ?SIG_RSA_PSS_RSAE_SHA256;
-select_signature_algorithm(_) ->
-    %% Default to RSA PSS
-    ?SIG_RSA_PSS_RSAE_SHA256.
+%% Pick the client's CertificateVerify scheme for mTLS: intersect the
+%% server's advertised schemes with the client key's schemes, falling
+%% back to the key's natural scheme when the server offered none.
+client_cert_verify_code(#state{client_private_key = Key, peer_sig_algs = Offered}) ->
+    case Offered of
+        [] ->
+            select_signature_algorithm(Key);
+        _ ->
+            case select_signature_algorithm(Key, undefined, Offered) of
+                error -> select_signature_algorithm(Key);
+                Code -> Code
+            end
+    end.
+
+%% Build a CertificateRequest advertising the server's configured
+%% signature schemes (defaults when none set).
+build_cert_request(#state{tls_sig_algs = undefined}) ->
+    quic_tls:build_certificate_request(<<>>);
+build_cert_request(#state{tls_sig_algs = SigAlgs}) ->
+    quic_tls:build_certificate_request(<<>>, SigAlgs).
+
+%% Select signature algorithm based on private key type (mTLS client
+%% path, no negotiation; picks the key's natural scheme).
+select_signature_algorithm(PrivateKey) ->
+    hd(compatible_sig_schemes_codes(PrivateKey) ++ [?SIG_RSA_PSS_RSAE_SHA256]).
+
+%% CertificateVerify scheme negotiation (RFC 8446 §4.4.3). Intersects
+%% the schemes the private key can produce (server preference order,
+%% optionally narrowed by `signature_algs') with the peer's offered
+%% list. `rsa_pkcs1_*` is never selected for CertificateVerify.
+%% Returns the wire code, or `error' when there is no common scheme.
+select_signature_algorithm(PrivateKey, ServerSigAlgs, ClientOfferedCodes) ->
+    KeyCodes = compatible_sig_schemes_codes(PrivateKey),
+    Allowed =
+        case ServerSigAlgs of
+            undefined -> KeyCodes;
+            Atoms -> [C || C <- KeyCodes, lists:member(code_to_sig_alg(C), Atoms)]
+        end,
+    case [C || C <- Allowed, lists:member(C, ClientOfferedCodes)] of
+        [Code | _] -> Code;
+        [] -> error
+    end.
+
+%% Wire codes the given private key can sign CertificateVerify with,
+%% in preference order. Excludes rsa_pkcs1_* (RFC 8446 §4.4.3).
+%% Ed25519 decodes to an ECPrivateKey tuple carrying OID 1.3.101.112;
+%% match it before the generic EC clauses.
+compatible_sig_schemes_codes({'ECPrivateKey', _, _, {namedCurve, {1, 3, 101, 112}}, _, _}) ->
+    [?SIG_ED25519];
+compatible_sig_schemes_codes(
+    {'ECPrivateKey', _, _, {namedCurve, {1, 2, 840, 10045, 3, 1, 7}}, _, _}
+) ->
+    [?SIG_ECDSA_SECP256R1_SHA256];
+compatible_sig_schemes_codes({'ECPrivateKey', _, _, {namedCurve, {1, 3, 132, 0, 34}}, _, _}) ->
+    [?SIG_ECDSA_SECP384R1_SHA384];
+compatible_sig_schemes_codes({'ECPrivateKey', _, _, _, _, _}) ->
+    [?SIG_ECDSA_SECP256R1_SHA256];
+compatible_sig_schemes_codes({'RSAPrivateKey', _, _, _, _, _, _, _, _, _, _}) ->
+    [?SIG_RSA_PSS_RSAE_SHA256, ?SIG_RSA_PSS_RSAE_SHA384, ?SIG_RSA_PSS_RSAE_SHA512];
+compatible_sig_schemes_codes(Key) ->
+    case is_ed25519_key(Key) of
+        true -> [?SIG_ED25519];
+        false -> [?SIG_RSA_PSS_RSAE_SHA256]
+    end.
+
+%% Recognise an Ed25519 private key across the OTP representations
+%% (tagged tuple, or an ECPrivateKey tuple carrying the Ed25519 OID
+%% 1.3.101.112). Tuple form avoids depending on the public_key hrl.
+is_ed25519_key({ed_pri, ed25519, _Pub, _Priv}) -> true;
+is_ed25519_key({'ECPrivateKey', _, _, {namedCurve, {1, 3, 101, 112}}, _, _}) -> true;
+is_ed25519_key(_) -> false.
+
+%% Map a signature-scheme wire code to its atom.
+code_to_sig_alg(?SIG_ECDSA_SECP256R1_SHA256) -> ecdsa_secp256r1_sha256;
+code_to_sig_alg(?SIG_ECDSA_SECP384R1_SHA384) -> ecdsa_secp384r1_sha384;
+code_to_sig_alg(?SIG_RSA_PSS_RSAE_SHA256) -> rsa_pss_rsae_sha256;
+code_to_sig_alg(?SIG_RSA_PSS_RSAE_SHA384) -> rsa_pss_rsae_sha384;
+code_to_sig_alg(?SIG_RSA_PSS_RSAE_SHA512) -> rsa_pss_rsae_sha512;
+code_to_sig_alg(?SIG_ED25519) -> ed25519;
+code_to_sig_alg(?SIG_RSA_PKCS1_SHA256) -> rsa_pkcs1_sha256;
+code_to_sig_alg(_) -> unknown.
 
 %% Check if we should transition to a new state
 check_state_transition(CurrentState, State) ->
@@ -7713,17 +8024,28 @@ send_connection_close(Reason, State) ->
     end,
     ok.
 
-%% Send TLS alert as QUIC crypto error and close connection
-%% QUIC crypto errors are 0x100 + TLS alert code (RFC 9001 Section 4.8)
+%% Send TLS alert as QUIC crypto error and close connection.
+%% QUIC crypto errors are 0x100 + TLS alert code (RFC 9001 §4.8).
+%% The /2 form defaults the close reason phrase per alert code.
 send_tls_alert(AlertCode, State) ->
+    send_tls_alert(AlertCode, default_alert_phrase(AlertCode), State).
+
+%% Emit the alert at the highest available encryption level
+%% (app -> handshake -> initial). Pre-handshake negotiation errors
+%% (HRR-phase) ship at the Initial level, where only initial_keys
+%% exist, instead of being silently dropped.
+send_tls_alert(AlertCode, Phrase, State) ->
     ErrorCode = ?QUIC_CRYPTO_ERROR_BASE + AlertCode,
-    CloseFrame = {connection_close, transport, ErrorCode, 0, <<"certificate verify failed">>},
-    case State#state.handshake_keys of
-        undefined ->
-            State#state{close_reason = {tls_alert, AlertCode}};
-        _ ->
-            send_frame(CloseFrame, State#state{close_reason = {tls_alert, AlertCode}})
-    end.
+    CloseState = State#state{close_reason = {tls_alert, AlertCode}},
+    CloseFrame = {connection_close, transport, ErrorCode, 0, Phrase},
+    emit_close_at_level(select_close_level(app, CloseState), CloseFrame, CloseState).
+
+default_alert_phrase(?TLS_ALERT_HANDSHAKE_FAILURE) -> <<"handshake failure">>;
+default_alert_phrase(?TLS_ALERT_ILLEGAL_PARAMETER) -> <<"illegal parameter">>;
+default_alert_phrase(?TLS_ALERT_UNEXPECTED_MESSAGE) -> <<"unexpected message">>;
+default_alert_phrase(?TLS_ALERT_DECRYPT_ERROR) -> <<"decrypt error">>;
+default_alert_phrase(?TLS_ALERT_UNKNOWN_PSK_IDENTITY) -> <<"unknown psk identity">>;
+default_alert_phrase(_) -> <<"tls alert">>.
 
 %% Check timeouts
 check_timeouts(State) ->

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -69,6 +69,7 @@
     %% Transcript hash
     transcript_hash/1,
     transcript_hash/2,
+    hrr_transcript_prefix/2,
 
     %% Cipher to hash mapping
     cipher_to_hash/1,
@@ -340,6 +341,16 @@ transcript_hash(HashOrCipher, Messages) ->
     %% Always go through cipher_to_hash which passes through sha256/sha384 unchanged
     Hash = cipher_to_hash(HashOrCipher),
     crypto:hash(Hash, Messages).
+
+%% @doc Synthetic `message_hash` handshake message that replaces
+%% ClientHello1 in the transcript after a HelloRetryRequest
+%% (RFC 8446 §4.4.1). `HashClientHello1` is the digest over the
+%% complete CH1 handshake message. Both peers prepend the result
+%% to the post-HRR transcript.
+-spec hrr_transcript_prefix(atom(), binary()) -> binary().
+hrr_transcript_prefix(HashOrCipher, HashClientHello1) ->
+    HashLen = hash_len(cipher_to_hash(HashOrCipher)),
+    <<254:8, HashLen:24, HashClientHello1/binary>>.
 
 %%====================================================================
 %% Cipher to Hash Mapping

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -43,6 +43,7 @@
     %% Server-side message building
     parse_client_hello/1,
     build_server_hello/1,
+    build_hello_retry_request/3,
     build_encrypted_extensions/1,
     build_certificate/2,
     build_certificate_verify/3,
@@ -61,6 +62,7 @@
 
     %% Client certificate support (mutual TLS)
     build_certificate_request/1,
+    build_certificate_request/2,
     parse_certificate_request/1,
     build_certificate_verify_client/3,
     verify_certificate_verify/4,
@@ -84,21 +86,62 @@
 %% Returns: {ClientHelloMsg, PrivateKey, Random}
 -spec build_client_hello(map()) -> {binary(), binary(), binary()}.
 build_client_hello(Opts) ->
-    %% Generate client random (32 bytes)
-    Random = crypto:strong_rand_bytes(32),
+    %% Key-share group: the head of `groups` (default x25519). The
+    %% remaining groups are advertised in supported_groups so the
+    %% server can request one via HelloRetryRequest.
+    Groups = maps:get(groups, Opts, default_groups()),
+    %% Group that gets the key_share entry: the head of `groups`, or an
+    %% explicit override (used by a HelloRetryRequest retry where
+    %% supported_groups is unchanged but the share moves to the
+    %% server-selected group).
+    HeadGroup = maps:get(key_share_group, Opts, hd(Groups)),
+    {PubKey, PrivKey} = quic_crypto:generate_key_pair(HeadGroup),
 
-    %% Generate ECDHE key pair (x25519)
-    {PubKey, PrivKey} = crypto:generate_key(ecdh, x25519),
+    %% On a HelloRetryRequest retry, CH2 MUST reuse CH1's random and
+    %% legacy_session_id (RFC 8446 §4.1.2).
+    Random =
+        case maps:get(retry_random, Opts, undefined) of
+            undefined -> crypto:strong_rand_bytes(32);
+            R when is_binary(R) -> R
+        end,
+    Opts1 = Opts#{
+        groups => Groups,
+        head_group => HeadGroup,
+        session_id => maps:get(retry_session_id, Opts, <<>>)
+    },
 
     %% Resolve PSK offer (resumption ticket or external PSK). The
     %% caller is responsible for ensuring at most one is supplied;
     %% psk_offer_from_opts/1 raises {bad_opts, psk_conflict} otherwise.
-    case psk_offer_from_opts(Opts) of
+    case psk_offer_from_opts(Opts1) of
         undefined ->
-            build_client_hello_standard(Random, PubKey, PrivKey, Opts);
+            build_client_hello_standard(Random, PubKey, PrivKey, Opts1);
         #psk_offer{} = Offer ->
-            build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, Offer)
+            build_client_hello_with_psk(Random, PubKey, PrivKey, Opts1, Offer)
     end.
+
+%% @private Default key-exchange groups (wire-compatible with the
+%% pre-multigroup behaviour: x25519 only).
+default_groups() -> [x25519].
+
+%% @private Default advertised signature schemes, identical to the
+%% historical hardcoded ClientHello list.
+default_sig_algs() ->
+    [ecdsa_secp256r1_sha256, rsa_pss_rsae_sha256, rsa_pkcs1_sha256, ed25519].
+
+%% @private Named-group atom to RFC 8446 §4.2.7 wire code.
+group_to_code(x25519) -> ?GROUP_X25519;
+group_to_code(secp256r1) -> ?GROUP_SECP256R1;
+group_to_code(secp384r1) -> ?GROUP_SECP384R1.
+
+%% @private Signature-scheme atom to RFC 8446 §4.2.3 wire code.
+sig_alg_to_code(ecdsa_secp256r1_sha256) -> ?SIG_ECDSA_SECP256R1_SHA256;
+sig_alg_to_code(ecdsa_secp384r1_sha384) -> ?SIG_ECDSA_SECP384R1_SHA384;
+sig_alg_to_code(rsa_pss_rsae_sha256) -> ?SIG_RSA_PSS_RSAE_SHA256;
+sig_alg_to_code(rsa_pss_rsae_sha384) -> ?SIG_RSA_PSS_RSAE_SHA384;
+sig_alg_to_code(rsa_pss_rsae_sha512) -> ?SIG_RSA_PSS_RSAE_SHA512;
+sig_alg_to_code(ed25519) -> ?SIG_ED25519;
+sig_alg_to_code(rsa_pkcs1_sha256) -> ?SIG_RSA_PKCS1_SHA256.
 
 %% @private Resolve external_psk/session_ticket into a #psk_offer{}.
 psk_offer_from_opts(Opts) ->
@@ -161,8 +204,8 @@ build_client_hello_standard(Random, PubKey, PrivKey, Opts) ->
     %% Build extensions
     Extensions = build_client_hello_extensions(PubKey, Opts),
 
-    %% Legacy session ID (empty for TLS 1.3)
-    SessionId = <<>>,
+    %% Legacy session ID (empty for TLS 1.3, or CH1's value on retry)
+    SessionId = maps:get(session_id, Opts, <<>>),
 
     %% Cipher suites (TLS 1.3 only)
     CipherSuites = <<?TLS_AES_128_GCM_SHA256:16>>,
@@ -237,7 +280,7 @@ build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, #psk_offer{} = Offer)
     AllExtensions = <<BaseExtensions/binary, PskExt/binary>>,
     ExtensionsLen = byte_size(AllExtensions),
 
-    SessionId = <<>>,
+    SessionId = maps:get(session_id, Opts, <<>>),
     CipherSuites = <<?TLS_AES_128_GCM_SHA256:16>>,
     CompressionMethods = <<1, 0>>,
 
@@ -282,21 +325,27 @@ build_client_hello_extensions(PubKey, Opts) ->
         <<2, ?TLS_VERSION_1_3:16>>
     ),
 
-    %% Supported groups (x25519)
+    %% Supported groups: every entry the client offers (head gets a
+    %% key_share below; the rest are HRR-eligible).
+    Groups = maps:get(groups, Opts, default_groups()),
+    GroupCodes = iolist_to_binary([<<(group_to_code(G)):16>> || G <- Groups]),
     SupportedGroups = encode_extension(
         ?EXT_SUPPORTED_GROUPS,
-        <<2:16, ?GROUP_X25519:16>>
+        <<(byte_size(GroupCodes)):16, GroupCodes/binary>>
     ),
 
-    %% Signature algorithms
+    %% Signature algorithms (caller-configurable; defaults to the
+    %% historical wire list).
+    SigAlgAtoms = maps:get(signature_algs, Opts, default_sig_algs()),
+    SigAlgCodes = iolist_to_binary([<<(sig_alg_to_code(A)):16>> || A <- SigAlgAtoms]),
     SigAlgs = encode_extension(
         ?EXT_SIGNATURE_ALGORITHMS,
-        <<8:16, ?SIG_ECDSA_SECP256R1_SHA256:16, ?SIG_RSA_PSS_RSAE_SHA256:16,
-            ?SIG_RSA_PKCS1_SHA256:16, ?SIG_ED25519:16>>
+        <<(byte_size(SigAlgCodes)):16, SigAlgCodes/binary>>
     ),
 
-    %% Key share (x25519 public key)
-    KeyShareEntry = <<?GROUP_X25519:16, 32:16, PubKey:32/binary>>,
+    %% Key share: single entry for the head group.
+    HeadGroup = maps:get(head_group, Opts, hd(Groups)),
+    KeyShareEntry = <<(group_to_code(HeadGroup)):16, (byte_size(PubKey)):16, PubKey/binary>>,
     KeyShare = encode_extension(
         ?EXT_KEY_SHARE,
         <<(byte_size(KeyShareEntry)):16, KeyShareEntry/binary>>
@@ -373,6 +422,7 @@ encode_alpn_list(Protocols) ->
         random := binary(),
         selected_psk_identity => non_neg_integer()
     }}
+    | {hrr, #{cipher := atom(), selected_group := atom() | unknown, extensions := map()}}
     | {error, term()}.
 parse_server_hello(<<
     % legacy_version
@@ -388,6 +438,21 @@ parse_server_hello(<<
     _Rest/binary
 >>) ->
     case parse_extensions(Extensions) of
+        {ok, ExtMap} when Random =:= ?TLS_HRR_RANDOM ->
+            %% HelloRetryRequest (RFC 8446 §4.1.4): a ServerHello whose
+            %% random is the HRR sentinel. Its key_share extension
+            %% carries only the selected group (KeyShareHelloRetryRequest).
+            Cipher = cipher_from_suite(CipherSuite),
+            case maps:find(?EXT_KEY_SHARE, ExtMap) of
+                {ok, <<GroupCode:16>>} ->
+                    {hrr, #{
+                        cipher => Cipher,
+                        selected_group => code_to_group(GroupCode),
+                        extensions => ExtMap
+                    }};
+                _ ->
+                    {error, hrr_missing_key_share}
+            end;
         {ok, ExtMap} ->
             Cipher = cipher_from_suite(CipherSuite),
             SelectedPsk =
@@ -1007,6 +1072,34 @@ build_server_hello(Opts) ->
     Message = encode_handshake_message(?TLS_SERVER_HELLO, ServerHello),
     {Message, PrivKey}.
 
+%% @doc Build a HelloRetryRequest (RFC 8446 §4.1.4). Wire-encoded as
+%% a ServerHello with the HRR sentinel random; its key_share carries
+%% only the selected group (no public key). Echoes the client's
+%% legacy_session_id and the negotiated cipher suite.
+-spec build_hello_retry_request(binary(), non_neg_integer(), atom()) -> binary().
+build_hello_retry_request(SessionId, CipherSuite, SelectedGroup) ->
+    SessionIdLen = byte_size(SessionId),
+    SupportedVersions = encode_extension(
+        ?EXT_SUPPORTED_VERSIONS,
+        <<?TLS_VERSION_1_3:16>>
+    ),
+    KeyShare = encode_extension(
+        ?EXT_KEY_SHARE,
+        <<(group_to_code(SelectedGroup)):16>>
+    ),
+    Extensions = <<SupportedVersions/binary, KeyShare/binary>>,
+    Body = <<
+        ?TLS_VERSION_1_2:16,
+        (?TLS_HRR_RANDOM)/binary,
+        SessionIdLen:8,
+        SessionId/binary,
+        CipherSuite:16,
+        0:8,
+        (byte_size(Extensions)):16,
+        Extensions/binary
+    >>,
+    encode_handshake_message(?TLS_SERVER_HELLO, Body).
+
 %% @doc Build EncryptedExtensions message.
 %% Options:
 %%   - alpn: Selected ALPN protocol
@@ -1163,6 +1256,16 @@ finalise_client_hello(Random, SessionId, Ciphers, OrderedExts, ExtMap, ExtBlob) 
             {ok, ModesData} -> parse_psk_modes_ext(ModesData);
             error -> []
         end,
+    SupportedGroups =
+        case maps:find(?EXT_SUPPORTED_GROUPS, ExtMap) of
+            {ok, SgData} -> parse_supported_groups_ext(SgData);
+            error -> []
+        end,
+    SignatureAlgs =
+        case maps:find(?EXT_SIGNATURE_ALGORITHMS, ExtMap) of
+            {ok, SaData} -> parse_signature_algorithms_ext(SaData);
+            error -> []
+        end,
     EarlyData = maps:is_key(?EXT_EARLY_DATA, ExtMap),
 
     %% Binders-section offset within the extension data of the PSK
@@ -1184,8 +1287,30 @@ finalise_client_hello(Random, SessionId, Ciphers, OrderedExts, ExtMap, ExtBlob) 
         pre_shared_key => PSK,
         psk_key_exchange_modes => PskModes,
         psk_binders => PskBinders,
+        supported_groups => SupportedGroups,
+        signature_algorithms => SignatureAlgs,
         early_data => EarlyData
     }}.
+
+%% @private Parse supported_groups (RFC 8446 §4.2.7) into recognised
+%% group atoms; unknown codes are dropped (they can't be selected).
+parse_supported_groups_ext(<<ListLen:16, Codes:ListLen/binary, _/binary>>) ->
+    [code_to_group(C) || <<C:16>> <= Codes, code_to_group(C) =/= unknown];
+parse_supported_groups_ext(_) ->
+    [].
+
+%% @private Parse signature_algorithms (RFC 8446 §4.2.3) into the
+%% list of wire codes (integers) in the order offered.
+parse_signature_algorithms_ext(<<ListLen:16, Codes:ListLen/binary, _/binary>>) ->
+    [C || <<C:16>> <= Codes];
+parse_signature_algorithms_ext(_) ->
+    [].
+
+%% @private Named-group wire code to atom (unknown -> unknown).
+code_to_group(?GROUP_X25519) -> x25519;
+code_to_group(?GROUP_SECP256R1) -> secp256r1;
+code_to_group(?GROUP_SECP384R1) -> secp384r1;
+code_to_group(_) -> unknown.
 
 %% @private
 %% Parse the psk_key_exchange_modes extension into a list of atoms.
@@ -1438,9 +1563,10 @@ build_server_hello_extensions(PubKey, Opts) ->
             psk_ke ->
                 <<>>;
             _ ->
+                Group = maps:get(key_share_group, Opts, x25519),
                 encode_extension(
                     ?EXT_KEY_SHARE,
-                    <<?GROUP_X25519:16, 32:16, PubKey:32/binary>>
+                    <<(group_to_code(Group)):16, (byte_size(PubKey)):16, PubKey/binary>>
                 )
         end,
 
@@ -1507,8 +1633,14 @@ get_signature_params(?SIG_ECDSA_SECP256R1_SHA256) ->
     {ecdsa, sha256, []};
 get_signature_params(?SIG_ECDSA_SECP384R1_SHA384) ->
     {ecdsa, sha384, []};
-get_signature_params(_) ->
-    {rsa, sha256, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]}.
+get_signature_params(?SIG_ED25519) ->
+    %% EdDSA pre-hashes internally; no separate hash and no padding.
+    %% The curve atom rides in the key list (see convert_private_key).
+    {eddsa, none, []};
+get_signature_params(Scheme) ->
+    %% No silent fallback — an unsupported scheme must fail loudly
+    %% rather than sign/verify with the wrong algorithm.
+    error({unsupported_signature_scheme, Scheme}).
 
 %% Convert private key to format expected by crypto:sign
 convert_private_key(
@@ -1528,6 +1660,11 @@ convert_private_key(rsa, {'RSAPrivateKey', _, N, E, D, _P, _Q, _Dp, _Dq, _Qi, _}
 convert_private_key(rsa, Key) when is_list(Key) ->
     %% Already in list format
     Key;
+convert_private_key(eddsa, {ed_pri, ed25519, _Pub, Priv}) ->
+    %% crypto:sign(eddsa, none, Msg, [PrivKeyBin, ed25519])
+    [Priv, ed25519];
+convert_private_key(eddsa, {'ECPrivateKey', _, PrivKeyBin, {namedCurve, {1, 3, 101, 112}}, _, _}) ->
+    [PrivKeyBin, ed25519];
 convert_private_key(_, Key) ->
     Key.
 
@@ -1535,16 +1672,19 @@ convert_private_key(_, Key) ->
 %% Client Certificate Support (Mutual TLS)
 %%====================================================================
 
-%% @doc Build a CertificateRequest message (RFC 8446 Section 4.3.2).
-%% Context is the certificate_request_context (typically empty for TLS 1.3).
+%% @doc Build a CertificateRequest message (RFC 8446 §4.3.2) with the
+%% default advertised signature schemes.
 -spec build_certificate_request(binary()) -> binary().
 build_certificate_request(Context) ->
-    %% RFC 8446 Section 4.3.2: signature_algorithms extension is required
-    SigAlgs = <<
-        ?SIG_ECDSA_SECP256R1_SHA256:16,
-        ?SIG_RSA_PSS_RSAE_SHA256:16,
-        ?SIG_RSA_PKCS1_SHA256:16
-    >>,
+    build_certificate_request(Context, [
+        ecdsa_secp256r1_sha256, rsa_pss_rsae_sha256, rsa_pkcs1_sha256, ed25519
+    ]).
+
+%% @doc Build a CertificateRequest advertising the given signature
+%% schemes (RFC 8446 §4.3.2; signature_algorithms is required).
+-spec build_certificate_request(binary(), [atom()]) -> binary().
+build_certificate_request(Context, SigAlgAtoms) ->
+    SigAlgs = iolist_to_binary([<<(sig_alg_to_code(A)):16>> || A <- SigAlgAtoms]),
     SigAlgsLen = byte_size(SigAlgs),
     SigAlgsExt =
         <<?EXT_SIGNATURE_ALGORITHMS:16, (SigAlgsLen + 2):16, SigAlgsLen:16, SigAlgs/binary>>,
@@ -1553,12 +1693,24 @@ build_certificate_request(Context) ->
     Body = <<ContextLen:8, Context/binary, ExtLen:16, SigAlgsExt/binary>>,
     encode_handshake_message(?TLS_CERTIFICATE_REQUEST, Body).
 
-%% @doc Parse a CertificateRequest message.
+%% @doc Parse a CertificateRequest message. Returns the context and
+%% the advertised signature_algorithms (wire codes) so an mTLS client
+%% can pick a compatible CertificateVerify scheme.
 -spec parse_certificate_request(binary()) -> {ok, map()} | {error, term()}.
 parse_certificate_request(
-    <<ContextLen:8, Context:ContextLen/binary, ExtLen:16, _Extensions:ExtLen/binary, _/binary>>
+    <<ContextLen:8, Context:ContextLen/binary, ExtLen:16, Extensions:ExtLen/binary, _/binary>>
 ) ->
-    {ok, #{context => Context}};
+    SigAlgs =
+        case parse_extensions(Extensions) of
+            {ok, ExtMap} ->
+                case maps:find(?EXT_SIGNATURE_ALGORITHMS, ExtMap) of
+                    {ok, SaData} -> parse_signature_algorithms_ext(SaData);
+                    error -> []
+                end;
+            _ ->
+                []
+        end,
+    {ok, #{context => Context, signature_algorithms => SigAlgs}};
 parse_certificate_request(_) ->
     {error, invalid_certificate_request}.
 
@@ -1651,5 +1803,23 @@ convert_public_key_for_verify(
 ) ->
     %% RSA: [E, N]
     {ok, [E, N]};
+convert_public_key_for_verify(
+    #'OTPSubjectPublicKeyInfo'{
+        algorithm = #'PublicKeyAlgorithm'{algorithm = {1, 3, 101, 112}},
+        subjectPublicKey = #'ECPoint'{point = PubKey}
+    },
+    ?SIG_ED25519
+) ->
+    %% Ed25519 (OID 1.3.101.112): OTP wraps the 32-byte public key in
+    %% an ECPoint.
+    {ok, [PubKey, ed25519]};
+convert_public_key_for_verify(
+    #'OTPSubjectPublicKeyInfo'{
+        algorithm = #'PublicKeyAlgorithm'{algorithm = {1, 3, 101, 112}},
+        subjectPublicKey = PubKey
+    },
+    ?SIG_ED25519
+) when is_binary(PubKey) ->
+    {ok, [PubKey, ed25519]};
 convert_public_key_for_verify(_, _) ->
     {error, unsupported_key_type}.

--- a/test/quic_hrr_e2e_SUITE.erl
+++ b/test/quic_hrr_e2e_SUITE.erl
@@ -1,0 +1,153 @@
+%%% -*- erlang -*-
+%%%
+%%% HelloRetryRequest end-to-end suite (RFC 8446 §4.1.4).
+%%%
+%%% Drives full handshakes where the server's preferred key-exchange
+%%% group differs from the group the client sent a key_share for,
+%%% forcing an HRR + CH2 retry. Also covers the failure modes.
+
+-module(quic_hrr_e2e_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    hrr_secp256r1/1,
+    no_common_group/1,
+    psk_plus_hrr_aborts/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [hrr_secp256r1, no_common_group, psk_plus_hrr_aborts].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+%% Server prefers secp256r1 only; client offers [x25519, secp256r1]
+%% with a key_share for x25519. Server must HRR, client retries with
+%% secp256r1, handshake completes and data echoes.
+hrr_secp256r1(_Config) ->
+    {ok, Server} = start_echo(#{groups => [secp256r1]}),
+    try
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            groups => [x25519, secp256r1]
+        },
+        ConnRef = connect(Server, Opts),
+        Info = wait_connected(ConnRef),
+        ?assertEqual(secp256r1, maps:get(negotiated_group, Info)),
+        ok = echo(ConnRef, <<"hrr works">>),
+        quic:close(ConnRef, normal)
+    after
+        stop_echo(Server)
+    end.
+
+%% Server only supports secp384r1; client offers only x25519. No
+%% group intersection at all → handshake fails.
+no_common_group(_Config) ->
+    {ok, Server} = start_echo(#{groups => [secp384r1]}),
+    try
+        Opts = #{verify => false, alpn => [<<"echo">>], groups => [x25519]},
+        ?assertMatch({error, _}, try_connect(Server, Opts))
+    after
+        stop_echo(Server)
+    end.
+
+%% Client offers external_psk AND a group set that forces HRR. Per
+%% the v1 rule the client aborts when HRR follows a PSK ClientHello.
+psk_plus_hrr_aborts(_Config) ->
+    Identity = <<"id">>,
+    Secret = <<"this-is-a-32-byte-test-secret!!!">>,
+    {ok, Server} = start_echo(#{
+        groups => [secp256r1],
+        psks => #{Identity => Secret},
+        with_cert => true
+    }),
+    try
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            groups => [x25519, secp256r1],
+            external_psk => {Identity, Secret}
+        },
+        ?assertMatch({error, _}, try_connect(Server, Opts))
+    after
+        stop_echo(Server)
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+start_echo(Extra0) ->
+    WithCert = maps:get(with_cert, Extra0, true),
+    Extra = maps:remove(with_cert, Extra0),
+    case WithCert of
+        true -> quic_test_echo_server:start(Extra);
+        false -> quic_test_echo_server:start(Extra)
+    end.
+
+stop_echo(Server) ->
+    quic_test_echo_server:stop(Server).
+
+connect(#{port := Port}, Opts) ->
+    {ok, ConnRef} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    ConnRef.
+
+wait_connected(ConnRef) ->
+    receive
+        {quic, ConnRef, {connected, Info}} -> Info
+    after 10000 ->
+        catch quic:close(ConnRef, timeout),
+        ct:fail("connection timeout")
+    end.
+
+try_connect(#{port := Port}, Opts) ->
+    case quic:connect(<<"127.0.0.1">>, Port, Opts, self()) of
+        {error, _} = E ->
+            E;
+        {ok, ConnRef} ->
+            receive
+                {quic, ConnRef, {connected, _}} ->
+                    quic:close(ConnRef, normal),
+                    ok;
+                {quic, ConnRef, {error, R}} ->
+                    {error, R};
+                {quic, ConnRef, {closed, R}} ->
+                    {error, R}
+            after 10000 ->
+                catch quic:close(ConnRef, timeout),
+                {error, timeout}
+            end
+    end.
+
+echo(ConnRef, Payload) ->
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    ok = quic:send_data(ConnRef, StreamId, Payload, true),
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Got, true}} ->
+            ?assertEqual(Payload, Got),
+            ok
+    after 10000 ->
+        ct:fail("echo timeout")
+    end.

--- a/test/quic_sigalg_e2e_SUITE.erl
+++ b/test/quic_sigalg_e2e_SUITE.erl
@@ -1,0 +1,188 @@
+%%% -*- erlang -*-
+%%%
+%%% Signature-algorithm negotiation end-to-end suite
+%%% (RFC 8446 §4.2.3 / §4.4.3).
+%%%
+%%% One single-cert listener per key type (matches the current
+%%% single-cert server API). Each test connects with a client
+%%% signature_algs list compatible with that key and asserts the
+%%% negotiated CertificateVerify scheme.
+
+-module(quic_sigalg_e2e_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    rsa_listener/1,
+    ecdsa_p256_listener/1,
+    ecdsa_p384_listener/1,
+    ed25519_listener/1,
+    incompatible_sig_alg_fails/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [
+        rsa_listener,
+        ecdsa_p256_listener,
+        ecdsa_p384_listener,
+        ed25519_listener,
+        incompatible_sig_alg_fails
+    ].
+
+init_per_suite(Config) ->
+    case os:find_executable("openssl") of
+        false ->
+            {skip, openssl_not_found};
+        _ ->
+            {ok, _} = application:ensure_all_started(crypto),
+            {ok, _} = application:ensure_all_started(quic),
+            Config
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Tests: each listener has a single cert of one key type
+%%====================================================================
+
+rsa_listener(Config) ->
+    negotiates(Config, rsa, [rsa_pss_rsae_sha256], rsa_pss_rsae_sha256).
+
+ecdsa_p256_listener(Config) ->
+    negotiates(Config, p256, [ecdsa_secp256r1_sha256], ecdsa_secp256r1_sha256).
+
+ecdsa_p384_listener(Config) ->
+    negotiates(
+        Config, p384, [ecdsa_secp384r1_sha384], ecdsa_secp384r1_sha384
+    ).
+
+ed25519_listener(Config) ->
+    negotiates(Config, ed25519, [ed25519], ed25519).
+
+%% RSA listener, client offers only ed25519 → no common scheme →
+%% handshake fails.
+incompatible_sig_alg_fails(Config) ->
+    {Cert, Key} = cert_of(Config, rsa),
+    {ok, Server} = quic_test_echo_server:start(#{cert => Cert, key => Key}),
+    try
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            signature_algs => [ed25519]
+        },
+        ?assertMatch({error, _}, try_connect(Server, Opts))
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+negotiates(Config, KeyType, ClientSigAlgs, ExpectedScheme) ->
+    {Cert, Key} = cert_of(Config, KeyType),
+    {ok, Server} = quic_test_echo_server:start(#{cert => Cert, key => Key}),
+    try
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            signature_algs => ClientSigAlgs
+        },
+        {ok, ConnRef} = quic:connect(<<"127.0.0.1">>, port(Server), Opts, self()),
+        Info = wait_connected(ConnRef),
+        ?assertEqual(ExpectedScheme, maps:get(negotiated_scheme, Info)),
+        ok = echo(ConnRef, <<"sig ok">>),
+        quic:close(ConnRef, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+port(#{port := Port}) -> Port.
+
+wait_connected(ConnRef) ->
+    receive
+        {quic, ConnRef, {connected, Info}} -> Info
+    after 10000 ->
+        catch quic:close(ConnRef, timeout),
+        ct:fail("connection timeout")
+    end.
+
+try_connect(#{port := Port}, Opts) ->
+    case quic:connect(<<"127.0.0.1">>, Port, Opts, self()) of
+        {error, _} = E ->
+            E;
+        {ok, ConnRef} ->
+            receive
+                {quic, ConnRef, {connected, _}} ->
+                    quic:close(ConnRef, normal),
+                    ok;
+                {quic, ConnRef, {error, R}} ->
+                    {error, R};
+                {quic, ConnRef, {closed, R}} ->
+                    {error, R}
+            after 10000 ->
+                catch quic:close(ConnRef, timeout),
+                {error, timeout}
+            end
+    end.
+
+echo(ConnRef, Payload) ->
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    ok = quic:send_data(ConnRef, StreamId, Payload, true),
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Got, true}} ->
+            ?assertEqual(Payload, Got),
+            ok
+    after 10000 ->
+        ct:fail("echo timeout")
+    end.
+
+%% Generate (once per type) a self-signed cert + key and return
+%% {CertDER, KeyTerm}. KeyTerm is the pem_entry_decode form expected
+%% by quic_tls:convert_private_key/2.
+cert_of(Config, Type) ->
+    Dir = ?config(priv_dir, Config),
+    CertFile = filename:join(Dir, atom_to_list(Type) ++ "_cert.pem"),
+    KeyFile = filename:join(Dir, atom_to_list(Type) ++ "_key.pem"),
+    case filelib:is_file(CertFile) of
+        true -> ok;
+        false -> ok = gen_cert(Type, CertFile, KeyFile)
+    end,
+    {ok, CertPem} = file:read_file(CertFile),
+    {ok, KeyPem} = file:read_file(KeyFile),
+    [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+    [KeyEntry] = public_key:pem_decode(KeyPem),
+    {CertDer, public_key:pem_entry_decode(KeyEntry)}.
+
+gen_cert(Type, CertFile, KeyFile) ->
+    Newkey =
+        case Type of
+            rsa -> "rsa:2048";
+            p256 -> "ec -pkeyopt ec_paramgen_curve:prime256v1";
+            p384 -> "ec -pkeyopt ec_paramgen_curve:secp384r1";
+            ed25519 -> "ed25519"
+        end,
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey ~s -keyout ~s -out ~s "
+            "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+            [Newkey, KeyFile, CertFile]
+        )
+    ),
+    os:cmd(Cmd),
+    case filelib:is_file(CertFile) andalso filelib:is_file(KeyFile) of
+        true -> ok;
+        false -> {error, openssl_failed}
+    end.

--- a/test/quic_tls_negotiation_tests.erl
+++ b/test/quic_tls_negotiation_tests.erl
@@ -1,0 +1,191 @@
+%%% -*- erlang -*-
+%%%
+%%% Unit tests for TLS 1.3 group + signature negotiation:
+%%% multi-group ClientHello, HelloRetryRequest wire format, the
+%%% synthetic message_hash transcript prefix, and the new
+%%% CertificateVerify signature schemes.
+
+-module(quic_tls_negotiation_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+%%====================================================================
+%% Multi-group ClientHello
+%%====================================================================
+
+multi_group_client_hello_test() ->
+    Opts = #{
+        alpn => [<<"h3">>],
+        transport_params => #{initial_scid => crypto:strong_rand_bytes(8)},
+        groups => [x25519, secp256r1, secp384r1]
+    },
+    {CH, _Priv, _Random} = quic_tls:build_client_hello(Opts),
+    <<?TLS_CLIENT_HELLO, _Len:24, Body/binary>> = CH,
+    {ok, Map} = quic_tls:parse_client_hello(Body),
+    %% supported_groups echoes all three, in order
+    ?assertEqual([x25519, secp256r1, secp384r1], maps:get(supported_groups, Map)),
+    %% key_share carries exactly one entry, for the head group (x25519)
+    [{Code, PubKey}] = maps:get(key_share, Map),
+    ?assertEqual(?GROUP_X25519, Code),
+    ?assertEqual(32, byte_size(PubKey)).
+
+default_client_hello_single_group_test() ->
+    %% No `groups' opt → wire-identical single x25519 key_share.
+    Opts = #{alpn => [<<"h3">>], transport_params => #{}},
+    {CH, _Priv, _Random} = quic_tls:build_client_hello(Opts),
+    <<?TLS_CLIENT_HELLO, _Len:24, Body/binary>> = CH,
+    {ok, Map} = quic_tls:parse_client_hello(Body),
+    ?assertEqual([x25519], maps:get(supported_groups, Map)),
+    [{?GROUP_X25519, _}] = maps:get(key_share, Map).
+
+secp256r1_keyshare_head_test() ->
+    %% Head group secp256r1 → 65-byte uncompressed point in key_share.
+    Opts = #{
+        alpn => [<<"h3">>],
+        transport_params => #{},
+        groups => [secp256r1, x25519]
+    },
+    {CH, _Priv, _Random} = quic_tls:build_client_hello(Opts),
+    <<?TLS_CLIENT_HELLO, _Len:24, Body/binary>> = CH,
+    {ok, Map} = quic_tls:parse_client_hello(Body),
+    [{Code, PubKey}] = maps:get(key_share, Map),
+    ?assertEqual(?GROUP_SECP256R1, Code),
+    ?assertEqual(65, byte_size(PubKey)).
+
+retry_random_reused_test() ->
+    %% retry_random / retry_session_id are echoed verbatim into CH2.
+    R = crypto:strong_rand_bytes(32),
+    Opts = #{
+        alpn => [<<"h3">>],
+        transport_params => #{},
+        groups => [x25519, secp256r1],
+        key_share_group => secp256r1,
+        retry_random => R,
+        retry_session_id => <<>>
+    },
+    {CH, _Priv, Random} = quic_tls:build_client_hello(Opts),
+    ?assertEqual(R, Random),
+    <<?TLS_CLIENT_HELLO, _Len:24, Body/binary>> = CH,
+    {ok, Map} = quic_tls:parse_client_hello(Body),
+    %% supported_groups unchanged; key_share moved to secp256r1
+    ?assertEqual([x25519, secp256r1], maps:get(supported_groups, Map)),
+    [{?GROUP_SECP256R1, _}] = maps:get(key_share, Map).
+
+%%====================================================================
+%% Custom signature_algorithms advertisement
+%%====================================================================
+
+custom_signature_algs_test() ->
+    Opts = #{
+        alpn => [<<"h3">>],
+        transport_params => #{},
+        signature_algs => [ecdsa_secp384r1_sha384, ed25519]
+    },
+    {CH, _Priv, _Random} = quic_tls:build_client_hello(Opts),
+    <<?TLS_CLIENT_HELLO, _Len:24, Body/binary>> = CH,
+    {ok, Map} = quic_tls:parse_client_hello(Body),
+    ?assertEqual(
+        [?SIG_ECDSA_SECP384R1_SHA384, ?SIG_ED25519],
+        maps:get(signature_algorithms, Map)
+    ).
+
+%%====================================================================
+%% HelloRetryRequest wire format
+%%====================================================================
+
+hrr_roundtrip_test_() ->
+    [
+        {atom_to_list(G), fun() -> hrr_roundtrip(G) end}
+     || G <- [x25519, secp256r1, secp384r1]
+    ].
+
+hrr_roundtrip(Group) ->
+    HRR = quic_tls:build_hello_retry_request(<<>>, ?TLS_AES_128_GCM_SHA256, Group),
+    <<?TLS_SERVER_HELLO, _Len:24, Body/binary>> = HRR,
+    {hrr, Info} = quic_tls:parse_server_hello(Body),
+    ?assertEqual(aes_128_gcm, maps:get(cipher, Info)),
+    ?assertEqual(Group, maps:get(selected_group, Info)).
+
+hrr_random_is_sentinel_test() ->
+    HRR = quic_tls:build_hello_retry_request(<<>>, ?TLS_AES_128_GCM_SHA256, secp256r1),
+    %% Body random field = bytes 3..34 (after 1B type + 3B len + 2B version)
+    <<?TLS_SERVER_HELLO, _Len:24, ?TLS_VERSION_1_2:16, Random:32/binary, _/binary>> = HRR,
+    ?assertEqual(?TLS_HRR_RANDOM, Random).
+
+%%====================================================================
+%% Synthetic message_hash transcript prefix (RFC 8446 §4.4.1)
+%%====================================================================
+
+hrr_transcript_prefix_sha256_test() ->
+    CH1 = <<"a fake clienthello">>,
+    Hash = crypto:hash(sha256, CH1),
+    Prefix = quic_crypto:hrr_transcript_prefix(aes_128_gcm, Hash),
+    ?assertEqual(<<254:8, 32:24, Hash/binary>>, Prefix).
+
+hrr_transcript_prefix_sha384_test() ->
+    CH1 = <<"another fake clienthello">>,
+    Hash = crypto:hash(sha384, CH1),
+    Prefix = quic_crypto:hrr_transcript_prefix(aes_256_gcm, Hash),
+    ?assertEqual(<<254:8, 48:24, Hash/binary>>, Prefix).
+
+%%====================================================================
+%% Signature scheme sign + verify round-trips
+%%====================================================================
+
+sign_verify_ecdsa_p384_test() ->
+    Key = public_key:generate_key({namedCurve, secp384r1}),
+    sign_verify_roundtrip(?SIG_ECDSA_SECP384R1_SHA384, Key, ec_pubkey(Key, secp384r1)).
+
+sign_verify_rsa_pss_384_test() ->
+    Key = public_key:generate_key({rsa, 2048, 65537}),
+    %% {'RSAPrivateKey', Version, Modulus, PublicExponent, ...}
+    N = element(3, Key),
+    E = element(4, Key),
+    sign_verify_roundtrip(?SIG_RSA_PSS_RSAE_SHA384, Key, [E, N]).
+
+sign_verify_ed25519_test() ->
+    {Pub, Priv} = crypto:generate_key(eddsa, ed25519),
+    Key = {ed_pri, ed25519, Pub, Priv},
+    sign_verify_roundtrip(?SIG_ED25519, Key, [Pub, ed25519]).
+
+%% Build a server CertificateVerify with `Scheme', then verify the
+%% signature against `PubKey' using the same content string.
+sign_verify_roundtrip(Scheme, PrivKey, PubKey) ->
+    Hash = crypto:hash(sha256, <<"transcript">>),
+    CV = quic_tls:build_certificate_verify(Scheme, PrivKey, Hash),
+    <<?TLS_CERTIFICATE_VERIFY, _Len:24, Scheme:16, SigLen:16, Sig:SigLen/binary>> = CV,
+    Spaces = binary:copy(<<32>>, 64),
+    Content = <<Spaces/binary, "TLS 1.3, server CertificateVerify", 0, Hash/binary>>,
+    {SigAlg, HashAlg, Opts} = sig_params(Scheme),
+    ?assert(crypto:verify(SigAlg, HashAlg, Content, Sig, PubKey, Opts)).
+
+%% Mirror quic_tls:get_signature_params/1 (it is not exported).
+sig_params(?SIG_ECDSA_SECP384R1_SHA384) ->
+    {ecdsa, sha384, []};
+sig_params(?SIG_RSA_PSS_RSAE_SHA384) ->
+    {rsa, sha384, [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, -1}]};
+sig_params(?SIG_ED25519) ->
+    {eddsa, none, []}.
+
+ec_pubkey(Key, Curve) ->
+    %% #'ECPrivateKey'{} tuple: {tag, ver, priv, params, pubpoint, ...}
+    PubPoint = element(5, Key),
+    [PubPoint, Curve].
+
+%%====================================================================
+%% Unsupported scheme fails loudly (no RSA-PSS fallback)
+%%====================================================================
+
+unsupported_scheme_errors_test() ->
+    %% ed448 and a bogus code are not wired; signing must fail rather
+    %% than silently using RSA-PSS.
+    Key = public_key:generate_key({namedCurve, secp256r1}),
+    ?assertError(
+        {unsupported_signature_scheme, _},
+        quic_tls:build_certificate_verify(?SIG_ED448, Key, crypto:hash(sha256, <<"x">>))
+    ),
+    ?assertError(
+        {unsupported_signature_scheme, _},
+        quic_tls:build_certificate_verify(16#FFFF, Key, crypto:hash(sha256, <<"x">>))
+    ).


### PR DESCRIPTION
Widens TLS 1.3 negotiation so QUIC handshakes interoperate with peers that prefer NIST curves or non-default signature schemes.

```erlang
%% Client offers x25519 first, falls back to NIST curves via HelloRetryRequest
quic:connect(Host, Port, #{groups => [x25519, secp256r1, secp384r1]}, self()).

%% Server pinned to a curve; an x25519-only client that also advertises
%% secp256r1 gets a HelloRetryRequest and retries transparently.
quic:start_server(srv, 4433, #{cert => Cert, key => Key, groups => [secp256r1]}).
```

## What's in

- **HelloRetryRequest** (RFC 8446 §4.1.4): server-side decision + build, client-side retry with the synthetic `message_hash(CH1)` transcript prefix, continuous Initial CRYPTO offsets across the CH1/HRR/CH2 flight.
- **Multi-group key exchange**: ClientHello advertises every configured group in `supported_groups` and a `key_share` for the head; `x25519`, `secp256r1`, `secp384r1` are wired through key generation and the shared-secret path.
- **Signature negotiation**: `select_signature_algorithm/3` intersects the key's schemes (server preference order) with the peer's offered `signature_algorithms`. Adds ECDSA secp384r1-SHA384, RSA-PSS-RSAE SHA384/512, and Ed25519 signing + verifying. `rsa_pkcs1_*` is advertised for cert-chain signatures but never selected for CertificateVerify (RFC 8446 §4.4.3). The unknown-scheme path errors instead of silently falling back to RSA-PSS.
- **Alerts**: `send_tls_alert/3` emits the CONNECTION_CLOSE at the Initial level when handshake keys are absent, so pre-handshake negotiation failures (`handshake_failure`, `illegal_parameter`, `unexpected_message`) actually reach the peer.
- The `connected` event now reports `negotiated_group` and `negotiated_scheme`.

## Defaults unchanged

`groups` defaults to `[x25519]` and the advertised signature list matches the historical one, so the wire is identical unless a caller opts in. The existing single-group handshake, interop suite, and PSK paths are untouched.

## Out of scope (v1)

- PSK + HelloRetryRequest in one handshake: the client aborts with `unexpected_message` if HRR follows a PSK ClientHello (binder recompute over the synthetic transcript is deferred).
- `secp521r1` / `x448` groups and `ed448` / ECDSA secp521r1-SHA512 schemes (constants only).

## Docs

- `docs/features.md` TLS section + Roadmap.
- `docs/CLIENT_GUIDE.md` / `docs/SERVER_GUIDE.md` option tables + mixed-group example.
- Docstrings on `quic:connect/4` and `quic:start_server/3`.