### PR TITLE
refactor(qpack): move field-section prefix reconstruction into its own module

### DIFF
--- a/src/qpack/quic_qpack.erl
+++ b/src/qpack/quic_qpack.erl
@@ -71,11 +71,6 @@
     encode_stream_cancel/1
 ]).
 
-%% Exported for unit tests only.
--ifdef(TEST).
--export([decode_base/3]).
--endif.
-
 %%====================================================================
 %% Types
 %%====================================================================
@@ -786,35 +781,10 @@ decode_prefix(Data, State) ->
                 end,
             %% Reconstruct RIC using modulo arithmetic
             MaxEntries = max(1, State#qpack.dyn_max_size div ?ENTRY_OVERHEAD),
-            RIC = decode_ric(ERIC, MaxEntries, State#qpack.insert_count),
+            RIC = quic_qpack_prefix:decode_ric(ERIC, MaxEntries, State#qpack.insert_count),
             %% Reconstruct Base per RFC 9204 Section 4.5.1.2.
-            Base = decode_base(SBit, RIC, DeltaBase),
+            Base = quic_qpack_prefix:decode_base(SBit, RIC, DeltaBase),
             {{RIC, Base}, Rest2}
-    end.
-
-%% Reconstruct the Base from the field section prefix Sign bit and Delta
-%% Base (RFC 9204 Section 4.5.1.2):
-%%   S=0 -> Base = ReqInsertCount + DeltaBase     (Base >= Required Insert Count)
-%%   S=1 -> Base = ReqInsertCount - DeltaBase - 1  (Base < Required Insert Count)
--spec decode_base(0 | 1, non_neg_integer(), non_neg_integer()) -> integer().
-decode_base(0, RIC, DeltaBase) ->
-    RIC + DeltaBase;
-decode_base(1, RIC, DeltaBase) ->
-    RIC - DeltaBase - 1.
-
-%% Decode Required Insert Count per RFC 9204 Section 4.5.1.1
--spec decode_ric(non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
-    non_neg_integer().
-decode_ric(0, _MaxEntries, _TotalInsertCount) ->
-    0;
-decode_ric(ERIC, MaxEntries, TotalInsertCount) ->
-    FullRange = 2 * MaxEntries,
-    MaxValue = TotalInsertCount + MaxEntries,
-    MaxWrapped = (MaxValue div FullRange) * FullRange,
-    RIC = MaxWrapped + ERIC - 1,
-    case RIC > MaxValue of
-        true -> RIC - FullRange;
-        false -> RIC
     end.
 
 %% Decode headers with Required Insert Count (RIC) and Base from prefix

--- a/src/qpack/quic_qpack_prefix.erl
+++ b/src/qpack/quic_qpack_prefix.erl
@@ -1,0 +1,42 @@
+%%% -*- erlang -*-
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+%%% @doc Encoded Field Section Prefix reconstruction for QPACK (RFC 9204
+%%% Section 4.5.1): rebuild the Required Insert Count and Base from the wire.
+%%% @end
+-module(quic_qpack_prefix).
+
+-export([
+    decode_ric/3,
+    decode_base/3
+]).
+
+%% @doc Reconstruct the Required Insert Count from its encoded value using the
+%% modulo scheme of RFC 9204 Section 4.5.1.1. `MaxEntries` is the table's
+%% maximum entry count and `TotalInsertCount` the decoder's current insert
+%% count.
+-spec decode_ric(non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
+    non_neg_integer().
+decode_ric(0, _MaxEntries, _TotalInsertCount) ->
+    0;
+decode_ric(ERIC, MaxEntries, TotalInsertCount) ->
+    FullRange = 2 * MaxEntries,
+    MaxValue = TotalInsertCount + MaxEntries,
+    MaxWrapped = (MaxValue div FullRange) * FullRange,
+    RIC = MaxWrapped + ERIC - 1,
+    case RIC > MaxValue of
+        true -> RIC - FullRange;
+        false -> RIC
+    end.
+
+%% @doc Reconstruct the Base from the field section prefix Sign bit and Delta
+%% Base (RFC 9204 Section 4.5.1.2):
+%%   S=0 -> Base = ReqInsertCount + DeltaBase      (Base >= Required Insert Count)
+%%   S=1 -> Base = ReqInsertCount - DeltaBase - 1   (Base < Required Insert Count)
+-spec decode_base(0 | 1, non_neg_integer(), non_neg_integer()) -> integer().
+decode_base(0, RIC, DeltaBase) ->
+    RIC + DeltaBase;
+decode_base(1, RIC, DeltaBase) ->
+    RIC - DeltaBase - 1.

--- a/test/quic_qpack_tests.erl
+++ b/test/quic_qpack_tests.erl
@@ -132,19 +132,45 @@ encode_response_headers_bytes_test() ->
 
 decode_base_sign_zero_test() ->
     %% S=0: Base = Required Insert Count + Delta Base.
-    ?assertEqual(13, quic_qpack:decode_base(0, 10, 3)).
+    ?assertEqual(13, quic_qpack_prefix:decode_base(0, 10, 3)).
 
 decode_base_sign_one_test() ->
     %% S=1: Base = Required Insert Count - Delta Base - 1.
-    ?assertEqual(6, quic_qpack:decode_base(1, 10, 3)).
+    ?assertEqual(6, quic_qpack_prefix:decode_base(1, 10, 3)).
 
 decode_base_static_only_test() ->
     %% Static-only prefix (00 00): RIC=0, S=0, DeltaBase=0 -> Base=0.
-    ?assertEqual(0, quic_qpack:decode_base(0, 0, 0)).
+    ?assertEqual(0, quic_qpack_prefix:decode_base(0, 0, 0)).
 
 decode_base_sign_one_boundary_test() ->
     %% S=1 with DeltaBase=0 -> Base = RIC - 1.
-    ?assertEqual(4, quic_qpack:decode_base(1, 5, 0)).
+    ?assertEqual(4, quic_qpack_prefix:decode_base(1, 5, 0)).
+
+%%====================================================================
+%% Required Insert Count reconstruction (RFC 9204 Section 4.5.1.1)
+%%
+%%   EncInsertCount = 0 -> RIC = 0
+%%   else MaxValue   = TotalInserts + MaxEntries
+%%        MaxWrapped = floor(MaxValue / 2*MaxEntries) * 2*MaxEntries
+%%        RIC        = MaxWrapped + EncInsertCount - 1  (wrap if > MaxValue)
+%%====================================================================
+
+decode_ric_zero_test() ->
+    %% EncInsertCount 0 decodes to 0 regardless of table state.
+    ?assertEqual(0, quic_qpack_prefix:decode_ric(0, 128, 1000)).
+
+decode_ric_no_wrap_test() ->
+    %% MaxEntries=128: RIC=1 encodes as (1 rem 256)+1 = 2.
+    ?assertEqual(1, quic_qpack_prefix:decode_ric(2, 128, 1)).
+
+decode_ric_no_wrap_large_test() ->
+    %% RIC=100 encodes as (100 rem 256)+1 = 101.
+    ?assertEqual(100, quic_qpack_prefix:decode_ric(101, 128, 100)).
+
+decode_ric_wraparound_test() ->
+    %% MaxEntries=2 (FullRange 4), TotalInserts=10: EncInsertCount 2 wraps
+    %% back to RIC=9 ((9 rem 4)+1 = 2).
+    ?assertEqual(9, quic_qpack_prefix:decode_ric(2, 2, 10)).
 
 %%====================================================================
 %% Literal Header Tests


### PR DESCRIPTION
Moves the Encoded Field Section Prefix reconstruction (Required Insert Count and Base, RFC 9204 Section 4.5.1) out of `quic_qpack` into a new `quic_qpack_prefix` module, dropping the `-ifdef(TEST)` `decode_base/3` export. `quic_qpack_prefix:decode_ric/3` and `decode_base/3` are plain functions now covered by direct unit tests.

Follow-up to #142.