### PR TITLE
Expose the listener's bound address (get_sockname)

### DIFF
--- a/docs/SERVER_GUIDE.md
+++ b/docs/SERVER_GUIDE.md
@@ -17,6 +17,9 @@ application:ensure_all_started(quic).
 
 %% Get the listening port (useful when using port 0)
 {ok, Port} = quic:get_server_port(my_server).
+
+%% Get the full bound address (resolves inet6 / {ip, _} / {ifaddr, _})
+{ok, {IP, Port}} = quic:get_server_sockname(my_server).
 ```
 
 ## Server Configuration Options
@@ -72,6 +75,10 @@ quic:start_server(my_server, 4433, Opts#{extra_socket_opts => [inet6]}).
 quic:start_server(my_server, 4433,
     Opts#{extra_socket_opts => [{ip, {16#2001, 16#db8, 0, 0, 0, 0, 0, 1}}]}).
 ```
+
+Use `quic:get_server_sockname/1` to read the resolved `{IP, Port}` the listener
+actually bound to, which is the reliable way to learn the address when it depends
+on `inet6`, `{ip, _}` or `{ifaddr, _}`.
 
 ### Server Pool Options
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -238,6 +238,7 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `quic:stop_server/1` - Stop named server
 - `quic:get_server_info/1` - Get server information
 - `quic:get_server_port/1` - Get server listening port
+- `quic:get_server_sockname/1` - Get server bound address (`{IP, Port}`)
 - `quic:get_server_connections/1` - Get server connection PIDs
 - `quic:which_servers/0` - List all running servers
 

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -133,6 +133,7 @@
     server_spec/3,
     get_server_info/1,
     get_server_port/1,
+    get_server_sockname/1,
     get_server_connections/1,
     which_servers/0
 ]).
@@ -835,6 +836,20 @@ get_server_info(_Name) ->
 get_server_port(Name) when is_atom(Name) ->
     quic_server_registry:get_port(Name);
 get_server_port(_Name) ->
+    {error, badarg}.
+
+%% @doc Get the bound address of a named server.
+%%
+%% Returns the listener's actual `{IP, Port}', resolved from the socket, so it is
+%% correct even when the server was started with port 0, `inet6', `{ip, _}' or
+%% `{ifaddr, _}'.
+-spec get_server_sockname(Name) ->
+    {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}
+when
+    Name :: atom().
+get_server_sockname(Name) when is_atom(Name) ->
+    quic_server_registry:get_sockname(Name);
+get_server_sockname(_Name) ->
     {error, badarg}.
 
 %% @doc Get the list of connection PIDs for a named server.

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -42,6 +42,7 @@
     start/2,
     stop/1,
     get_port/1,
+    get_sockname/1,
     get_connections/1,
     register_cid/3,
     retire_cid/2
@@ -149,6 +150,14 @@ stop(Listener) ->
 -spec get_port(pid()) -> inet:port_number().
 get_port(Listener) ->
     gen_server:call(Listener, get_port).
+
+%% @doc Get the address the listener is bound to. Resolves the actual bound
+%% address from the socket, so it reflects the real value even when the listener
+%% was opened with `inet6', `{ip, Addr}' or `{ifaddr, Addr}'.
+-spec get_sockname(pid()) ->
+    {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.
+get_sockname(Listener) ->
+    gen_server:call(Listener, get_sockname).
 
 %% @doc Get list of active connections.
 -spec get_connections(pid()) -> [pid()].
@@ -322,6 +331,12 @@ get_socket_port(Socket, _SocketState, gen_udp) ->
         {error, _} -> 0
     end.
 
+%% Get the bound {IP, Port} depending on backend.
+get_socket_sockname(_Socket, SocketState, socket) when SocketState =/= undefined ->
+    quic_socket:sockname(SocketState);
+get_socket_sockname(Socket, _SocketState, gen_udp) ->
+    inet:sockname(Socket).
+
 %% Start GRO receiver process for socket backend
 maybe_start_gro_receiver(socket, SocketState) when SocketState =/= undefined ->
     Listener = self(),
@@ -348,6 +363,15 @@ gro_receive_loop(SocketState, Listener) ->
 -spec handle_call(term(), gen_server:from(), state()) -> {reply, term(), state()}.
 handle_call(get_port, _From, #listener_state{port = Port} = State) ->
     {reply, Port, State};
+%% @doc false
+handle_call(
+    get_sockname,
+    _From,
+    #listener_state{
+        socket = Socket, socket_state = SocketState, socket_backend = Backend
+    } = State
+) ->
+    {reply, get_socket_sockname(Socket, SocketState, Backend), State};
 %% @doc false
 handle_call(get_socket_info, _From, #listener_state{socket = Socket, port = Port} = State) ->
     SockInfo = inet:info(Socket),

--- a/src/quic_server_registry.erl
+++ b/src/quic_server_registry.erl
@@ -35,6 +35,7 @@
     lookup/1,
     list/0,
     get_port/1,
+    get_sockname/1,
     update_port/2,
     get_connections/1
 ]).
@@ -104,6 +105,28 @@ get_port(Name) ->
             end;
         {ok, #{port := Port}} ->
             {ok, Port};
+        {error, not_found} ->
+            {error, not_found}
+    end.
+
+%% @doc Get the bound address of a named server's listener.
+%% Queried live from the listening socket, so it reflects the real address even
+%% when the server was started with port 0, `inet6', `{ip, _}' or `{ifaddr, _}'.
+-spec get_sockname(atom()) ->
+    {ok, {inet:ip_address(), inet:port_number()}} | {error, term()}.
+get_sockname(Name) ->
+    case lookup(Name) of
+        {ok, #{pid := Pid}} ->
+            %% Mirror get_actual_port_from_listener/1: catch a teardown-race
+            %% exception into an {error, _} rather than letting it propagate.
+            try
+                case first_listener_pid(Pid) of
+                    {ok, ListenerPid} -> quic_listener:get_sockname(ListenerPid);
+                    Error -> Error
+                end
+            catch
+                _:_ -> {error, failed_to_get_sockname}
+            end;
         {error, not_found} ->
             {error, not_found}
     end.
@@ -244,24 +267,29 @@ find_monitor_by_pid(Pid, Monitors) ->
 %% @doc Get actual bound port from a listener when server was started with port 0.
 %% Navigates the supervision tree: listener_sup -> listener_sup_sup -> quic_listener
 get_actual_port_from_listener(ListenerSupPid) ->
+    %% Keep the catch wrapping BOTH the listener lookup and the get_port call so
+    %% the historical {error, failed_to_get_port} return is preserved.
     try
-        %% Get children of listener_sup - includes quic_listener_sup_sup
-        Children = supervisor:which_children(ListenerSupPid),
-        %% Find the listener_sup_sup
-        case lists:keyfind(quic_listener_sup_sup, 1, Children) of
-            {quic_listener_sup_sup, SupSupPid, _, _} when is_pid(SupSupPid) ->
-                %% Get listeners from sup_sup
-                ListenerChildren = supervisor:which_children(SupSupPid),
-                case [P || {{quic_listener, _}, P, _, _} <- ListenerChildren, is_pid(P)] of
-                    [ListenerPid | _] ->
-                        {ok, quic_listener:get_port(ListenerPid)};
-                    [] ->
-                        {error, no_listeners}
-                end;
-            _ ->
-                {error, no_listener_sup}
+        case first_listener_pid(ListenerSupPid) of
+            {ok, ListenerPid} -> {ok, quic_listener:get_port(ListenerPid)};
+            Error -> Error
         end
     catch
         _:_ ->
             {error, failed_to_get_port}
+    end.
+
+%% Resolve the first live listener pid under a server's listener supervisor.
+first_listener_pid(ListenerSupPid) ->
+    %% Get children of listener_sup - includes quic_listener_sup_sup
+    Children = supervisor:which_children(ListenerSupPid),
+    case lists:keyfind(quic_listener_sup_sup, 1, Children) of
+        {quic_listener_sup_sup, SupSupPid, _, _} when is_pid(SupSupPid) ->
+            ListenerChildren = supervisor:which_children(SupSupPid),
+            case [P || {{quic_listener, _}, P, _, _} <- ListenerChildren, is_pid(P)] of
+                [ListenerPid | _] -> {ok, ListenerPid};
+                [] -> {error, no_listeners}
+            end;
+        _ ->
+            {error, no_listener_sup}
     end.

--- a/test/quic_listener_tests.erl
+++ b/test/quic_listener_tests.erl
@@ -56,6 +56,22 @@ get_port_test() ->
     ?assert(Port > 0),
     ok = quic_listener:stop(Listener).
 
+get_sockname_test() ->
+    {Cert, PrivKey} = generate_test_cert(),
+    Opts = #{
+        cert => Cert,
+        key => PrivKey,
+        alpn => [<<"h3">>]
+    },
+    {ok, Listener} = quic_listener:start_link(0, Opts),
+    {ok, {IP, Port}} = quic_listener:get_sockname(Listener),
+    ?assert(is_tuple(IP)),
+    ?assert(is_integer(Port)),
+    ?assert(Port > 0),
+    %% The sockname port must match the cached get_port/1 value.
+    ?assertEqual(quic_listener:get_port(Listener), Port),
+    ok = quic_listener:stop(Listener).
+
 specific_port_test() ->
     {Cert, PrivKey} = generate_test_cert(),
     Opts = #{

--- a/test/quic_server_tests.erl
+++ b/test/quic_server_tests.erl
@@ -71,6 +71,7 @@ server_test_() ->
         {"Pool size option", fun pool_size_test/0},
         {"Which servers", fun which_servers_test/0},
         {"Get server port", fun get_server_port_test/0},
+        {"Get server sockname", fun get_server_sockname_test/0},
         {"Badarg tests", fun badarg_test/0}
     ]}.
 
@@ -154,6 +155,7 @@ get_server_info_test() ->
 server_not_found_test() ->
     ?assertEqual({error, not_found}, quic:get_server_info(nonexistent)),
     ?assertEqual({error, not_found}, quic:get_server_port(nonexistent)),
+    ?assertEqual({error, not_found}, quic:get_server_sockname(nonexistent)),
     ?assertEqual({error, not_found}, quic:get_server_connections(nonexistent)).
 
 pool_size_test() ->
@@ -204,12 +206,25 @@ get_server_port_test() ->
     {ok, Port2} = quic:get_server_port(port_server),
     ?assertEqual(Port, Port2).
 
+get_server_sockname_test() ->
+    {ok, _} = quic:start_server(sockname_server, 0, base_opts()),
+
+    %% Resolved live from the socket; port matches get_server_port/1.
+    {ok, {IP, Port}} = quic:get_server_sockname(sockname_server),
+    ?assert(is_tuple(IP)),
+    ?assert(is_integer(Port)),
+    ?assert(Port > 0),
+    ?assert(Port < 65536),
+    {ok, PortViaPort} = quic:get_server_port(sockname_server),
+    ?assertEqual(PortViaPort, Port).
+
 badarg_test() ->
     %% Invalid name
     ?assertEqual({error, badarg}, quic:start_server("not_atom", 0, #{})),
     ?assertEqual({error, badarg}, quic:stop_server("not_atom")),
     ?assertEqual({error, badarg}, quic:get_server_info("not_atom")),
     ?assertEqual({error, badarg}, quic:get_server_port("not_atom")),
+    ?assertEqual({error, badarg}, quic:get_server_sockname("not_atom")),
     ?assertEqual({error, badarg}, quic:get_server_connections("not_atom")),
 
     %% Invalid port


### PR DESCRIPTION
Closes #153.

`quic_listener:get_port/1` returns only the port, so a caller cannot reliably learn the bound address when the listener was opened with `inet6`, `{ip, _}` or `{ifaddr, _}`. This adds `quic_listener:get_sockname/1`, returning the `{IP, Port}` resolved live from the listening socket, plus `quic:get_server_sockname/1` to read it by server name alongside `get_server_port/1`.

The registry resolution is refactored to share a `first_listener_pid/1` helper between the port and sockname paths, preserving `get_port`'s existing error returns (`no_listeners` / `no_listener_sup` / `failed_to_get_port`).