### PR TITLE
Add quic_h3:respond/5 for full-response coalescing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `quic_h3:respond/5` sends an HTTP/3 response status, headers and full body with end-stream in a single connection call, coalescing what previously took `send_response/4` plus `send_data/4`. HEAD, 204 and 304 responses send no body.
+
 ## [1.6.4] - 2026-06-05
 
 ### Changed

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -126,7 +126,8 @@
 -export([
     start_server/3,
     stop_server/1,
-    send_response/4
+    send_response/4,
+    respond/5
 ]).
 
 %% Server Push API (RFC 9114 Section 4.6)
@@ -568,6 +569,16 @@ stop_server(Name) ->
     ok | {error, term()}.
 send_response(Conn, StreamId, Status, Headers) ->
     quic_h3_connection:send_response(Conn, StreamId, Status, Headers).
+
+%% @doc Send a full HTTP response (status, headers and body) in one call.
+%%
+%% Coalesces the work of `send_response/4' plus a final `send_data/4' with
+%% end-stream. HEAD, 204 and 304 responses send no body.
+%% @end
+-spec respond(conn(), stream_id(), status(), headers(), binary()) ->
+    ok | {error, term()}.
+respond(Conn, StreamId, Status, Headers, Body) ->
+    quic_h3_connection:respond(Conn, StreamId, Status, Headers, Body).
 
 %%====================================================================
 %% Server Push API (RFC 9114 Section 4.6)

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -25,6 +25,7 @@
     request/3,
     open_bidi_stream/2,
     send_response/4,
+    respond/5,
     send_data/3,
     send_data/4,
     send_trailers/3,
@@ -103,6 +104,7 @@
     handle_priority_update_frame/2,
     handle_priority_update_push_frame/2,
     do_send_trailers/3,
+    do_respond/5,
     pre_claim_bidi_stream/3,
     assign_uni_stream/3,
     validate_peer_h3_datagram_with/1
@@ -324,6 +326,12 @@ open_bidi_stream(Conn, SignalType) ->
     ok | {error, term()}.
 send_response(Conn, StreamId, Status, Headers) ->
     gen_statem:call(Conn, {send_response, StreamId, Status, Headers}).
+
+%% @doc Send a full response (status, headers and body) in one call (server only).
+-spec respond(pid(), stream_id(), pos_integer(), [{binary(), binary()}], binary()) ->
+    ok | {error, term()}.
+respond(Conn, StreamId, Status, Headers, Body) ->
+    gen_statem:call(Conn, {respond, StreamId, Status, Headers, Body}).
 
 %% @doc Send body data on a stream.
 -spec send_data(pid(), stream_id(), binary()) -> ok | {error, term()}.
@@ -1001,6 +1009,13 @@ connected({call, From}, {send_response, StreamId, Status, Headers}, State) ->
     end;
 connected({call, From}, {send_data, StreamId, Data, Fin}, State) ->
     case do_send_data(StreamId, Data, Fin, State) of
+        {ok, State1} ->
+            {keep_state, State1, [{reply, From, ok}]};
+        {error, Reason} ->
+            {keep_state_and_data, [{reply, From, {error, Reason}}]}
+    end;
+connected({call, From}, {respond, StreamId, Status, Headers, Body}, State) ->
+    case do_respond(StreamId, Status, Headers, Body, State) of
         {ok, State1} ->
             {keep_state, State1, [{reply, From, ok}]};
         {error, Reason} ->
@@ -3577,6 +3592,32 @@ send_request_validated(Headers, Opts, QuicConn, Encoder, NextId, Streams, State)
             end;
         {error, Reason} ->
             {error, Reason}
+    end.
+
+%% Coalesce a full response: send_response then a final send_data with end-stream
+%% in one connection call. Reuses do_send_response/4 (validation, QPACK, HEADERS
+%% buffering) and do_send_data/4 (which prepends the buffered HEADERS so they ride
+%% in the same QUIC packet as the body). HEAD, 204 and 304 send no body.
+do_respond(StreamId, Status, Headers, Body, State) ->
+    case do_send_response(StreamId, Status, Headers, State) of
+        {ok, State1} ->
+            Data =
+                case response_body_allowed(StreamId, Status, State1) of
+                    true -> Body;
+                    false -> <<>>
+                end,
+            do_send_data(StreamId, Data, true, State1);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% RFC 9110: HEAD requests and 204/304 responses carry no body.
+response_body_allowed(_StreamId, Status, _State) when Status =:= 204; Status =:= 304 ->
+    false;
+response_body_allowed(StreamId, _Status, #state{streams = Streams}) ->
+    case maps:find(StreamId, Streams) of
+        {ok, #h3_stream{method = <<"HEAD">>}} -> false;
+        _ -> true
     end.
 
 do_send_response(

--- a/test/quic_h3_compliance_tests.erl
+++ b/test/quic_h3_compliance_tests.erl
@@ -178,6 +178,127 @@ data_frames_track_size_without_accumulating_body_test() ->
     end.
 
 %%====================================================================
+%% Coalesced response: quic_h3:respond/5 (do_respond/5)
+%%====================================================================
+
+%% Drive do_respond/5 against a fake quic_conn that captures the emitted
+%% transport writes. Returns {Result, Sends} where Sends is the list of
+%% {StreamId, Payload, Fin} captured on the request stream (id 0).
+respond_capture(Status, Headers, Body, Method) ->
+    Conn = spawn_capture_conn(self()),
+    Stream = #h3_stream{
+        id = 0,
+        type = request,
+        state = open,
+        method = Method,
+        frame_state = expecting_data
+    },
+    State = make_test_state(#{
+        role => server,
+        quic_conn => Conn,
+        streams => #{0 => Stream}
+    }),
+    Result = quic_h3_connection:do_respond(0, Status, Headers, Body, State),
+    Sends = collect_sends(0, []),
+    Conn ! stop,
+    {Result, Sends}.
+
+spawn_capture_conn(Reporter) ->
+    spawn(fun() -> capture_loop(Reporter) end).
+
+capture_loop(Reporter) ->
+    receive
+        {'$gen_call', From, {send_data, StreamId, Data, Fin}} ->
+            Reporter ! {sent, StreamId, Data, Fin},
+            gen_statem:reply(From, ok),
+            capture_loop(Reporter);
+        stop ->
+            ok;
+        _Other ->
+            capture_loop(Reporter)
+    end.
+
+%% Collect the sends emitted for the request stream; ignore any encoder-stream
+%% instruction writes (different stream id).
+collect_sends(StreamId, Acc) ->
+    receive
+        {sent, StreamId, Data, Fin} -> collect_sends(StreamId, [{StreamId, Data, Fin} | Acc]);
+        {sent, _Other, _Data, _Fin} -> collect_sends(StreamId, Acc)
+    after 100 ->
+        lists:reverse(Acc)
+    end.
+
+respond_sends_headers_and_body_with_fin_test() ->
+    {Result, Sends} = respond_capture(
+        200,
+        [{<<"content-type">>, <<"text/plain">>}],
+        <<"hello">>,
+        <<"GET">>
+    ),
+    ?assertMatch({ok, _}, Result),
+    ?assertMatch([{0, _Payload, true}], Sends),
+    [{0, Payload, true}] = Sends,
+    DataFrame = quic_h3_frame:encode_data(<<"hello">>),
+    ?assertEqual(
+        DataFrame,
+        binary:part(
+            Payload,
+            byte_size(Payload) - byte_size(DataFrame),
+            byte_size(DataFrame)
+        )
+    ),
+    %% A HEADERS frame rode in front of the DATA frame in the same write.
+    ?assert(byte_size(Payload) > byte_size(DataFrame)),
+    {ok, State1} = Result,
+    Stream1 = quic_h3_connection:test_stream(0, State1),
+    ?assertEqual(half_closed_local, Stream1#h3_stream.state).
+
+respond_head_suppresses_body_test() ->
+    {Result, Sends} = respond_capture(
+        200,
+        [{<<"content-length">>, <<"5">>}],
+        <<"hello">>,
+        <<"HEAD">>
+    ),
+    ?assertMatch({ok, _}, Result),
+    assert_empty_body(Sends).
+
+respond_204_suppresses_body_test() ->
+    {Result, Sends} = respond_capture(204, [], <<"hello">>, <<"GET">>),
+    ?assertMatch({ok, _}, Result),
+    assert_empty_body(Sends).
+
+respond_304_suppresses_body_test() ->
+    {Result, Sends} = respond_capture(304, [], <<"hello">>, <<"GET">>),
+    ?assertMatch({ok, _}, Result),
+    assert_empty_body(Sends).
+
+assert_empty_body(Sends) ->
+    ?assertMatch([{0, _Payload, true}], Sends),
+    [{0, Payload, true}] = Sends,
+    EmptyData = quic_h3_frame:encode_data(<<>>),
+    ?assertEqual(
+        EmptyData,
+        binary:part(
+            Payload,
+            byte_size(Payload) - byte_size(EmptyData),
+            byte_size(EmptyData)
+        )
+    ).
+
+respond_invalid_status_test() ->
+    {Result, Sends} = respond_capture(700, [], <<"hello">>, <<"GET">>),
+    ?assertEqual({error, {invalid_status, 700}}, Result),
+    ?assertEqual([], Sends).
+
+respond_unknown_stream_test() ->
+    Conn = spawn_capture_conn(self()),
+    State = make_test_state(#{role => server, quic_conn => Conn, streams => #{}}),
+    Result = quic_h3_connection:do_respond(0, 200, [], <<"hello">>, State),
+    Conn ! stop,
+    ?assertEqual({error, unknown_stream}, Result).
+
+%%====================================================================
 %% QPACK Section Acknowledgment Tests (RFC 9204 Section 4.4)
 %%====================================================================
 

--- a/test/quic_h3_tests.erl
+++ b/test/quic_h3_tests.erl
@@ -48,7 +48,8 @@ server_api_exists_test_() ->
     [
         ?_assert(erlang:function_exported(quic_h3, start_server, 3)),
         ?_assert(erlang:function_exported(quic_h3, stop_server, 1)),
-        ?_assert(erlang:function_exported(quic_h3, send_response, 4))
+        ?_assert(erlang:function_exported(quic_h3, send_response, 4)),
+        ?_assert(erlang:function_exported(quic_h3, respond, 5))
     ].
 
 query_api_exists_test_() ->


### PR DESCRIPTION
Add `quic_h3:respond/5` to send a full HTTP/3 response in one connection call:

    quic_h3:respond(Conn, StreamId, 200, [{<<"content-type">>, <<"text/plain">>}], <<"hello">>).

It sends the status, headers and body with end-stream, coalescing what previously took `send_response/4` plus `send_data/4`. HEAD, 204 and 304 responses send no body.

Internally it reuses the existing HEADERS/DATA coalescing, so headers and the first body chunk still ride in one QUIC packet; the change removes the extra connection round-trip per response. No version bump, to be bundled into a future release.