### PR TITLE
Bind IPv6 listeners and sockets

### DIFF
--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -204,6 +204,7 @@ init_genudp_backend(Port, Opts) ->
     ActiveN = maps:get(active_n, Opts, 100),
     ReusePort = maps:get(reuseport, Opts, false),
     ExtraFlags = maps:get(extra_socket_opts, Opts, []),
+    Family = extra_socket_family(ExtraFlags),
 
     %% UDP buffer sizing - larger buffers improve throughput significantly
     %% OS may cap to lower values (check sysctl net.core.rmem_max on Linux)
@@ -213,7 +214,7 @@ init_genudp_backend(Port, Opts) ->
     SocketOpts =
         [
             binary,
-            inet,
+            Family,
             {active, ActiveN},
             {reuseaddr, true},
             {recbuf, RecBuf},
@@ -228,6 +229,19 @@ init_genudp_backend(Port, Opts) ->
             {ok, {Socket, undefined, gen_udp, Opts}, {continue, discover_manager}};
         {error, Reason} ->
             {stop, Reason}
+    end.
+
+%% Infer the UDP address family from caller socket options: inet6 when an
+%% `inet6' atom or an 8-tuple `{ip, _}' is present, inet otherwise.
+extra_socket_family(Extra) ->
+    case lists:member(inet6, Extra) of
+        true ->
+            inet6;
+        false ->
+            case proplists:get_value(ip, Extra) of
+                {_, _, _, _, _, _, _, _} -> inet6;
+                _ -> inet
+            end
     end.
 
 %% @doc false

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -135,7 +135,8 @@
 -spec open(inet:port_number(), map()) ->
     {ok, socket_state()} | {error, term()}.
 open(Port, Opts) ->
-    Capabilities = detect_capabilities(),
+    Family = extra_socket_family(maps:get(extra_socket_opts, Opts, [])),
+    Capabilities = detect_capabilities(Family),
     Backend = maps:get(backend, Capabilities, gen_udp),
     GSOSupported = maps:get(gso, Capabilities, false),
     GROSupported = maps:get(gro, Capabilities, false),
@@ -147,7 +148,7 @@ open(Port, Opts) ->
 
     case Backend of
         socket ->
-            open_socket_backend(Port, Opts, #{
+            open_socket_backend(Port, Family, Opts, #{
                 gso_supported => GSOSupported,
                 gro_supported => GROSupported,
                 batching_enabled => BatchingEnabled,
@@ -168,7 +169,8 @@ open(Port, Opts) ->
 -spec open_for_send(inet:ip_address(), map()) ->
     {ok, socket_state()} | {error, term()}.
 open_for_send(RemoteIP, Opts) ->
-    Capabilities = detect_capabilities(),
+    Family = family(RemoteIP),
+    Capabilities = detect_capabilities(Family),
     %% Allow the caller to force a backend (via `backend => socket'
     %% in Opts) so the opt-in client path can request the OTP socket
     %% NIF even on platforms where capability detection would pick
@@ -188,14 +190,14 @@ open_for_send(RemoteIP, Opts) ->
 
     case Backend of
         socket ->
-            open_send_socket_backend(RemoteIP, Opts, #{
+            open_send_socket_backend(Family, Opts, #{
                 gso_supported => GSOSupported,
                 batching_enabled => BatchingEnabled,
                 max_batch => MaxBatch,
                 gso_size => GSOSize
             });
         gen_udp ->
-            open_send_genudp_backend(RemoteIP, Opts, #{
+            open_send_genudp_backend(Family, Opts, #{
                 batching_enabled => BatchingEnabled,
                 max_batch => MaxBatch,
                 gso_size => GSOSize
@@ -208,7 +210,8 @@ open_for_send(RemoteIP, Opts) ->
 -spec open_server_send({inet:ip_address(), inet:port_number()}, map()) ->
     {ok, socket_state()} | {error, term()}.
 open_server_send({LocalIP, LocalPort}, Opts) ->
-    Capabilities = detect_capabilities(),
+    Family = family(LocalIP),
+    Capabilities = detect_capabilities(Family),
     Backend = maps:get(backend, Capabilities, gen_udp),
     GSOSupported = maps:get(gso, Capabilities, false),
 
@@ -226,14 +229,13 @@ open_server_send({LocalIP, LocalPort}, Opts) ->
 
     case Backend of
         socket ->
-            open_server_send_socket(LocalIP, LocalPort, Opts, BatchConfig);
+            open_server_send_socket(LocalIP, LocalPort, Family, Opts, BatchConfig);
         gen_udp ->
             open_server_send_genudp(LocalIP, LocalPort, Opts, BatchConfig)
     end.
 
 %% Open OTP socket for server send with reuseport binding
-open_server_send_socket(LocalIP, LocalPort, Opts, BatchConfig) ->
-    Family = family(LocalIP),
+open_server_send_socket(LocalIP, LocalPort, Family, Opts, BatchConfig) ->
     case socket:open(Family, dgram, udp) of
         {ok, Socket} ->
             configure_server_send_socket(Socket, LocalIP, LocalPort, Family, Opts, BatchConfig);
@@ -688,12 +690,18 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
             ok
     end.
 
-%% @doc Detect platform capabilities for GSO/GRO.
+%% @doc Detect platform capabilities for GSO/GRO. Context-free wrapper that
+%% probes the IPv4 family; callers that know their target family should use
+%% detect_capabilities/1 so an IPv6-only host is not wrongly downgraded.
 -spec detect_capabilities() -> map().
 detect_capabilities() ->
+    detect_capabilities(inet).
+
+-spec detect_capabilities(inet | inet6) -> map().
+detect_capabilities(Family) ->
     case os:type() of
         {unix, linux} ->
-            detect_linux_capabilities();
+            detect_linux_capabilities(Family);
         _ ->
             #{gso => false, gro => false, backend => gen_udp}
     end.
@@ -702,19 +710,22 @@ detect_capabilities() ->
 %% Internal Functions - Socket Backend
 %%====================================================================
 
-open_socket_backend(Port, Opts, BatchConfig) ->
-    case socket:open(inet, dgram, udp) of
+open_socket_backend(Port, Family, Opts, BatchConfig) ->
+    case socket:open(Family, dgram, udp) of
         {ok, Socket} ->
-            configure_and_bind_socket(Socket, Port, Opts, BatchConfig);
+            configure_and_bind_socket(Socket, Port, Family, Opts, BatchConfig);
         {error, _} = Error ->
             Error
     end.
 
-configure_and_bind_socket(Socket, Port, Opts, BatchConfig) ->
+configure_and_bind_socket(Socket, Port, Family, Opts, BatchConfig) ->
     ok = socket:setopt(Socket, {socket, reuseaddr}, true),
     set_socket_buffer_sizes(Socket, Opts),
     maybe_set_reuseport(Socket, Opts),
-    bind_and_finalize_socket(Socket, Port, BatchConfig).
+    %% Honor a specific bind address from extra_socket_opts {ip, Addr};
+    %% fall back to the family wildcard.
+    BindAddr = proplists:get_value(ip, maps:get(extra_socket_opts, Opts, []), any),
+    bind_and_finalize_socket(Socket, Port, Family, BindAddr, BatchConfig).
 
 set_socket_buffer_sizes(Socket, Opts) ->
     RecBuf = maps:get(recbuf, Opts, ?DEFAULT_UDP_RECBUF),
@@ -729,8 +740,8 @@ maybe_set_reuseport(Socket, Opts) ->
         false -> ok
     end.
 
-bind_and_finalize_socket(Socket, Port, BatchConfig) ->
-    Addr = #{family => inet, addr => any, port => Port},
+bind_and_finalize_socket(Socket, Port, Family, BindAddr, BatchConfig) ->
+    Addr = #{family => Family, addr => BindAddr, port => Port},
     case socket:bind(Socket, Addr) of
         ok ->
             build_socket_state(Socket, BatchConfig);
@@ -784,8 +795,7 @@ maybe_enable_gro(_, _) ->
 %%====================================================================
 
 %% Open socket backend optimized for sending (no binding to specific port)
-open_send_socket_backend(RemoteIP, Opts, BatchConfig) ->
-    Family = family(RemoteIP),
+open_send_socket_backend(Family, Opts, BatchConfig) ->
     case socket:open(Family, dgram, udp) of
         {ok, Socket} ->
             configure_send_socket(Socket, Opts, BatchConfig);
@@ -816,8 +826,8 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
     {ok, State}.
 
 %% Open gen_udp backend optimized for sending (ephemeral port)
-open_send_genudp_backend(_RemoteIP, Opts, BatchConfig) ->
-    SocketOpts = build_send_genudp_opts(Opts),
+open_send_genudp_backend(Family, Opts, BatchConfig) ->
+    SocketOpts = build_send_genudp_opts(Family, Opts),
     case gen_udp:open(0, SocketOpts) of
         {ok, Socket} ->
             {ok, build_genudp_state(Socket, BatchConfig)};
@@ -825,14 +835,14 @@ open_send_genudp_backend(_RemoteIP, Opts, BatchConfig) ->
             Error
     end.
 
-build_send_genudp_opts(Opts) ->
+build_send_genudp_opts(Family, Opts) ->
     ActiveN = maps:get(active_n, Opts, 100),
     ExtraFlags = maps:get(extra_socket_opts, Opts, []),
     RecBuf = maps:get(recbuf, Opts, ?DEFAULT_UDP_RECBUF),
     SndBuf = maps:get(sndbuf, Opts, ?DEFAULT_UDP_SNDBUF),
     [
         binary,
-        inet,
+        Family,
         {active, ActiveN},
         {reuseaddr, true},
         {recbuf, RecBuf},
@@ -860,7 +870,7 @@ build_genudp_opts(Opts) ->
     SndBuf = maps:get(sndbuf, Opts, ?DEFAULT_UDP_SNDBUF),
     BaseOpts = [
         binary,
-        inet,
+        extra_socket_family(ExtraFlags),
         {active, ActiveN},
         {reuseaddr, true},
         {recbuf, RecBuf},
@@ -1153,6 +1163,19 @@ record_flush(
 family({_, _, _, _}) -> inet;
 family({_, _, _, _, _, _, _, _}) -> inet6.
 
+%% Infer the UDP address family from caller socket options: inet6 when an
+%% `inet6' atom or an 8-tuple `{ip, _}' is present, inet otherwise.
+extra_socket_family(Extra) ->
+    case lists:member(inet6, Extra) of
+        true ->
+            inet6;
+        false ->
+            case proplists:get_value(ip, Extra) of
+                {_, _, _, _, _, _, _, _} -> inet6;
+                _ -> inet
+            end
+    end.
+
 %%====================================================================
 %% Internal Functions - GRO Receive
 %%====================================================================
@@ -1200,14 +1223,14 @@ split_gro_packets(Data, SegmentSize, Acc) ->
 %% Internal Functions - Linux Capability Detection
 %%====================================================================
 
-detect_linux_capabilities() ->
+detect_linux_capabilities(Family) ->
     %% Check OTP version - need 27+ for socket module features
     case otp_version_check() of
         false ->
             #{gso => false, gro => false, backend => gen_udp};
         true ->
             %% Try to create a test socket and check GSO/GRO
-            test_linux_socket_capabilities()
+            test_linux_socket_capabilities(Family)
     end.
 
 otp_version_check() ->
@@ -1220,8 +1243,8 @@ otp_version_check() ->
         _:_ -> false
     end.
 
-test_linux_socket_capabilities() ->
-    case socket:open(inet, dgram, udp) of
+test_linux_socket_capabilities(Family) ->
+    case socket:open(Family, dgram, udp) of
         {ok, Socket} ->
             %% Test GSO
             GSOSupported = test_gso(Socket),

--- a/test/quic_listener_tests.erl
+++ b/test/quic_listener_tests.erl
@@ -82,6 +82,35 @@ get_connections_empty_test() ->
     ?assertEqual([], Connections),
     ok = quic_listener:stop(Listener).
 
+%% Regression for #146: an IPv6 family in extra_socket_opts must start a
+%% listener instead of crashing init with the hard-coded inet family.
+listen_ipv6_inet6_atom_test() ->
+    listen_ipv6_with(#{extra_socket_opts => [inet6]}).
+
+listen_ipv6_bind_addr_test() ->
+    listen_ipv6_with(#{extra_socket_opts => [{ip, {0, 0, 0, 0, 0, 0, 0, 1}}]}).
+
+listen_ipv6_with(Extra) ->
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            {Cert, PrivKey} = generate_test_cert(),
+            Opts = maps:merge(#{cert => Cert, key => PrivKey, alpn => [<<"h3">>]}, Extra),
+            {ok, Listener} = quic_listener:start_link(0, Opts),
+            ?assert(is_process_alive(Listener)),
+            ok = quic_listener:stop(Listener)
+    end.
+
+ipv6_available() ->
+    case gen_udp:open(0, [binary, inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
+        {ok, S} ->
+            gen_udp:close(S),
+            true;
+        {error, _} ->
+            false
+    end.
+
 %%====================================================================
 %% Multiple Listener Tests
 %%====================================================================

--- a/test/quic_socket_tests.erl
+++ b/test/quic_socket_tests.erl
@@ -62,6 +62,46 @@ open_with_custom_batch_config_test() ->
     ?assertMatch({ok, {_, _}}, quic_socket:sockname(State)),
     ok = quic_socket:close(State).
 
+%% open/2 selects the OTP socket backend on Linux and gen_udp elsewhere, so
+%% these exercise whichever backend the platform uses.
+open_ipv4_default_test() ->
+    {ok, State} = quic_socket:open(0, #{}),
+    {ok, {Addr, _Port}} = quic_socket:sockname(State),
+    ?assertEqual(4, tuple_size(Addr)),
+    ok = quic_socket:close(State).
+
+open_ipv6_inet6_atom_test() ->
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            {ok, State} = quic_socket:open(0, #{extra_socket_opts => [inet6]}),
+            {ok, {Addr, _Port}} = quic_socket:sockname(State),
+            ?assertEqual(8, tuple_size(Addr)),
+            ok = quic_socket:close(State)
+    end.
+
+open_ipv6_bind_addr_test() ->
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            V6 = {0, 0, 0, 0, 0, 0, 0, 1},
+            {ok, State} = quic_socket:open(0, #{extra_socket_opts => [{ip, V6}]}),
+            {ok, {Addr, _Port}} = quic_socket:sockname(State),
+            ?assertEqual(V6, Addr),
+            ok = quic_socket:close(State)
+    end.
+
+ipv6_available() ->
+    case gen_udp:open(0, [binary, inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
+        {ok, S} ->
+            gen_udp:close(S),
+            true;
+        {error, _} ->
+            false
+    end.
+
 %%====================================================================
 %% Wrap Existing Socket Tests
 %%====================================================================


### PR DESCRIPTION
Listeners could not start on IPv6: the server socket paths hard-coded the `inet` family, so an IPv6 bind crashed init with `badarg` and an `inet6` entry in `extra_socket_opts` was ignored.

The address family is now inferred from `extra_socket_opts`: `inet6` when an `inet6` atom or an 8-tuple `{ip, V6}` is present, `inet` otherwise (IPv4 default unchanged). This covers the gen_udp listener, the gen_udp client/server send sockets, and the OTP `socket` backend. Capability detection probes the inferred family so an IPv6-only host keeps the socket backend, and the socket backend now binds a specific `{ip, Addr}` instead of always `any`.

```erlang
quic_listener:start_link(0, Opts#{extra_socket_opts => [inet6]}).
quic_listener:start_link(0, Opts#{extra_socket_opts => [{ip, {0,0,0,0,0,0,0,1}}]}).
```

Fixes #146