### PR TITLE
docs: fix edoc inline-code quoting that broke ex_doc / hex publish

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -82,6 +82,7 @@
         <<"docs/SERVER_GUIDE.md">>,
         <<"docs/CLIENT_GUIDE.md">>,
         <<"docs/QUIC_DIST.md">>,
+        <<"docs/PSK.md">>,
         <<"docs/QLOG_GUIDE.md">>,
         <<"docs/HTTP3.md">>,
         <<"docs/PERFORMANCE.md">>
@@ -100,6 +101,7 @@
         ]},
         {<<"Advanced">>, [
             <<"docs/QUIC_DIST.md">>,
+            <<"docs/PSK.md">>,
             <<"docs/QLOG_GUIDE.md">>,
             <<"docs/HTTP3.md">>
         ]}

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -580,7 +580,7 @@ connected(enter, _OldState, _State) ->
     %% No DHandle (shouldn't happen in normal flow)
     keep_state_and_data;
 %% Handle send in connected state (direct send, not from VM).
-%% `send/2` is bound to f_send in #hs_data{} and only used by dist_util
+%% `send/2' is bound to f_send in #hs_data{} and only used by dist_util
 %% during the handshake — under normal post-handshake operation this
 %% handler is unreachable. The function is exported, so route any caller
 %% through the same picker + framing + per-stream queue as the VM path.
@@ -1185,7 +1185,7 @@ send_dist_data_limited_loop(DHandle, Conn, Streams, Remaining, State) ->
     end.
 
 %% @private
-%% dist_ctrl_get_data/1 may return `Data` (iovec) or `{Size, Data}'
+%% dist_ctrl_get_data/1 may return `Data' (iovec) or `{Size, Data}'
 %% (iovec with precomputed size); peel the size off.
 payload_bytes({_Size, Data}) -> Data;
 payload_bytes(Data) -> Data.

--- a/src/h3/quic_h3_capsule.erl
+++ b/src/h3/quic_h3_capsule.erl
@@ -4,7 +4,7 @@
 %%%
 %%% A capsule is a reliable framed unit carried on the body of an
 %%% extended-CONNECT request stream, distinct from the unreliable HTTP
-%%% Datagrams delivered via `quic_h3:send_datagram/3`. The wire format
+%%% Datagrams delivered via `quic_h3:send_datagram/3'. The wire format
 %%% is simply `Type (varint) | Length (varint) | Value`.
 %%%
 %%% We expose encode/2 and decode/1 as low-level primitives. Higher

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -227,8 +227,8 @@
     %% Placed at the end so prior tuple positions stay stable for tests.
     local_connect_enabled = false :: boolean(),
 
-    %% Extension hook. When set, `handle_uni_stream_type/4` consults
-    %% this function for unknown stream types and, on `claim`, routes
+    %% Extension hook. When set, `handle_uni_stream_type/4' consults
+    %% this function for unknown stream types and, on `claim', routes
     %% subsequent bytes to the owner as `{stream_type_*, ...}` events
     %% instead of discarding them.
     stream_type_handler ::

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -594,7 +594,7 @@
     ack_elicited_count = 0 :: non_neg_integer(),
     ack_timer = undefined :: reference() | undefined,
     %% Transient: classification of the most recently received 1-RTT
-    %% packet. Set by `record_received_pn/3` and consumed once by
+    %% packet. Set by `record_received_pn/3' and consumed once by
     %% `maybe_send_ack(app, ...)` to choose between immediate ACK
     %% (RFC 9002 §6.2 reordering recommendation) and count-based
     %% decimation.
@@ -1017,7 +1017,7 @@ init({server, Opts}) ->
         initial_keys = InitialKeys,
         tls_state = ?TLS_AWAITING_CLIENT_HELLO,
         %% TLS 1.3 external PSK config (RFC 8446 §4.2.11). Either or
-        %% both may be `undefined`; if both are undefined the server
+        %% both may be `undefined'; if both are undefined the server
         %% only accepts cert-authenticated handshakes.
         psk_config = #{
             psk_callback => maps:get(psk_callback, Opts, undefined),
@@ -4738,7 +4738,7 @@ process_tls_message(_Level, ?TLS_SERVER_HELLO, Body, OriginalMsg, State) ->
         {ok, #{cipher := Cipher} = ServerHelloMap} ->
             %% Determine handshake type: PSK (with or without DHE) vs
             %% standard cert-auth. PSK selection is signalled by the
-            %% `selected_psk_identity` extension echoed in ServerHello.
+            %% `selected_psk_identity' extension echoed in ServerHello.
             ServerPubKey = maps:get(public_key, ServerHelloMap),
             SelectedPskIdx = maps:get(selected_psk_identity, ServerHelloMap, undefined),
             case validate_client_psk_selection(SelectedPskIdx, State) of
@@ -5359,7 +5359,7 @@ do_server_client_hello(SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, Ori
     ALPN = negotiate_alpn(ClientALPN, State#state.alpn_list),
 
     %% Build ServerHello. For PSK handshakes the ServerHello
-    %% carries `selected_psk_identity`; for psk_ke it also
+    %% carries `selected_psk_identity'; for psk_ke it also
     %% omits key_share (RFC 8446 §4.2.9).
     ServerHelloOpts0 = #{
         cipher_suite => cipher_atom_to_code(Cipher),
@@ -9673,7 +9673,7 @@ apply_peer_transport_params(TransportParams, State) ->
                 ?QUIC_LOG_META
             ),
             ReasonBin = tp_reason_to_binary(Reason),
-            %% Mark the violation. `maybe_emit_pending_close/1` picks this up
+            %% Mark the violation. `maybe_emit_pending_close/1' picks this up
             %% after the server flight so the peer has handshake keys to
             %% decrypt the CLOSE. The `{pending_close, ...}' tag is distinct
             %% from `{transport, ...}' so check_state_transition does not

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -342,9 +342,9 @@ transcript_hash(HashOrCipher, Messages) ->
     Hash = cipher_to_hash(HashOrCipher),
     crypto:hash(Hash, Messages).
 
-%% @doc Synthetic `message_hash` handshake message that replaces
+%% @doc Synthetic `message_hash' handshake message that replaces
 %% ClientHello1 in the transcript after a HelloRetryRequest
-%% (RFC 8446 §4.4.1). `HashClientHello1` is the digest over the
+%% (RFC 8446 §4.4.1). `HashClientHello1' is the digest over the
 %% complete CH1 handshake message. Both peers prepend the result
 %% to the post-HRR transcript.
 -spec hrr_transcript_prefix(atom(), binary()) -> binary().

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -76,7 +76,7 @@
     gro_receiver :: pid() | undefined,
     port :: inet:port_number(),
     %% Cert + private_key are optional; PSK-only listeners run with
-    %% both `undefined` and rely on `psks` / `psk_callback`.
+    %% both `undefined' and rely on `psks' / `psk_callback'.
     cert :: binary() | undefined,
     cert_chain :: [binary()],
     private_key :: term() | undefined,

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -86,11 +86,11 @@
 %% Returns: {ClientHelloMsg, PrivateKey, Random}
 -spec build_client_hello(map()) -> {binary(), binary(), binary()}.
 build_client_hello(Opts) ->
-    %% Key-share group: the head of `groups` (default x25519). The
+    %% Key-share group: the head of `groups' (default x25519). The
     %% remaining groups are advertised in supported_groups so the
     %% server can request one via HelloRetryRequest.
     Groups = maps:get(groups, Opts, default_groups()),
-    %% Group that gets the key_share entry: the head of `groups`, or an
+    %% Group that gets the key_share entry: the head of `groups', or an
     %% explicit override (used by a HelloRetryRequest retry where
     %% supported_groups is unchanged but the share moves to the
     %% server-selected group).
@@ -180,7 +180,7 @@ psk_offer_from_external({Identity, Secret, Modes}) when
 ->
     %% Currently only TLS_AES_128_GCM_SHA256 is supported; binder
     %% length, key schedule hash and HKDF all key off this. When more
-    %% suites land, surface a `cipher` option here.
+    %% suites land, surface a `cipher' option here.
     #psk_offer{
         type = external,
         identity = Identity,
@@ -239,7 +239,7 @@ build_client_hello_standard(Random, PubKey, PrivKey, Opts) ->
     Msg = encode_handshake_message(?TLS_CLIENT_HELLO, ClientHello),
     {Msg, PrivKey, Random}.
 
-%% Build ClientHello with `pre_shared_key` extension for either a
+%% Build ClientHello with `pre_shared_key' extension for either a
 %% resumption ticket or an external PSK.
 %% RFC 8446 §4.2.11: pre_shared_key MUST be the last extension; the
 %% binder is computed over the truncated ClientHello (everything
@@ -255,7 +255,7 @@ build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, #psk_offer{} = Offer)
     } = Offer,
 
     %% Base extensions advertise the configured PSK modes (drives the
-    %% server's `psk_key_exchange_modes` decision).
+    %% server's `psk_key_exchange_modes' decision).
     OptsWithModes = Opts#{psk_modes => Modes},
     BaseExtensions = build_client_hello_extensions(PubKey, OptsWithModes),
 
@@ -386,7 +386,7 @@ build_client_hello_extensions(PubKey, Opts) ->
     ),
 
     %% PSK Key Exchange Modes — list of bytes per RFC 8446 §4.2.9.
-    %% Defaults to `psk_dhe_ke` only; callers offering external PSK
+    %% Defaults to `psk_dhe_ke' only; callers offering external PSK
     %% may pass `psk_modes => [psk_ke, psk_dhe_ke]` etc.
     Modes = maps:get(psk_modes, Opts, [psk_dhe_ke]),
     ModeBytes = iolist_to_binary([encode_psk_mode(M) || M <- Modes]),
@@ -906,7 +906,7 @@ parse_extensions(Data) ->
 
 %% @doc Parse an extensions blob preserving order and byte offsets.
 %% Returns [{Type, Data, ByteOffset, ByteSize}] where ByteOffset is the
-%% position of `Type` within `Data`. Rejects duplicate extension types
+%% position of `Type' within `Data'. Rejects duplicate extension types
 %% per RFC 8446 §4.2 with {error, {duplicate_extension, Type}}; the
 %% caller maps that to an illegal_parameter alert.
 -spec parse_extensions_ordered(binary()) ->
@@ -1327,7 +1327,7 @@ decode_psk_mode(Other) -> {unknown, Other}.
 %% @private
 %% Locate the pre_shared_key extension and compute the offset (within
 %% the extensions blob) of the binders-length field. Returns a map
-%% `#{ext_offset, binders_offset, binders_size}` or `undefined` if no
+%% `#{ext_offset, binders_offset, binders_size}` or `undefined' if no
 %% PSK was offered.
 psk_binders_offset(OrderedExts, _ExtBlob) ->
     case lists:keyfind(?EXT_PRE_SHARED_KEY, 1, OrderedExts) of
@@ -1357,20 +1357,20 @@ psk_binders_offset(OrderedExts, _ExtBlob) ->
 
 %% @doc Select a PSK from a ClientHello and verify the binder.
 %%
-%% `ClientHelloMap` is the result of `parse_client_hello/1`.
-%% `FullHandshakeMsg` is the raw 4-byte-headered handshake bytes for
+%% `ClientHelloMap' is the result of `parse_client_hello/1'.
+%% `FullHandshakeMsg' is the raw 4-byte-headered handshake bytes for
 %%   ClientHello (msg_type + length + body) — needed to compute the
 %%   truncated ClientHello hash for binder verification.
-%% `PskConfig` is `#{psk_callback => Fn | undefined,
+%% `PskConfig' is `#{psk_callback => Fn | undefined,
 %%                   psks => Map | undefined}`.
-%% `ServerModes` is the list of psk_key_exchange modes the server is
+%% `ServerModes' is the list of psk_key_exchange modes the server is
 %%   willing to negotiate (defaults to `[psk_dhe_ke]`).
 %%
 %% Returns:
 %%   `{ok, #{identity_idx => N, secret => Secret, mode => Mode}}` on
 %%   successful selection (identity found, binder verified, modes
 %%   compatible);
-%%   `none` when the client didn't offer pre_shared_key OR offered
+%%   `none' when the client didn't offer pre_shared_key OR offered
 %%   identities don't match local config OR no compatible mode
 %%   (caller falls through to cert path or sends
 %%   unknown_psk_identity);


### PR DESCRIPTION
`rebar3 hex publish` (and `rebar3 ex_doc`) crashed in the edoc chunks doclet:

```
function hrr_transcript_prefix/2: `-quote ended unexpectedly
function parse_extensions_ordered/1: `-quote ended unexpectedly
edoc: error in doclet 'edoc_doclet_chunks'
```

edoc treats a backtick as an inline-quote opener that must be closed with an apostrophe (`` `name' ``, the form used in ~255 places here). A handful of doc comments used `` `name` `` (backtick-closed), which edoc cannot parse, aborting doc generation and blocking the hex release.

Converts every `` `name` `` span in `src/` to `` `name' ``, and adds `docs/PSK.md` to the ex_doc extras so the external-PSK guide renders and its cross-links resolve. Comment/doc-config only; no code changes.

`rebar3 ex_doc` now builds cleanly (only a pre-existing benign `net_kernel:epmd_module/0` hidden-function warning).