### PR TITLE
Pace dist keep-alive off net_ticktime so connections survive load

### DIFF
--- a/include/quic_dist.hrl
+++ b/include/quic_dist.hrl
@@ -60,9 +60,15 @@
 %% Longer than default to allow for infrequent cluster traffic
 -define(QUIC_DIST_IDLE_TIMEOUT, 300000).
 
-%% Keep-alive interval for distribution connections (150 seconds = half of idle timeout)
-%% QUIC-level PING frames ensure liveness without relying on application-layer ticks
--define(QUIC_DIST_KEEP_ALIVE_INTERVAL, 150000).
+%% Keep-alive cadence for distribution connections. net_kernel declares a peer
+%% down after net_ticktime (default 60s) of no received QUIC packets (getstat
+%% reports packets_received), so the PING keep-alive (which bypasses stream flow
+%% control) must fire several times per net_ticktime window. The interval is
+%% derived from net_ticktime by quic_dist:keep_alive_interval/0; this value is
+%% the fallback when net_ticktime is unavailable (60s / 4).
+-define(QUIC_DIST_KEEP_ALIVE_INTERVAL, 15000).
+%% Floor for the derived interval (matches the connection layer's 5s minimum).
+-define(QUIC_DIST_KEEP_ALIVE_MIN, 5000).
 
 %% Distribution backpressure thresholds (can be overridden via config)
 %% Congested when queue > cwnd * congestion threshold

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -81,6 +81,9 @@
     get_controller/1
 ]).
 
+%% Keep-alive cadence derivation (exported for testing the net_ticktime logic)
+-export([keep_alive_interval/0, keep_alive_interval_for/1]).
+
 %% Types
 -export_type([stream_ref/0, stream_info/0, stream_opt/0]).
 
@@ -574,6 +577,34 @@ get_listen_port() ->
     end.
 
 %% @private
+%% @doc QUIC keep-alive interval for distribution connections, in milliseconds.
+%%
+%% net_kernel declares a peer down after net_ticktime with no received QUIC
+%% packets (the transport's getstat reports packets_received), so the PING
+%% keep-alive — which bypasses stream flow control — must fire well within that
+%% window even when a post-burst flow-control stall delays the dist tick. We pace
+%% it at net_ticktime/4, matching net_kernel's own tick cadence (~4 chances per
+%% window), so a healthy link (latency well under net_ticktime) never trips a
+%% false timeout.
+%%
+%% net_ticktime is read from the kernel application env, NOT via
+%% net_kernel:get_net_ticktime/0: this runs inside the dist listen/connect
+%% callback, which executes in the net_kernel process, so calling net_kernel
+%% would deadlock ({calling_self,...}). The env holds the configured value
+%% net_kernel itself uses at startup (a runtime set_net_ticktime/1 is not
+%% reflected, which is acceptable for picking a keep-alive cadence).
+-spec keep_alive_interval() -> pos_integer().
+keep_alive_interval() ->
+    keep_alive_interval_for(application:get_env(kernel, net_ticktime, 60)).
+
+%% @private Pure derivation, split out so the net_ticktime cases are testable.
+-spec keep_alive_interval_for(term()) -> pos_integer().
+keep_alive_interval_for(Ticktime) when is_integer(Ticktime), Ticktime > 0 ->
+    max(?QUIC_DIST_KEEP_ALIVE_MIN, (Ticktime * 1000) div 4);
+keep_alive_interval_for(_Other) ->
+    %% net_ticktime unset or invalid - use the configured fallback.
+    ?QUIC_DIST_KEEP_ALIVE_INTERVAL.
+
 %% Start QUIC server for distribution.
 %%
 %% Two modes of operation:
@@ -587,8 +618,10 @@ start_quic_server(Name, Port, Config, _ExtraOpts) ->
             BaseOpts0 = #{
                 alpn => [?QUIC_DIST_ALPN],
                 idle_timeout => ?QUIC_DIST_IDLE_TIMEOUT,
-                %% QUIC-level keep-alive via PING frames (bypasses flow control)
-                keep_alive_interval => ?QUIC_DIST_KEEP_ALIVE_INTERVAL,
+                %% QUIC-level keep-alive via PING frames (bypasses flow control).
+                %% Paced off net_ticktime so net_kernel never sees a stale
+                %% connection under load.
+                keep_alive_interval => keep_alive_interval(),
                 %% Use aggressive initial cwnd for distribution bulk transfers
                 initial_window => ?INITIAL_WINDOW_AGGRESSIVE,
                 %% Keep a higher congestion floor to avoid liveness stalls
@@ -1137,8 +1170,10 @@ connect_to_node(Kernel, Node, IP, Port, MyNode, Type, Timer) ->
             BaseOpts0 = #{
                 alpn => [?QUIC_DIST_ALPN],
                 idle_timeout => ?QUIC_DIST_IDLE_TIMEOUT,
-                %% QUIC-level keep-alive via PING frames (bypasses flow control)
-                keep_alive_interval => ?QUIC_DIST_KEEP_ALIVE_INTERVAL,
+                %% QUIC-level keep-alive via PING frames (bypasses flow control).
+                %% Paced off net_ticktime so net_kernel never sees a stale
+                %% connection under load.
+                keep_alive_interval => keep_alive_interval(),
                 %% Use aggressive initial cwnd for distribution bulk transfers
                 initial_window => ?INITIAL_WINDOW_AGGRESSIVE,
                 %% Keep a higher congestion floor to avoid liveness stalls

--- a/test/quic_dist_keepalive_tests.erl
+++ b/test/quic_dist_keepalive_tests.erl
@@ -1,0 +1,45 @@
+%%% -*- erlang -*-
+%%%
+%%% The QUIC dist keep-alive PING must fire several times per net_ticktime
+%%% window, otherwise net_kernel sees a stale connection (getstat reports QUIC
+%%% packets_received) and tears it down under load. These tests pin the
+%%% net_ticktime -> interval derivation.
+
+-module(quic_dist_keepalive_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic_dist.hrl").
+
+%% Default net_ticktime (60s) -> quarter window, comfortably below 60s.
+default_ticktime_test() ->
+    ?assertEqual(15000, quic_dist:keep_alive_interval_for(60)).
+
+%% The interval must stay below net_ticktime for any sane ticktime, so a
+%% healthy link always refreshes liveness within the window.
+below_ticktime_test() ->
+    lists:foreach(
+        fun(T) ->
+            ?assert(quic_dist:keep_alive_interval_for(T) < (T * 1000))
+        end,
+        [20, 60, 120, 600]
+    ).
+
+%% Small net_ticktime clamps to the 5s floor (the connection layer's minimum).
+floor_test() ->
+    ?assertEqual(?QUIC_DIST_KEEP_ALIVE_MIN, quic_dist:keep_alive_interval_for(8)).
+
+%% A longer net_ticktime scales the interval up but keeps the quarter ratio.
+large_ticktime_test() ->
+    ?assertEqual(30000, quic_dist:keep_alive_interval_for(120)).
+
+%% When net_ticktime is unset or invalid, fall back to the configured default,
+%% which is itself below 60s.
+fallback_test() ->
+    ?assertEqual(?QUIC_DIST_KEEP_ALIVE_INTERVAL, quic_dist:keep_alive_interval_for(undefined)),
+    ?assert(?QUIC_DIST_KEEP_ALIVE_INTERVAL < 60000).
+
+%% The live call must not touch the net_kernel process (it runs inside the dist
+%% callback, which IS net_kernel), and must return a usable interval below 60s.
+live_call_no_deadlock_test() ->
+    I = quic_dist:keep_alive_interval(),
+    ?assert(is_integer(I) andalso I >= ?QUIC_DIST_KEEP_ALIVE_MIN andalso I < 60000).


### PR DESCRIPTION
The QUIC distribution keep-alive PING was paced at 150s (half the QUIC idle timeout). But `net_kernel` declares a peer down after `net_ticktime` (default 60s) with no received QUIC packets, since the transport's `getstat` reports `packets_received` for liveness. The Erlang dist tick is a stream frame subject to connection flow control, so after a burst exhausts the connection window it can stall, and the PING backstop fired too rarely to refresh liveness within the 60s window. Healthy connections were torn down under load with `Node not responding, Removing (timedout) connection`.

Derive the keep-alive interval from `net_ticktime` instead of the idle timeout: PING at `net_ticktime/4`, matching net_kernel's own tick cadence (~4 chances per window), floored at 5s. The PING bypasses flow control, so a link whose latency is well under `net_ticktime` always refreshes liveness in time regardless of application load.

`net_ticktime` is read from the kernel application env, not `net_kernel:get_net_ticktime/0`: the dist listen/connect callback runs in the net_kernel process, so calling back into it deadlocks with `{calling_self,...}` and the node fails to boot.

Verified with 3-node and 5-node Docker distribution clusters (no net_tick timeouts) and the full unit suite.