### PR TITLE
Add sni_callback for per-SNI server certificate selection

### DIFF
--- a/src/quic.erl
+++ b/src/quic.erl
@@ -783,6 +783,14 @@ get_peer_transport_params(Conn) when is_pid(Conn) ->
 %%       CertificateVerify (RFC 8446 §4.4.3).</li>
 %%   <li>`pool_size' - Number of listener processes (default: 1)</li>
 %%   <li>`connection_handler' - Fun(Conn) -> {ok, HandlerPid} where Conn is the pid</li>
+%%   <li>`sni_callback' -
+%%       `fun((ServerName :: binary() | undefined) -> {ok, CertMap} | {error, term()})'
+%%       where `CertMap :: #{cert := binary(), key := term(), cert_chain => [binary()]}'.
+%%       Invoked per connection with the ClientHello SNI (RFC 6066 §3);
+%%       the returned cert/key override the static `cert'/`key' for that
+%%       handshake. `cert'/`key' may be omitted when this is set. An
+%%       `{error, _}', a malformed result, or a raised exception fails the
+%%       handshake with a `handshake_failure' alert.</li>
 %% </ul>
 %%
 %% Example:

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -557,6 +557,10 @@
     server_cert :: binary() | undefined,
     server_cert_chain = [] :: [binary()],
     server_private_key :: term() | undefined,
+    %% Per-SNI cert selection (RFC 6066 §3). When set, invoked on the
+    %% ClientHello server_name to override the cert fields above.
+    sni_callback ::
+        fun((binary() | undefined) -> {ok, map()} | {error, term()}) | undefined,
     %% Server preferred address config (RFC 9000 Section 9.6)
     %% Set from listener options: {IPv4, IPv6} where each is {Addr, Port} | undefined
     server_preferred_address :: #preferred_address{} | undefined,
@@ -1013,9 +1017,12 @@ init({server, Opts}) ->
     RemoteAddr = maps:get(remote_addr, Opts),
     InitialDCID = maps:get(initial_dcid, Opts),
     SCID = maps:get(scid, Opts),
-    Cert = maps:get(cert, Opts),
+    %% Cert/key are optional: a `sni_callback' may supply them per
+    %% handshake from the ClientHello server_name.
+    Cert = maps:get(cert, Opts, undefined),
     CertChain = maps:get(cert_chain, Opts, []),
-    PrivateKey = maps:get(private_key, Opts),
+    PrivateKey = maps:get(private_key, Opts, undefined),
+    SniCallback = maps:get(sni_callback, Opts, undefined),
     ALPNList = maps:get(alpn, Opts, [<<"h3">>]),
     Listener = maps:get(listener, Opts),
     %% Use client's QUIC version for key derivation (defaults to v1)
@@ -1148,6 +1155,7 @@ init({server, Opts}) ->
         server_cert = Cert,
         server_cert_chain = CertChain,
         server_private_key = PrivateKey,
+        sni_callback = SniCallback,
         server_preferred_address = build_server_preferred_address(Opts),
         cid_config = maps:get(cid_config, Opts, undefined),
         congestion_threshold = maps:get(congestion_threshold, Opts, 2),
@@ -5735,14 +5743,28 @@ process_tls_message(_Level, _Type, _Body, _OriginalMsg, State) ->
 %% group is settled (direct or post-HRR). SelectedGroup is the agreed
 %% named group; ClientPubKey is the client's key_share for it.
 do_server_client_hello(SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State0In) ->
+    %% Remember the client's offered signature schemes for the server's
+    %% CertificateVerify negotiation, then resolve the server cert (static
+    %% or via the per-SNI callback) before any cert-path work runs.
+    StateSig = State0In#state{
+        peer_sig_algs = maps:get(signature_algorithms, ClientHelloInfo, [])
+    },
+    case resolve_server_cert(ClientHelloInfo, StateSig) of
+        {error, Phrase} ->
+            send_tls_alert(?TLS_ALERT_HANDSHAKE_FAILURE, Phrase, StateSig);
+        {ok, State} ->
+            do_server_client_hello_cont(
+                SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
+            )
+    end.
+
+%% @private Continue the ClientHello once the server cert/key are settled.
+do_server_client_hello_cont(
+    SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
+) ->
     ClientALPN = maps:get(alpn_protocols, ClientHelloInfo, []),
     TP = maps:get(transport_params, ClientHelloInfo, #{}),
     SessionId = maps:get(session_id, ClientHelloInfo, <<>>),
-    %% Remember the client's offered signature schemes for the
-    %% server's CertificateVerify negotiation.
-    State = State0In#state{
-        peer_sig_algs = maps:get(signature_algorithms, ClientHelloInfo, [])
-    },
     %% Check for PSK (0-RTT/resumption/external)
     PSKInfo = maps:get(pre_shared_key, ClientHelloInfo, undefined),
     WantsEarlyData = maps:get(early_data, ClientHelloInfo, false),
@@ -5963,6 +5985,43 @@ do_server_client_hello(SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, Ori
             State2 = send_server_hello(ServerHello, State1),
             State3 = send_server_handshake_flight(Cipher, TranscriptHash, State2),
             maybe_emit_pending_close(State3)
+    end.
+
+%% @private Select the server cert/key for this handshake. With no
+%% `sni_callback' the static cert configured on the listener is kept.
+%% Otherwise the callback is invoked with the ClientHello server_name
+%% (RFC 6066 §3); its cert/key/chain override the static ones. A
+%% rejection, malformed result, or raised exception fails the handshake.
+resolve_server_cert(_ClientHelloInfo, #state{sni_callback = undefined} = State) ->
+    {ok, State};
+resolve_server_cert(ClientHelloInfo, #state{sni_callback = Fn} = State) ->
+    ServerName = maps:get(server_name, ClientHelloInfo, undefined),
+    try Fn(ServerName) of
+        {ok, #{cert := Cert, key := Key} = CertMap} when is_binary(Cert) ->
+            {ok, State#state{
+                server_cert = Cert,
+                server_private_key = Key,
+                server_cert_chain = maps:get(cert_chain, CertMap, [])
+            }};
+        Other ->
+            ?LOG_WARNING(
+                #{what => sni_callback_rejected, server_name => ServerName, result => Other},
+                ?QUIC_LOG_META
+            ),
+            {error, <<"sni callback rejected server name">>}
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                #{
+                    what => sni_callback_failed,
+                    server_name => ServerName,
+                    class => Class,
+                    reason => Reason,
+                    stacktrace => Stack
+                },
+                ?QUIC_LOG_META
+            ),
+            {error, <<"sni callback failed">>}
     end.
 
 %% @private Choose the server's CertificateVerify scheme. PSK

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -87,6 +87,10 @@
     %% independently; per-handshake selection happens in quic_connection.
     psks :: #{binary() => binary()} | undefined,
     psk_callback :: fun((binary()) -> {ok, binary()} | not_found) | undefined,
+    %% Per-SNI cert selection (RFC 6066 §3). Invoked with the ClientHello
+    %% server_name; its returned cert/key override the static ones above.
+    sni_callback ::
+        fun((binary() | undefined) -> {ok, map()} | {error, term()}) | undefined,
     alpn_list :: [binary()],
     %% Connection ID -> Pid mapping
     connections :: ets:tid(),
@@ -263,7 +267,8 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
     PrivateKey = maps:get(key, Opts, undefined),
     Psks = maps:get(psks, Opts, undefined),
     PskCallback = maps:get(psk_callback, Opts, undefined),
-    case has_auth_method(Cert, PrivateKey, Psks, PskCallback) of
+    SniCallback = maps:get(sni_callback, Opts, undefined),
+    case has_auth_method(Cert, PrivateKey, Psks, PskCallback, SniCallback) of
         ok -> ok;
         {error, no_auth_method} -> exit({listener_init_failed, no_auth_method})
     end,
@@ -296,6 +301,7 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
         private_key = PrivateKey,
         psks = Psks,
         psk_callback = PskCallback,
+        sni_callback = SniCallback,
         alpn_list = ALPNList,
         connections = ConnTab,
         tickets_table = TicketTab,
@@ -314,10 +320,13 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
 %% Validate that the listener has at least one viable auth method.
 %% Either a cert+key pair for X.509 auth or PSK config for TLS 1.3
 %% external PSK (RFC 8446 §4.2.11) must be present. Both may coexist.
-has_auth_method(Cert, Key, _Psks, _Cb) when Cert =/= undefined, Key =/= undefined -> ok;
-has_auth_method(_Cert, _Key, Psks, _Cb) when is_map(Psks), map_size(Psks) > 0 -> ok;
-has_auth_method(_Cert, _Key, _Psks, Cb) when is_function(Cb, 1) -> ok;
-has_auth_method(_, _, _, _) -> {error, no_auth_method}.
+%% A `sni_callback' supplies the cert/key per handshake, so it counts as
+%% an auth method even when no static cert/key is configured.
+has_auth_method(Cert, Key, _Psks, _Cb, _Sni) when Cert =/= undefined, Key =/= undefined -> ok;
+has_auth_method(_Cert, _Key, Psks, _Cb, _Sni) when is_map(Psks), map_size(Psks) > 0 -> ok;
+has_auth_method(_Cert, _Key, _Psks, Cb, _Sni) when is_function(Cb, 1) -> ok;
+has_auth_method(_Cert, _Key, _Psks, _Cb, Sni) when is_function(Sni, 1) -> ok;
+has_auth_method(_, _, _, _, _) -> {error, no_auth_method}.
 
 %% Get socket port depending on backend
 get_socket_port(_Socket, SocketState, socket) when SocketState =/= undefined ->
@@ -831,6 +840,7 @@ create_connection_unconditional(
         private_key = PrivateKey,
         psks = Psks,
         psk_callback = PskCallback,
+        sni_callback = SniCallback,
         alpn_list = ALPNList,
         connections = Conns,
         connection_handler = ConnHandler,
@@ -877,6 +887,7 @@ create_connection_unconditional(
         private_key => PrivateKey,
         psks => Psks,
         psk_callback => PskCallback,
+        sni_callback => SniCallback,
         alpn => ALPNList,
         listener => self(),
         cid_config => CIDConfig,

--- a/test/quic_sni_cert_tests.erl
+++ b/test/quic_sni_cert_tests.erl
@@ -1,0 +1,168 @@
+%%% @doc EUnit tests for per-SNI server certificate selection.
+%%%
+%%% A server configured with `sni_callback' picks its cert/key from the
+%%% ClientHello SNI (RFC 6066 §3). These tests prove the callback receives
+%%% the SNI, the returned cert is the one presented, and that a rejected
+%%% host fails the handshake.
+-module(quic_sni_cert_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+-define(CONNECT_TIMEOUT, 5000).
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+%% The callback maps two hostnames to two distinct certs; each client
+%% sees the cert the callback returned for its SNI.
+sni_callback_selects_cert_test() ->
+    with_two_certs(fun(C1, K1, C2, K2) ->
+        SniCb = sni_map_callback(#{
+            <<"host1.test">> => {C1, K1},
+            <<"host2.test">> => {C2, K2}
+        }),
+        Name = start_server(#{sni_callback => SniCb}),
+        try
+            ?assertEqual(C1, presented_cert(Name, <<"host1.test">>)),
+            ?assertEqual(C2, presented_cert(Name, <<"host2.test">>))
+        after
+            stop(Name)
+        end
+    end).
+
+%% An SNI the callback does not recognise aborts the handshake.
+sni_callback_rejects_unknown_host_test() ->
+    with_two_certs(fun(C1, K1, _C2, _K2) ->
+        SniCb = sni_map_callback(#{<<"host1.test">> => {C1, K1}}),
+        Name = start_server(#{sni_callback => SniCb}),
+        try
+            ?assertMatch({error, _}, connect(Name, <<"unknown.test">>))
+        after
+            stop(Name)
+        end
+    end).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Build a callback that looks the SNI up in Map. Asserts it is a binary
+%% so the test also covers "the callback receives the SNI".
+sni_map_callback(Map) ->
+    fun(ServerName) ->
+        case is_binary(ServerName) andalso maps:find(ServerName, Map) of
+            {ok, {Cert, Key}} -> {ok, #{cert => Cert, key => Key}};
+            _ -> {error, unknown_host}
+        end
+    end.
+
+start_server(Opts) ->
+    {ok, _} = application:ensure_all_started(quic),
+    Name = list_to_atom("quic_sni_" ++ suffix()),
+    {ok, _} = quic:start_server(Name, 0, Opts#{alpn => [<<"h3">>]}),
+    Name.
+
+stop(Name) ->
+    try
+        quic:stop_server(Name)
+    catch
+        _:_ -> ok
+    end,
+    ok.
+
+%% Connect with the given SNI and return the server's presented leaf cert.
+presented_cert(Name, ServerName) ->
+    {ok, Conn} = connect(Name, ServerName),
+    try
+        {ok, Cert} = quic:peercert(Conn),
+        Cert
+    after
+        close(Conn)
+    end.
+
+connect(Name, ServerName) ->
+    {ok, Port} = quic:get_server_port(Name),
+    case
+        quic:connect(
+            "127.0.0.1",
+            Port,
+            #{
+                alpn => [<<"h3">>],
+                verify => false,
+                server_name => ServerName,
+                connect_timeout => ?CONNECT_TIMEOUT
+            },
+            self()
+        )
+    of
+        {ok, Conn} ->
+            receive
+                {quic, Conn, {connected, _Info}} ->
+                    {ok, Conn};
+                {quic, Conn, {closed, Reason}} ->
+                    {error, Reason};
+                {quic, Conn, {error, Reason}} ->
+                    {error, Reason}
+            after ?CONNECT_TIMEOUT ->
+                close(Conn),
+                {error, timeout}
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+close(Conn) ->
+    try
+        quic:close(Conn, normal)
+    catch
+        _:_ -> ok
+    end.
+
+%% Generate two self-signed certs and run F with them, or skip when
+%% openssl is unavailable.
+with_two_certs(F) ->
+    case {gen_cert("/CN=host1.test"), gen_cert("/CN=host2.test")} of
+        {{ok, C1, K1}, {ok, C2, K2}} -> F(C1, K1, C2, K2);
+        _ -> {skip, "OpenSSL not available"}
+    end.
+
+%% Self-signed leaf cert for Subject. Returns the leaf DER and decoded key.
+gen_cert(Subject) ->
+    Dir = filename:join("/tmp", "quic_sni_test_" ++ suffix()),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    CertFile = filename:join(Dir, "cert.pem"),
+    KeyFile = filename:join(Dir, "key.pem"),
+    Cmd = lists:flatten(
+        io_lib:format(
+            "openssl req -x509 -newkey rsa:2048 -keyout ~s -out ~s "
+            "-days 1 -nodes -subj '~s' 2>/dev/null",
+            [KeyFile, CertFile, Subject]
+        )
+    ),
+    _ = os:cmd(Cmd),
+    case {filelib:is_file(CertFile), filelib:is_file(KeyFile)} of
+        {true, true} ->
+            {ok, CertPem} = file:read_file(CertFile),
+            {ok, KeyPem} = file:read_file(KeyFile),
+            [{'Certificate', CertDer, _}] = public_key:pem_decode(CertPem),
+            {ok, CertDer, decode_key(KeyPem)};
+        _ ->
+            {error, cert_generation_failed}
+    end.
+
+decode_key(KeyPem) ->
+    case public_key:pem_decode(KeyPem) of
+        [{'RSAPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('RSAPrivateKey', Der);
+        [{'ECPrivateKey', Der, not_encrypted}] ->
+            public_key:der_decode('ECPrivateKey', Der);
+        [{'PrivateKeyInfo', Der, not_encrypted}] ->
+            public_key:der_decode('PrivateKeyInfo', Der);
+        [{_Type, Der, not_encrypted}] ->
+            Der
+    end.
+
+suffix() ->
+    integer_to_list(erlang:unique_integer([positive, monotonic])).


### PR DESCRIPTION
Lets a QUIC server select its certificate and key per connection from the ClientHello SNI, closing the gap H1/H2 already covered with `sni_fun` (the H3 stack runs on this library's own TLS 1.3 code, not Erlang `:ssl`).

`quic:start_server/3` gains a `sni_callback` option:

```erlang
quic:start_server(my_server, 4433, #{
    sni_callback => fun
        (<<"a.example">>) -> {ok, #{cert => CertA, key => KeyA}};
        (<<"b.example">>) -> {ok, #{cert => CertB, key => KeyB}};
        (_)               -> {error, unknown_host}
    end
}).
```

The callback receives the parsed `server_name` (`binary() | undefined`) and returns `{ok, #{cert := binary(), key := term(), cert_chain => [binary()]}}` or `{error, term()}`. It fires after the SNI is parsed and before Certificate/CertificateVerify, so the selected cert/key drive the rest of the handshake; `negotiate_cert_verify` re-runs against the chosen key so an EC↔RSA swap still negotiates a valid scheme. A rejection, malformed result, or raised exception fails the handshake with a `handshake_failure` alert. When no `sni_callback` is given the static `cert`/`key` path is unchanged; `cert`/`key` may be omitted when the callback supplies them.