### PR TITLE
Close HTTP/3 client connection cleanly on invalid peer SETTINGS

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -1810,13 +1810,22 @@ process_control_frames(Data, State) ->
     end.
 
 handle_control_frame({settings, Settings}, #state{settings_received = false} = State) ->
-    %% First frame on control stream must be SETTINGS
-    %% Apply peer settings to QPACK encoder (RFC 9114 Section 7.2.4.1)
-    State1 = apply_peer_settings(Settings, State),
-    {ok, State1#state{
-        peer_settings = Settings,
-        settings_received = true
-    }};
+    %% First frame on control stream must be SETTINGS.
+    %% apply_peer_settings/2 signals SETTINGS violations with
+    %% throw({connection_error, ...}); gen_statem treats a throw from a state
+    %% callback as its return value, so let it escape and it crashes the
+    %% process with bad_return_from_state_function. Convert it to a returned
+    %% error that flows through handle_connection_error/2 for a clean close.
+    try apply_peer_settings(Settings, State) of
+        State1 ->
+            {ok, State1#state{
+                peer_settings = Settings,
+                settings_received = true
+            }}
+    catch
+        throw:{connection_error, _Code, _Reason} = Err ->
+            {error, Err}
+    end;
 handle_control_frame({settings, _Settings}, #state{settings_received = true}) ->
     %% Duplicate SETTINGS frame
     {error, {connection_error, ?H3_FRAME_UNEXPECTED, <<"duplicate SETTINGS">>}};

--- a/test/quic_h3_settings_error_tests.erl
+++ b/test/quic_h3_settings_error_tests.erl
@@ -1,0 +1,163 @@
+%%% -*- erlang -*-
+%%%
+%%% Regression tests for HTTP/3 client SETTINGS error handling.
+%%%
+%%% A peer SETTINGS frame that fails validation (RFC 9114 §7.2.4 /
+%%% RFC 9297 §2.1) must close the connection with H3_SETTINGS_ERROR,
+%%% never crash the gen_statem. apply_peer_settings/2 signals such
+%%% violations with throw({connection_error, ...}); gen_statem treats a
+%%% throw from a state callback as its return value, so an uncaught throw
+%%% terminates the process with bad_return_from_state_function and, because
+%%% the connection is start_link'd to its owner, takes the owner down too.
+
+-module(quic_h3_settings_error_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+setup() ->
+    meck:new(quic, [passthrough]),
+    meck:expect(quic, set_owner_sync, fun(_, _) -> ok end),
+    meck:expect(quic, close, fun(_) -> ok end),
+    meck:expect(quic, close, fun(_, _, _) -> ok end),
+    meck:expect(quic, safe_close, fun(_) -> ok end),
+    meck:expect(quic, safe_close, fun(_, _, _) -> ok end),
+    %% Peer never advertised QUIC max_datagram_frame_size.
+    meck:expect(quic, datagram_max_size, fun(_) -> 0 end),
+    meck:expect(quic, has_early_keys, fun(_) -> true end),
+    meck:expect(quic, early_data_accepted, fun(_) -> unknown end),
+    UniCounter = counters:new(1, []),
+    meck:expect(quic, open_unidirectional_stream, fun(_) ->
+        counters:add(UniCounter, 1, 1),
+        N = counters:get(UniCounter, 1),
+        {ok, (N - 1) * 4 + 2}
+    end),
+    meck:expect(quic, open_stream, fun(_) -> {ok, 0} end),
+    meck:expect(quic, send_data, fun(_, _, _, _) -> ok end),
+    ok.
+
+teardown(_) ->
+    meck:unload(quic),
+    ok.
+
+%%====================================================================
+%% SETTINGS_H3_DATAGRAM=1 without QUIC datagram support -> clean close
+%%====================================================================
+
+h3_datagram_without_quic_support_closes_cleanly_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        assert_settings_close(#{h3_datagram => 1})
+    end}.
+
+%%====================================================================
+%% Invalid SETTINGS_H3_DATAGRAM value (not 0 or 1) -> clean close
+%%====================================================================
+
+invalid_h3_datagram_value_closes_cleanly_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        assert_settings_close(#{h3_datagram => 2})
+    end}.
+
+%%====================================================================
+%% Valid SETTINGS must not trip the error path (no false positive)
+%%====================================================================
+
+valid_settings_keep_connection_alive_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        process_flag(trap_exit, true),
+        FakeQuic = spawn(fun fake_quic_loop/0),
+        {ok, H3} = start_client_h3(FakeQuic),
+        ok = quic_h3_connection:prime(H3),
+        wait_state(H3, early_data, 500),
+        send_peer_settings(H3, FakeQuic, #{}),
+        wait_settings_received(H3, 500),
+        no_error_event(H3, 150),
+        ?assertEqual(#{}, quic_h3_connection:get_peer_settings(H3)),
+        ?assert(is_process_alive(H3)),
+        stop_h3(H3, FakeQuic)
+    end}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Deliver an invalid peer SETTINGS frame and assert the owner sees a
+%% clean H3_SETTINGS_ERROR and the gen_statem terminates `normal' rather
+%% than crashing with bad_return_from_state_function.
+assert_settings_close(Settings) ->
+    process_flag(trap_exit, true),
+    FakeQuic = spawn(fun fake_quic_loop/0),
+    {ok, H3} = start_client_h3(FakeQuic),
+    MRef = monitor(process, H3),
+    ok = quic_h3_connection:prime(H3),
+    wait_state(H3, early_data, 500),
+    send_peer_settings(H3, FakeQuic, Settings),
+    receive
+        {quic_h3, H3, {error, ErrCode, _Phrase}} ->
+            ?assertEqual(?H3_SETTINGS_ERROR, ErrCode)
+    after 1000 ->
+        erlang:error(no_settings_error_event)
+    end,
+    receive
+        {'DOWN', MRef, process, H3, Reason} ->
+            ?assertEqual(normal, Reason)
+    after 1000 ->
+        erlang:error(process_did_not_terminate)
+    end,
+    stop_h3(H3, FakeQuic).
+
+start_client_h3(QuicConn) ->
+    quic_h3_connection:start_link(QuicConn, <<"example.com">>, 443, #{}).
+
+send_peer_settings(H3, FakeQuic, Settings) ->
+    StreamId = 3,
+    TypeBin = quic_h3_frame:encode_stream_type(control),
+    SettingsBin = quic_h3_frame:encode_settings(Settings),
+    H3 ! {quic, FakeQuic, {stream_data, StreamId, <<TypeBin/binary, SettingsBin/binary>>, false}},
+    ok.
+
+current_state(Pid) ->
+    {StateName, _StateData} = sys:get_state(Pid, 1000),
+    StateName.
+
+wait_state(_Pid, Target, Timeout) when Timeout =< 0 ->
+    erlang:error({timeout_waiting_for_state, Target});
+wait_state(Pid, Target, Timeout) ->
+    case current_state(Pid) of
+        Target ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_state(Pid, Target, Timeout - 10)
+    end.
+
+wait_settings_received(_Pid, Timeout) when Timeout =< 0 ->
+    erlang:error(timeout_waiting_for_peer_settings);
+wait_settings_received(Pid, Timeout) ->
+    case quic_h3_connection:get_peer_settings(Pid) of
+        undefined ->
+            timer:sleep(10),
+            wait_settings_received(Pid, Timeout - 10);
+        _ ->
+            ok
+    end.
+
+no_error_event(H3, Timeout) ->
+    receive
+        {quic_h3, H3, {error, _, _}} = Msg -> erlang:error({unexpected_error_event, Msg})
+    after Timeout ->
+        ok
+    end.
+
+stop_h3(H3, FakeQuic) ->
+    unlink(H3),
+    exit(H3, shutdown),
+    unlink(FakeQuic),
+    exit(FakeQuic, shutdown),
+    ok.
+
+fake_quic_loop() ->
+    receive
+        stop -> ok;
+        _ -> fake_quic_loop()
+    end.


### PR DESCRIPTION
A peer SETTINGS frame that fails validation (for example `SETTINGS_H3_DATAGRAM=1` without QUIC datagram support, or an out-of-range `h3_datagram` value) crashed the client `quic_h3_connection` gen_statem. `apply_peer_settings/2` signals these violations with `throw({connection_error, ...})`, and gen_statem treats a throw from a state callback as its return value, so the uncaught throw terminated the process with `bad_return_from_state_function`. Because the connection is start_link'd to its owner, the EXIT took the request down.

The fix catches the thrown connection_error and routes it through `handle_connection_error/2`, so an invalid SETTINGS frame now ends in a clean `H3_SETTINGS_ERROR` close with an `{error, 265, _}` event to the owner instead of crashing.