### PR TITLE
quic_connection: slide connection-level MAX_DATA instead of capping absolutely

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -157,6 +157,8 @@
     short_header_first_byte/3,
     test_spin_state/1,
     test_spin_state_for/2,
+    %% Connection-level receive-window auto-tuning (RFC 9000 §4.1)
+    next_conn_max_data/5,
     %% Stateless reset token derivation (RFC 9000 §10.3.2)
     generate_stateless_reset_token/2,
     test_state_with_secret/1,
@@ -6524,23 +6526,14 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                             (Now2 - LastConnUpdate) <
                                                 (SmoothedRTT2 * ?AUTO_TUNE_RTT_FACTOR)
                                     end,
-                                %% Calculate new window based on RTT-aware growth
-                                BaseNewMaxData =
-                                    case FastConsumption2 of
-                                        true ->
-                                            %% Double (aggressive growth)
-                                            min(
-                                                (NewDataReceivedVal + MaxDataLocalVal) * 2,
-                                                MaxWindow2
-                                            );
-                                        false ->
-                                            %% Linear (conservative growth)
-                                            min(
-                                                NewDataReceivedVal + MaxDataLocalVal +
-                                                    InitialConnWindow,
-                                                MaxWindow2
-                                            )
-                                    end,
+                                %% Calculate new window based on RTT-aware growth.
+                                BaseNewMaxData = next_conn_max_data(
+                                    NewDataReceivedVal,
+                                    MaxDataLocalVal,
+                                    MaxWindow2,
+                                    InitialConnWindow,
+                                    FastConsumption2
+                                ),
                                 %% Ensure connection window >= 1.5x largest stream window
                                 MaxStreamWindow = get_max_stream_recv_window(State2),
                                 MinConnWindow = trunc(
@@ -10716,6 +10709,29 @@ maybe_retire_cid(CID, #state{role = server, listener = Listener}) when is_pid(Li
     quic_listener:retire_cid(Listener, CID);
 maybe_retire_cid(_CID, _State) ->
     ok.
+
+%% @doc Compute the next connection-level MAX_DATA limit during receive-window
+%% auto-tuning. The limit is anchored at the bytes already received and a window
+%% is added on top, with only the *window size* capped at MaxWindow (the largest
+%% buffer we are willing to hold). This makes MAX_DATA slide forward as data is
+%% consumed — exactly as the per-stream MAX_STREAM_DATA update does.
+%%
+%% Capping the *absolute* limit at MaxWindow instead (the previous behaviour)
+%% froze MAX_DATA once the connection had received MaxWindow bytes in total: the
+%% sender then exhausted the connection window and stalled permanently on any
+%% transfer larger than MaxWindow, regardless of how fast the receiver consumed.
+%% Fast consumption doubles the window; otherwise it grows by one initial window.
+-spec next_conn_max_data(
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    boolean()
+) -> non_neg_integer().
+next_conn_max_data(DataReceived, MaxDataLocal, MaxWindow, _InitialWindow, true) ->
+    DataReceived + min(MaxDataLocal * 2, MaxWindow);
+next_conn_max_data(DataReceived, MaxDataLocal, MaxWindow, InitialWindow, false) ->
+    DataReceived + min(MaxDataLocal + InitialWindow, MaxWindow).
 
 %% @doc Generate a stateless reset token for a connection ID.
 %% RFC 9000 §10.3.2 requires the token to be hard for an external

--- a/test/quic_connection_tests.erl
+++ b/test/quic_connection_tests.erl
@@ -779,3 +779,53 @@ make_test_session_ticket(ServerName) ->
         cipher = aes_128_gcm,
         alpn = <<"h3">>
     }.
+
+%%====================================================================
+%% Connection-level receive-window auto-tuning (next_conn_max_data/5)
+%%
+%% Regression: the limit must keep sliding forward past MaxWindow as data is
+%% received, so a sustained sender is never permanently blocked once the
+%% connection has received MaxWindow bytes in total.
+%%====================================================================
+
+%% The advertised limit must always stay ahead of what has been received,
+%% even when total bytes received far exceed the max receive window.
+conn_max_data_slides_past_window_test() ->
+    MaxWindow = 8 * 1024 * 1024,
+    %% A long transfer: 100 MiB already received, well beyond MaxWindow.
+    Received = 100 * 1024 * 1024,
+    MaxDataLocal = Received,
+    NewMax = quic_connection:next_conn_max_data(
+        Received, MaxDataLocal, MaxWindow, 768 * 1024, true
+    ),
+    ?assert(NewMax > Received),
+    %% Headroom offered to the sender is bounded by MaxWindow...
+    ?assert(NewMax - Received =< MaxWindow),
+    %% ...and the absolute limit is far above MaxWindow (it slid forward).
+    ?assert(NewMax > MaxWindow).
+
+%% Window size is capped at MaxWindow; the limit equals received + MaxWindow
+%% once the doubling/linear growth has saturated the cap.
+conn_max_data_window_capped_test() ->
+    MaxWindow = 8 * 1024 * 1024,
+    Received = 50 * 1024 * 1024,
+    %% MaxDataLocal large enough that *2 and +Initial both exceed MaxWindow.
+    MaxDataLocal = 20 * 1024 * 1024,
+    Fast = quic_connection:next_conn_max_data(Received, MaxDataLocal, MaxWindow, 768 * 1024, true),
+    Slow = quic_connection:next_conn_max_data(Received, MaxDataLocal, MaxWindow, 768 * 1024, false),
+    ?assertEqual(Received + MaxWindow, Fast),
+    ?assertEqual(Received + MaxWindow, Slow).
+
+%% Early in a connection the window grows: fast consumption doubles the current
+%% limit, slow consumption adds one initial window — both anchored at received.
+conn_max_data_growth_modes_test() ->
+    MaxWindow = 8 * 1024 * 1024,
+    Received = 100 * 1024,
+    MaxDataLocal = 1024 * 1024,
+    Initial = 768 * 1024,
+    Fast = quic_connection:next_conn_max_data(Received, MaxDataLocal, MaxWindow, Initial, true),
+    Slow = quic_connection:next_conn_max_data(Received, MaxDataLocal, MaxWindow, Initial, false),
+    ?assertEqual(Received + MaxDataLocal * 2, Fast),
+    ?assertEqual(Received + MaxDataLocal + Initial, Slow),
+    %% Fast (doubling) grows the window more aggressively than slow (linear).
+    ?assert(Fast > Slow).


### PR DESCRIPTION

The receive-window auto-tuner capped the new connection-level MAX_DATA at fc_max_receive_window (the max buffer we will hold) as an *absolute* value:

    min((DataReceived + MaxDataLocal) * 2, MaxWindow)

Because MAX_DATA is the cumulative connection send limit, once the connection had received MaxWindow bytes in total the advertised limit stopped advancing, the sender exhausted the connection window, and any sustained transfer larger than MaxWindow stalled permanently — regardless of how promptly the receiver consumed. The per-stream MAX_STREAM_DATA update already avoided this by anchoring at the consumed offset; the connection-level update did not.

Anchor the connection limit at the bytes already received and cap only the *window size*, so MAX_DATA slides forward as data is consumed:

    DataReceived + min(MaxDataLocal * 2, MaxWindow)

Extracted as the pure helper next_conn_max_data/5 with eunit coverage for the slide-past-window, window-cap, and growth-mode behaviours.