### PR TITLE
Fix server cert chain validation for HTTP/3 clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.4.5] - 2026-05-28
+
+### Fixed
+- Server certificate chain validation accepts chains where the server sends an extra or cross-signed cert above the cert that actually anchors. The previous topmost-only anchor lookup rejected valid chains (notably `cloudflare.com` over Google Trust Services on Mozilla NSS, `certifi` and FreeBSD `ca_root_nss`) with `unknown_ca`. The client now walks the served chain for the highest cert whose issuer is in the trust store and validates the sub-path from there.
+- Server certificate verification failures reach the QUIC owner as a synchronous `{closed, {certificate_invalid, _}}` event alongside the existing `{error, {certificate_invalid, _}}` notification, so HTTP/3 clients waiting on the close fail fast instead of stalling until their connect timeout fires.
+
 ## [1.4.4] - 2026-05-28
 
 ### Security

--- a/src/quic.app.src
+++ b/src/quic.app.src
@@ -1,6 +1,6 @@
 {application, quic, [
     {description, "Pure Erlang QUIC implementation (RFC 9000)"},
-    {vsn, "1.4.4"},
+    {vsn, "1.4.5"},
     {registered, [
         quic_sup,
         quic_server_registry,

--- a/src/quic_cert.erl
+++ b/src/quic_cert.erl
@@ -67,12 +67,11 @@ verify_chain(Leaf, Intermediates, Anchors) ->
     %% issued by the anchor down to the leaf; the wire order is the
     %% reverse (leaf first).
     Path = lists:reverse([Leaf | Intermediates]),
-    Top = hd(Path),
-    case find_anchor(Top, Anchors) of
-        {ok, Anchor} ->
+    case anchored_subpath(Path, Anchors) of
+        {ok, Anchor, SubPath} ->
             try
                 public_key:pkix_path_validation(
-                    Anchor, Path, [{max_path_length, ?MAX_PATH_LENGTH}]
+                    Anchor, SubPath, [{max_path_length, ?MAX_PATH_LENGTH}]
                 )
             of
                 {ok, _} -> ok;
@@ -82,6 +81,17 @@ verify_chain(Leaf, Intermediates, Anchors) ->
             end;
         error ->
             {error, unknown_ca}
+    end.
+
+%% Highest cert in the path whose issuer is a trust anchor, plus the
+%% sub-path from that cert down to the leaf. Lets the server send extra
+%% or cross-signed certs above the cert that actually chains.
+anchored_subpath([], _Anchors) ->
+    error;
+anchored_subpath([Cert | Rest] = SubPath, Anchors) ->
+    case find_anchor(Cert, Anchors) of
+        {ok, Anchor} -> {ok, Anchor, SubPath};
+        error -> anchored_subpath(Rest, Anchors)
     end.
 
 %% Find the anchor that issued `Cert' (a self-signed cert is its own

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8449,11 +8449,16 @@ verify_server_authentication(Body, TranscriptHash, Advance, State) ->
                         #{what => server_cert_invalid, reason => Reason}, ?QUIC_LOG_META
                     ),
                     notify_owner({error, {certificate_invalid, Reason}}, State),
+                    %% Synchronous close event so callers waiting on
+                    %% `{closed, _}' fail fast, not after the alert
+                    %% round-trips through the state machine.
+                    notify_owner({closed, {certificate_invalid, Reason}}, State),
                     send_tls_alert(cert_alert_code(Reason), State)
             end;
         false ->
             ?LOG_ERROR(#{what => server_cert_verify_failed}, ?QUIC_LOG_META),
             notify_owner({error, {certificate_invalid, bad_signature}}, State),
+            notify_owner({closed, {certificate_invalid, bad_signature}}, State),
             send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State)
     end.
 

--- a/test/quic_cert_tests.erl
+++ b/test/quic_cert_tests.erl
@@ -50,6 +50,51 @@ validate_server_test_() ->
             []
     end.
 
+%% Regression: a server commonly sends an extra or cross-signed cert
+%% above the cert that actually chains to a trust anchor (e.g.
+%% cloudflare.com over Google Trust Services with the Mozilla NSS /
+%% certifi bundle). The topmost-only anchor lookup used to reject these
+%% chains with `unknown_ca'.
+cross_signed_chain_test_() ->
+    case gen_ca_files("/CN=RootA") of
+        {ok, RootA} ->
+            {ok, Int} = gen_signed_cert(
+                "/CN=IntA", "basicConstraints=critical,CA:true", RootA
+            ),
+            {ok, Leaf} = gen_signed_cert(
+                "/CN=leaf.test", "subjectAltName=DNS:leaf.test", Int
+            ),
+            {ok, Extra, _} = gen_cert("/CN=Extra", "subjectAltName=DNS:extra"),
+            #{cert := RootADer} = RootA,
+            #{cert := IntDer} = Int,
+            #{cert := LeafDer} = Leaf,
+            [
+                {"extra cross-signed cert above the anchored intermediate is accepted",
+                    ?_assertEqual(
+                        ok,
+                        quic_cert:validate_server(
+                            LeafDer, [IntDer, Extra], [RootADer], <<"leaf.test">>
+                        )
+                    )},
+                {"chain with only the unrelated root as anchor is rejected",
+                    ?_assertMatch(
+                        {error, _},
+                        quic_cert:validate_server(
+                            LeafDer, [IntDer, Extra], [Extra], <<"leaf.test">>
+                        )
+                    )},
+                {"two-cert chain without the extra cert validates",
+                    ?_assertEqual(
+                        ok,
+                        quic_cert:validate_server(
+                            LeafDer, [IntDer], [RootADer], <<"leaf.test">>
+                        )
+                    )}
+            ];
+        {error, _} ->
+            []
+    end.
+
 %%====================================================================
 %% End-to-end client behaviour
 %%====================================================================
@@ -303,6 +348,67 @@ gen_cert(Subject, SanExt) ->
             {ok, KeyPem} = file:read_file(KeyFile),
             [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
             {ok, CertDer, decode_key(KeyPem)};
+        _ ->
+            {error, cert_generation_failed}
+    end.
+
+%% Make a self-signed CA cert (CA:true). Returns the DER plus the
+%% openssl files so other certs can be signed by it.
+gen_ca_files(Subject) ->
+    Dir = filename:join("/tmp", "quic_cert_test_" ++ suffix()),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    KeyFile = filename:join(Dir, "ca.key"),
+    CertFile = filename:join(Dir, "ca.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -keyout ~s -out ~s "
+            "-days 1 -nodes -subj '~s' "
+            "-addext basicConstraints=critical,CA:true 2>/dev/null",
+            [KeyFile, CertFile, Subject]
+        )
+    ),
+    _ = os:cmd(Cmd),
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            {ok, CertPem} = file:read_file(CertFile),
+            [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+            {ok, #{cert => CertDer, cert_file => CertFile, key_file => KeyFile}};
+        _ ->
+            {error, cert_generation_failed}
+    end.
+
+%% CSR for `Subject', signed by `Parent's' files with `Ext' as the
+%% x509v3 extensions. Returns the DER plus openssl files so further
+%% intermediates can chain off it.
+gen_signed_cert(Subject, Ext, #{cert_file := ParentCert, key_file := ParentKey}) ->
+    Dir = filename:join("/tmp", "quic_cert_test_" ++ suffix()),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    KeyFile = filename:join(Dir, "key.pem"),
+    CsrFile = filename:join(Dir, "csr.pem"),
+    CertFile = filename:join(Dir, "cert.pem"),
+    ExtFile = filename:join(Dir, "ext.cnf"),
+    ok = file:write_file(ExtFile, Ext),
+    CsrCmd = lists:flatten(
+        io_lib:format(
+            "openssl req -newkey rsa:2048 -keyout ~s -out ~s "
+            "-nodes -subj '~s' 2>/dev/null",
+            [KeyFile, CsrFile, Subject]
+        )
+    ),
+    SignCmd = lists:flatten(
+        io_lib:format(
+            "openssl x509 -req -in ~s -CA ~s -CAkey ~s -CAcreateserial "
+            "-out ~s -days 1 -extfile ~s 2>/dev/null",
+            [CsrFile, ParentCert, ParentKey, CertFile, ExtFile]
+        )
+    ),
+    _ = os:cmd(CsrCmd),
+    _ = os:cmd(SignCmd),
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            {ok, CertPem} = file:read_file(CertFile),
+            [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+            {ok, #{cert => CertDer, cert_file => CertFile, key_file => KeyFile}};
         _ ->
             {error, cert_generation_failed}
     end.


### PR DESCRIPTION
The QUIC client's topmost-only anchor lookup rejected valid chains that include an extra or cross-signed cert above the cert that actually anchors. With trust stores like Mozilla NSS, certifi and FreeBSD ca_root_nss this failed against real servers (notably cloudflare.com over Google Trust Services) with unknown_ca, while Debian/macOS bundles happened to pass.

The fix walks the served chain for the highest cert whose issuer is in the trust store and validates the sub-path from there, dropping any extra certs above. The QUIC owner also gets a synchronous {closed, {certificate_invalid, _}} event on verification failure so HTTP/3 callers fail fast instead of timing out.

Ships as 1.4.5.