### PR TITLE
fix(qpack): correct field-section prefix Base and dynamic-table encoding (RFC 9204)

### DIFF
--- a/src/qpack/quic_qpack.erl
+++ b/src/qpack/quic_qpack.erl
@@ -156,28 +156,34 @@ new(Opts) ->
 %% @doc Encode headers using QPACK with state.
 -spec encode(headers(), state()) -> {binary(), state()}.
 encode(Headers, State) ->
-    %% First pass: encode headers and track max dynamic table index referenced
-    {EncodedHeaders, NewState, MaxRefIndex} = encode_headers_tracking(Headers, State, <<>>, -1),
+    %% Base is the reference frame for the dynamic relative indices in this
+    %% field section (RFC 9204 Section 3.2.6). The field lines below encode
+    %% each RelIndex relative to the insert count at section start, so snapshot
+    %% it and signal it as the Base. Entries referenced here were inserted (and
+    %% acknowledged) before this section, so their absolute index < BaseIC; the
+    %% running insert count must not be used, as inserts during this section
+    %% would shift the frame between field lines.
+    BaseIC = State#qpack.insert_count,
+    {EncodedHeaders, NewState, MaxRefIndex} = encode_headers_tracking(
+        Headers, BaseIC, State, <<>>, -1
+    ),
 
-    %% Calculate Required Insert Count (RIC)
-    %% RIC = MaxRefIndex + 1 if any dynamic entry was referenced, else 0
+    %% Required Insert Count: 1 + the largest absolute index referenced, or 0
+    %% when no dynamic entry was referenced (RFC 9204 Section 4.5.1.1).
     RIC =
         case MaxRefIndex >= 0 of
             true -> MaxRefIndex + 1;
             false -> 0
         end,
 
-    %% Encode prefix: Required Insert Count + Base (RFC 9204 Section 4.5.1).
-    %% This encoder always sets Base = Required Insert Count. Per Section
-    %% 4.5.1.2 that is the S=0 case (Base = RIC + DeltaBase) with DeltaBase = 0,
-    %% i.e. a Base byte of 0x00. Encoding S=1 (0x80) instead means
-    %% Base = RIC - DeltaBase - 1 = RIC - 1, so for the static-only RIC = 0
-    %% it yields Base = -1 and a conformant decoder (e.g. nghttp3) rejects
-    %% the field section with QPACK_DECOMPRESSION_FAILED.
+    %% Encoded Field Section Prefix (RFC 9204 Section 4.5.1): the Required
+    %% Insert Count, then the Base as a Sign bit and Delta Base. Base = BaseIC
+    %% >= RIC, so per Section 4.5.1.2 the Sign bit is 0 and DeltaBase =
+    %% BaseIC - RIC. A static-only section has BaseIC = RIC = 0, giving the
+    %% two prefix bytes 00 00.
     RICEncoded = encode_ric(RIC, State#qpack.dyn_max_size),
-    %% S=0 (bit 7), DeltaBase=0 (bits 0-6) -> Base = RIC.
-    BaseEncoded = 16#00,
-    Prefix = <<RICEncoded, BaseEncoded>>,
+    BaseEncoded = encode_prefixed_int(BaseIC - RIC, 7, 0),
+    Prefix = <<RICEncoded, BaseEncoded/binary>>,
 
     {<<Prefix/binary, EncodedHeaders/binary>>, NewState#qpack{last_ric = RIC}}.
 
@@ -522,30 +528,33 @@ encode_ric(RIC, MaxSize) ->
     MaxEntries = max(1, MaxSize div ?ENTRY_OVERHEAD),
     (RIC rem (2 * MaxEntries)) + 1.
 
-%% Encode headers while tracking maximum dynamic table index referenced
--spec encode_headers_tracking(headers(), state(), binary(), integer()) ->
+%% Encode headers while tracking the maximum dynamic table index referenced.
+%% `BaseIC` is the fixed Base (insert count at section start) that every
+%% dynamic relative index is encoded against.
+-spec encode_headers_tracking(headers(), non_neg_integer(), state(), binary(), integer()) ->
     {binary(), state(), integer()}.
-encode_headers_tracking([], State, Acc, MaxRef) ->
+encode_headers_tracking([], _BaseIC, State, Acc, MaxRef) ->
     {Acc, State, MaxRef};
-encode_headers_tracking([Header | Rest], State, Acc, MaxRef) ->
-    {Encoded, NewState, RefIndex} = encode_header_tracking(Header, State),
+encode_headers_tracking([Header | Rest], BaseIC, State, Acc, MaxRef) ->
+    {Encoded, NewState, RefIndex} = encode_header_tracking(Header, BaseIC, State),
     NewMaxRef =
         case RefIndex of
             none -> MaxRef;
             Idx -> max(MaxRef, Idx)
         end,
-    encode_headers_tracking(Rest, NewState, <<Acc/binary, Encoded/binary>>, NewMaxRef).
+    encode_headers_tracking(Rest, BaseIC, NewState, <<Acc/binary, Encoded/binary>>, NewMaxRef).
 
 %% Encode header with tracking of referenced dynamic index
 %% This function also inserts entries into the dynamic table when appropriate
--spec encode_header_tracking(header(), state()) -> {binary(), state(), integer() | none}.
-encode_header_tracking({Name, Value}, #qpack{use_dynamic = true} = State) ->
+-spec encode_header_tracking(header(), non_neg_integer(), state()) ->
+    {binary(), state(), integer() | none}.
+encode_header_tracking({Name, Value}, BaseIC, #qpack{use_dynamic = true} = State) ->
     case find_dynamic_match(Name, Value, State) of
         {exact, AbsIndex} ->
             %% Check if peer has received this entry (can reference)
             case can_reference(AbsIndex, State) of
                 true ->
-                    RelIndex = State#qpack.insert_count - AbsIndex - 1,
+                    RelIndex = BaseIC - AbsIndex - 1,
                     {encode_indexed_dynamic(RelIndex), State, AbsIndex};
                 false ->
                     %% Entry exists but peer hasn't acked, use literal
@@ -554,7 +563,7 @@ encode_header_tracking({Name, Value}, #qpack{use_dynamic = true} = State) ->
         {name, AbsIndex} ->
             case can_reference(AbsIndex, State) of
                 true ->
-                    RelIndex = State#qpack.insert_count - AbsIndex - 1,
+                    RelIndex = BaseIC - AbsIndex - 1,
                     {encode_literal_with_dynamic_name_ref(RelIndex, Value), State, AbsIndex};
                 false ->
                     encode_with_insertion({Name, Value}, State)
@@ -563,7 +572,7 @@ encode_header_tracking({Name, Value}, #qpack{use_dynamic = true} = State) ->
             %% No match in dynamic table, try to insert
             encode_with_insertion({Name, Value}, State)
     end;
-encode_header_tracking({Name, Value}, State) ->
+encode_header_tracking({Name, Value}, _BaseIC, State) ->
     {Encoded, NewState} = encode_header_static({Name, Value}, State),
     {Encoded, NewState, none}.
 
@@ -658,7 +667,11 @@ encode_insert_with_dynamic_name_ref(RelIndex, Value) ->
 -spec encode_insert_with_literal_name(binary(), binary()) -> binary().
 encode_insert_with_literal_name(Name, Value) ->
     NameLen = byte_size(Name),
-    NameLenEnc = encode_prefixed_int(NameLen, 5, 2#01),
+    %% Opcode bits 010 (01 = Insert With Literal Name, H=0): the 3-bit
+    %% prefix pattern is 2#010, i.e. 2#10 left of the 5-bit name length.
+    %% 2#01 here produced 001xxxxx, which the decoder reads as Set
+    %% Dynamic Table Capacity (RFC 9204 Section 4.3.3 vs 4.3.1).
+    NameLenEnc = encode_prefixed_int(NameLen, 5, 2#10),
     ValueEnc = encode_string(Value),
     <<NameLenEnc/binary, Name/binary, ValueEnc/binary>>.
 

--- a/src/qpack/quic_qpack.erl
+++ b/src/qpack/quic_qpack.erl
@@ -71,6 +71,11 @@
     encode_stream_cancel/1
 ]).
 
+%% Exported for unit tests only.
+-ifdef(TEST).
+-export([decode_base/3]).
+-endif.
+
 %%====================================================================
 %% Types
 %%====================================================================
@@ -764,16 +769,20 @@ decode_prefix(Data, State) ->
             %% Reconstruct RIC using modulo arithmetic
             MaxEntries = max(1, State#qpack.dyn_max_size div ?ENTRY_OVERHEAD),
             RIC = decode_ric(ERIC, MaxEntries, State#qpack.insert_count),
-            %% Reconstruct Base per RFC 9204 Section 4.5.1.2
-            Base =
-                case SBit of
-                    %% Pre-base: DeltaBase = RIC - Base - 1
-                    0 -> RIC - DeltaBase - 1;
-                    %% Post-base: DeltaBase = Base - RIC
-                    1 -> RIC + DeltaBase
-                end,
+            %% Reconstruct Base per RFC 9204 Section 4.5.1.2.
+            Base = decode_base(SBit, RIC, DeltaBase),
             {{RIC, Base}, Rest2}
     end.
+
+%% Reconstruct the Base from the field section prefix Sign bit and Delta
+%% Base (RFC 9204 Section 4.5.1.2):
+%%   S=0 -> Base = ReqInsertCount + DeltaBase     (Base >= Required Insert Count)
+%%   S=1 -> Base = ReqInsertCount - DeltaBase - 1  (Base < Required Insert Count)
+-spec decode_base(0 | 1, non_neg_integer(), non_neg_integer()) -> integer().
+decode_base(0, RIC, DeltaBase) ->
+    RIC + DeltaBase;
+decode_base(1, RIC, DeltaBase) ->
+    RIC - DeltaBase - 1.
 
 %% Decode Required Insert Count per RFC 9204 Section 4.5.1.1
 -spec decode_ric(non_neg_integer(), non_neg_integer(), non_neg_integer()) ->

--- a/src/qpack/quic_qpack.erl
+++ b/src/qpack/quic_qpack.erl
@@ -162,12 +162,16 @@ encode(Headers, State) ->
             false -> 0
         end,
 
-    %% Encode prefix: Required Insert Count + Base (Section 4.5.1)
-    %% Per RFC 9204 Section 4.5.1.2:
-    %% S=1, DeltaBase=0 means Base = RIC + DeltaBase = RIC
+    %% Encode prefix: Required Insert Count + Base (RFC 9204 Section 4.5.1).
+    %% This encoder always sets Base = Required Insert Count. Per Section
+    %% 4.5.1.2 that is the S=0 case (Base = RIC + DeltaBase) with DeltaBase = 0,
+    %% i.e. a Base byte of 0x00. Encoding S=1 (0x80) instead means
+    %% Base = RIC - DeltaBase - 1 = RIC - 1, so for the static-only RIC = 0
+    %% it yields Base = -1 and a conformant decoder (e.g. nghttp3) rejects
+    %% the field section with QPACK_DECOMPRESSION_FAILED.
     RICEncoded = encode_ric(RIC, State#qpack.dyn_max_size),
-    %% S=1 (bit 7), DeltaBase=0 (bits 0-6)
-    BaseEncoded = 16#80,
+    %% S=0 (bit 7), DeltaBase=0 (bits 0-6) -> Base = RIC.
+    BaseEncoded = 16#00,
     Prefix = <<RICEncoded, BaseEncoded>>,
 
     {<<Prefix/binary, EncodedHeaders/binary>>, NewState#qpack{last_ric = RIC}}.

--- a/src/qpack/quic_qpack.erl
+++ b/src/qpack/quic_qpack.erl
@@ -181,9 +181,14 @@ encode(Headers, State) ->
     %% >= RIC, so per Section 4.5.1.2 the Sign bit is 0 and DeltaBase =
     %% BaseIC - RIC. A static-only section has BaseIC = RIC = 0, giving the
     %% two prefix bytes 00 00.
-    RICEncoded = encode_ric(RIC, State#qpack.dyn_max_size),
+    %% Both fields are prefix integers (Section 4.5.1.1: 8-bit prefix for the
+    %% Required Insert Count, 7-bit for Delta Base). Encoding them as raw bytes
+    %% silently corrupts the section once a value reaches the prefix maximum
+    %% (e.g. an encoded insert count of 255 on a long-lived dynamic table),
+    %% because the decoder then reads a continuation byte that was never sent.
+    RICEncoded = encode_prefixed_int(encode_ric(RIC, State#qpack.dyn_max_size), 8, 0),
     BaseEncoded = encode_prefixed_int(BaseIC - RIC, 7, 0),
-    Prefix = <<RICEncoded, BaseEncoded/binary>>,
+    Prefix = <<RICEncoded/binary, BaseEncoded/binary>>,
 
     {<<Prefix/binary, EncodedHeaders/binary>>, NewState#qpack{last_ric = RIC}}.
 

--- a/test/quic_qpack_interop_SUITE.erl
+++ b/test/quic_qpack_interop_SUITE.erl
@@ -29,6 +29,10 @@
     decode_nghttp3_fb_req_static/1,
     decode_nghttp3_fb_resp_static/1,
     decode_ls_qpack_netbsd_static/1,
+    decode_nghttp3_netbsd_dynamic/1,
+    decode_nghttp3_netbsd_dynamic_small/1,
+    decode_nghttp3_fb_req_dynamic/1,
+    decode_nghttp3_fb_resp_dynamic/1,
     roundtrip_netbsd_qif/1,
     roundtrip_fb_req_qif/1
 ]).
@@ -46,6 +50,10 @@ all() ->
         decode_nghttp3_fb_req_static,
         decode_nghttp3_fb_resp_static,
         decode_ls_qpack_netbsd_static,
+        decode_nghttp3_netbsd_dynamic,
+        decode_nghttp3_netbsd_dynamic_small,
+        decode_nghttp3_fb_req_dynamic,
+        decode_nghttp3_fb_resp_dynamic,
         roundtrip_netbsd_qif,
         roundtrip_fb_req_qif
     ].
@@ -122,6 +130,28 @@ decode_ls_qpack_netbsd_static(Config) ->
         true -> decode_and_compare(EncodedFile, QifFile);
         false -> {skip, "ls-qpack encoded file not found"}
     end.
+
+%%====================================================================
+%% Test Cases - Decode nghttp3 dynamic-table output (capacity > 0)
+%%
+%% Stream 0 carries the encoder-stream instructions (inserts / set
+%% capacity); other streams carry field sections that reference the
+%% dynamic table. These fixtures use maxblocked = 0, so an entry's
+%% encoder-stream insert always precedes the field section using it.
+%%====================================================================
+
+decode_nghttp3_netbsd_dynamic(Config) ->
+    decode_dynamic_fixture(Config, "netbsd", 4096).
+
+%% Small capacity forces eviction on the decoder's dynamic table.
+decode_nghttp3_netbsd_dynamic_small(Config) ->
+    decode_dynamic_fixture(Config, "netbsd", 256).
+
+decode_nghttp3_fb_req_dynamic(Config) ->
+    decode_dynamic_fixture(Config, "fb-req", 4096).
+
+decode_nghttp3_fb_resp_dynamic(Config) ->
+    decode_dynamic_fixture(Config, "fb-resp", 4096).
 
 %%====================================================================
 %% Test Cases - Round-trip our own encoding
@@ -209,6 +239,46 @@ decode_encoded_blocks(<<_StreamId:64/big, Length:32/big, Rest/binary>>, State, A
             ct:fail({decode_error, Reason, byte_size(EncodedBlock)})
     end;
 decode_encoded_blocks(Bin, _State, _Acc) ->
+    ct:fail({invalid_encoded_format, byte_size(Bin)}).
+
+%% Decode a dynamic-table fixture (capacity > 0) and compare with the QIF.
+decode_dynamic_fixture(Config, Name, Capacity) ->
+    QifsDir = ?config(qifs_dir, Config),
+    Encoded = Name ++ ".out." ++ integer_to_list(Capacity) ++ ".0.0",
+    EncodedFile = filename:join([QifsDir, "encoded", "qpack-06", "nghttp3", Encoded]),
+    QifFile = filename:join([QifsDir, "qifs", Name ++ ".qif"]),
+    {ok, EncodedBin} = file:read_file(EncodedFile),
+    {ok, QifBin} = file:read_file(QifFile),
+    ExpectedBlocks = parse_qif(QifBin),
+    DecodedBlocks = decode_dynamic_encoded_file(EncodedBin, Capacity),
+    ?assertEqual(length(ExpectedBlocks), length(DecodedBlocks)),
+    compare_blocks(ExpectedBlocks, DecodedBlocks, 1),
+    ok.
+
+%% Like decode_encoded_file/1 but threads a dynamic-table state: stream 0 is
+%% the encoder stream (process_encoder_instructions), every other stream is a
+%% field section (decode). Only field sections yield comparable header blocks.
+decode_dynamic_encoded_file(Bin, Capacity) ->
+    State = quic_qpack:new(#{max_dynamic_size => Capacity}),
+    decode_dynamic_blocks(Bin, State, []).
+
+decode_dynamic_blocks(<<>>, _State, Acc) ->
+    lists:reverse(Acc);
+decode_dynamic_blocks(<<0:64/big, Length:32/big, Rest/binary>>, State, Acc) ->
+    <<Block:Length/binary, Rest2/binary>> = Rest,
+    {ok, State1} = quic_qpack:process_encoder_instructions(Block, State),
+    decode_dynamic_blocks(Rest2, State1, Acc);
+decode_dynamic_blocks(<<_StreamId:64/big, Length:32/big, Rest/binary>>, State, Acc) ->
+    <<Block:Length/binary, Rest2/binary>> = Rest,
+    case quic_qpack:decode(Block, State) of
+        {{ok, Headers}, State1} ->
+            decode_dynamic_blocks(Rest2, State1, [Headers | Acc]);
+        {{blocked, RIC}, _} ->
+            ct:fail({unexpected_blocked, RIC});
+        {{error, Reason}, _} ->
+            ct:fail({decode_error, Reason})
+    end;
+decode_dynamic_blocks(Bin, _State, _Acc) ->
     ct:fail({invalid_encoded_format, byte_size(Bin)}).
 
 %% Compare two lists of header blocks

--- a/test/quic_qpack_tests.erl
+++ b/test/quic_qpack_tests.erl
@@ -216,6 +216,70 @@ dynamic_table_capacity_test() ->
     ?assertEqual(0, quic_qpack:get_insert_count(State)).
 
 %%====================================================================
+%% Dynamic Table round-trip (encoder stream + field section)
+%%
+%% Full flow: encode (insert + literal) -> feed encoder instructions to
+%% the decoder -> acknowledge -> re-encode (dynamic reference) -> decode.
+%%====================================================================
+
+%% Insert one entry, acknowledge it, then reference it (RIC = insert_count).
+dynamic_reference_newest_roundtrip_test() ->
+    H = [{<<"x-custom">>, <<"value">>}],
+    E0 = quic_qpack:new(#{max_dynamic_size => 4096}),
+    D0 = quic_qpack:new(#{max_dynamic_size => 4096}),
+    {_Literal, E1} = quic_qpack:encode(H, 0, E0),
+    {ok, D1} = quic_qpack:process_encoder_instructions(
+        quic_qpack:get_encoder_instructions(E1), D0
+    ),
+    {ok, E2} = quic_qpack:process_decoder_instructions(
+        quic_qpack:encode_insert_count_increment(1), quic_qpack:clear_encoder_instructions(E1)
+    ),
+    {Ref, _E3} = quic_qpack:encode(H, 4, E2),
+    %% The re-encode is a dynamic Indexed Field Line (10xxxxxx) after the
+    %% 2-byte prefix, not another literal.
+    <<_Prefix:2/binary, Tag:2, _/bitstring>> = Ref,
+    ?assertEqual(2#10, Tag),
+    ?assertEqual({ok, H}, element(1, quic_qpack:decode(Ref, D1))).
+
+%% Reference a NON-newest entry (RIC < insert_count). The field section must
+%% signal Base = insert_count (DeltaBase = insert_count - RIC); signalling
+%% Base = RIC made the decoder resolve the wrong absolute index.
+dynamic_reference_older_entry_roundtrip_test() ->
+    A = {<<"a">>, <<"1">>},
+    B = {<<"b">>, <<"2">>},
+    E0 = quic_qpack:new(#{max_dynamic_size => 4096}),
+    D0 = quic_qpack:new(#{max_dynamic_size => 4096}),
+    {_, E1} = quic_qpack:encode([A], 0, E0),
+    {ok, D1} = quic_qpack:process_encoder_instructions(
+        quic_qpack:get_encoder_instructions(E1), D0
+    ),
+    {_, E2} = quic_qpack:encode([B], 4, quic_qpack:clear_encoder_instructions(E1)),
+    {ok, D2} = quic_qpack:process_encoder_instructions(
+        quic_qpack:get_encoder_instructions(E2), D1
+    ),
+    {ok, E3} = quic_qpack:process_decoder_instructions(
+        quic_qpack:encode_insert_count_increment(2), quic_qpack:clear_encoder_instructions(E2)
+    ),
+    {Ref, _E4} = quic_qpack:encode([A], 8, E3),
+    ?assertEqual({ok, [A]}, element(1, quic_qpack:decode(Ref, D2))).
+
+%% A field section that arrives before its encoder-stream inserts decodes as
+%% {blocked, RIC}; once the inserts are processed, the retry succeeds.
+dynamic_blocked_stream_recovery_test() ->
+    H = [{<<"x-custom">>, <<"value">>}],
+    E0 = quic_qpack:new(#{max_dynamic_size => 4096}),
+    D0 = quic_qpack:new(#{max_dynamic_size => 4096}),
+    {_, E1} = quic_qpack:encode(H, 0, E0),
+    Instr = quic_qpack:get_encoder_instructions(E1),
+    {ok, E2} = quic_qpack:process_decoder_instructions(
+        quic_qpack:encode_insert_count_increment(1), quic_qpack:clear_encoder_instructions(E1)
+    ),
+    {Ref, _E3} = quic_qpack:encode(H, 4, E2),
+    ?assertMatch({blocked, 1}, element(1, quic_qpack:decode(Ref, D0))),
+    {ok, D1} = quic_qpack:process_encoder_instructions(Instr, D0),
+    ?assertEqual({ok, H}, element(1, quic_qpack:decode(Ref, D1))).
+
+%%====================================================================
 %% Huffman Encoding Tests
 %%====================================================================
 

--- a/test/quic_qpack_tests.erl
+++ b/test/quic_qpack_tests.erl
@@ -124,6 +124,29 @@ encode_response_headers_bytes_test() ->
     ?assertEqual(<<16#00, 16#00, 16#D9, 16#54, 16#01, 16#31>>, Encoded).
 
 %%====================================================================
+%% Field Section Prefix Base reconstruction (RFC 9204 Section 4.5.1.2)
+%%
+%%   if Sign == 0: Base = ReqInsertCount + DeltaBase
+%%   else:         Base = ReqInsertCount - DeltaBase - 1
+%%====================================================================
+
+decode_base_sign_zero_test() ->
+    %% S=0: Base = Required Insert Count + Delta Base.
+    ?assertEqual(13, quic_qpack:decode_base(0, 10, 3)).
+
+decode_base_sign_one_test() ->
+    %% S=1: Base = Required Insert Count - Delta Base - 1.
+    ?assertEqual(6, quic_qpack:decode_base(1, 10, 3)).
+
+decode_base_static_only_test() ->
+    %% Static-only prefix (00 00): RIC=0, S=0, DeltaBase=0 -> Base=0.
+    ?assertEqual(0, quic_qpack:decode_base(0, 0, 0)).
+
+decode_base_sign_one_boundary_test() ->
+    %% S=1 with DeltaBase=0 -> Base = RIC - 1.
+    ?assertEqual(4, quic_qpack:decode_base(1, 5, 0)).
+
+%%====================================================================
 %% Literal Header Tests
 %%====================================================================
 

--- a/test/quic_qpack_tests.erl
+++ b/test/quic_qpack_tests.erl
@@ -91,6 +91,39 @@ static_table_content_type_test() ->
     ?assertEqual(Headers, Decoded).
 
 %%====================================================================
+%% Byte-vector Tests (RFC 9204 wire format)
+%%
+%% The round-trip tests above pass even when the encoder emits a
+%% malformed prefix, because the bundled decoder is lenient. These
+%% assert the exact bytes a conformant peer (e.g. nghttp3) would see.
+%%====================================================================
+
+field_section_prefix_static_only_test() ->
+    %% RFC 9204 Section 4.5.1: a static-only field section carries
+    %% Required Insert Count 0 and Base 0, encoded as S=0, DeltaBase=0.
+    %% The two-byte prefix is therefore `00 00`. A Base byte of 0x80
+    %% (S=1) would mean Base = RIC - DeltaBase - 1 = -1 and is rejected
+    %% as QPACK_DECOMPRESSION_FAILED.
+    Encoded = quic_qpack:encode([{<<":status">>, <<"200">>}]),
+    ?assertMatch(<<16#00, 16#00, _/binary>>, Encoded).
+
+encode_status_200_bytes_test() ->
+    %% Prefix `00 00` + `:status 200` as static index 25 (indexed field
+    %% line `11011001` = 0xD9).
+    Encoded = quic_qpack:encode([{<<":status">>, <<"200">>}]),
+    ?assertEqual(<<16#00, 16#00, 16#D9>>, Encoded).
+
+encode_response_headers_bytes_test() ->
+    %% Prefix `00 00` + `:status 200` (0xD9) + `content-length 1`:
+    %% literal with name reference to static index 4 (`01010100` = 0x54),
+    %% value "1" as a one-byte literal string (`01` length, `31`).
+    Encoded = quic_qpack:encode([
+        {<<":status">>, <<"200">>},
+        {<<"content-length">>, <<"1">>}
+    ]),
+    ?assertEqual(<<16#00, 16#00, 16#D9, 16#54, 16#01, 16#31>>, Encoded).
+
+%%====================================================================
 %% Literal Header Tests
 %%====================================================================
 

--- a/test/quic_qpack_tests.erl
+++ b/test/quic_qpack_tests.erl
@@ -279,6 +279,34 @@ dynamic_blocked_stream_recovery_test() ->
     {ok, D1} = quic_qpack:process_encoder_instructions(Instr, D0),
     ?assertEqual({ok, H}, element(1, quic_qpack:decode(Ref, D1))).
 
+%% A Required Insert Count whose encoded value reaches 255 must use the
+%% 8-bit prefix-integer continuation encoding (RFC 9204 Section 4.5.1.1);
+%% packing it as a raw byte truncated the prefix and silently dropped the
+%% section. Insert 254 entries, then reference entry 253 (RIC = 254 ->
+%% encoded insert count 255).
+dynamic_large_insert_count_roundtrip_test() ->
+    Cap = 4096,
+    E0 = quic_qpack:new(#{max_dynamic_size => Cap}),
+    D0 = quic_qpack:new(#{max_dynamic_size => Cap}),
+    {Ef, Df} = lists:foldl(
+        fun(I, {E, D}) ->
+            H = [{<<"h", (integer_to_binary(I))/binary>>, <<"v">>}],
+            {_, E1} = quic_qpack:encode(H, I, E),
+            {ok, D1} = quic_qpack:process_encoder_instructions(
+                quic_qpack:get_encoder_instructions(E1), D
+            ),
+            {quic_qpack:clear_encoder_instructions(E1), D1}
+        end,
+        {E0, D0},
+        lists:seq(0, 253)
+    ),
+    {ok, Eack} = quic_qpack:process_decoder_instructions(
+        quic_qpack:encode_insert_count_increment(254), Ef
+    ),
+    H = [{<<"h253">>, <<"v">>}],
+    {Ref, _E} = quic_qpack:encode(H, 999, Eack),
+    ?assertEqual({ok, H}, element(1, quic_qpack:decode(Ref, Df))).
+
 %%====================================================================
 %% Huffman Encoding Tests
 %%====================================================================


### PR DESCRIPTION
The QPACK Encoded Field Section Prefix and the dynamic table did not follow RFC 9204. Because of that, nghttp3 rejected the encoder output and the dynamic table did not work. The library's own decoder is not strict, so the bug stayed hidden. The dynamic path also had no round-trip tests. This PR fixes the prefix Base (encode and decode), the Insert With Literal Name opcode, the dynamic-table Base frame, and the Required Insert Count integer width. It also adds round-trip tests and nghttp3 interop tests.

Example, static `:status: 200`: `00 80 D9` becomes `00 00 D9`. The old Base byte `0x80` means Base = -1, which a strict decoder rejects.

The main rule is RFC 9204 §4.5.1.2 (Base):

> A Sign bit of 0 indicates that the Base is greater than or equal to the value of the Required Insert Count; the decoder adds the value of Delta Base to the Required Insert Count to determine the value of the Base. A Sign bit of 1 indicates that the Base is less than the Required Insert Count; the decoder subtracts the value of Delta Base from the Required Insert Count and also subtracts one [...]. That is:
>
> ```
> if Sign == 0: Base = ReqInsertCount + DeltaBase
> else:         Base = ReqInsertCount - DeltaBase - 1
> ```
>
> An encoder that produces table updates before encoding a field section might set Base to the value of Required Insert Count. In such a case, both the Sign bit and the Delta Base will be set to zero.

So a static-only section (Required Insert Count 0, Base 0) is `00 00`. A dynamic section signals `Base = insert_count` with `DeltaBase = insert_count - RIC`. Related parts: §4.5.1.1 (the Required Insert Count is an 8-bit prefix integer, not a raw byte) and §4.3.3 (Insert With Literal Name is `01Hxxxxx`).

Verified against nghttp3: `h2load --alpn-list=h3` went from 0/200 to 200/200, and the qifs dynamic fixtures (capacity 256 and 4096) now decode correctly.

These bugs came up while adding HTTP/3 to roadrunner (arizona-framework/roadrunner#20), which builds on erlang_quic.

Thanks for the library, @benoitc! I am happy to change anything here if you prefer a different approach.