### PR TITLE
Optimize H3 body data tracking

### DIFF
--- a/include/quic_h3.hrl
+++ b/include/quic_h3.hrl
@@ -120,7 +120,8 @@
     %% Response status (for client)
     status :: non_neg_integer() | undefined,
 
-    %% Body data buffer
+    %% Retained for compatibility; DATA payloads are delivered through
+    %% events/handlers and are not accumulated in the stream record.
     body = <<>> :: binary(),
 
     %% Content-Length tracking

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -2567,7 +2567,6 @@ handle_request_frame(
             {error, {stream_reset, StreamId, ?H3_MESSAGE_ERROR}};
         false ->
             Stream1 = Stream#h3_stream{
-                body = <<(Stream#h3_stream.body)/binary, Payload/binary>>,
                 body_received = NewReceived
             },
             State1 = notify_stream_data(StreamId, Payload, Fin, State),
@@ -2585,9 +2584,9 @@ handle_request_frame(
     _Fin,
     #h3_stream{frame_state = expecting_data} = Stream,
     _State
-) when (byte_size(Stream#h3_stream.body) + byte_size(Payload)) > ?H3_MAX_BUFFERED_BODY ->
-    %% Without a Content-Length the body buffer would otherwise grow with
-    %% the stream; cap it (RFC 9114 §4.1 allows H3_EXCESSIVE_LOAD).
+) when (Stream#h3_stream.body_received + byte_size(Payload)) > ?H3_MAX_BUFFERED_BODY ->
+    %% Without Content-Length, cap the total received body bytes so a peer
+    %% cannot keep an unbounded application stream open indefinitely.
     {error, {stream_reset, StreamId, ?H3_EXCESSIVE_LOAD}};
 handle_request_frame(
     StreamId,
@@ -2597,7 +2596,6 @@ handle_request_frame(
     State
 ) ->
     Stream1 = Stream#h3_stream{
-        body = <<(Stream#h3_stream.body)/binary, Payload/binary>>,
         body_received = Stream#h3_stream.body_received + byte_size(Payload)
     },
     State1 = notify_stream_data(StreamId, Payload, Fin, State),
@@ -4061,7 +4059,7 @@ do_send_push_data(
                             }};
                         false ->
                             Stream1 = Stream#h3_stream{
-                                body = <<(Stream#h3_stream.body)/binary, Data/binary>>
+                                body_received = Stream#h3_stream.body_received + byte_size(Data)
                             },
                             {ok, State#state{
                                 push_streams = maps:put(PushId, {StreamId, Stream1}, PushStreams)

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -157,6 +157,26 @@ no_content_length_allows_any_size_test() ->
     ),
     ?assertMatch({ok, _, _}, Result).
 
+data_frames_track_size_without_accumulating_body_test() ->
+    Stream = #h3_stream{
+        id = 0,
+        frame_state = expecting_data,
+        content_length = undefined,
+        body_received = 5,
+        body = <<>>
+    },
+    State = make_test_state(#{owner => self()}),
+    {ok, Stream1, _State1} = quic_h3_connection:handle_request_frame(
+        0, {data, <<"hello">>}, false, Stream, State
+    ),
+    ?assertEqual(10, Stream1#h3_stream.body_received),
+    ?assertEqual(<<>>, Stream1#h3_stream.body),
+    receive
+        {quic_h3, _, {data, 0, <<"hello">>, false}} -> ok
+    after 100 ->
+        ?assert(false)
+    end.
+
 %%====================================================================
 %% QPACK Section Acknowledgment Tests (RFC 9204 Section 4.4)
 %%====================================================================


### PR DESCRIPTION
Superseded by #167, which uses the conventional branch name `perf/h3-body-data-tracking`.