### PR TITLE
Fix server-side 0-RTT acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-06-02
+
+### Fixed
+- Server-side 0-RTT acceptance now works end to end. The server echoes the empty `early_data` extension in EncryptedExtensions when it accepts 0-RTT, so a resuming client reports `early_data_accepted/1 =:= true` instead of always seeing the data rejected. Inbound 0-RTT frames are dispatched at the application level, so the early request and its control/QPACK streams are processed rather than dropped, and the resumed request completes normally.
+
 ## [1.6.0] - 2026-06-02
 
 ### Added

--- a/src/quic.app.src
+++ b/src/quic.app.src
@@ -1,6 +1,6 @@
 {application, quic, [
     {description, "Pure Erlang QUIC implementation (RFC 9000)"},
-    {vsn, "1.6.0"},
+    {vsn, "1.6.1"},
     {registered, [
         quic_sup,
         quic_server_registry,

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2942,7 +2942,8 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     %% Build EncryptedExtensions
     EncExtMsg = quic_tls:build_encrypted_extensions(#{
         alpn => ALPN,
-        transport_params => TransportParams
+        transport_params => TransportParams,
+        early_data => State#state.early_data_accepted
     }),
 
     %% PSK handshakes (RFC 8446 §4.6) skip CertificateRequest / Certificate /

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4372,7 +4372,14 @@ process_frame_track_probing(Level, Frame, State) ->
                     false -> State#state{has_non_probing_frame = true}
                 end
         end,
-    process_frame(Level, Frame, State1).
+    %% 0-RTT shares the application packet number space and frame
+    %% semantics with 1-RTT (RFC 9001 §5.7). Dispatch its frames at the
+    %% app level so STREAM and flow-control frames are handled rather than
+    %% dropped by the catch-all clause.
+    process_frame(frame_dispatch_level(Level), Frame, State1).
+
+frame_dispatch_level(zero_rtt) -> app;
+frame_dispatch_level(Level) -> Level.
 
 %% Process individual frames
 process_frame(_Level, padding, State) ->

--- a/test/quic_h3_0rtt_SUITE.erl
+++ b/test/quic_h3_0rtt_SUITE.erl
@@ -48,6 +48,7 @@
     session_ticket_emitted_inproc/1,
     session_ticket_emitted_aioquic/1,
     session_ticket_emitted_quic_go/1,
+    resumed_connection_0rtt_inproc/1,
     resumed_connection_0rtt_aioquic/1,
     rejected_emits_event_and_does_not_auto_retry/1,
     multiple_session_tickets_emitted/1,
@@ -66,6 +67,7 @@ all() ->
         session_ticket_emitted_inproc,
         session_ticket_emitted_aioquic,
         session_ticket_emitted_quic_go,
+        resumed_connection_0rtt_inproc,
         resumed_connection_0rtt_aioquic,
         rejected_emits_event_and_does_not_auto_retry,
         multiple_session_tickets_emitted,
@@ -167,6 +169,27 @@ run_session_ticket_emitted(Host, Port) ->
 %%====================================================================
 %% Test cases - resumed connection with 0-RTT
 %%====================================================================
+
+%% Full in-process round trip against the shipped quic_test_h3_server:
+%% connect once and capture a ticket, reconnect with that ticket, send a
+%% bodyless 0-RTT request, and assert the server signalled acceptance
+%% (early_data_accepted/1 =:= true) and answered normally. This is the
+%% server-side companion to resumed_connection_0rtt_aioquic and the case
+%% that exercises the EncryptedExtensions early_data echo.
+resumed_connection_0rtt_inproc(Config) ->
+    Host = ?config(h3_host, Config),
+    Port = ?config(h3_port, Config),
+    case run_resumption_cycle(Host, Port, 5000) of
+        {ok, EarlyData, Status} ->
+            ct:pal("Resumed in-proc: early_data_accepted=~p status=~p", [EarlyData, Status]),
+            ?assertEqual(true, EarlyData),
+            ?assertEqual(200, Status),
+            ok;
+        no_ticket ->
+            {skip, "in-proc server did not emit a session ticket"};
+        {error, Reason} ->
+            ct:fail({resumption_failed, Reason})
+    end.
 
 resumed_connection_0rtt_aioquic(_Config) ->
     case discover_external(aioquic) of


### PR DESCRIPTION
0-RTT shipped in 1.6.0 (#148) but server acceptance never worked end to end.

Two bugs: the server accepted 0-RTT internally but never echoed the `early_data` extension in EncryptedExtensions, so a resuming client always concluded rejection; and inbound 0-RTT packets were processed with a `zero_rtt` frame level while the STREAM and flow-control handlers only match `app`, so the client's early control/QPACK/request data was dropped by the catch-all. The server then never received peer SETTINGS, never reached `connected`, and the response stalled.

The server now passes its accepted flag into the EncryptedExtensions build, and 0-RTT frames are dispatched at the application level (RFC 9001 5.7, shared packet number space). A resuming client now reports `quic:early_data_accepted(Conn) =:= true` and the resumed request completes normally.

Bumps to 1.6.1.