### PR TITLE
fix(tls): segment server handshake flight to respect max_udp_payload_size (#134)

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -136,6 +136,7 @@
 %% Test exports
 -ifdef(TEST).
 -export([
+    chunk_crypto/3,
     add_to_ack_ranges/2,
     merge_ack_ranges/1,
     convert_ack_ranges_for_encode/1,
@@ -2820,12 +2821,11 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
         update_state = idle
     },
 
-    %% Combine all messages into CRYPTO frame payload
-    %% Include CertificateRequest if verify is enabled
+    %% Combine all messages into the handshake CRYPTO payload.
+    %% Include CertificateRequest if verify is enabled.
     HandshakePayload =
         <<EncExtMsg/binary, CertReqMsg/binary, CertMsg/binary, CertVerifyMsg/binary,
             FinishedMsg/binary>>,
-    CryptoFrame = quic_frame:encode({crypto, 0, HandshakePayload}),
 
     %% Determine next TLS state based on verify option
     %% If verify=true, we expect Certificate from client next
@@ -2845,8 +2845,55 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
         key_state = KeyState
     },
 
-    %% Send in Handshake packet
-    send_handshake_packet(CryptoFrame, State1).
+    %% Send the flight, segmented so no datagram exceeds the peer's
+    %% max_udp_payload_size (issue #134).
+    send_handshake_crypto(HandshakePayload, State1).
+
+%% @private Send a handshake CRYPTO payload as one or more packets,
+%% each sized to stay within max_udp_payload_size (RFC 9000 §14.1).
+%% A single oversized datagram is dropped by strict clients (Chromium),
+%% stalling the handshake.
+send_handshake_crypto(Payload, State) ->
+    Max = handshake_crypto_budget(State),
+    lists:foldl(
+        fun({Offset, Chunk}, AccState) ->
+            Frame = quic_frame:encode({crypto, Offset, Chunk}),
+            send_handshake_packet(Frame, AccState)
+        end,
+        State,
+        chunk_crypto(Payload, 0, Max)
+    ).
+
+%% @private Conservative per-chunk CRYPTO data budget for a Handshake
+%% packet. The ceiling is the QUIC baseline (1200): PMTU is unvalidated
+%% mid-handshake and every peer's max_udp_payload_size is >= 1200, so
+%% 1200 is universally safe. Overhead covers the long header, packet
+%% number, AEAD tag and CRYPTO frame header (generous varints).
+handshake_crypto_budget(#state{dcid = DCID, scid = SCID} = State) ->
+    PeerMax = maps:get(
+        max_udp_payload_size,
+        State#state.transport_params,
+        ?DEFAULT_MAX_UDP_PAYLOAD_SIZE
+    ),
+    Ceiling = min(PeerMax, ?DEFAULT_MAX_UDP_PAYLOAD_SIZE),
+    Overhead =
+        %% long header: first byte + version + DCID len/bytes + SCID len/bytes
+        1 + 4 + 1 + byte_size(DCID) + 1 + byte_size(SCID) +
+            %% length varint + packet number + AEAD tag
+            2 + 4 + 16 +
+            %% CRYPTO frame header: type + offset varint + length varint
+            1 + 8 + 4,
+    max(1, Ceiling - Overhead).
+
+%% @private Split a handshake CRYPTO payload into {Offset, Chunk}
+%% pieces, each Chunk =< Max, with contiguous offsets from Offset.
+%% The concatenation of the chunks equals the original payload.
+chunk_crypto(<<>>, _Offset, _Max) ->
+    [];
+chunk_crypto(Payload, Offset, Max) ->
+    Take = min(byte_size(Payload), Max),
+    <<Chunk:Take/binary, Rest/binary>> = Payload,
+    [{Offset, Chunk} | chunk_crypto(Rest, Offset + Take, Max)].
 
 %% Server: Send HANDSHAKE_DONE frame after receiving client Finished
 send_handshake_done(State) ->
@@ -4965,7 +5012,6 @@ process_tls_message(
 
                     %% Combine Certificate(+CertificateVerify) and Finished into one payload
                     HandshakePayload = <<CertPayload/binary, ClientFinishedMsg/binary>>,
-                    CryptoFrame = quic_frame:encode({crypto, 0, HandshakePayload}),
 
                     State1 = State#state{
                         tls_state = ?TLS_HANDSHAKE_COMPLETE,
@@ -4975,8 +5021,9 @@ process_tls_message(
                         key_state = KeyState
                     },
 
-                    %% Send client Certificate(+CertificateVerify)+Finished in Handshake packet
-                    send_handshake_packet(CryptoFrame, State1);
+                    %% Send client Certificate(+CertificateVerify)+Finished,
+                    %% segmented so no datagram exceeds max_udp_payload_size.
+                    send_handshake_crypto(HandshakePayload, State1);
                 false ->
                     %% Verification failed
                     State

--- a/test/quic_crypto_chunk_tests.erl
+++ b/test/quic_crypto_chunk_tests.erl
@@ -1,0 +1,64 @@
+%%% -*- erlang -*-
+%%%
+%%% Unit tests for quic_connection:chunk_crypto/3, the pure splitter
+%%% that segments a handshake CRYPTO payload into sized, contiguous
+%%% pieces (issue #134).
+
+-module(quic_crypto_chunk_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+empty_payload_test() ->
+    ?assertEqual([], quic_connection:chunk_crypto(<<>>, 0, 1144)).
+
+fits_in_one_chunk_test() ->
+    Payload = <<"short handshake">>,
+    ?assertEqual(
+        [{0, Payload}],
+        quic_connection:chunk_crypto(Payload, 0, 1144)
+    ).
+
+exact_multiple_test() ->
+    %% 6 bytes, Max 2 -> three 2-byte chunks at 0, 2, 4.
+    ?assertEqual(
+        [{0, <<"ab">>}, {2, <<"cd">>}, {4, <<"ef">>}],
+        quic_connection:chunk_crypto(<<"abcdef">>, 0, 2)
+    ).
+
+remainder_chunk_test() ->
+    %% 7 bytes, Max 3 -> 3,3,1.
+    ?assertEqual(
+        [{0, <<"abc">>}, {3, <<"def">>}, {6, <<"g">>}],
+        quic_connection:chunk_crypto(<<"abcdefg">>, 0, 3)
+    ).
+
+offset_preserved_from_start_test() ->
+    %% Starting offset is honoured and stays contiguous.
+    ?assertEqual(
+        [{10, <<"abc">>}, {13, <<"de">>}],
+        quic_connection:chunk_crypto(<<"abcde">>, 10, 3)
+    ).
+
+%% A realistic ~4 KB flight at the 1144-byte budget: every chunk is
+%% within budget, offsets are contiguous, and reassembly is lossless.
+large_flight_invariants_test() ->
+    Max = 1144,
+    Payload = crypto:strong_rand_bytes(4000),
+    Chunks = quic_connection:chunk_crypto(Payload, 0, Max),
+    %% 4000 / 1144 -> 4 chunks (1144, 1144, 1144, 568)
+    ?assertEqual(4, length(Chunks)),
+    %% every chunk within budget
+    [?assert(byte_size(C) =< Max) || {_, C} <- Chunks],
+    %% offsets contiguous starting at 0
+    ?assertEqual([0, 1144, 2288, 3432], [Off || {Off, _} <- Chunks]),
+    %% each offset equals the running byte count
+    lists:foldl(
+        fun({Off, C}, Acc) ->
+            ?assertEqual(Acc, Off),
+            Acc + byte_size(C)
+        end,
+        0,
+        Chunks
+    ),
+    %% lossless reassembly
+    ?assertEqual(Payload, iolist_to_binary([C || {_, C} <- Chunks])).

--- a/test/quic_handshake_mtu_SUITE.erl
+++ b/test/quic_handshake_mtu_SUITE.erl
@@ -1,0 +1,189 @@
+%%% -*- erlang -*-
+%%%
+%%% Regression test for issue #134: the server handshake flight must be
+%%% segmented so no UDP datagram exceeds max_udp_payload_size. A strict
+%%% client (Chromium) drops an oversized datagram and the handshake
+%%% stalls.
+%%%
+%%% A gen_udp relay sits between the client and the echo server and
+%%% records the byte size of every server-origin datagram. With a cert
+%%% chain large enough to push the flight past 1200 bytes, the test
+%%% asserts that no server datagram exceeds 1200 (the chunk budget).
+%%% This fails on the pre-fix code (one ~4 KB handshake datagram).
+
+-module(quic_handshake_mtu_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    server_flight_fits_max_udp_payload/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [server_flight_fits_max_udp_payload].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Test
+%%====================================================================
+
+server_flight_fits_max_udp_payload(_Config) ->
+    %% Inflate the server's Certificate message well past 1200 bytes by
+    %% padding the chain with extra cert DERs, forcing a multi-packet
+    %% flight.
+    CertDer = load_cert_der(),
+    Chain = lists:duplicate(3, CertDer),
+    {ok, Server} = quic_test_echo_server:start(#{cert_chain => Chain}),
+    ServerPort = maps:get(port, Server),
+
+    %% Relay between client and server; records server-origin datagram
+    %% sizes.
+    {Relay, RelayPort} = start_relay(ServerPort),
+    try
+        Opts = #{verify => false, alpn => [<<"echo">>]},
+        {ok, ConnRef} = quic:connect(<<"127.0.0.1">>, RelayPort, Opts, self()),
+        ok = wait_connected(ConnRef),
+        ok = echo_roundtrip(ConnRef, <<"hello mtu">>),
+        quic:close(ConnRef, normal),
+
+        Tagged = relay_server_sizes(Relay),
+        ct:pal("server datagrams {size, firstbyte}: ~p", [Tagged]),
+        %% Issue #134 is about the handshake flight: the long-header
+        %% Initial (0xC0-0xCF) and Handshake (0xE0-0xEF) packets, sent
+        %% before PMTU is validated, must each fit the 1200 baseline.
+        %% Post-handshake 1-RTT short-header packets (bit 7 = 0) are
+        %% bounded by the peer's max_udp_payload_size, not 1200, so they
+        %% are out of scope here.
+        HandshakeSizes = [Sz || {Sz, FB} <- Tagged, FB >= 16#80],
+        ?assert(HandshakeSizes =/= []),
+        Max = lists:max(HandshakeSizes),
+        ?assert(
+            Max =< 1200,
+            lists:flatten(
+                io_lib:format(
+                    "largest long-header (handshake) datagram ~p bytes exceeds 1200", [Max]
+                )
+            )
+        )
+    after
+        stop_relay(Relay),
+        quic_test_echo_server:stop(Server)
+    end.
+
+%%====================================================================
+%% UDP relay
+%%====================================================================
+
+start_relay(ServerPort) ->
+    Parent = self(),
+    Pid = spawn_link(fun() ->
+        {ok, Sock} = gen_udp:open(0, [binary, {active, true}, {reuseaddr, true}]),
+        {ok, Port} = inet:port(Sock),
+        Parent ! {relay_port, self(), Port},
+        relay_loop(Sock, ServerPort, undefined, [])
+    end),
+    receive
+        {relay_port, Pid, Port} -> {Pid, Port}
+    after 5000 ->
+        exit(relay_start_timeout)
+    end.
+
+relay_loop(Sock, ServerPort, ClientAddr, ServerSizes) ->
+    receive
+        {udp, Sock, {127, 0, 0, 1}, ServerPort, Data} ->
+            %% From the server: record size (+ first byte = packet type),
+            %% forward to the client.
+            case ClientAddr of
+                {CIP, CPort} -> gen_udp:send(Sock, CIP, CPort, Data);
+                undefined -> ok
+            end,
+            <<FirstByte, _/binary>> = Data,
+            relay_loop(Sock, ServerPort, ClientAddr, [{byte_size(Data), FirstByte} | ServerSizes]);
+        {udp, Sock, FromIP, FromPort, Data} ->
+            %% From the client: remember its address, forward to server.
+            gen_udp:send(Sock, {127, 0, 0, 1}, ServerPort, Data),
+            relay_loop(Sock, ServerPort, {FromIP, FromPort}, ServerSizes);
+        {get_sizes, Caller} ->
+            Caller ! {sizes, lists:reverse(ServerSizes)},
+            relay_loop(Sock, ServerPort, ClientAddr, ServerSizes);
+        stop ->
+            gen_udp:close(Sock),
+            ok
+    end.
+
+relay_server_sizes(Relay) ->
+    Relay ! {get_sizes, self()},
+    receive
+        {sizes, Sizes} -> Sizes
+    after 5000 ->
+        []
+    end.
+
+stop_relay(Relay) ->
+    Relay ! stop,
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+load_cert_der() ->
+    CertFile = filename:join([code:lib_dir(quic), "..", "..", "certs", "cert.pem"]),
+    {ok, Pem} =
+        case filelib:is_file(CertFile) of
+            true -> file:read_file(CertFile);
+            false -> generate_cert_pem()
+        end,
+    [{'Certificate', Der, _} | _] = public_key:pem_decode(Pem),
+    Der.
+
+generate_cert_pem() ->
+    Dir = "/tmp/quic_mtu_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    Cert = filename:join(Dir, "cert.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -keyout ~s/key.pem -out ~s "
+            "-days 1 -nodes -subj '/CN=localhost' 2>/dev/null",
+            [Dir, Cert]
+        )
+    ),
+    os:cmd(Cmd),
+    file:read_file(Cert).
+
+wait_connected(ConnRef) ->
+    receive
+        {quic, ConnRef, {connected, _Info}} -> ok
+    after 10000 ->
+        catch quic:close(ConnRef, timeout),
+        ct:fail("connection timeout")
+    end.
+
+echo_roundtrip(ConnRef, Payload) ->
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    ok = quic:send_data(ConnRef, StreamId, Payload, true),
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Got, true}} ->
+            ?assertEqual(Payload, Got),
+            ok
+    after 10000 ->
+        ct:fail("echo timeout")
+    end.


### PR DESCRIPTION
Fixes #134.

The server emitted its entire TLS handshake flight (EncryptedExtensions + Certificate chain + CertificateVerify + Finished, ~3–5 KB) as **one** UDP datagram. A client that strictly enforces its advertised `max_udp_payload_size` (Chromium advertises 1472) drops the oversized datagram with `ERR_MSG_TOO_BIG`; the handshake stalls and dies on idle timeout. curl/our own client only work by accident (generous UDP buffers).

## Fix

Split the handshake CRYPTO payload into multiple Handshake packets, each sized to the QUIC 1200-byte baseline, via `chunk_crypto/3` + `send_handshake_crypto/2`. PMTU is unvalidated mid-handshake and every peer's `max_udp_payload_size` is ≥ 1200, so 1200 is universally safe. Applied to both the server flight and the client mTLS certificate flight, which shared the single-packet send path. The peer reassembles by CRYPTO offset (the existing machinery), so this is wire-correct.

## Scope

Handshake-level loss tracking/retransmission is a separate, pre-existing gap (`send_handshake_packet/2` doesn't register packets for loss, and the retransmit path resends via the 1-RTT layer) and is left as a follow-up. Segmentation doesn't regress it: a guaranteed oversized drop is replaced with correctly-sized delivery.

## Tests

- `quic_crypto_chunk_tests` — `chunk_crypto/3` size/offset/lossless math (empty, single, exact-multiple, remainder, contiguous offsets, 4 KB flight).
- `quic_handshake_mtu_SUITE` — a `gen_udp` relay between client and server records every server-origin datagram size; with a padded cert chain it asserts **no long-header (Initial/Handshake) datagram exceeds 1200**. Confirmed it **fails on the pre-fix code** (a 3584-byte handshake datagram) and passes with the fix. Short-header 1-RTT packets are excluded — they are post-handshake and bounded by the peer's `max_udp_payload_size`, not 1200.

The authoritative Chromium (v150 dev/canary) interop check is the reporter's to confirm; verified locally by the size/offset unit tests plus the relay datagram-size assertion.