### PR TITLE
Reject peer references to unopened local streams

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5972,18 +5972,34 @@ validate_receive_stream(StreamId, Role) ->
     end.
 
 process_stream_data_validated(StreamId, Offset, Data, Fin, State) ->
-    case
-        (not is_map_key(StreamId, State#state.streams)) andalso
-            stream_reclaimed(StreamId, State#state.role, State)
-    of
+    NotInMap = not is_map_key(StreamId, State#state.streams),
+    case NotInMap andalso stream_reclaimed(StreamId, State#state.role, State) of
         true ->
             %% Late/retransmitted frame for an already-reclaimed stream. Stream
             %% ids are never reused (RFC 9000 §2.1), so this is never a new
             %% stream; ignore it rather than resurrecting the record.
             State;
         false ->
-            do_process_stream_data_validated(StreamId, Offset, Data, Fin, State)
+            case NotInMap andalso stream_locally_initiated(StreamId, State#state.role) of
+                true ->
+                    %% The peer sent STREAM data for one of our locally-initiated
+                    %% stream ids that we never opened (RFC 9000 §3.2). The peer
+                    %% cannot open our streams: STREAM_STATE_ERROR.
+                    stream_state_error_close(
+                        StreamId, <<"data for unopened local stream">>, State
+                    );
+                false ->
+                    do_process_stream_data_validated(StreamId, Offset, Data, Fin, State)
+            end
     end.
+
+%% Close the connection with STREAM_STATE_ERROR for a frame that references a
+%% stream in a way the peer is not allowed to.
+stream_state_error_close(StreamId, Reason, State) ->
+    ?LOG_WARNING(
+        #{what => stream_state_error, stream_id => StreamId, reason => Reason}, ?QUIC_LOG_META
+    ),
+    close_with_transport_error(?QUIC_STREAM_STATE_ERROR, Reason, State).
 
 do_process_stream_data_validated(StreamId, Offset, Data, Fin, State) ->
     #state{

--- a/test/quic_frame_violation_tests.erl
+++ b/test/quic_frame_violation_tests.erl
@@ -48,6 +48,17 @@ server_rejects_over_limit_stream_test() ->
         quic_connection:test_close_reason(S1)
     ).
 
+%% RFC 9000 §3.2: the peer cannot open our locally-initiated streams. STREAM
+%% data for one we never opened (stream 1 is server-initiated bidi #0) is a
+%% STREAM_STATE_ERROR, not a new stream.
+server_rejects_data_for_unopened_local_stream_test() ->
+    S0 = quic_connection:test_state_for_role(server),
+    S1 = quic_connection:process_frame(app, {stream, 1, 0, <<"x">>, false}, S0),
+    ?assertMatch(
+        {transport, ?QUIC_STREAM_STATE_ERROR, _},
+        quic_connection:test_close_reason(S1)
+    ).
+
 %% RFC 9000 §19.15: NEW_CONNECTION_ID with retire_prior_to greater than the
 %% sequence number is a FRAME_ENCODING_ERROR.
 new_connection_id_retire_prior_to_exceeds_seq_test() ->


### PR DESCRIPTION
Follow-up to #154. A peer cannot open one of our locally-initiated streams (RFC 9000 3.2), but STREAM data for a local id we never opened was creating the stream and emitting `{stream_opened}`. It now closes the connection with STREAM_STATE_ERROR.

The other #154 follow-up, the full RESET_STREAM_AT reliable-reset lifecycle, is deliberately not included: those streams are conservatively retained (never early-reclaimed), which is safe. Reclaiming them correctly needs distinguishing a local reset-at (retain until its frames are acked, for the retransmit filter) from an incoming one (terminal once the reliable bytes are delivered), which the shared `reset_reliable_size` field does not capture. Given reset_stream_at is an opt-in draft feature, the conservative retention is left as-is.