### PR TITLE
1.6.2: fix Happy Eyeballs + HTTP/3 connect hang on multi-address hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-06-03
+
+### Fixed
+- Happy Eyeballs + HTTP/3: a client connecting to a hostname that resolves to more than one address (so the race path runs) could hang in `quic_h3:connect/3` until `connect_timeout`. The QUIC connection completes its handshake while owned by the race coordinator, so the server's HTTP/3 control stream and SETTINGS were delivered to the transient owner and dropped before the H3 connection process existed. `set_owner` re-delivers `{connected}` but not that already-arrived stream data; the race coordinator and `quic_h3:connect/3` now forward the buffered `{quic, Conn, _}` backlog to the new owner at each ownership handoff.
+
 ## [1.6.1] - 2026-06-02
 
 ### Fixed

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -278,6 +278,12 @@ start_h3_connection(QuicConn, HostBin, Port, Opts) ->
         {ok, H3Conn} ->
             %% Transfer ownership to H3 process so it receives QUIC events
             ok = quic:set_owner_sync(QuicConn, H3Conn),
+            %% With Happy Eyeballs the connection can already be `connected'
+            %% by the time we get here, so the server's control stream and
+            %% SETTINGS may have been delivered to us (the prior owner) before
+            %% H3Conn existed. set_owner_sync re-delivers {connected} but not
+            %% that backlog, so forward it on in order.
+            forward_quic_backlog(QuicConn, H3Conn),
             %% Prime the H3 process so it can choose between the 0-RTT
             %% `early_data' path and the regular `awaiting_quic' wait.
             ok = quic_h3_connection:prime(H3Conn),
@@ -285,6 +291,20 @@ start_h3_connection(QuicConn, HostBin, Port, Opts) ->
         {error, Reason} ->
             quic:close(QuicConn, 0, <<"h3 init failed">>),
             {error, Reason}
+    end.
+
+%% Drain this process's mailbox of `{quic, Conn, _}' messages and forward them
+%% to H3Conn in arrival order. {connected} is skipped: set_owner re-delivers it
+%% to the new owner already, so forwarding it too would duplicate it.
+forward_quic_backlog(Conn, H3Conn) ->
+    receive
+        {quic, Conn, {connected, _}} ->
+            forward_quic_backlog(Conn, H3Conn);
+        {quic, Conn, _} = Msg ->
+            H3Conn ! Msg,
+            forward_quic_backlog(Conn, H3Conn)
+    after 0 ->
+        ok
     end.
 
 maybe_wait_connected(H3Conn, Opts) ->

--- a/src/quic.app.src
+++ b/src/quic.app.src
@@ -1,6 +1,6 @@
 {application, quic, [
     {description, "Pure Erlang QUIC implementation (RFC 9000)"},
-    {vsn, "1.6.1"},
+    {vsn, "1.6.2"},
     {registered, [
         quic_sup,
         quic_server_registry,

--- a/src/quic_happy.erl
+++ b/src/quic_happy.erl
@@ -208,11 +208,31 @@ on_connected(#{owner := Owner, caller := Caller} = St, Pid, _Info) ->
     %% {connected} and here raises, and we continue the race.
     try quic_connection:set_owner_sync(Pid, Owner) of
         ok ->
+            %% The connection handshaked while we owned it, so any peer data
+            %% it already delivered (e.g. the server's HTTP/3 control stream
+            %% and SETTINGS) is sitting in our mailbox and would be lost when
+            %% we exit. set_owner_sync re-delivers {connected} but not that
+            %% backlog, so hand it to the new owner in order.
+            forward_quic_backlog(Pid, Owner),
             Caller ! {quic_happy_result, self(), {ok, Pid}},
             ok
     catch
         _:_ ->
             loop(drop_attempt(St, Pid))
+    end.
+
+%% Drain this process's mailbox of `{quic, Conn, _}' messages and forward them
+%% to NewOwner in arrival order. {connected} is skipped: set_owner re-delivers
+%% it to the new owner already, so forwarding it too would duplicate it.
+forward_quic_backlog(Conn, NewOwner) ->
+    receive
+        {quic, Conn, {connected, _}} ->
+            forward_quic_backlog(Conn, NewOwner);
+        {quic, Conn, _} = Msg ->
+            NewOwner ! Msg,
+            forward_quic_backlog(Conn, NewOwner)
+    after 0 ->
+        ok
     end.
 
 finish(#{caller := Caller}, Result) ->

--- a/test/quic_h3_connect_race_tests.erl
+++ b/test/quic_h3_connect_race_tests.erl
@@ -1,0 +1,88 @@
+%%% -*- erlang -*-
+%%%
+%%% Regression test for the HTTP/3 connect owner-transfer race.
+%%%
+%%% quic_h3:connect/3 opens the QUIC connection owned by the caller, then
+%%% transfers ownership to the H3 process via set_owner_sync/2. On fast
+%%% handshakes (localhost, low-RTT, 0-RTT) — and on the Happy Eyeballs race
+%%% path, where the connection handshakes while owned by the race
+%%% coordinator — the QUIC `connected' event and the peer's control-stream
+%%% SETTINGS arrive in the (transient) owner's mailbox before that transfer.
+%%% set_owner re-emits `connected' to the new owner but cannot replay the
+%%% already-delivered stream_data, so the H3 FSM never receives SETTINGS,
+%%% never converges, and the caller blocks until connect_timeout. connect/3
+%%% must drain and forward the leaked `{quic, QuicConn, _}' stream events to
+%%% the H3 process after the ownership transfer.
+
+-module(quic_h3_connect_race_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+setup() ->
+    meck:new(quic, [passthrough]),
+    %% Mirror the real set_owner_sync/2: in the `connected' state it
+    %% re-emits `connected' to the new owner. It does NOT replay already
+    %% delivered stream data, so the leaked SETTINGS can only reach the H3
+    %% FSM if connect/3 drains and forwards them.
+    meck:expect(quic, set_owner_sync, fun(Conn, NewOwner) ->
+        NewOwner ! {quic, Conn, {connected, #{}}},
+        ok
+    end),
+    meck:expect(quic, close, fun(_) -> ok end),
+    meck:expect(quic, close, fun(_, _, _) -> ok end),
+    meck:expect(quic, datagram_max_size, fun(_) -> 0 end),
+    meck:expect(quic, has_early_keys, fun(_) -> false end),
+    meck:expect(quic, early_data_accepted, fun(_) -> unknown end),
+    UniCounter = counters:new(1, []),
+    meck:expect(quic, open_unidirectional_stream, fun(_) ->
+        counters:add(UniCounter, 1, 1),
+        N = counters:get(UniCounter, 1),
+        {ok, (N - 1) * 4 + 2}
+    end),
+    meck:expect(quic, open_stream, fun(_) -> {ok, 0} end),
+    meck:expect(quic, send_data, fun(_, _, _, _) -> ok end),
+    ok.
+
+teardown(_) ->
+    meck:unload(quic),
+    ok.
+
+leaked_owner_events_forwarded_to_h3_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        FakeQuicConn = spawn_link(fun fake_quic_loop/0),
+        Payload = control_settings_payload(),
+        %% Reproduce the race: quic:connect/4 returns with the QUIC
+        %% `connected' event AND the peer's control-stream SETTINGS already
+        %% sitting in the caller's mailbox, because a transient process (the
+        %% caller, or the Happy Eyeballs coordinator that handed off to it)
+        %% was the owner when they arrived.
+        meck:expect(quic, connect, fun(_Host, _Port, _Opts, Owner) ->
+            Owner ! {quic, FakeQuicConn, {connected, #{}}},
+            Owner ! {quic, FakeQuicConn, {stream_data, 3, Payload, false}},
+            {ok, FakeQuicConn}
+        end),
+        Result = quic_h3:connect(<<"example.com">>, 443, #{
+            sync => true, connect_timeout => 1000
+        }),
+        ?assertMatch({ok, _}, Result),
+        {ok, H3Conn} = Result,
+        cleanup(H3Conn, FakeQuicConn)
+    end}.
+
+control_settings_payload() ->
+    StreamTypeBin = quic_h3_frame:encode_stream_type(control),
+    SettingsBin = quic_h3_frame:encode_settings(#{}),
+    <<StreamTypeBin/binary, SettingsBin/binary>>.
+
+cleanup(H3Conn, FakeQuicConn) ->
+    unlink(H3Conn),
+    exit(H3Conn, shutdown),
+    unlink(FakeQuicConn),
+    exit(FakeQuicConn, shutdown),
+    ok.
+
+fake_quic_loop() ->
+    receive
+        stop -> ok;
+        _ -> fake_quic_loop()
+    end.


### PR DESCRIPTION
A client connecting to a hostname that resolves to more than one address (so the Happy Eyeballs race path runs) could hang in `quic_h3:connect/3` until `connect_timeout`.

The race completes the QUIC handshake while the connection is owned by the race coordinator. The server's HTTP/3 control stream and SETTINGS are then delivered to that transient owner (and the intermediate `quic:connect` caller) and dropped before the H3 connection process becomes the owner, so the H3 handshake never converges.

`set_owner` re-delivers `{connected}` but not the already-arrived stream data. The race coordinator and `quic_h3:connect/3` now forward the buffered `{quic, Conn, _}` backlog to the new owner at each ownership handoff.

Verified with the erlang-webtransport interop suite (erlang↔erlang and erlang↔go, Happy Eyeballs on by default): all cases pass. Raw `quic:connect` was already fine; only the H3 layer was affected. eunit: 2185 passing.