### PR TITLE
Remove dead stream_closed receive arms

### DIFF
--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -418,6 +418,13 @@ Messages sent to the owner process:
 | `{quic, Conn, {closed, Reason}}` | Connection closed |
 | `{quic, Conn, {transport_error, Code, Reason}}` | Transport error |
 
+### Detecting stream closure
+
+There is no separate `stream_closed` message. A stream ends in one of two ways:
+
+- Graceful: `{stream_data, StreamId, _, true}` - the `Fin` flag marks the end of the receive side.
+- Abrupt: `{stream_reset, StreamId, Code}` (peer reset) or `{stop_sending, StreamId, Code}` (peer asked us to stop).
+
 ## Error Handling
 
 ```erlang

--- a/test/quic_client_migrate_tests.erl
+++ b/test/quic_client_migrate_tests.erl
@@ -82,8 +82,6 @@ collect_echo(Conn, StreamId, Acc, Timeout) ->
             <<Acc/binary, Data/binary>>;
         {quic, Conn, {stream_data, StreamId, Data, false}} ->
             collect_echo(Conn, StreamId, <<Acc/binary, Data/binary>>, Timeout);
-        {quic, Conn, {stream_closed, StreamId, _}} ->
-            Acc;
         {quic, Conn, {closed, _}} ->
             Acc;
         {quic, Conn, _Other} ->

--- a/test/quic_client_socket_backend_tests.erl
+++ b/test/quic_client_socket_backend_tests.erl
@@ -190,8 +190,6 @@ collect_echo(Conn, StreamId, Acc, Timeout) ->
             <<Acc/binary, Data/binary>>;
         {quic, Conn, {stream_data, StreamId, Data, false}} ->
             collect_echo(Conn, StreamId, <<Acc/binary, Data/binary>>, Timeout);
-        {quic, Conn, {stream_closed, StreamId, _}} ->
-            Acc;
         {quic, Conn, {closed, _}} ->
             Acc;
         %% Ignore unrelated events (e.g. session_ticket) that may show

--- a/test/quic_comparison_bench.erl
+++ b/test/quic_comparison_bench.erl
@@ -395,8 +395,6 @@ wait_for_completion(Conn, StreamId, Timeout) ->
     receive
         {quic, Conn, {stream_data, StreamId, _Data, true}} ->
             ok;
-        {quic, Conn, {stream_closed, StreamId}} ->
-            ok;
         {quic, Conn, {stream_data, StreamId, _Data, false}} ->
             wait_for_completion(Conn, StreamId, Timeout);
         {quic, Conn, {closed, _Reason}} ->
@@ -414,8 +412,6 @@ wait_for_data_loop(Conn, StreamId, BytesRecv, Timeout) ->
             {ok, BytesRecv + byte_size(Data)};
         {quic, Conn, {stream_data, StreamId, Data, false}} ->
             wait_for_data_loop(Conn, StreamId, BytesRecv + byte_size(Data), Timeout);
-        {quic, Conn, {stream_closed, StreamId}} ->
-            {ok, BytesRecv};
         {quic, Conn, {closed, _Reason}} ->
             {ok, BytesRecv}
     after Timeout ->

--- a/test/quic_h3_bench.erl
+++ b/test/quic_h3_bench.erl
@@ -576,10 +576,7 @@ echo_body(Conn, StreamId, Acc, false) ->
         {quic_h3, Conn, {data, StreamId, Data, false}} ->
             echo_body(Conn, StreamId, <<Acc/binary, Data/binary>>, false);
         {quic_h3, Conn, {data, StreamId, Data, true}} ->
-            send_echo_response(Conn, StreamId, <<Acc/binary, Data/binary>>);
-        {quic_h3, Conn, {stream_closed, StreamId}} ->
-            %% Stream closed without FIN, send what we have
-            send_echo_response(Conn, StreamId, Acc)
+            send_echo_response(Conn, StreamId, <<Acc/binary, Data/binary>>)
     after 30000 ->
         ok
     end.
@@ -655,9 +652,7 @@ wait_response(Conn, StreamId, AccBody, Timeout) ->
         {quic_h3, Conn, {data, StreamId, Data, false}} ->
             wait_response(Conn, StreamId, <<AccBody/binary, Data/binary>>, Timeout);
         {quic_h3, Conn, {data, StreamId, Data, true}} ->
-            {ok, undefined, [], <<AccBody/binary, Data/binary>>};
-        {quic_h3, Conn, {stream_closed, StreamId}} ->
-            {ok, undefined, [], AccBody}
+            {ok, undefined, [], <<AccBody/binary, Data/binary>>}
     after Timeout ->
         {error, timeout}
     end.
@@ -669,9 +664,7 @@ wait_response_body(Conn, StreamId, Status, Headers, AccBody, Timeout) ->
                 Conn, StreamId, Status, Headers, <<AccBody/binary, Data/binary>>, Timeout
             );
         {quic_h3, Conn, {data, StreamId, Data, true}} ->
-            {ok, Status, Headers, <<AccBody/binary, Data/binary>>};
-        {quic_h3, Conn, {stream_closed, StreamId}} ->
-            {ok, Status, Headers, AccBody}
+            {ok, Status, Headers, <<AccBody/binary, Data/binary>>}
     after Timeout ->
         {ok, Status, Headers, AccBody}
     end.

--- a/test/quic_psk_e2e_SUITE.erl
+++ b/test/quic_psk_e2e_SUITE.erl
@@ -334,8 +334,6 @@ echo_loop(Conn) ->
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             _ = quic:send_data_async(Conn, StreamId, Data, Fin),
             echo_loop(Conn);
-        {quic, Conn, {stream_closed, _StreamId, _Code}} ->
-            echo_loop(Conn);
         {quic, Conn, {closed, _Reason}} ->
             ok;
         {quic, Conn, _Other} ->

--- a/test/quic_server_batching_SUITE.erl
+++ b/test/quic_server_batching_SUITE.erl
@@ -235,8 +235,6 @@ download_loop(Conn, PendingReq) ->
                 _ ->
                     download_loop(Conn, PendingReq#{StreamId => Buffer})
             end;
-        {quic, Conn, {stream_closed, _StreamId, _Code}} ->
-            download_loop(Conn, PendingReq);
         {quic, Conn, {closed, _Reason}} ->
             ok;
         {quic, Conn, _Other} ->
@@ -329,8 +327,6 @@ collect_stream_data(Conn, StreamId, Acc) ->
             <<Acc/binary, Data/binary>>;
         {quic, Conn, {stream_data, StreamId, Data, false}} ->
             collect_stream_data(Conn, StreamId, <<Acc/binary, Data/binary>>);
-        {quic, Conn, {stream_closed, StreamId, _Code}} ->
-            Acc;
         {quic, Conn, {closed, _Reason}} ->
             Acc
     after ?REQUEST_TIMEOUT_MS ->

--- a/test/quic_stream_bench.erl
+++ b/test/quic_stream_bench.erl
@@ -462,8 +462,6 @@ wait_streams_loop(ConnRef, Pending, Deadline) ->
         false ->
             Remaining = max(0, Deadline - erlang:monotonic_time(millisecond)),
             receive
-                {quic, ConnRef, {stream_closed, StreamId}} ->
-                    wait_streams_loop(ConnRef, sets:del_element(StreamId, Pending), Deadline);
                 {quic, ConnRef, {stream_data, StreamId, _Data, true}} ->
                     wait_streams_loop(ConnRef, sets:del_element(StreamId, Pending), Deadline);
                 {quic, ConnRef, {stream_data, _StreamId, _Data, false}} ->

--- a/test/quic_stream_reclaim_tests.erl
+++ b/test/quic_stream_reclaim_tests.erl
@@ -48,8 +48,6 @@ drain_fins(Conn, Pending, Timeout) ->
     receive
         {quic, Conn, {stream_data, Sid, _Data, true}} ->
             drain_fins(Conn, lists:delete(Sid, Pending), Timeout);
-        {quic, Conn, {stream_closed, Sid, _}} ->
-            drain_fins(Conn, lists:delete(Sid, Pending), Timeout);
         {quic, Conn, _Other} ->
             drain_fins(Conn, Pending, Timeout)
     after Timeout ->

--- a/test/quic_test_echo_server.erl
+++ b/test/quic_test_echo_server.erl
@@ -96,8 +96,6 @@ echo_loop(Conn) ->
             %% still being delivered.
             _ = quic:send_data_async(Conn, StreamId, Data, Fin),
             echo_loop(Conn);
-        {quic, Conn, {stream_closed, _StreamId, _Code}} ->
-            echo_loop(Conn);
         {quic, Conn, {closed, _Reason}} ->
             ok;
         {quic, Conn, _Other} ->

--- a/test/quic_throughput_bench.erl
+++ b/test/quic_throughput_bench.erl
@@ -249,8 +249,6 @@ collect_download(Conn, StreamId, Acc, Timeout) ->
             <<Acc/binary, Data/binary>>;
         {quic, Conn, {stream_data, StreamId, Data, false}} ->
             collect_download(Conn, StreamId, <<Acc/binary, Data/binary>>, Timeout);
-        {quic, Conn, {stream_closed, StreamId, _Code}} ->
-            Acc;
         {quic, Conn, {closed, _}} ->
             Acc
     after Timeout ->
@@ -604,8 +602,6 @@ wait_stream_close(Conn, StreamId, Timeout) ->
     receive
         {quic, Conn, {stream_data, StreamId, _Data, true}} ->
             ok;
-        {quic, Conn, {stream_closed, StreamId}} ->
-            ok;
         {quic, Conn, {stream_data, StreamId, _Data, false}} ->
             wait_stream_close(Conn, StreamId, Timeout)
     after Timeout ->
@@ -615,8 +611,6 @@ wait_stream_close(Conn, StreamId, Timeout) ->
 %% Wait for stream to close (sink mode - server closes stream after receiving FIN)
 wait_stream_close_sink(Conn, StreamId, Timeout) ->
     receive
-        {quic, Conn, {stream_closed, StreamId}} ->
-            ok;
         {quic, Conn, {stream_data, StreamId, _Data, true}} ->
             %% Server sent FIN (empty response)
             ok;


### PR DESCRIPTION
Nothing sends a `stream_closed` owner message, but several test and bench receive blocks had clauses for it, which is misleading (reported in #169). This removes those unreachable clauses and documents in the client guide that stream closure is signalled by the FIN flag (`{stream_data, _, _, true}`), `stream_reset`, or `stop_sending`.

No protocol change; the removed clauses never matched.

Closes #169