### PR TITLE
Add quic:safe_close and modernize catch usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
         include:
           - os: ubuntu-22.04
             otp: '26'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-24.04
             otp: '28'
             rebar3: 'nightly'
+          - os: ubuntu-24.04
+            otp: '29'
+            rebar3: 'nightly'
 
     steps:
       - uses: actions/checkout@v4

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -124,14 +124,17 @@ select(Node) ->
         {node, Name, Host} ->
             %% Try to resolve address via EPMD module
             EpmdMod = net_kernel:epmd_module(),
-            case catch EpmdMod:address_please(Name, Host, inet) of
+            try EpmdMod:address_please(Name, Host, inet) of
                 {ok, _Addr} ->
                     true;
                 {ok, _Addr, _Port, _Version} ->
                     true;
                 _ ->
-                    %% Even if address lookup fails, allow local connections
-                    %% This is needed during initial node startup
+                    true
+            catch
+                %% Even if address lookup fails, allow local connections.
+                %% This is needed during initial node startup.
+                _:_ ->
                     true
             end;
         _ ->
@@ -297,15 +300,27 @@ setup(Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 -spec close(Listen :: term()) -> ok.
 close(#quic_dist_listener{server_name = ServerName}) ->
     %% First try to stop via supervised server
-    catch quic:stop_server(ServerName),
+    try
+        quic:stop_server(ServerName)
+    catch
+        _:_ -> ok
+    end,
     %% Also check for early boot standalone listener
     Key = {quic_dist_early_listener, ServerName},
     case persistent_term:get(Key, undefined) of
         undefined ->
             ok;
         #{pid := Pid} ->
-            catch quic_listener:stop(Pid),
-            catch persistent_term:erase(Key),
+            try
+                quic_listener:stop(Pid)
+            catch
+                _:_ -> ok
+            end,
+            try
+                persistent_term:erase(Key)
+            catch
+                _:_ -> ok
+            end,
             ok
     end;
 close(_) ->
@@ -875,7 +890,7 @@ gatekeeper(Conn, Callback, Timeout) ->
                 {ok, _} ->
                     finalize_server_handoff(Conn);
                 {error, Reason} ->
-                    catch quic:close(Conn, normal),
+                    quic:safe_close(Conn, normal),
                     exit({auth_failed, Reason})
             end;
         {quic, Conn, {closed, Reason}} ->
@@ -883,7 +898,7 @@ gatekeeper(Conn, Callback, Timeout) ->
         {quic, Conn, {transport_error, Code, Reason}} ->
             exit({transport_error, Code, Reason})
     after Timeout ->
-        catch quic:close(Conn, normal),
+        quic:safe_close(Conn, normal),
         exit({auth_failed, handshake_timeout})
     end.
 
@@ -898,7 +913,7 @@ finalize_server_handoff(Conn) ->
             drain_quic_events(Conn, ControllerPid),
             notify_acceptor(ControllerPid);
         {error, Reason} ->
-            catch quic:close(Conn, normal),
+            quic:safe_close(Conn, normal),
             exit({controller_failed, Reason})
     end.
 
@@ -1238,7 +1253,7 @@ wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer, Config) ->
                 ok ->
                     start_client_controller(Kernel, Node, Conn, MyNode, Type, Timer);
                 {error, AuthReason} ->
-                    catch quic:close(Conn, normal),
+                    quic:safe_close(Conn, normal),
                     ?shutdown2(Node, {auth_failed, AuthReason})
             end;
         {quic, Conn, {closed, Reason}} ->
@@ -1271,7 +1286,7 @@ start_client_controller(Kernel, Node, Conn, MyNode, Type, Timer) ->
             HSData = create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer),
             dist_util:handshake_we_started(HSData);
         {error, Reason} ->
-            quic:close(Conn, normal),
+            quic:safe_close(Conn, normal),
             ?shutdown2(Node, {controller_failed, Reason})
     end.
 

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -289,7 +289,7 @@ start_h3_connection(QuicConn, HostBin, Port, Opts) ->
             ok = quic_h3_connection:prime(H3Conn),
             maybe_wait_connected(H3Conn, Opts);
         {error, Reason} ->
-            quic:close(QuicConn, 0, <<"h3 init failed">>),
+            quic:safe_close(QuicConn, 0, <<"h3 init failed">>),
             {error, Reason}
     end.
 

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -556,7 +556,7 @@ init({server, QuicConn, Opts, Owner}) ->
     {ok, awaiting_quic, State}.
 
 terminate(_Reason, _StateName, #state{quic_conn = QuicConn}) ->
-    catch quic:close(QuicConn),
+    quic:safe_close(QuicConn),
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
@@ -1263,7 +1263,7 @@ goaway_received(_EventType, _Event, _State) ->
 %%====================================================================
 
 closing(enter, _OldState, #state{quic_conn = QuicConn, owner = Owner}) ->
-    catch quic:close(QuicConn),
+    quic:safe_close(QuicConn),
     Owner ! {quic_h3, self(), closed},
     {stop, normal};
 closing(
@@ -2582,9 +2582,9 @@ handle_request_frame(
 handle_request_frame(
     StreamId,
     {data, Payload},
-    Fin,
+    _Fin,
     #h3_stream{frame_state = expecting_data} = Stream,
-    State
+    _State
 ) when (byte_size(Stream#h3_stream.body) + byte_size(Payload)) > ?H3_MAX_BUFFERED_BODY ->
     %% Without a Content-Length the body buffer would otherwise grow with
     %% the stream; cap it (RFC 9114 §4.1 allows H3_EXCESSIVE_LOAD).
@@ -3390,11 +3390,15 @@ parse_priority_params([Param | Rest], Urgency, Incremental) ->
     Trimmed = string:trim(Param),
     case Trimmed of
         <<"u=", UBin/binary>> ->
-            case catch binary_to_integer(UBin) of
+            try binary_to_integer(UBin) of
                 U when is_integer(U), U >= 0, U =< 7 ->
                     parse_priority_params(Rest, U, Incremental);
                 _ ->
                     %% Invalid urgency - use default
+                    parse_priority_params(Rest, Urgency, Incremental)
+            catch
+                _:_ ->
+                    %% Not an integer - use default
                     parse_priority_params(Rest, Urgency, Incremental)
             end;
         <<"i">> ->
@@ -4436,9 +4440,21 @@ maybe_close_if_drained(State) ->
 handle_connection_error(
     {connection_error, ErrorCode, Reason}, #state{quic_conn = QuicConn, owner = Owner} = State
 ) ->
-    Owner ! {quic_h3, self(), {error, ErrorCode, Reason}},
-    catch quic:close(QuicConn, ErrorCode, Reason),
+    %% Some call sites forward a non-binary decode reason; quic:close/3
+    %% requires a binary phrase, so coerce before sending CONNECTION_CLOSE.
+    Phrase = reason_phrase(Reason),
+    Owner ! {quic_h3, self(), {error, ErrorCode, Phrase}},
+    quic:safe_close(QuicConn, ErrorCode, Phrase),
     {next_state, closing, State}.
+
+reason_phrase(Reason) when is_binary(Reason) ->
+    Reason;
+reason_phrase(Reason) ->
+    try
+        iolist_to_binary(Reason)
+    catch
+        _:_ -> iolist_to_binary(io_lib:format("~0p", [Reason]))
+    end.
 
 notify_stream_reset(StreamId, ErrorCode, #state{owner = Owner}) ->
     Owner ! {quic_h3, self(), {stream_reset, StreamId, ErrorCode}}.

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -78,6 +78,9 @@
     close/1,
     close/2,
     close/3,
+    safe_close/1,
+    safe_close/2,
+    safe_close/3,
     open_stream/1,
     open_unidirectional_stream/1,
     send_data/4,
@@ -330,6 +333,41 @@ close(Conn, ErrorCode, Reason) when
     is_binary(Reason)
 ->
     quic_connection:close(Conn, {app_error, ErrorCode, Reason}).
+
+%% @doc Close a connection, ignoring any error if it is already gone.
+%% For teardown paths that must not crash when the connection has
+%% already closed or the pid is dead.
+-spec safe_close(Conn) -> ok when
+    Conn :: pid().
+safe_close(Conn) ->
+    try
+        close(Conn)
+    catch
+        _:_ -> ok
+    end.
+
+%% @doc Like {@link safe_close/1} with a close reason.
+-spec safe_close(Conn, Reason) -> ok when
+    Conn :: pid(),
+    Reason :: non_neg_integer() | term().
+safe_close(Conn, Reason) ->
+    try
+        close(Conn, Reason)
+    catch
+        _:_ -> ok
+    end.
+
+%% @doc Like {@link safe_close/1} with an application error code and reason phrase.
+-spec safe_close(Conn, ErrorCode, Reason) -> ok when
+    Conn :: pid(),
+    ErrorCode :: 0..16#3FFFFFFFFFFFFFFF,
+    Reason :: binary().
+safe_close(Conn, ErrorCode, Reason) ->
+    try
+        close(Conn, ErrorCode, Reason)
+    catch
+        _:_ -> ok
+    end.
 
 %% @doc Open a new bidirectional stream.
 %% Returns {ok, StreamId} on success.

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -451,7 +451,12 @@ close(#socket_state{backend = adapter, adapter_close_fun = Fun}) ->
         undefined ->
             ok;
         F when is_function(F, 0) ->
-            _ = catch F(),
+            _ =
+                try
+                    F()
+                catch
+                    _:_ -> ok
+                end,
             ok
     end;
 close(#socket_state{owns_socket = false}) ->

--- a/test/prop_quic_h3_0rtt.erl
+++ b/test/prop_quic_h3_0rtt.erl
@@ -158,7 +158,11 @@ reset_stream_counters() ->
     ok.
 
 setup_meck(HasEarlyKeys) ->
-    catch meck:unload(quic),
+    try
+        meck:unload(quic)
+    catch
+        _:_ -> ok
+    end,
     meck:new(quic, [passthrough]),
     meck:expect(quic, set_owner_sync, fun(_, _) -> ok end),
     meck:expect(quic, close, fun(_) -> ok end),
@@ -184,7 +188,11 @@ setup_meck(HasEarlyKeys) ->
     ok.
 
 teardown_meck() ->
-    catch meck:unload(quic),
+    try
+        meck:unload(quic)
+    catch
+        _:_ -> ok
+    end,
     persistent_term:erase({?MODULE, uni_counter}),
     persistent_term:erase({?MODULE, bidi_counter}),
     ok.
@@ -315,9 +323,17 @@ check_request_results(Results, N) ->
     Sorted =:= Expected andalso length(Unique) =:= N.
 
 teardown_h3(H3, FakeQC) ->
-    catch unlink(H3),
+    try
+        unlink(H3)
+    catch
+        _:_ -> ok
+    end,
     wait_down(H3, shutdown),
-    catch unlink(FakeQC),
+    try
+        unlink(FakeQC)
+    catch
+        _:_ -> ok
+    end,
     wait_down(FakeQC, shutdown),
     ok.
 
@@ -326,7 +342,11 @@ teardown_h3(H3, FakeQC) ->
 %% next iteration (or the ?SETUP finalizer's meck:unload) runs.
 wait_down(Pid, Reason) ->
     MRef = erlang:monitor(process, Pid),
-    catch exit(Pid, Reason),
+    try
+        exit(Pid, Reason)
+    catch
+        _:_ -> ok
+    end,
     receive
         {'DOWN', MRef, process, Pid, _} -> ok
     after ?WAIT_MS ->

--- a/test/quic_call_SUITE.erl
+++ b/test/quic_call_SUITE.erl
@@ -115,10 +115,18 @@ stop_port(Port) ->
             os:cmd("kill " ++ integer_to_list(OsPid)),
             timer:sleep(200),
             os:cmd("kill -9 " ++ integer_to_list(OsPid) ++ " 2>/dev/null"),
-            catch erlang:port_close(Port),
+            try
+                erlang:port_close(Port)
+            catch
+                _:_ -> ok
+            end,
             ok;
         _ ->
-            catch erlang:port_close(Port),
+            try
+                erlang:port_close(Port)
+            catch
+                _:_ -> ok
+            end,
             ok
     end.
 
@@ -437,6 +445,10 @@ collect(Port, Acc, TimeoutMs) ->
             _ ->
                 ok
         end,
-        catch erlang:port_close(Port),
+        try
+            erlang:port_close(Port)
+        catch
+            _:_ -> ok
+        end,
         {binary_to_list(iolist_to_binary(lists:reverse(Acc))), 124}
     end.

--- a/test/quic_cert_tests.erl
+++ b/test/quic_cert_tests.erl
@@ -220,7 +220,7 @@ connect(Port, Opts0) ->
                 {quic, _, {error, Reason}} -> {error, Reason}
             after ?CONNECT_TIMEOUT -> timeout
             end,
-        catch quic:close(Conn),
+        quic:safe_close(Conn),
         Parent ! {result, self(), Result}
     end),
     receive
@@ -358,7 +358,11 @@ h3_setup() ->
 h3_cleanup(skip) ->
     ok;
 h3_cleanup(#{name := Name}) ->
-    catch quic:stop_server(Name),
+    try
+        quic:stop_server(Name)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 %% Connect over HTTP/3 to localhost and report whether the handshake
@@ -373,7 +377,11 @@ h3_connect(Port, Opts0) ->
     },
     case quic_h3:connect("127.0.0.1", Port, Opts) of
         {ok, Conn} ->
-            catch quic_h3:close(Conn),
+            try
+                quic_h3:close(Conn)
+            catch
+                _:_ -> ok
+            end,
             connected;
         {error, Reason} ->
             {error, Reason}

--- a/test/quic_client_cert_tests.erl
+++ b/test/quic_client_cert_tests.erl
@@ -74,8 +74,16 @@ decode_key(KeyPem) ->
     end.
 
 cleanup_server_only(TmpDir, ServerName) ->
-    catch quic:stop_server(ServerName),
-    catch os:cmd("rm -rf " ++ TmpDir),
+    try
+        quic:stop_server(ServerName)
+    catch
+        _:_ -> ok
+    end,
+    try
+        os:cmd("rm -rf " ++ TmpDir)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 %%====================================================================

--- a/test/quic_client_migrate_tests.erl
+++ b/test/quic_client_migrate_tests.erl
@@ -61,7 +61,7 @@ do_migrate(ServerExtra, Host) ->
             Received = collect_echo(Conn, StreamId, <<>>, 10000),
             ?assertEqual(Payload, Received)
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)

--- a/test/quic_client_socket_backend_tests.erl
+++ b/test/quic_client_socket_backend_tests.erl
@@ -44,7 +44,7 @@ client_socket_backend_roundtrip() ->
             Received = collect_echo(Conn, StreamId, <<>>, 10000),
             ?assertEqual(Payload, Received)
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)
@@ -83,7 +83,7 @@ client_socket_backend_migrate() ->
             Received = collect_echo(Conn, StreamId, <<>>, 10000),
             ?assertEqual(Payload, Received)
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)
@@ -110,7 +110,11 @@ client_pre_opened_socket_rejects_socket_backend() ->
             Result = quic:connect("127.0.0.1", Port, Opts, self()),
             ?assertMatch({error, {incompatible_options, _}}, Result)
         after
-            catch gen_udp:close(UdpSocket)
+            try
+                gen_udp:close(UdpSocket)
+            catch
+                _:_ -> ok
+            end
         end
     after
         quic_test_echo_server:stop(Srv)
@@ -149,7 +153,7 @@ client_receiver_crash_closes_connection() ->
                 error(no_close_event)
             end
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)

--- a/test/quic_close_tests.erl
+++ b/test/quic_close_tests.erl
@@ -172,7 +172,11 @@ draining_handles_owner_exit_test() ->
     end,
 
     %% Cleanup - unlink from owner if still linked
-    catch unlink(Owner).
+    try
+        unlink(Owner)
+    catch
+        _:_ -> ok
+    end.
 
 %%====================================================================
 %% Synchronous close tests

--- a/test/quic_datagram_e2e_SUITE.erl
+++ b/test/quic_datagram_e2e_SUITE.erl
@@ -120,7 +120,11 @@ init_per_testcase(TestCase, Config) ->
 
 end_per_testcase(_TestCase, Config) ->
     ServerName = ?config(server_name, Config),
-    catch quic:stop_server(ServerName),
+    try
+        quic:stop_server(ServerName)
+    catch
+        _:_ -> ok
+    end,
     timer:sleep(50),
     ok.
 

--- a/test/quic_dist_auth_SUITE.erl
+++ b/test/quic_dist_auth_SUITE.erl
@@ -379,10 +379,18 @@ stop_port(Port) ->
             os:cmd("kill " ++ integer_to_list(OsPid)),
             timer:sleep(200),
             os:cmd("kill -9 " ++ integer_to_list(OsPid) ++ " 2>/dev/null"),
-            catch erlang:port_close(Port),
+            try
+                erlang:port_close(Port)
+            catch
+                _:_ -> ok
+            end,
             ok;
         _ ->
-            catch erlang:port_close(Port),
+            try
+                erlang:port_close(Port)
+            catch
+                _:_ -> ok
+            end,
             ok
     end.
 
@@ -410,7 +418,11 @@ wait_for_port_exit(Port, TimeoutMs, Acc) ->
             _ ->
                 ok
         end,
-        catch erlang:port_close(Port),
+        try
+            erlang:port_close(Port)
+        catch
+            _:_ -> ok
+        end,
         binary_to_list(iolist_to_binary(lists:reverse(Acc)))
     end.
 

--- a/test/quic_dist_basic_SUITE.erl
+++ b/test/quic_dist_basic_SUITE.erl
@@ -113,8 +113,16 @@ end_per_group(two_node, Config) ->
     Peer1 = proplists:get_value(peer1, Config),
     Peer2 = proplists:get_value(peer2, Config),
 
-    catch peer:stop(Peer1),
-    catch peer:stop(Peer2),
+    try
+        peer:stop(Peer1)
+    catch
+        _:_ -> ok
+    end,
+    try
+        peer:stop(Peer2)
+    catch
+        _:_ -> ok
+    end,
     ok;
 end_per_group(_Group, _Config) ->
     ok.

--- a/test/quic_dist_cluster_SUITE.erl
+++ b/test/quic_dist_cluster_SUITE.erl
@@ -357,7 +357,11 @@ start_cluster(N, _CertDir) ->
 stop_cluster(Nodes) ->
     lists:foreach(
         fun(Node) ->
-            catch rpc:call(Node, erlang, halt, [0])
+            try
+                rpc:call(Node, erlang, halt, [0])
+            catch
+                _:_ -> ok
+            end
         end,
         Nodes
     ).

--- a/test/quic_dist_connect_opts_SUITE.erl
+++ b/test/quic_dist_connect_opts_SUITE.erl
@@ -38,11 +38,19 @@ all() ->
 
 init_per_testcase(_Name, Config) ->
     %% Drop any leftover entry from a previous test.
-    catch ets:delete(quic_dist_connect_opts),
+    try
+        ets:delete(quic_dist_connect_opts)
+    catch
+        _:_ -> ok
+    end,
     Config.
 
 end_per_testcase(_Name, _Config) ->
-    catch ets:delete(quic_dist_connect_opts),
+    try
+        ets:delete(quic_dist_connect_opts)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 %%====================================================================

--- a/test/quic_dist_psk_SUITE.erl
+++ b/test/quic_dist_psk_SUITE.erl
@@ -241,10 +241,18 @@ stop_port(Port) ->
             os:cmd("kill " ++ integer_to_list(OsPid)),
             timer:sleep(200),
             os:cmd("kill -9 " ++ integer_to_list(OsPid) ++ " 2>/dev/null"),
-            catch erlang:port_close(Port),
+            try
+                erlang:port_close(Port)
+            catch
+                _:_ -> ok
+            end,
             ok;
         _ ->
-            catch erlang:port_close(Port),
+            try
+                erlang:port_close(Port)
+            catch
+                _:_ -> ok
+            end,
             ok
     end.
 
@@ -272,6 +280,10 @@ wait_for_port_exit(Port, TimeoutMs, Acc) ->
             _ ->
                 ok
         end,
-        catch erlang:port_close(Port),
+        try
+            erlang:port_close(Port)
+        catch
+            _:_ -> ok
+        end,
         binary_to_list(iolist_to_binary(lists:reverse(Acc)))
     end.

--- a/test/quic_dist_rpc_tests.erl
+++ b/test/quic_dist_rpc_tests.erl
@@ -204,8 +204,16 @@ start_peer_nodes(TmpDir, CertFile, KeyFile) ->
 cleanup({skip, _}) ->
     ok;
 cleanup({#{peer1 := Peer1, peer2 := Peer2}, TmpDir}) ->
-    catch peer:stop(Peer1),
-    catch peer:stop(Peer2),
+    try
+        peer:stop(Peer1)
+    catch
+        _:_ -> ok
+    end,
+    try
+        peer:stop(Peer2)
+    catch
+        _:_ -> ok
+    end,
     os:cmd("rm -rf " ++ TmpDir),
     ok.
 

--- a/test/quic_dist_simultaneous_connect_SUITE.erl
+++ b/test/quic_dist_simultaneous_connect_SUITE.erl
@@ -78,8 +78,16 @@ init_per_group(_Group, Config) ->
     Config.
 
 end_per_group(two_node, Config) ->
-    catch peer:stop(?config(peer1, Config)),
-    catch peer:stop(?config(peer2, Config)),
+    try
+        peer:stop(?config(peer1, Config))
+    catch
+        _:_ -> ok
+    end,
+    try
+        peer:stop(?config(peer2, Config))
+    catch
+        _:_ -> ok
+    end,
     ok;
 end_per_group(_Group, _Config) ->
     ok.

--- a/test/quic_dist_tickets_tests.erl
+++ b/test/quic_dist_tickets_tests.erl
@@ -28,7 +28,11 @@ setup() ->
 
 cleanup({started, Pid}) ->
     %% We started it, so we own its lifecycle.
-    catch gen_server:stop(Pid),
+    try
+        gen_server:stop(Pid)
+    catch
+        _:_ -> ok
+    end,
     ok;
 cleanup({existing, _Pid}) ->
     %% Supervised by quic_dist_sup; leave it running.

--- a/test/quic_dist_user_stream_SUITE.erl
+++ b/test/quic_dist_user_stream_SUITE.erl
@@ -115,8 +115,16 @@ end_per_group(two_node, Config) ->
     Peer1 = proplists:get_value(peer1, Config),
     Peer2 = proplists:get_value(peer2, Config),
 
-    catch peer:stop(Peer1),
-    catch peer:stop(Peer2),
+    try
+        peer:stop(Peer1)
+    catch
+        _:_ -> ok
+    end,
+    try
+        peer:stop(Peer2)
+    catch
+        _:_ -> ok
+    end,
     ok;
 end_per_group(_Group, _Config) ->
     ok.

--- a/test/quic_h3_0rtt_SUITE.erl
+++ b/test/quic_h3_0rtt_SUITE.erl
@@ -378,13 +378,16 @@ do_discover(HostVar, PortVar, Label) ->
             {skip, Label ++ " not configured (set " ++ HostVar ++ "/" ++ PortVar ++ ")"};
         Host ->
             PortStr = os:getenv(PortVar, "0"),
-            case (catch list_to_integer(PortStr)) of
+            try list_to_integer(PortStr) of
                 Port when is_integer(Port), Port > 0 ->
                     case probe_udp(Host, Port) of
                         true -> {Host, Port};
                         false -> {skip, Label ++ " endpoint not reachable"}
                     end;
                 _ ->
+                    {skip, Label ++ " port invalid: " ++ PortStr}
+            catch
+                _:_ ->
                     {skip, Label ++ " port invalid: " ++ PortStr}
             end
     end.
@@ -582,15 +585,16 @@ assert_streams_dropped(Conn, RejectedIds) ->
     {_State, StateData} = sys:get_state(Conn, 1000),
     lists:foreach(
         fun(Id) ->
-            case catch quic_h3_connection:test_stream(Id, StateData) of
-                {'EXIT', {{badkey, Id}, _}} ->
-                    ok;
+            try quic_h3_connection:test_stream(Id, StateData) of
                 {error, _} ->
                     ok;
                 _ ->
                     %% If test_stream/2 ever returns the stream record,
                     %% that's a regression in the rejection plumbing.
                     ct:fail({stream_not_dropped, Id})
+            catch
+                error:{badkey, Id} ->
+                    ok
             end
         end,
         RejectedIds

--- a/test/quic_h3_owner_SUITE.erl
+++ b/test/quic_h3_owner_SUITE.erl
@@ -85,7 +85,11 @@ transient_caller_with_datagram_flag(Config) ->
     try
         {200, <<"hello">>} = do_get(Port)
     after
-        catch quic_h3:stop_server(Name)
+        try
+            quic_h3:stop_server(Name)
+        catch
+            _:_ -> ok
+        end
     end,
     ok.
 
@@ -134,7 +138,11 @@ custom_owner_receives_datagram(Config) ->
 
         quic_h3:close(Conn)
     after
-        catch quic_h3:stop_server(Name)
+        try
+            quic_h3:stop_server(Name)
+        catch
+            _:_ -> ok
+        end
     end,
     ok.
 

--- a/test/quic_h3_server_SUITE.erl
+++ b/test/quic_h3_server_SUITE.erl
@@ -358,7 +358,11 @@ exec_cmd_loop(Port, Acc, Timeout) ->
             Output = iolist_to_binary(lists:reverse(Acc)),
             {Status, Output}
     after Timeout ->
-        catch port_close(Port),
+        try
+            port_close(Port)
+        catch
+            _:_ -> ok
+        end,
         Output = iolist_to_binary(lists:reverse(Acc)),
         {timeout, Output}
     end.

--- a/test/quic_handshake_mtu_SUITE.erl
+++ b/test/quic_handshake_mtu_SUITE.erl
@@ -173,7 +173,7 @@ wait_connected(ConnRef) ->
     receive
         {quic, ConnRef, {connected, _Info}} -> ok
     after 10000 ->
-        catch quic:close(ConnRef, timeout),
+        quic:safe_close(ConnRef, timeout),
         ct:fail("connection timeout")
     end.
 

--- a/test/quic_happy_tests.erl
+++ b/test/quic_happy_tests.erl
@@ -47,7 +47,7 @@ he_disabled_async() ->
             after 5000 -> ?assert(false)
             end
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)
@@ -70,7 +70,7 @@ tuple_host() ->
             after 5000 -> ?assert(false)
             end
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)
@@ -102,7 +102,7 @@ he_ipv6_winner() ->
                     {ok, {PeerIP, _}} = quic:peername(Conn),
                     ?assertEqual(8, tuple_size(PeerIP))
                 after
-                    catch quic:close(Conn)
+                    quic:safe_close(Conn)
                 end
             after
                 quic_test_echo_server:stop(Srv)

--- a/test/quic_hrr_e2e_SUITE.erl
+++ b/test/quic_hrr_e2e_SUITE.erl
@@ -118,7 +118,7 @@ wait_connected(ConnRef) ->
     receive
         {quic, ConnRef, {connected, Info}} -> Info
     after 10000 ->
-        catch quic:close(ConnRef, timeout),
+        quic:safe_close(ConnRef, timeout),
         ct:fail("connection timeout")
     end.
 
@@ -136,7 +136,7 @@ try_connect(#{port := Port}, Opts) ->
                 {quic, ConnRef, {closed, R}} ->
                     {error, R}
             after 10000 ->
-                catch quic:close(ConnRef, timeout),
+                quic:safe_close(ConnRef, timeout),
                 {error, timeout}
             end
     end.

--- a/test/quic_multi_server_SUITE.erl
+++ b/test/quic_multi_server_SUITE.erl
@@ -80,7 +80,12 @@ init_per_testcase(_TestCase, Config) ->
     lists:foreach(
         fun(Name) ->
             _ = quic:stop_server(Name),
-            _ = (catch quic_server_registry:unregister(Name))
+            _ =
+                (try
+                    quic_server_registry:unregister(Name)
+                catch
+                    _:_ -> ok
+                end)
         end,
         quic:which_servers()
     ),
@@ -154,7 +159,12 @@ server_restart_recovery(_Config) ->
 
     %% Stop server
     ok = quic:stop_server(recovery_server),
-    _ = (catch quic_server_registry:unregister(recovery_server)),
+    _ =
+        (try
+            quic_server_registry:unregister(recovery_server)
+        catch
+            _:_ -> ok
+        end),
     timer:sleep(100),
 
     %% Verify it's gone
@@ -237,7 +247,12 @@ server_port_reuse_after_stop(_Config) ->
 
     %% Stop the server
     ok = quic:stop_server(port_test_server),
-    _ = (catch quic_server_registry:unregister(port_test_server)),
+    _ =
+        (try
+            quic_server_registry:unregister(port_test_server)
+        catch
+            _:_ -> ok
+        end),
     %% Give OS time to release the port
     timer:sleep(200),
 

--- a/test/quic_packet_activity_tests.erl
+++ b/test/quic_packet_activity_tests.erl
@@ -79,10 +79,18 @@ decode_key(KeyPem) ->
     end.
 
 cleanup(TmpDir, ServerName, ConnRef) ->
-    catch quic:close(ConnRef, normal),
+    quic:safe_close(ConnRef, normal),
     timer:sleep(50),
-    catch quic:stop_server(ServerName),
-    catch os:cmd("rm -rf " ++ TmpDir),
+    try
+        quic:stop_server(ServerName)
+    catch
+        _:_ -> ok
+    end,
+    try
+        os:cmd("rm -rf " ++ TmpDir)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 %%====================================================================

--- a/test/quic_path_stats_tests.erl
+++ b/test/quic_path_stats_tests.erl
@@ -114,7 +114,7 @@ test_not_connected() ->
                 %% Process must still be alive (no crash).
                 ?assert(is_process_alive(Conn))
             after
-                catch quic:close(Conn, normal)
+                quic:safe_close(Conn, normal)
             end;
         {error, _} ->
             %% Connect failed synchronously; the {error, _} guarantee
@@ -245,9 +245,17 @@ collect([Ref | Rest], Timeout) ->
 cleanup(TmpDir, ServerName, ConnRef) ->
     case ConnRef of
         undefined -> ok;
-        _ -> catch quic:close(ConnRef, normal)
+        _ -> quic:safe_close(ConnRef, normal)
     end,
     timer:sleep(50),
-    catch quic:stop_server(ServerName),
-    catch os:cmd("rm -rf " ++ TmpDir),
+    try
+        quic:stop_server(ServerName)
+    catch
+        _:_ -> ok
+    end,
+    try
+        os:cmd("rm -rf " ++ TmpDir)
+    catch
+        _:_ -> ok
+    end,
     ok.

--- a/test/quic_psk_e2e_SUITE.erl
+++ b/test/quic_psk_e2e_SUITE.erl
@@ -256,7 +256,11 @@ start_psk_only_server(Extra) ->
     {ok, #{name => Name, port => Port}}.
 
 stop_server(#{name := Name}) ->
-    catch quic:stop_server(Name),
+    try
+        quic:stop_server(Name)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 connect_with_psk(#{port := Port}, PskOffer) ->
@@ -300,7 +304,7 @@ await_outcome(ConnRef, Timeout) ->
         {quic, ConnRef, {closed, Reason}} ->
             {error, Reason}
     after Timeout ->
-        catch quic:close(ConnRef, timeout),
+        quic:safe_close(ConnRef, timeout),
         {error, timeout}
     end.
 
@@ -308,7 +312,7 @@ wait_connected(ConnRef, Timeout) ->
     receive
         {quic, ConnRef, {connected, _Info}} -> ok
     after Timeout ->
-        catch quic:close(ConnRef, timeout),
+        quic:safe_close(ConnRef, timeout),
         ct:fail("Connection timeout")
     end.
 

--- a/test/quic_reset_stream_at_SUITE.erl
+++ b/test/quic_reset_stream_at_SUITE.erl
@@ -144,7 +144,11 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(TestCase, Config) ->
     ct:pal("Finished test: ~p", [TestCase]),
     ServerName = ?config(server_name, Config),
-    catch quic:stop_server(ServerName),
+    try
+        quic:stop_server(ServerName)
+    catch
+        _:_ -> ok
+    end,
     timer:sleep(50),
     ok.
 

--- a/test/quic_resolve_tests.erl
+++ b/test/quic_resolve_tests.erl
@@ -37,7 +37,7 @@ ipv6_literal_brackets() ->
                         ?assert(false)
                     end
                 after
-                    catch quic:close(Conn)
+                    quic:safe_close(Conn)
                 end
             after
                 quic_test_echo_server:stop(Srv)

--- a/test/quic_server_send_batching_off_tests.erl
+++ b/test/quic_server_send_batching_off_tests.erl
@@ -39,7 +39,7 @@ server_socket_backend_batching_off() ->
             Received = collect_echo(Conn, StreamId, <<>>, 5000),
             ?assertEqual(Payload, Received)
         after
-            catch quic:close(Conn)
+            quic:safe_close(Conn)
         end
     after
         quic_test_echo_server:stop(Srv)

--- a/test/quic_server_send_batching_off_tests.erl
+++ b/test/quic_server_send_batching_off_tests.erl
@@ -13,9 +13,19 @@ server_socket_backend_batching_off_test_() ->
     %% Linux-only: detect_capabilities/0 only exposes the OTP socket
     %% NIF as the listener backend there. Elsewhere the bug this test
     %% targets (gen_udp:send/4 on an OTP socket handle) cannot fire.
-    case os:type() of
-        {unix, linux} -> [{timeout, 15, fun server_socket_backend_batching_off/0}];
+    %% The socket backend needs the OTP 27+ socket module (matching
+    %% quic_socket:otp_version_check/0); forcing it on OTP 26 cannot
+    %% complete the handshake.
+    case {os:type(), otp_27_plus()} of
+        {{unix, linux}, true} -> [{timeout, 15, fun server_socket_backend_batching_off/0}];
         _ -> []
+    end.
+
+otp_27_plus() ->
+    try
+        list_to_integer(erlang:system_info(otp_release)) >= 27
+    catch
+        _:_ -> false
     end.
 
 server_socket_backend_batching_off() ->

--- a/test/quic_server_tests.erl
+++ b/test/quic_server_tests.erl
@@ -49,7 +49,12 @@ cleanup(_) ->
     lists:foreach(
         fun(Name) ->
             _ = quic:stop_server(Name),
-            _ = (catch quic_server_registry:unregister(Name))
+            _ =
+                (try
+                    quic_server_registry:unregister(Name)
+                catch
+                    _:_ -> ok
+                end)
         end,
         Servers
     ),
@@ -173,7 +178,12 @@ which_servers_test() ->
     lists:foreach(
         fun(N) ->
             _ = quic:stop_server(N),
-            _ = (catch quic_server_registry:unregister(N))
+            _ =
+                (try
+                    quic_server_registry:unregister(N)
+                catch
+                    _:_ -> ok
+                end)
         end,
         quic:which_servers()
     ),

--- a/test/quic_sigalg_e2e_SUITE.erl
+++ b/test/quic_sigalg_e2e_SUITE.erl
@@ -115,7 +115,7 @@ wait_connected(ConnRef) ->
     receive
         {quic, ConnRef, {connected, Info}} -> Info
     after 10000 ->
-        catch quic:close(ConnRef, timeout),
+        quic:safe_close(ConnRef, timeout),
         ct:fail("connection timeout")
     end.
 
@@ -133,7 +133,7 @@ try_connect(#{port := Port}, Opts) ->
                 {quic, ConnRef, {closed, R}} ->
                     {error, R}
             after 10000 ->
-                catch quic:close(ConnRef, timeout),
+                quic:safe_close(ConnRef, timeout),
                 {error, timeout}
             end
     end.

--- a/test/quic_socket_opts_tests.erl
+++ b/test/quic_socket_opts_tests.erl
@@ -35,7 +35,12 @@ cleanup(_) ->
     lists:foreach(
         fun(Name) ->
             _ = quic:stop_server(Name),
-            _ = (catch quic_server_registry:unregister(Name))
+            _ =
+                (try
+                    quic_server_registry:unregister(Name)
+                catch
+                    _:_ -> ok
+                end)
         end,
         Servers
     ),

--- a/test/quic_stream_reclaim_tests.erl
+++ b/test/quic_stream_reclaim_tests.erl
@@ -32,7 +32,7 @@ reclaim_after_fin() ->
         %% Both directions are now terminal on the client, so the stream map
         %% must have been reclaimed back down (not stuck at N).
         ?assert(wait_streams_below(Conn, 5, 10000)),
-        catch quic:close(Conn)
+        quic:safe_close(Conn)
     after
         quic_test_echo_server:stop(Srv)
     end.

--- a/test/quic_test_echo_server.erl
+++ b/test/quic_test_echo_server.erl
@@ -58,7 +58,11 @@ start(Extra) when is_map(Extra) ->
 %% @doc Stop the echo server.
 -spec stop(handle()) -> ok.
 stop(#{name := Name}) ->
-    catch quic:stop_server(Name),
+    try
+        quic:stop_server(Name)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 %% @doc Recommended client connect options for talking to the echo

--- a/test/quic_test_h3_server.erl
+++ b/test/quic_test_h3_server.erl
@@ -48,7 +48,11 @@ start(Extra) when is_map(Extra) ->
 
 -spec stop(handle()) -> ok.
 stop(#{name := Name}) ->
-    catch quic_h3:stop_server(Name),
+    try
+        quic_h3:stop_server(Name)
+    catch
+        _:_ -> ok
+    end,
     ok.
 
 %%====================================================================

--- a/test/quic_throughput_bench.erl
+++ b/test/quic_throughput_bench.erl
@@ -114,7 +114,11 @@ run_download_sink(Opts) ->
             retransmits => Retransmits
         }
     after
-        catch quic_test_echo_server:stop(Srv)
+        try
+            quic_test_echo_server:stop(Srv)
+        catch
+            _:_ -> ok
+        end
     end.
 
 start_download_server(Extra) ->


### PR DESCRIPTION
Fixes the H3 connection-error close path and clears the deprecated `catch` compiler warnings.

`quic_h3_connection:handle_connection_error/2` did `catch quic:close(QuicConn, ErrorCode, Reason)`. Several call sites forward a non-binary `Reason` (decode error terms), which fails `quic:close/3`'s `is_binary` guard; the bare `catch` swallowed the resulting `function_clause`, so no CONNECTION_CLOSE was ever sent and the connection stayed open. It now coerces the reason to a binary phrase and closes via the new helper.

Adds `quic:safe_close/1,2,3`, which wraps `quic:close` in `try ... catch _:_ -> ok end` for teardown paths that must not crash on an already-closed connection:

```erlang
quic:safe_close(Conn),
quic:safe_close(Conn, normal),
quic:safe_close(Conn, ErrorCode, Phrase).
```

Replaces the remaining deprecated bare `catch` expressions across `src/` and the test suites with `try ... catch` or `safe_close`, and underscores two unused variables. The only `catch` warnings left are in the `proper` dependency.