### PR TITLE
perf(h3): inline header field-char classification into scanner guards

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -2637,37 +2637,40 @@ validate_field_name(<<$:, Rest/binary>>) ->
 validate_field_name(Name) ->
     validate_field_name_chars(Name, Name).
 
+%% The char class is inlined as clause guards so each byte is a single
+%% (tail-recursive) call rather than a call plus a separate predicate;
+%% the common lowercase-letter case matches the first guard immediately.
+%% tchar per RFC 7230 §3.2.6, restricted to lowercase letters.
 validate_field_name_chars(<<>>, Full) ->
     %% empty after ":" is invalid
     case Full of
         <<":">> -> throw({header_error, {invalid_field, Full, <<>>}});
         _ -> ok
     end;
-validate_field_name_chars(<<C, Rest/binary>>, Full) ->
-    case is_tchar_lowercase(C) of
-        true -> validate_field_name_chars(Rest, Full);
-        false -> throw({header_error, {invalid_field, Full, <<>>}})
-    end.
-
-%% tchar per RFC 7230 §3.2.6, restricted to lowercase letters.
-is_tchar_lowercase(C) when C >= $a, C =< $z -> true;
-is_tchar_lowercase(C) when C >= $0, C =< $9 -> true;
-is_tchar_lowercase($!) -> true;
-is_tchar_lowercase($#) -> true;
-is_tchar_lowercase($$) -> true;
-is_tchar_lowercase($%) -> true;
-is_tchar_lowercase($&) -> true;
-is_tchar_lowercase($') -> true;
-is_tchar_lowercase($*) -> true;
-is_tchar_lowercase($+) -> true;
-is_tchar_lowercase($-) -> true;
-is_tchar_lowercase($.) -> true;
-is_tchar_lowercase($^) -> true;
-is_tchar_lowercase($_) -> true;
-is_tchar_lowercase($`) -> true;
-is_tchar_lowercase($|) -> true;
-is_tchar_lowercase($~) -> true;
-is_tchar_lowercase(_) -> false.
+validate_field_name_chars(<<C, Rest/binary>>, Full) when C >= $a, C =< $z ->
+    validate_field_name_chars(Rest, Full);
+validate_field_name_chars(<<C, Rest/binary>>, Full) when C >= $0, C =< $9 ->
+    validate_field_name_chars(Rest, Full);
+validate_field_name_chars(<<C, Rest/binary>>, Full) when
+    C =:= $!;
+    C =:= $#;
+    C =:= $$;
+    C =:= $%;
+    C =:= $&;
+    C =:= $';
+    C =:= $*;
+    C =:= $+;
+    C =:= $-;
+    C =:= $.;
+    C =:= $^;
+    C =:= $_;
+    C =:= $`;
+    C =:= $|;
+    C =:= $~
+->
+    validate_field_name_chars(Rest, Full);
+validate_field_name_chars(<<_, _/binary>>, Full) ->
+    throw({header_error, {invalid_field, Full, <<>>}}).
 
 %% Field values: VCHAR / SP / HTAB / obs-text, no leading/trailing whitespace,
 %% no CR/LF/NUL (RFC 9110 §5.5).
@@ -2687,19 +2690,17 @@ validate_field_value(Name, Value) ->
             validate_field_value_chars(Value, Name)
     end.
 
+%% Char class inlined as clause guards (see validate_field_name_chars/2).
 validate_field_value_chars(<<>>, _Name) ->
     ok;
-validate_field_value_chars(<<C, Rest/binary>>, Name) ->
-    case is_field_value_char(C) of
-        true -> validate_field_value_chars(Rest, Name);
-        false -> throw({header_error, {invalid_field, Name, <<C>>}})
-    end.
-
-is_field_value_char($\s) -> true;
-is_field_value_char($\t) -> true;
-is_field_value_char(C) when C >= 16#21, C =< 16#7E -> true;
-is_field_value_char(C) when C >= 16#80, C =< 16#FF -> true;
-is_field_value_char(_) -> false.
+validate_field_value_chars(<<C, Rest/binary>>, Name) when C >= 16#21, C =< 16#7E ->
+    validate_field_value_chars(Rest, Name);
+validate_field_value_chars(<<C, Rest/binary>>, Name) when C >= 16#80, C =< 16#FF ->
+    validate_field_value_chars(Rest, Name);
+validate_field_value_chars(<<C, Rest/binary>>, Name) when C =:= $\s; C =:= $\t ->
+    validate_field_value_chars(Rest, Name);
+validate_field_value_chars(<<C, _/binary>>, Name) ->
+    throw({header_error, {invalid_field, Name, <<C>>}}).
 
 %% RFC 9114 §4.2: connection-specific fields MUST NOT appear in HTTP/3.
 %% te is allowed only with value "trailers".

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -789,6 +789,69 @@ no_duplicates_accepted_test() ->
     ?assertMatch({ok, _}, Result).
 
 %%====================================================================
+%% Field-character validation (table-lookup path)
+%%====================================================================
+%% Each case starts from a complete valid request pseudo-header set so
+%% the failure is attributable to character validation, not a missing
+%% or malformed pseudo-header. Char validation runs before pseudo-header
+%% checks, so name/value rejections fire first.
+
+valid_request_field_chars_accepted_test() ->
+    Stream = #h3_stream{id = 0, frame_state = expecting_headers},
+    State = make_test_state(#{role => server}),
+    Result = quic_h3_connection:update_stream_with_headers(
+        valid_request_headers(), Stream, server, State
+    ),
+    ?assertMatch({ok, _}, Result).
+
+invalid_field_name_char_rejected_test() ->
+    %% Uppercase in a regular field name is not a lowercase tchar.
+    Headers = valid_request_headers() ++ [{<<"x-Bad">>, <<"v">>}],
+    Stream = #h3_stream{id = 0, frame_state = expecting_headers},
+    State = make_test_state(#{role => server}),
+    ?assertEqual(
+        {error, {invalid_field, <<"x-Bad">>, <<>>}},
+        quic_h3_connection:update_stream_with_headers(Headers, Stream, server, State)
+    ).
+
+invalid_field_value_char_rejected_test() ->
+    %% A control char (LF) is not a valid field-value char; the
+    %% offending byte is reported.
+    Headers = valid_request_headers() ++ [{<<"x-h">>, <<"a\nb">>}],
+    Stream = #h3_stream{id = 0, frame_state = expecting_headers},
+    State = make_test_state(#{role => server}),
+    ?assertEqual(
+        {error, {invalid_field, <<"x-h">>, <<"\n">>}},
+        quic_h3_connection:update_stream_with_headers(Headers, Stream, server, State)
+    ).
+
+empty_field_name_rejected_test() ->
+    Headers = valid_request_headers() ++ [{<<>>, <<"v">>}],
+    Stream = #h3_stream{id = 0, frame_state = expecting_headers},
+    State = make_test_state(#{role => server}),
+    ?assertEqual(
+        {error, {invalid_field, <<>>, <<>>}},
+        quic_h3_connection:update_stream_with_headers(Headers, Stream, server, State)
+    ).
+
+bare_colon_field_name_rejected_test() ->
+    Headers = valid_request_headers() ++ [{<<":">>, <<"v">>}],
+    Stream = #h3_stream{id = 0, frame_state = expecting_headers},
+    State = make_test_state(#{role => server}),
+    ?assertEqual(
+        {error, {invalid_field, <<":">>, <<>>}},
+        quic_h3_connection:update_stream_with_headers(Headers, Stream, server, State)
+    ).
+
+valid_request_headers() ->
+    [
+        {<<":method">>, <<"GET">>},
+        {<<":scheme">>, <<"https">>},
+        {<<":authority">>, <<"example.com">>},
+        {<<":path">>, <<"/">>}
+    ].
+
+%%====================================================================
 %% GOAWAY Role-Aware Identifier Tests (RFC 9114 Section 7.2.6)
 %%====================================================================
 


### PR DESCRIPTION
HTTP/3 header validation scanned each byte with a tail-recursive call **plus** a separate guard-based predicate (`is_tchar_lowercase/1`, `is_field_value_char/1`) — two function calls per character, which fprof flagged as a top own-time path on the request/response loop.

This folds the character class into the scanner clause guards, so each byte is a single tail-recursive call and the common case (lowercase letters for names, printable ASCII for values) matches the first clause immediately.

```erlang
validate_field_name_chars(<<C, Rest/binary>>, Full) when C >= $a, C =< $z ->
    validate_field_name_chars(Rest, Full);
%% ... digits, then the punctuation tchar set, then reject
```

## Why guards, not a lookup table

The original plan was a 256-entry byte-classification table. Benchmarking over representative header names rejected it:

| approach | time | vs baseline |
|---|---|---|
| predicate call per byte (before) | 992 ms | 1.00x |
| `binary:at/2` table | 988 ms | **1.00x (no win)** |
| `element/2` tuple | 409 ms | 2.43x |
| inlined clause guards | 309 ms | **3.21x** |

Under the BeamAsm JIT the guard comparisons are already inlined, so a `binary:at/2` table just adds BIF overhead. Inlining the class into the scanner guards removes the predicate call entirely and is both the fastest and the simplest (no table, no `persistent_term`).

## Semantics unchanged

The guards mirror the removed predicates exactly. Error payloads are identical (`{invalid_field, Full, <<>>}` for names, `{invalid_field, Name, <<C>>}` for values). All 177 `quic_h3_compliance_tests` pass, plus 5 added field-char cases (invalid name char, invalid value char, empty name, bare `:`) built on a complete valid request header set so each rejection is attributable to char validation rather than a missing pseudo-header.

The authoritative re-profile with Livery's `livery_bench:profile(h3, 100)` is for the maintainer to run; the table above is a focused micro-benchmark of the exact change.