### PR TITLE
fix: drive idle timer from received activity, not sends (RFC 9000 §10.1)

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -3541,13 +3541,19 @@ send_app_packet_internal(Payload, Frames, State) ->
                     undefined -> State#state.socket_state;
                     _ -> NewSocketState
                 end,
+            %% Note: `last_activity' is deliberately NOT updated here. It tracks
+            %% activity *received from the peer* and drives the idle timer
+            %% (RFC 9000 §10.1) and keep-alive. Bumping it on every send meant a
+            %% peer that kept sending keep-alive PINGs / PTO retransmits into a
+            %% black hole reset its own idle timer forever and never timed out a
+            %% dead path. On a healthy path the peer's ACK is a received packet
+            %% that restarts the timer, so genuine activity is still covered.
             maybe_force_key_update(State#state{
                 pn_app = NewPNSpace,
                 cc_state = NewCCState,
                 loss_state = NewLossState,
                 packets_sent = State#state.packets_sent + 1,
                 socket_state = EffectiveSocketState,
-                last_activity = Now,
                 pto_dirty = true
             });
         {error, Reason, ClearedSocketState} ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -452,6 +452,10 @@
     %% Timers
     idle_timeout :: non_neg_integer(),
     last_activity :: non_neg_integer(),
+    %% RFC 9000 §10.1: true once an ack-eliciting packet has been sent since the
+    %% last received packet. Gates the send-side idle-timer restart so it fires
+    %% at most once per received packet (a black-holed sender still times out).
+    ack_eliciting_since_recv = false :: boolean(),
     timer_ref :: reference() | undefined,
 
     %% Congestion control and loss detection
@@ -2429,8 +2433,9 @@ handle_common_event(
             %% no PING needed.
             {keep_state, set_keep_alive_timer(State#state{keep_alive_timer = undefined})};
         false ->
-            %% Idle for a full interval: send a PING (which refreshes
-            %% last_activity via the send path) and re-arm a full interval.
+            %% Idle for a full interval: send a PING. Being ack-eliciting, it
+            %% refreshes last_activity if it is the first such packet since our
+            %% last receive (RFC 9000 §10.1); re-arm a full interval.
             State1 = send_keep_alive_ping(State#state{keep_alive_timer = undefined}),
             State2 = flush_dirty_timers(flush_socket_batch(State1)),
             {keep_state, set_keep_alive_timer(State2)}
@@ -3541,19 +3546,28 @@ send_app_packet_internal(Payload, Frames, State) ->
                     undefined -> State#state.socket_state;
                     _ -> NewSocketState
                 end,
-            %% Note: `last_activity' is deliberately NOT updated here. It tracks
-            %% activity *received from the peer* and drives the idle timer
-            %% (RFC 9000 §10.1) and keep-alive. Bumping it on every send meant a
-            %% peer that kept sending keep-alive PINGs / PTO retransmits into a
-            %% black hole reset its own idle timer forever and never timed out a
-            %% dead path. On a healthy path the peer's ACK is a received packet
-            %% that restarts the timer, so genuine activity is still covered.
+            %% RFC 9000 §10.1: restart the idle timer (by bumping last_activity)
+            %% only on the first ack-eliciting packet sent since we last received
+            %% one. Restarting on every send let a peer sending keep-alive PINGs /
+            %% PTO retransmits into a black hole hold its own idle timer open
+            %% forever; never restarting would spuriously close a reactivated idle
+            %% connection before its first ack returns. The flag is cleared on
+            %% every receive (update_last_activity/2).
+            RestartIdle = AckEliciting andalso (not State#state.ack_eliciting_since_recv),
+            NewLastActivity =
+                case RestartIdle of
+                    true -> Now;
+                    false -> State#state.last_activity
+                end,
             maybe_force_key_update(State#state{
                 pn_app = NewPNSpace,
                 cc_state = NewCCState,
                 loss_state = NewLossState,
                 packets_sent = State#state.packets_sent + 1,
                 socket_state = EffectiveSocketState,
+                last_activity = NewLastActivity,
+                ack_eliciting_since_recv =
+                    AckEliciting orelse State#state.ack_eliciting_since_recv,
                 pto_dirty = true
             });
         {error, Reason, ClearedSocketState} ->
@@ -7179,9 +7193,11 @@ merge_ack_ranges(Ranges) ->
 update_last_activity(State) ->
     update_last_activity(State, erlang:monotonic_time(millisecond)).
 
-%% Now-accepting variant used by the receive hot path.
+%% Now-accepting variant used by the receive hot path. Clears
+%% ack_eliciting_since_recv so the next ack-eliciting send restarts the idle
+%% timer (RFC 9000 §10.1).
 update_last_activity(State, Now) ->
-    State#state{last_activity = Now}.
+    State#state{last_activity = Now, ack_eliciting_since_recv = false}.
 
 %% Flush the deferred PTO timer reset at batch boundaries. The idle and
 %% keep-alive timers are lazy (armed once, re-armed only on fire), so the

--- a/test/quic_idle_timeout_tests.erl
+++ b/test/quic_idle_timeout_tests.erl
@@ -100,3 +100,141 @@ just_below_timeout_boundary_test() ->
     TimeSinceActivity = Now - LastActivity,
 
     ?assertNot(TimeSinceActivity >= IdleTimeout).
+
+%%====================================================================
+%% Behavioural tests: the idle timer is driven by *received* activity
+%% (RFC 9000 §10.1), not by our own sends.
+%%
+%% These run a real client (over a controllable in-process datagram bridge)
+%% against the in-process echo server, then black-hole the path. The client
+%% keeps sending keep-alive PINGs the whole time; the connection must still
+%% idle-close, because a peer that sends into a black hole must not keep its
+%% own idle timer alive forever. (Regression test for the bug where every send
+%% reset last_activity, so a sending-but-deaf connection never timed out.)
+%%====================================================================
+
+%% keep_alive_interval is floored to 5000ms by the implementation
+%% (calculate_keep_alive_interval/2), so the idle timeout must sit above that
+%% for keep-alive to hold a live connection open. Keep it just above so the
+%% tests stay reasonably quick.
+-define(IDLE_TIMEOUT, 7000).
+-define(KEEP_ALIVE, 5000).
+
+%% A black-holed path must idle-close within ~IDLE_TIMEOUT despite the client
+%% still emitting keep-alive PINGs.
+silent_path_idle_closes_test_() ->
+    {timeout, 30, fun silent_path_idle_closes/0}.
+
+%% A live path must NOT idle-close: keep-alive PINGs are answered, and the
+%% received ACKs keep the idle timer from firing. Guards against the fix being
+%% too aggressive.
+live_path_stays_open_test_() ->
+    {timeout, 30, fun live_path_stays_open/0}.
+
+silent_path_idle_closes() ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    {Conn, Bridge} = connect_via_bridge(maps:get(port, Echo)),
+    try
+        %% Black-hole the path in both directions. The client carries on sending
+        %% keep-alive PINGs (every ?KEEP_ALIVE ms) but receives nothing.
+        Bridge ! block,
+        receive
+            {quic, Conn, {closed, _Reason}} ->
+                ok
+        after ?IDLE_TIMEOUT + 5000 ->
+            erlang:error(idle_timeout_did_not_fire)
+        end
+    after
+        Bridge ! stop,
+        quic_test_echo_server:stop(Echo)
+    end.
+
+live_path_stays_open() ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    {Conn, Bridge} = connect_via_bridge(maps:get(port, Echo)),
+    try
+        %% Path stays up; keep-alive PING/ACK exchanges keep the idle timer from
+        %% firing well past several idle-timeout windows.
+        %% Wait past the idle timeout. A keep-alive PING fires at ~?KEEP_ALIVE
+        %% and its ACK (a received packet) pushes the idle deadline out, so the
+        %% connection must still be open here. If keep-alive did not hold it
+        %% open, the idle timer would have fired at ?IDLE_TIMEOUT (< this wait).
+        receive
+            {quic, Conn, {closed, Reason}} ->
+                erlang:error({unexpected_idle_close, Reason})
+        after ?IDLE_TIMEOUT + 2000 ->
+            ok
+        end
+    after
+        quic:safe_close(Conn, normal),
+        Bridge ! stop,
+        quic_test_echo_server:stop(Echo)
+    end.
+
+%% Connect to the echo server through a datagram bridge we control, with a short
+%% idle timeout and aggressive keep-alive. Returns once {connected} is received.
+connect_via_bridge(Port) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Owner = self(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = (quic_test_echo_server:client_opts())#{
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter,
+        idle_timeout => ?IDLE_TIMEOUT,
+        keep_alive_interval => ?KEEP_ALIVE
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, Owner),
+    Bridge ! {set_conn, Conn},
+    receive
+        {quic, Conn, {connected, _Info}} -> ok
+    after 10000 ->
+        erlang:error(connect_timeout)
+    end,
+    {Conn, Bridge}.
+
+%% Datagram bridge: shuttles packets between the client's adapter callbacks and
+%% a gen_udp socket to the echo server. `block' drops datagrams in both
+%% directions, simulating a dead path.
+bridge_init(ServerIP, ServerPort, SocketRef) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(Sock, undefined, ServerIP, ServerPort, SocketRef, false).
+
+bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef, Blocked) ->
+    Loop = fun(C, B) -> bridge_loop(Sock, C, ServerIP, ServerPort, SocketRef, B) end,
+    receive
+        {set_conn, NewConn} ->
+            Loop(NewConn, Blocked);
+        block ->
+            Loop(Conn, true);
+        {send, _IP, _Port, _Pkt} when Blocked ->
+            Loop(Conn, Blocked);
+        {send, _IP, _Port, Pkt} ->
+            ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+            Loop(Conn, Blocked);
+        {udp, Sock, _IP, _Port, _Data} when Blocked ->
+            Loop(Conn, Blocked);
+        {udp, Sock, _IP, _Port, Data} when is_pid(Conn) ->
+            Conn ! {udp, SocketRef, ServerIP, ServerPort, Data},
+            Loop(Conn, Blocked);
+        {udp, Sock, _IP, _Port, _Data} ->
+            Loop(Conn, Blocked);
+        stop ->
+            gen_udp:close(Sock),
+            ok;
+        _ ->
+            Loop(Conn, Blocked)
+    end.

--- a/test/quic_idle_timeout_tests.erl
+++ b/test/quic_idle_timeout_tests.erl
@@ -102,15 +102,17 @@ just_below_timeout_boundary_test() ->
     ?assertNot(TimeSinceActivity >= IdleTimeout).
 
 %%====================================================================
-%% Behavioural tests: the idle timer is driven by *received* activity
-%% (RFC 9000 §10.1), not by our own sends.
+%% Behavioural tests: the idle timer follows RFC 9000 §10.1 — restarted on
+%% every receive and on the first ack-eliciting send since the last receive,
+%% but not on subsequent sends.
 %%
 %% These run a real client (over a controllable in-process datagram bridge)
 %% against the in-process echo server, then black-hole the path. The client
 %% keeps sending keep-alive PINGs the whole time; the connection must still
-%% idle-close, because a peer that sends into a black hole must not keep its
-%% own idle timer alive forever. (Regression test for the bug where every send
-%% reset last_activity, so a sending-but-deaf connection never timed out.)
+%% idle-close, because after the one permitted send-side restart a peer sending
+%% into a black hole gets no further restarts. (Regression test for the bug
+%% where every send reset last_activity, so a sending-but-deaf connection never
+%% timed out.)
 %%====================================================================
 
 %% keep_alive_interval is floored to 5000ms by the implementation
@@ -120,8 +122,9 @@ just_below_timeout_boundary_test() ->
 -define(IDLE_TIMEOUT, 7000).
 -define(KEEP_ALIVE, 5000).
 
-%% A black-holed path must idle-close within ~IDLE_TIMEOUT despite the client
-%% still emitting keep-alive PINGs.
+%% A black-holed path must idle-close within ~IDLE_TIMEOUT plus one keep-alive
+%% interval (the single §10.1 send-side restart) despite the client still
+%% emitting keep-alive PINGs.
 silent_path_idle_closes_test_() ->
     {timeout, 30, fun silent_path_idle_closes/0}.
 
@@ -141,7 +144,7 @@ silent_path_idle_closes() ->
         receive
             {quic, Conn, {closed, _Reason}} ->
                 ok
-        after ?IDLE_TIMEOUT + 5000 ->
+        after ?IDLE_TIMEOUT + ?KEEP_ALIVE + 5000 ->
             erlang:error(idle_timeout_did_not_fire)
         end
     after


### PR DESCRIPTION
quic_connection reset `last_activity` on every successful 1-RTT packet send. Because the idle timer and keep-alive are both derived from `last_activity`, an endpoint that kept sending into a black hole — e.g. a client emitting keep-alive PINGs and PTO retransmits while its peer is unreachable — perpetually reset its own idle timer and never timed out a dead path. The connection stayed "up" forever, so application-level failover (e.g. QUIC -> TCP) that waits for the connection to close never triggered.

RFC 9000 §10.1 restarts the idle timer when a packet is *received*, and only on send for the first ack-eliciting packet since the last receive. The simplest correct behaviour is to drive the idle timer purely from received activity: a healthy peer ACKs our packets, and those received ACKs are what keep the timer alive; a dead path produces no ACKs and so idle-closes as intended. Keep-alive PINGs continue to keep the *peer's* timer from firing.

Fix: stop updating `last_activity` on the send path (send_app_packet_internal). It is already updated for every received packet (decrypt_packet) and at handshake completion, which is the correct semantics for both the idle timer and keep-alive.

Add a behavioural regression test (quic_idle_timeout_tests): a client connected over a controllable in-process datagram bridge keeps sending keep-alive PINGs while the path is black-holed and must still idle-close (fails before this fix), plus a live-path test asserting keep-alive holds a healthy connection open (guards against over-aggressive closing).