### PR TITLE
Add IPv6 client support with Happy Eyeballs

### DIFF
--- a/src/quic.erl
+++ b/src/quic.erl
@@ -169,12 +169,29 @@ get_fd(Socket) ->
     end.
 
 %% @doc Connect to a QUIC server.
-%% Returns {ok, Conn} on success where Conn is a pid().
+%% Returns {ok, Conn} on success where Conn is a pid(). `Host' may be a
+%% hostname, an IP-literal string (IPv4 or IPv6, optionally bracketed),
+%% or an `inet:ip_address()' tuple.
 %% The owner process will receive {quic, Conn, {connected, Info}}
 %% when the connection is established.
 %%
+%% For a hostname that resolves to both IPv4 and IPv6 addresses, RFC 8305
+%% Happy Eyeballs is used: the addresses are raced IPv6-first and the
+%% first to complete its handshake is returned. In that case `connect/4'
+%% blocks until the first attempt connects (or all fail / time out); a
+%% single address, IP literal/tuple, or pre-opened `socket' keeps the
+%% immediate, asynchronous return.
+%%
 %% Options:
 %% <ul>
+%%   <li>`happy_eyeballs' - Race IPv6/IPv4 for multi-address hostnames
+%%       (default: `true'). `false' forces the legacy IPv4-first resolver.</li>
+%%   <li>`family' - `inet | inet6 | any' (default `any'); restricts
+%%       resolution to one address family.</li>
+%%   <li>`connection_attempt_delay' - RFC 8305 stagger between attempts in
+%%       milliseconds (default: 250).</li>
+%%   <li>`connect_timeout' - Overall Happy Eyeballs deadline in
+%%       milliseconds (default: 5000).</li>
 %%   <li>`socket' - Use an existing UDP socket (gen_udp:socket())</li>
 %%   <li>`extra_socket_opts' - Options for socket creation (e.g., [{ip, Addr}])</li>
 %%   <li>`socket_backend' - `gen_udp' (default), `socket' (OTP NIF) or
@@ -207,14 +224,23 @@ get_fd(Socket) ->
 %%       Defaults to the historical wire list.</li>
 %% </ul>
 -spec connect(Host, Port, Opts, Owner) -> {ok, pid()} | {error, term()} when
-    Host :: binary() | string(),
+    Host :: binary() | string() | inet:ip_address(),
     Port :: inet:port_number(),
     Opts :: map(),
     Owner :: pid().
 connect(Host, Port, Opts, Owner) when is_list(Host) ->
     connect(list_to_binary(Host), Port, Opts, Owner);
 connect(Host, Port, Opts, Owner) when
-    is_binary(Host),
+    is_binary(Host), is_integer(Port), Port > 0, Port =< 65535, is_map(Opts), is_pid(Owner);
+    is_tuple(Host),
+    tuple_size(Host) =:= 4,
+    is_integer(Port),
+    Port > 0,
+    Port =< 65535,
+    is_map(Opts),
+    is_pid(Owner);
+    is_tuple(Host),
+    tuple_size(Host) =:= 8,
     is_integer(Port),
     Port > 0,
     Port =< 65535,
@@ -225,10 +251,10 @@ connect(Host, Port, Opts, Owner) when
     Socket = maps:get(socket, Opts, undefined),
     case validate_connect_opts(Socket, Opts) of
         ok ->
-            case quic_connection:start_link(Host, Port, Opts, Owner, Socket) of
-                {ok, Pid} -> {ok, Pid};
-                Error -> Error
-            end;
+            %% Resolution (and RFC 8305 Happy Eyeballs for hostnames) runs in
+            %% the caller process so a resolution failure returns {error, _}
+            %% instead of crashing the caller via the start_link.
+            quic_happy:connect(Host, Port, Opts, Owner, Socket);
         {error, _} = Error ->
             Error
     end;

--- a/src/quic_conn_sup.erl
+++ b/src/quic_conn_sup.erl
@@ -28,9 +28,11 @@ start_link() ->
     pid()
 ) -> {ok, pid()} | {error, term()}.
 start_child(Host, Port, Opts, Owner) ->
+    %% Supervised attempts are linked to this supervisor, not the caller, so
+    %% they monitor their owner to close when it dies (see quic_connection).
     Spec = #{
         id => {quic_connection, make_ref()},
-        start => {quic_connection, start_link, [Host, Port, Opts, Owner]},
+        start => {quic_connection, start_link, [Host, Port, Opts#{monitor_owner => true}, Owner]},
         restart => temporary,
         shutdown => 5000,
         type => worker,

--- a/src/quic_conn_sup.erl
+++ b/src/quic_conn_sup.erl
@@ -1,0 +1,42 @@
+%%% -*- erlang -*-
+%%%
+%%% Dynamic supervisor for client connection attempts started by the
+%%% Happy Eyeballs coordinator (quic_happy). Children are temporary
+%%% quic_connection workers identified by a unique reference so several
+%%% concurrent attempts can run under one supervisor.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+
+-module(quic_conn_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, start_child/4, init/1]).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Start a supervised client connection attempt. The connection is
+%% linked to this supervisor (not the caller), so the Happy Eyeballs
+%% coordinator can race several attempts and keep the winner after it
+%% exits. Returns the connection pid.
+-spec start_child(
+    inet:ip_address() | binary() | string(),
+    inet:port_number(),
+    map(),
+    pid()
+) -> {ok, pid()} | {error, term()}.
+start_child(Host, Port, Opts, Owner) ->
+    Spec = #{
+        id => {quic_connection, make_ref()},
+        start => {quic_connection, start_link, [Host, Port, Opts, Owner]},
+        restart => temporary,
+        shutdown => 5000,
+        type => worker,
+        modules => [quic_connection]
+    },
+    supervisor:start_child(?MODULE, Spec).
+
+init([]) ->
+    {ok, {#{strategy => one_for_one, intensity => 10, period => 10}, []}}.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1317,9 +1317,17 @@ open_client_socket_backend({IP, _Port}, Opts) ->
 address_family(IP) when tuple_size(IP) =:= 4 -> inet;
 address_family(IP) when tuple_size(IP) =:= 8 -> inet6.
 
-%% Swap the owner, re-pointing the owner monitor when one exists. Client
-%% connections monitor their owner (set in init_client_state); server
-%% connections do not (owner_mon =:= undefined) and keep that behavior.
+%% Monitor the owner only for supervised connections, which aren't linked to
+%% their caller. undefined keeps caller-linked and server connections as-is.
+maybe_monitor_owner(Opts, Owner) ->
+    case maps:get(monitor_owner, Opts, false) of
+        true -> erlang:monitor(process, Owner);
+        false -> undefined
+    end.
+
+%% Swap the owner, re-pointing the owner monitor when one exists. Supervised
+%% connections monitor their owner (set in init_client_state); caller-linked
+%% and server connections do not (owner_mon =:= undefined) and keep that.
 reown(#state{owner_mon = undefined} = State, NewOwner) ->
     State#state{owner = NewOwner};
 reown(#state{owner_mon = OldMon} = State, NewOwner) ->
@@ -1428,7 +1436,10 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         remote_addr = RemoteAddr,
         local_addr = LocalAddr,
         owner = Owner,
-        owner_mon = erlang:monitor(process, Owner),
+        %% Only supervised connections (started by quic_conn_sup) monitor their
+        %% owner; caller-linked connections rely on the link instead, so they do
+        %% not stop a different owner's death from propagating through the link.
+        owner_mon = maybe_monitor_owner(Opts, Owner),
         conn_ref = ConnRef,
         server_name = ServerName,
         verify = normalize_verify(maps:get(verify, Opts, true)),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -297,6 +297,10 @@
 
     %% Owner process (receives {quic, Conn, Event} messages where Conn is pid())
     owner :: pid(),
+    %% Monitor of the owner for client connections that are not linked to
+    %% their owner (e.g. Happy Eyeballs winners supervised by quic_conn_sup);
+    %% undefined for server connections.
+    owner_mon :: reference() | undefined,
     conn_ref :: reference(),
 
     %% Options
@@ -933,33 +937,39 @@ init([Host, Port, Opts, Owner, Socket]) ->
     SCID = generate_connection_id(),
     DCID = generate_connection_id(),
 
-    %% Determine remote address
-    RemoteAddr = resolve_address(Host, Port),
-
-    %% Create or use provided socket with proper cleanup on failure
-    %% Pass RemoteAddr to match address family (IPv4 vs IPv6)
-    %% Extra socket opts allow binding to specific address (fix for #28)
-    ExtraOpts = maps:get(extra_socket_opts, Opts, []),
-    case open_client_socket(Socket, RemoteAddr, Opts, ExtraOpts) of
-        {ok, Sock, LocalAddr, OwnsSocket} ->
-            try
-                init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr)
-            catch
-                Class:Reason:Stack ->
-                    %% Clean up socket on initialization failure — pick the
-                    %% right close based on the socket_backend option.
-                    case OwnsSocket of
-                        true -> close_raw_client_socket(Opts, Sock);
-                        false -> ok
-                    end,
-                    %% Drop any stashed socket_state left by
-                    %% open_client_socket_backend/2 (process dict)
-                    %% so we don't leak it across retries.
-                    _ = erase(client_socket_state),
-                    erlang:raise(Class, Reason, Stack)
-            end;
-        {error, Reason} ->
-            {stop, Reason}
+    %% Determine remote address (Happy Eyeballs / multi-address resolution is
+    %% handled upstream in quic_happy; here Host is a single address or name).
+    case resolve_address(Host, Port, maps:get(family, Opts, any)) of
+        {error, ResolveErr} ->
+            {stop, {resolve_failed, ResolveErr}};
+        {ok, RemoteAddr} ->
+            %% Create or use provided socket with proper cleanup on failure
+            %% Pass RemoteAddr to match address family (IPv4 vs IPv6)
+            %% Extra socket opts allow binding to specific address (fix for #28)
+            ExtraOpts = maps:get(extra_socket_opts, Opts, []),
+            case open_client_socket(Socket, RemoteAddr, Opts, ExtraOpts) of
+                {ok, Sock, LocalAddr, OwnsSocket} ->
+                    try
+                        init_client_state(
+                            Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr
+                        )
+                    catch
+                        Class:Reason:Stack ->
+                            %% Clean up socket on initialization failure — pick the
+                            %% right close based on the socket_backend option.
+                            case OwnsSocket of
+                                true -> close_raw_client_socket(Opts, Sock);
+                                false -> ok
+                            end,
+                            %% Drop any stashed socket_state left by
+                            %% open_client_socket_backend/2 (process dict)
+                            %% so we don't leak it across retries.
+                            _ = erase(client_socket_state),
+                            erlang:raise(Class, Reason, Stack)
+                    end;
+                {error, Reason} ->
+                    {stop, Reason}
+            end
     end;
 %% Server-side initialization
 init({server, Opts}) ->
@@ -1307,6 +1317,15 @@ open_client_socket_backend({IP, _Port}, Opts) ->
 address_family(IP) when tuple_size(IP) =:= 4 -> inet;
 address_family(IP) when tuple_size(IP) =:= 8 -> inet6.
 
+%% Swap the owner, re-pointing the owner monitor when one exists. Client
+%% connections monitor their owner (set in init_client_state); server
+%% connections do not (owner_mon =:= undefined) and keep that behavior.
+reown(#state{owner_mon = undefined} = State, NewOwner) ->
+    State#state{owner = NewOwner};
+reown(#state{owner_mon = OldMon} = State, NewOwner) ->
+    _ = erlang:demonitor(OldMon, [flush]),
+    State#state{owner = NewOwner, owner_mon = erlang:monitor(process, NewOwner)}.
+
 %% Continue client initialization after socket is ready
 init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
     %% Generate initial keys
@@ -1409,6 +1428,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         remote_addr = RemoteAddr,
         local_addr = LocalAddr,
         owner = Owner,
+        owner_mon = erlang:monitor(process, Owner),
         conn_ref = ConnRef,
         server_name = ServerName,
         verify = normalize_verify(maps:get(verify, Opts, true)),
@@ -1581,9 +1601,9 @@ idle({call, From}, peername, #state{remote_addr = Addr} = State) ->
 idle({call, From}, sockname, #state{local_addr = Addr} = State) ->
     {keep_state, State, [{reply, From, {ok, Addr}}]};
 idle({call, From}, {set_owner, NewOwner}, State) ->
-    {keep_state, State#state{owner = NewOwner}, [{reply, From, ok}]};
+    {keep_state, reown(State, NewOwner), [{reply, From, ok}]};
 idle(cast, {set_owner, NewOwner}, State) ->
-    {keep_state, State#state{owner = NewOwner}};
+    {keep_state, reown(State, NewOwner)};
 %% 0-RTT: Allow opening streams in idle state if early keys are available
 idle({call, From}, open_stream, #state{early_keys = undefined} = State) ->
     {keep_state, State, [{reply, From, {error, not_connected}}]};
@@ -1666,9 +1686,9 @@ handshaking({call, From}, peername, #state{remote_addr = Addr} = State) ->
 handshaking({call, From}, sockname, #state{local_addr = Addr} = State) ->
     {keep_state, State, [{reply, From, {ok, Addr}}]};
 handshaking({call, From}, {set_owner, NewOwner}, State) ->
-    {keep_state, State#state{owner = NewOwner}, [{reply, From, ok}]};
+    {keep_state, reown(State, NewOwner), [{reply, From, ok}]};
 handshaking(cast, {set_owner, NewOwner}, State) ->
-    {keep_state, State#state{owner = NewOwner}};
+    {keep_state, reown(State, NewOwner)};
 %% 0-RTT: Allow opening streams during handshake if early keys are available
 handshaking({call, From}, open_stream, #state{early_keys = undefined} = State) ->
     %% No early keys, must wait for handshake to complete
@@ -1821,12 +1841,12 @@ connected({call, From}, {set_owner, NewOwner}, #state{alpn = Alpn, transport_par
     %% Notify new owner that connection is already established
     Info = #{alpn => Alpn, alpn_protocol => Alpn, transport_params => TP},
     NewOwner ! {quic, self(), {connected, Info}},
-    {keep_state, State#state{owner = NewOwner}, [{reply, From, ok}]};
+    {keep_state, reown(State, NewOwner), [{reply, From, ok}]};
 connected(cast, {set_owner, NewOwner}, #state{alpn = Alpn, transport_params = TP} = State) ->
     %% Notify new owner that connection is already established
     Info = #{alpn => Alpn, alpn_protocol => Alpn, transport_params => TP},
     NewOwner ! {quic, self(), {connected, Info}},
-    {keep_state, State#state{owner = NewOwner}};
+    {keep_state, reown(State, NewOwner)};
 connected({call, From}, {send_datagram, Data}, State) ->
     case do_send_datagram(Data, State) of
         {ok, NewState} ->
@@ -2357,6 +2377,15 @@ handle_common_event(
 ) when Reason =/= normal andalso Reason =/= shutdown ->
     Owner ! {quic, self(), {closed, {receiver_exit, Reason}}},
     {stop, {shutdown, {receiver_exit, Reason}}, State};
+%% Owner process gone (client connections monitor their owner). Tear down
+%% so a supervised connection that is not linked to its owner doesn't leak.
+handle_common_event(
+    info,
+    {'DOWN', Mon, process, _Pid, _Reason},
+    _StateName,
+    #state{owner_mon = Mon} = State
+) ->
+    {stop, {shutdown, owner_down}, State};
 handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
@@ -6521,21 +6550,48 @@ generate_connection_id(undefined) ->
 generate_connection_id(#cid_config{} = Config) ->
     quic_lb:generate_cid(Config).
 
-%% Resolve hostname to IP address
-resolve_address(Host, Port) when is_tuple(Host) ->
-    {Host, Port};
-resolve_address(Host, Port) when is_list(Host) ->
-    case inet:getaddr(Host, inet) of
+%% Resolve a host to a single {IP, Port}. `Family' (inet | inet6 | any) sets the
+%% lookup order; `any' is IPv4-first then IPv6 for backward compatibility.
+%% Multi-address Happy Eyeballs lives in quic_happy; this resolves one address.
+-spec resolve_address(
+    inet:ip_address() | binary() | string(), inet:port_number(), inet | inet6 | any
+) ->
+    {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.
+resolve_address(Host, Port, _Family) when is_tuple(Host) ->
+    {ok, {Host, Port}};
+resolve_address(Host, Port, Family) when is_binary(Host) ->
+    resolve_address(binary_to_list(Host), Port, Family);
+resolve_address(Host, Port, Family) when is_list(Host) ->
+    Stripped = strip_brackets(Host),
+    case inet:parse_address(Stripped) of
         {ok, IP} ->
-            {IP, Port};
-        _ ->
-            case inet:getaddr(Host, inet6) of
-                {ok, IP} -> {IP, Port};
-                _ -> {{127, 0, 0, 1}, Port}
+            {ok, {IP, Port}};
+        {error, _} ->
+            case getaddr_family(Stripped, Family) of
+                {ok, IP} -> {ok, {IP, Port}};
+                {error, _} = Error -> Error
             end
+    end.
+
+%% Family-ordered name resolution. `any' tries IPv4 then IPv6.
+getaddr_family(Host, inet) ->
+    inet:getaddr(Host, inet);
+getaddr_family(Host, inet6) ->
+    inet:getaddr(Host, inet6);
+getaddr_family(Host, any) ->
+    case inet:getaddr(Host, inet) of
+        {ok, _} = Ok -> Ok;
+        {error, _} -> inet:getaddr(Host, inet6)
+    end.
+
+%% Drop a single pair of surrounding brackets from an IPv6 literal ("[::1]").
+strip_brackets([$[ | Rest]) ->
+    case lists:reverse(Rest) of
+        [$] | RevInner] -> lists:reverse(RevInner);
+        _ -> [$[ | Rest]
     end;
-resolve_address(Host, Port) when is_binary(Host) ->
-    resolve_address(binary_to_list(Host), Port).
+strip_brackets(Host) ->
+    Host.
 
 %% Derive initial encryption keys
 derive_initial_keys(DCID) ->
@@ -9263,10 +9319,10 @@ select_preferred_addr(_) ->
 %% @doc Rebind socket to a new local port (simulates network change).
 %% Open new before closing old so an allocation failure leaves the
 %% caller's handle usable.
--spec rebind_socket(gen_udp:socket()) -> {ok, gen_udp:socket()} | {error, term()}.
-rebind_socket(OldSocket) ->
+-spec rebind_socket(gen_udp:socket(), inet | inet6) -> {ok, gen_udp:socket()} | {error, term()}.
+rebind_socket(OldSocket, Family) ->
     {ok, [{active, Active}]} = inet:getopts(OldSocket, [active]),
-    case gen_udp:open(0, [binary, {active, Active}]) of
+    case gen_udp:open(0, [binary, Family, {active, Active}]) of
         {ok, NewSocket} ->
             gen_udp:close(OldSocket),
             {ok, NewSocket};
@@ -9285,7 +9341,9 @@ rebind_client_socket(#state{client_socket_backend = adapter}) ->
     %% Connection migration via fresh local UDP port has no analogue
     %% when the transport is a caller-supplied adapter.
     {error, not_supported_on_adapter};
-rebind_client_socket(#state{socket = OldSocket, socket_state = OldSocketState} = State) ->
+rebind_client_socket(
+    #state{socket = OldSocket, socket_state = OldSocketState, remote_addr = {RemoteIP, _}} = State
+) ->
     %% Flush any pending batch to the old socket before rebinding so
     %% already-sequenced packets reach the server under the pre-migrate
     %% path. Without this flush, encrypted packets sitting in
@@ -9293,7 +9351,7 @@ rebind_client_socket(#state{socket = OldSocket, socket_state = OldSocketState} =
     %% (old closed socket) or replayed from the new addr with stale
     %% CIDs (mis-routed on the server side).
     State0 = flush_socket_batch(State),
-    case rebind_socket(OldSocket) of
+    case rebind_socket(OldSocket, address_family(RemoteIP)) of
         {ok, NewSocket} ->
             %% `#socket_state{}' kept its reference to the now-closed
             %% old socket. Swap the handle while preserving batching

--- a/src/quic_happy.erl
+++ b/src/quic_happy.erl
@@ -1,0 +1,291 @@
+%%% -*- erlang -*-
+%%%
+%%% Happy Eyeballs v2 (RFC 8305) client connection establishment.
+%%%
+%%% Resolution happens in the caller process (so a resolution failure
+%%% returns `{error, Reason}' without ever linking a connection to the
+%%% caller). A literal IP, a single resolved address, or a pre-opened
+%%% socket take the direct, caller-linked, async path. A hostname that
+%%% resolves to two or more addresses is raced IPv6-first under a
+%%% supervised coordinator that returns the winning connection.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+
+-module(quic_happy).
+
+%% Public entry (called from quic:connect/4).
+-export([connect/5]).
+%% Supervisor + proc_lib entry points.
+-export([start_coordinator/1, coordinator_entry/1]).
+%% Pure helpers (exported for unit tests).
+-export([interleave/2, parse_host/1]).
+
+-define(DEFAULT_ATTEMPT_DELAY, 250).
+-define(DEFAULT_CONNECT_TIMEOUT, 5000).
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+%% @doc Establish a client connection. Runs resolution in the caller.
+-spec connect(
+    inet:ip_address() | binary() | string(),
+    inet:port_number(),
+    map(),
+    pid(),
+    gen_udp:socket() | undefined
+) -> {ok, pid()} | {error, term()}.
+connect(Host, Port, Opts, Owner, Socket) ->
+    case parse_host(Host) of
+        {literal, IP} ->
+            direct(IP, Port, Opts, Owner, Socket);
+        {name, Name} ->
+            Family = maps:get(family, Opts, any),
+            Opts1 = with_sni(Opts, Name),
+            case {Socket, maps:get(happy_eyeballs, Opts, true)} of
+                {undefined, true} ->
+                    happy(Name, Port, Opts1, Owner, Family);
+                _ ->
+                    %% Pre-opened socket or Happy Eyeballs disabled: resolve a
+                    %% single address (family-ordered) and take the direct path.
+                    case resolve_single(Name, Family) of
+                        {ok, IP} -> direct(IP, Port, Opts1, Owner, Socket);
+                        {error, _} = Error -> Error
+                    end
+            end
+    end.
+
+%%====================================================================
+%% Direct (caller-linked) path
+%%====================================================================
+
+direct(IP, Port, Opts, Owner, Socket) ->
+    quic_connection:start_link(IP, Port, Opts, Owner, Socket).
+
+%%====================================================================
+%% Happy Eyeballs path
+%%====================================================================
+
+happy(Name, Port, Opts, Owner, Family) ->
+    case resolve_all(Name, Family) of
+        {error, _} = Error ->
+            Error;
+        {ok, [{IP, _Fam}]} ->
+            %% Single address: caller-linked async path, no race.
+            direct(IP, Port, Opts, Owner, undefined);
+        {ok, Addrs} ->
+            race(Addrs, Port, Opts, Owner)
+    end.
+
+%% Start a supervised coordinator and block until it reports a winner,
+%% all attempts fail, or the overall timeout elapses.
+race(Addrs, Port, Opts, Owner) ->
+    Timeout = maps:get(connect_timeout, Opts, ?DEFAULT_CONNECT_TIMEOUT),
+    Args = #{
+        addrs => Addrs,
+        port => Port,
+        opts => Opts,
+        owner => Owner,
+        caller => self(),
+        delay => maps:get(connection_attempt_delay, Opts, ?DEFAULT_ATTEMPT_DELAY),
+        timeout => Timeout
+    },
+    case quic_happy_sup:start_child([Args]) of
+        {ok, Coord} ->
+            MRef = erlang:monitor(process, Coord),
+            receive
+                {quic_happy_result, Coord, Result} ->
+                    erlang:demonitor(MRef, [flush]),
+                    Result;
+                {'DOWN', MRef, process, Coord, Reason} ->
+                    {error, {coordinator_crash, Reason}}
+            after Timeout + 1000 ->
+                erlang:demonitor(MRef, [flush]),
+                exit(Coord, kill),
+                {error, connect_timeout}
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+%%====================================================================
+%% Coordinator process
+%%====================================================================
+
+%% Supervisor entry: spawn the coordinator via proc_lib so the
+%% supervisor receives {ok, Pid}.
+-spec start_coordinator(map()) -> {ok, pid()}.
+start_coordinator(Args) when is_map(Args) ->
+    proc_lib:start_link(?MODULE, coordinator_entry, [Args]).
+
+-spec coordinator_entry(map()) -> no_return().
+coordinator_entry(Args) ->
+    %% Trap exits so the link from quic_connection:start_link (attempts) does
+    %% not kill us; failures are observed through monitors instead.
+    process_flag(trap_exit, true),
+    proc_lib:init_ack({ok, self()}),
+    St = #{
+        remaining => maps:get(addrs, Args),
+        port => maps:get(port, Args),
+        opts => maps:get(opts, Args),
+        owner => maps:get(owner, Args),
+        caller => maps:get(caller, Args),
+        delay => maps:get(delay, Args),
+        attempts => #{}
+    },
+    %% Overall deadline. Messages to this process after it exits are dropped,
+    %% so no explicit timer cancellation is needed.
+    _ = erlang:start_timer(maps:get(timeout, Args), self(), overall_timeout),
+    loop(start_head(St)).
+
+loop(St) ->
+    #{remaining := Remaining, attempts := Attempts} = St,
+    case (map_size(Attempts) =:= 0) andalso (Remaining =:= []) of
+        true ->
+            finish(St, {error, all_attempts_failed});
+        false ->
+            receive
+                {timeout, _Ref, next_attempt} ->
+                    loop(start_head(St));
+                {timeout, _Ref, overall_timeout} ->
+                    finish(St, {error, connect_timeout});
+                {quic, Pid, {connected, Info}} ->
+                    case maps:is_key(Pid, Attempts) of
+                        true -> on_connected(St, Pid, Info);
+                        false -> loop(St)
+                    end;
+                {'DOWN', _MRef, process, Pid, _Reason} ->
+                    loop(drop_attempt(St, Pid));
+                _Other ->
+                    loop(St)
+            after infinity ->
+                %% The overall deadline is delivered as an `overall_timeout'
+                %% timer message above; this clause only satisfies the linter.
+                finish(St, {error, connect_timeout})
+            end
+    end.
+
+%% Start the next pending address and, if more remain, arm the staggered
+%% Connection Attempt Delay timer so the following one starts concurrently.
+start_head(#{remaining := []} = St) ->
+    St;
+start_head(#{remaining := [Addr | Rest], delay := Delay} = St) ->
+    St1 = start_attempt(Addr, St#{remaining := Rest}),
+    case Rest of
+        [] ->
+            St1;
+        _ ->
+            _ = erlang:start_timer(Delay, self(), next_attempt),
+            St1
+    end.
+
+start_attempt({IP, _Fam}, #{port := Port, opts := Opts, attempts := Attempts} = St) ->
+    case quic_conn_sup:start_child(IP, Port, Opts, self()) of
+        {ok, Pid} ->
+            MRef = erlang:monitor(process, Pid),
+            St#{attempts := maps:put(Pid, MRef, Attempts)};
+        {error, _} ->
+            %% Immediate start failure (no process): just don't track it; the
+            %% termination check / next timer handles progress.
+            St
+    end.
+
+drop_attempt(#{attempts := Attempts} = St, Pid) ->
+    case maps:take(Pid, Attempts) of
+        {MRef, Rest} ->
+            _ = erlang:demonitor(MRef, [flush]),
+            St#{attempts := Rest};
+        error ->
+            St
+    end.
+
+%% First attempt to finish its handshake wins. Hand it to the real owner
+%% (re-delivers {connected}); the remaining attempts are still owned by this
+%% coordinator and self-close on owner-DOWN when we exit below.
+on_connected(#{owner := Owner, caller := Caller} = St, Pid, _Info) ->
+    %% set_owner_sync is a gen_statem:call; a winner that died between
+    %% {connected} and here raises, and we continue the race.
+    try quic_connection:set_owner_sync(Pid, Owner) of
+        ok ->
+            Caller ! {quic_happy_result, self(), {ok, Pid}},
+            ok
+    catch
+        _:_ ->
+            loop(drop_attempt(St, Pid))
+    end.
+
+finish(#{caller := Caller}, Result) ->
+    Caller ! {quic_happy_result, self(), Result},
+    ok.
+
+%%====================================================================
+%% Resolution helpers
+%%====================================================================
+
+%% @doc Classify a host: a (possibly bracketed) IP literal or a name.
+-spec parse_host(inet:ip_address() | binary() | string()) ->
+    {literal, inet:ip_address()} | {name, string()}.
+parse_host(IP) when is_tuple(IP) ->
+    {literal, IP};
+parse_host(Host) when is_binary(Host) ->
+    parse_host(binary_to_list(Host));
+parse_host(Host) when is_list(Host) ->
+    Stripped = strip_brackets(Host),
+    case inet:parse_address(Stripped) of
+        {ok, IP} -> {literal, IP};
+        {error, _} -> {name, Stripped}
+    end.
+
+resolve_single(Name, inet) ->
+    inet:getaddr(Name, inet);
+resolve_single(Name, inet6) ->
+    inet:getaddr(Name, inet6);
+resolve_single(Name, any) ->
+    case inet:getaddr(Name, inet) of
+        {ok, _} = Ok -> Ok;
+        {error, _} -> inet:getaddr(Name, inet6)
+    end.
+
+resolve_all(Name, Family) ->
+    V6 = lookup(Name, inet6, Family =/= inet),
+    V4 = lookup(Name, inet, Family =/= inet6),
+    case {V6, V4} of
+        {[], []} ->
+            {error, nxdomain};
+        _ ->
+            Tagged6 = [{IP, inet6} || IP <- V6],
+            Tagged4 = [{IP, inet} || IP <- V4],
+            {ok, interleave(Tagged6, Tagged4)}
+    end.
+
+lookup(_Name, _Family, false) ->
+    [];
+lookup(Name, Family, true) ->
+    case inet:getaddrs(Name, Family) of
+        {ok, Addrs} -> Addrs;
+        {error, _} -> []
+    end.
+
+%% @doc RFC 8305 §4 address ordering: interleave families, IPv6 first.
+-spec interleave(list(), list()) -> list().
+interleave([], L4) ->
+    L4;
+interleave(L6, []) ->
+    L6;
+interleave([H6 | T6], [H4 | T4]) ->
+    [H6, H4 | interleave(T6, T4)].
+
+with_sni(Opts, Name) ->
+    case maps:is_key(server_name, Opts) of
+        true -> Opts;
+        false -> Opts#{server_name => list_to_binary(Name)}
+    end.
+
+strip_brackets([$[ | Rest]) ->
+    case lists:reverse(Rest) of
+        [$] | RevInner] -> lists:reverse(RevInner);
+        _ -> [$[ | Rest]
+    end;
+strip_brackets(Host) ->
+    Host.

--- a/src/quic_happy_sup.erl
+++ b/src/quic_happy_sup.erl
@@ -1,0 +1,34 @@
+%%% -*- erlang -*-
+%%%
+%%% Dynamic supervisor for Happy Eyeballs coordinator processes. One
+%%% coordinator runs per multi-address connect; children are temporary
+%%% and identified by a unique reference.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+
+-module(quic_happy_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, start_child/1, init/1]).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Start a supervised coordinator. `Args' is the argument list for
+%% `quic_happy:start_coordinator/1'. Returns the coordinator pid.
+-spec start_child(list()) -> {ok, pid()} | {error, term()}.
+start_child(Args) ->
+    Spec = #{
+        id => {quic_happy, make_ref()},
+        start => {quic_happy, start_coordinator, Args},
+        restart => temporary,
+        shutdown => 5000,
+        type => worker,
+        modules => [quic_happy]
+    },
+    supervisor:start_child(?MODULE, Spec).
+
+init([]) ->
+    {ok, {#{strategy => one_for_one, intensity => 10, period => 10}, []}}.

--- a/src/quic_sup.erl
+++ b/src/quic_sup.erl
@@ -91,6 +91,22 @@ init([]) ->
             modules => [quic_server_sup]
         },
         #{
+            id => quic_conn_sup,
+            start => {quic_conn_sup, start_link, []},
+            restart => permanent,
+            shutdown => infinity,
+            type => supervisor,
+            modules => [quic_conn_sup]
+        },
+        #{
+            id => quic_happy_sup,
+            start => {quic_happy_sup, start_link, []},
+            restart => permanent,
+            shutdown => infinity,
+            type => supervisor,
+            modules => [quic_happy_sup]
+        },
+        #{
             id => quic_dist_sup,
             start => {quic_dist_sup, start_link, [DistOpts]},
             restart => permanent,

--- a/test/quic_cert_tests.erl
+++ b/test/quic_cert_tests.erl
@@ -313,8 +313,14 @@ h3_cleanup(#{name := Name}) ->
 %% Connect over HTTP/3 to localhost and report whether the handshake
 %% completed. `server_name' is set by quic_h3 to the connect host.
 h3_connect(Port, Opts0) ->
-    Opts = Opts0#{sync => true, connect_timeout => ?CONNECT_TIMEOUT},
-    case quic_h3:connect("localhost", Port, Opts) of
+    %% Connect to the IPv4 loopback directly (deterministic, no Happy Eyeballs
+    %% race) while keeping the SNI/hostname as localhost for cert validation.
+    Opts = Opts0#{
+        sync => true,
+        connect_timeout => ?CONNECT_TIMEOUT,
+        quic_opts => #{server_name => <<"localhost">>}
+    },
+    case quic_h3:connect("127.0.0.1", Port, Opts) of
         {ok, Conn} ->
             catch quic_h3:close(Conn),
             connected;

--- a/test/quic_client_migrate_tests.erl
+++ b/test/quic_client_migrate_tests.erl
@@ -12,12 +12,33 @@ client_gen_udp_migrate_test_() ->
     {timeout, 30, fun client_gen_udp_migrate/0}.
 
 client_gen_udp_migrate() ->
-    {ok, Srv} = quic_test_echo_server:start(#{
-        max_data => 16 * 1024 * 1024,
-        max_stream_data_bidi_local => 8 * 1024 * 1024,
-        max_stream_data_bidi_remote => 8 * 1024 * 1024,
-        max_stream_data_uni => 8 * 1024 * 1024
-    }),
+    do_migrate(#{}, "127.0.0.1").
+
+%% Regression for the IPv6 client path: migration rebind must reopen an
+%% IPv6 socket, not silently fall back to inet.
+client_gen_udp_migrate_ipv6_test_() ->
+    {timeout, 30, fun client_gen_udp_migrate_ipv6/0}.
+
+client_gen_udp_migrate_ipv6() ->
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            do_migrate(#{extra_socket_opts => [{ip, {0, 0, 0, 0, 0, 0, 0, 1}}]}, "::1")
+    end.
+
+do_migrate(ServerExtra, Host) ->
+    {ok, Srv} = quic_test_echo_server:start(
+        maps:merge(
+            #{
+                max_data => 16 * 1024 * 1024,
+                max_stream_data_bidi_local => 8 * 1024 * 1024,
+                max_stream_data_bidi_remote => 8 * 1024 * 1024,
+                max_stream_data_uni => 8 * 1024 * 1024
+            },
+            ServerExtra
+        )
+    ),
     try
         #{port := Port} = Srv,
         ClientOpts = maps:merge(quic_test_echo_server:client_opts(), #{
@@ -26,7 +47,7 @@ client_gen_udp_migrate() ->
             max_stream_data_bidi_remote => 8 * 1024 * 1024,
             max_stream_data_uni => 8 * 1024 * 1024
         }),
-        {ok, Conn} = quic:connect("127.0.0.1", Port, ClientOpts, self()),
+        {ok, Conn} = quic:connect(Host, Port, ClientOpts, self()),
         try
             receive
                 {quic, Conn, {connected, _}} -> ok
@@ -44,6 +65,15 @@ client_gen_udp_migrate() ->
         end
     after
         quic_test_echo_server:stop(Srv)
+    end.
+
+ipv6_available() ->
+    case gen_udp:open(0, [binary, inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
+        {ok, S} ->
+            gen_udp:close(S),
+            true;
+        {error, _} ->
+            false
     end.
 
 collect_echo(Conn, StreamId, Acc, Timeout) ->

--- a/test/quic_h3_owner_SUITE.erl
+++ b/test/quic_h3_owner_SUITE.erl
@@ -109,7 +109,7 @@ custom_owner_receives_datagram(Config) ->
     {ok, Port} = quic:get_server_port(Name),
 
     try
-        {ok, Conn} = quic_h3:connect("localhost", Port, #{
+        {ok, Conn} = quic_h3:connect("127.0.0.1", Port, #{
             verify => false,
             sync => true,
             h3_datagram_enabled => true
@@ -149,7 +149,7 @@ handle_hello(Conn, StreamId, _Method, _Path, _Headers) ->
     quic_h3:send_data(Conn, StreamId, <<"hello">>, true).
 
 do_get(Port) ->
-    {ok, Conn} = quic_h3:connect("localhost", Port, #{verify => false, sync => true}),
+    {ok, Conn} = quic_h3:connect("127.0.0.1", Port, #{verify => false, sync => true}),
     Headers = [
         {<<":method">>, <<"GET">>},
         {<<":scheme">>, <<"https">>},

--- a/test/quic_happy_tests.erl
+++ b/test/quic_happy_tests.erl
@@ -1,0 +1,136 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for Happy Eyeballs (quic_happy): pure address ordering/parsing
+%%% and end-to-end racing against an in-process echo server.
+
+-module(quic_happy_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Pure helpers
+%%====================================================================
+
+interleave_test() ->
+    ?assertEqual([a, c, b, d], quic_happy:interleave([a, b], [c, d])),
+    ?assertEqual([a], quic_happy:interleave([a], [])),
+    ?assertEqual([c], quic_happy:interleave([], [c])),
+    ?assertEqual([a, d, b, c], quic_happy:interleave([a, b, c], [d])),
+    ?assertEqual([], quic_happy:interleave([], [])).
+
+parse_host_test() ->
+    ?assertEqual({literal, {0, 0, 0, 0, 0, 0, 0, 1}}, quic_happy:parse_host(<<"[::1]">>)),
+    ?assertEqual({literal, {0, 0, 0, 0, 0, 0, 0, 1}}, quic_happy:parse_host("::1")),
+    ?assertEqual({literal, {127, 0, 0, 1}}, quic_happy:parse_host("127.0.0.1")),
+    ?assertEqual({literal, {127, 0, 0, 1}}, quic_happy:parse_host({127, 0, 0, 1})),
+    ?assertEqual({name, "example.com"}, quic_happy:parse_host(<<"example.com">>)).
+
+%%====================================================================
+%% End-to-end
+%%====================================================================
+
+%% happy_eyeballs => false keeps the immediate async return and still
+%% connects (IPv4-first single resolve).
+he_disabled_async_test_() ->
+    {timeout, 30, fun he_disabled_async/0}.
+
+he_disabled_async() ->
+    {ok, Srv} = quic_test_echo_server:start(#{}),
+    try
+        #{port := Port} = Srv,
+        Opts = maps:put(happy_eyeballs, false, quic_test_echo_server:client_opts()),
+        {ok, Conn} = quic:connect("localhost", Port, Opts, self()),
+        try
+            ?assert(is_pid(Conn)),
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> ?assert(false)
+            end
+        after
+            catch quic:close(Conn)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+%% An IP-tuple host takes the direct path and connects.
+tuple_host_test_() ->
+    {timeout, 30, fun tuple_host/0}.
+
+tuple_host() ->
+    {ok, Srv} = quic_test_echo_server:start(#{}),
+    try
+        #{port := Port} = Srv,
+        {ok, Conn} = quic:connect(
+            {127, 0, 0, 1}, Port, quic_test_echo_server:client_opts(), self()
+        ),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> ?assert(false)
+            end
+        after
+            catch quic:close(Conn)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+%% Dual-stack "localhost" races; with the server only on IPv6, the IPv6
+%% attempt wins and the connection's peer is the v6 loopback.
+he_ipv6_winner_test_() ->
+    {timeout, 30, fun he_ipv6_winner/0}.
+
+he_ipv6_winner() ->
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            {ok, Srv} = quic_test_echo_server:start(#{
+                extra_socket_opts => [{ip, {0, 0, 0, 0, 0, 0, 0, 1}}]
+            }),
+            try
+                #{port := Port} = Srv,
+                {ok, Conn} = quic:connect(
+                    "localhost", Port, quic_test_echo_server:client_opts(), self()
+                ),
+                try
+                    receive
+                        {quic, Conn, {connected, _}} -> ok
+                    after 5000 -> ?assert(false)
+                    end,
+                    {ok, {PeerIP, _}} = quic:peername(Conn),
+                    ?assertEqual(8, tuple_size(PeerIP))
+                after
+                    catch quic:close(Conn)
+                end
+            after
+                quic_test_echo_server:stop(Srv)
+            end
+    end.
+
+%% No server: every raced attempt fails, connect returns an error within
+%% the (shortened) overall timeout rather than hanging or dialing localhost.
+he_all_fail_test_() ->
+    {timeout, 30, fun he_all_fail/0}.
+
+he_all_fail() ->
+    {ok, _} = application:ensure_all_started(quic),
+    DeadPort = 1,
+    Opts = #{
+        verify => false,
+        happy_eyeballs => true,
+        connection_attempt_delay => 100,
+        connect_timeout => 800
+    },
+    Result = quic:connect("localhost", DeadPort, Opts, self()),
+    ?assertMatch({error, _}, Result).
+
+ipv6_available() ->
+    case gen_udp:open(0, [binary, inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
+        {ok, S} ->
+            gen_udp:close(S),
+            true;
+        {error, _} ->
+            false
+    end.

--- a/test/quic_happy_tests.erl
+++ b/test/quic_happy_tests.erl
@@ -109,6 +109,51 @@ he_ipv6_winner() ->
             end
     end.
 
+%% A supervised Happy Eyeballs winner is linked to quic_conn_sup, not the
+%% caller, so it must close via owner-monitoring when its owner dies.
+he_winner_dies_with_owner_test_() ->
+    {timeout, 30, fun he_winner_dies_with_owner/0}.
+
+he_winner_dies_with_owner() ->
+    {ok, Srv} = quic_test_echo_server:start(#{}),
+    try
+        #{port := Port} = Srv,
+        Tester = self(),
+        %% "localhost" resolves to both ::1 and 127.0.0.1, so the connect goes
+        %% through the supervised race rather than the caller-linked fast path.
+        Owner = spawn(fun() ->
+            {ok, Conn} = quic:connect(
+                "localhost", Port, quic_test_echo_server:client_opts(), self()
+            ),
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> ok
+            end,
+            Tester ! {conn, self(), Conn},
+            receive
+                stop -> ok
+            end
+        end),
+        Conn =
+            receive
+                {conn, Owner, C} -> C
+            after 10000 -> error(no_conn)
+            end,
+        ?assert(is_process_alive(Conn)),
+        %% The winner is a supervised child, not linked to the owner.
+        ?assert(
+            lists:member(Conn, [P || {_, P, _, _} <- supervisor:which_children(quic_conn_sup)])
+        ),
+        MRef = erlang:monitor(process, Conn),
+        exit(Owner, kill),
+        receive
+            {'DOWN', MRef, process, Conn, _} -> ok
+        after 5000 -> error(winner_not_killed_with_owner)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
 %% No server: every raced attempt fails, connect returns an error within
 %% the (shortened) overall timeout rather than hanging or dialing localhost.
 he_all_fail_test_() ->

--- a/test/quic_happy_tests.erl
+++ b/test/quic_happy_tests.erl
@@ -115,12 +115,23 @@ he_winner_dies_with_owner_test_() ->
     {timeout, 30, fun he_winner_dies_with_owner/0}.
 
 he_winner_dies_with_owner() ->
-    {ok, Srv} = quic_test_echo_server:start(#{}),
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            do_he_winner_dies_with_owner()
+    end.
+
+do_he_winner_dies_with_owner() ->
+    %% Server on ::1 so the IPv6-first attempt (tried first) wins immediately:
+    %% "localhost" still resolves to two addresses, so the winner goes through
+    %% the supervised race rather than the caller-linked fast path.
+    {ok, Srv} = quic_test_echo_server:start(#{
+        extra_socket_opts => [{ip, {0, 0, 0, 0, 0, 0, 0, 1}}]
+    }),
     try
         #{port := Port} = Srv,
         Tester = self(),
-        %% "localhost" resolves to both ::1 and 127.0.0.1, so the connect goes
-        %% through the supervised race rather than the caller-linked fast path.
         Owner = spawn(fun() ->
             {ok, Conn} = quic:connect(
                 "localhost", Port, quic_test_echo_server:client_opts(), self()

--- a/test/quic_resolve_tests.erl
+++ b/test/quic_resolve_tests.erl
@@ -1,0 +1,54 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for client address resolution: no silent localhost fallback,
+%%% and IPv6 literal (bracketed) hosts.
+
+-module(quic_resolve_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% An unresolvable name must fail the connect, not silently dial 127.0.0.1.
+resolve_failure_returns_error_test() ->
+    {ok, _} = application:ensure_all_started(quic),
+    Result = quic:connect(<<"no-such-host.invalid">>, 9, #{verify => false}, self()),
+    ?assertMatch({error, _}, Result).
+
+%% A bracketed IPv6 literal resolves and connects to an IPv6 server.
+ipv6_literal_brackets_test_() ->
+    {timeout, 30, fun ipv6_literal_brackets/0}.
+
+ipv6_literal_brackets() ->
+    case ipv6_available() of
+        false ->
+            ok;
+        true ->
+            {ok, Srv} = quic_test_echo_server:start(#{
+                extra_socket_opts => [{ip, {0, 0, 0, 0, 0, 0, 0, 1}}]
+            }),
+            try
+                #{port := Port} = Srv,
+                {ok, Conn} = quic:connect(
+                    "[::1]", Port, quic_test_echo_server:client_opts(), self()
+                ),
+                try
+                    receive
+                        {quic, Conn, {connected, _}} -> ok
+                    after 5000 ->
+                        ?assert(false)
+                    end
+                after
+                    catch quic:close(Conn)
+                end
+            after
+                quic_test_echo_server:stop(Srv)
+            end
+    end.
+
+ipv6_available() ->
+    case gen_udp:open(0, [binary, inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
+        {ok, S} ->
+            gen_udp:close(S),
+            true;
+        {error, _} ->
+            false
+    end.


### PR DESCRIPTION
Adds IPv6 to the client connect path.

`quic:connect/4` now accepts IP-tuple and bracketed IPv6 literal hosts, resolves hostnames in the caller process (returning `{error, _}` instead of silently dialing localhost on failure), and uses RFC 8305 Happy Eyeballs for dual-stack hostnames: addresses are raced IPv6-first and the first to finish its handshake is returned. For a multi-address hostname `connect/4` blocks until the first attempt connects; a single address, IP literal/tuple, or pre-opened socket keeps the immediate async return.

The migration rebind now reopens the socket with the connection's address family. Racing attempts and coordinators run under supervision, and connections monitor their owner so a supervised winner closes when its owner exits.

New options: `happy_eyeballs` (default `true`), `family` (`inet | inet6 | any`), `connection_attempt_delay` (250 ms), `connect_timeout` (5000 ms).

```erlang
quic:connect("example.com", 443, #{}, self()).                 % Happy Eyeballs, IPv6-first
quic:connect("[::1]", 443, #{}, self()).                       % IPv6 literal
quic:connect("example.com", 443, #{family => inet6}, self()).  % force IPv6
```