### PR TITLE
stateless reset on restart: advertise + recognise initial-CID reset token

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -160,6 +160,10 @@
     %% Stateless reset token derivation (RFC 9000 §10.3.2)
     generate_stateless_reset_token/2,
     test_state_with_secret/1,
+    %% Stateless reset recognition (RFC 9000 §10.3)
+    maybe_store_initial_reset_token/2,
+    check_stateless_reset/2,
+    test_state_for_reset/3,
     %% NEW_TOKEN frame dispatch (RFC 9000 §8.1.3)
     process_frame/3,
     test_state_for_role/1,
@@ -2941,10 +2945,25 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     %% RFC 9000 §7.3: if this server issued a Retry for this client,
     %% echo the Retry's SCID in retry_source_connection_id so the
     %% client can verify the full handshake against the Retry it saw.
-    TransportParams =
+    TransportParams4 =
         case State#state.retry_scid_for_tp of
             undefined -> TransportParams3;
             RetrySCIDTP -> TransportParams3#{retry_scid => RetrySCIDTP}
+        end,
+
+    %% RFC 9000 §10.3: advertise a stateless_reset_token bound to our initial
+    %% SCID, so the peer can recognise a stateless reset for this connection if
+    %% we later lose its state (e.g. after a restart) and reply with a reset
+    %% derived from the same server-wide secret + CID. Only sent when a secret
+    %% is configured.
+    TransportParams =
+        case State#state.stateless_reset_secret of
+            undefined ->
+                TransportParams4;
+            _ ->
+                TransportParams4#{
+                    stateless_reset_token => generate_stateless_reset_token(SCID, State)
+                }
         end,
 
     %% Build EncryptedExtensions
@@ -10995,6 +11014,12 @@ apply_peer_transport_params_internal(TransportParams, State) ->
     %% If true, peer has indicated they don't want to receive traffic from different addresses
     PeerDisableMigration = maps:get(disable_active_migration, TransportParams, false),
 
+    %% RFC 9000 §10.3: the peer's stateless_reset_token applies to the CID it
+    %% chose as its initial source CID — i.e. our current DCID. Record it so a
+    %% later stateless reset for this connection is recognised by
+    %% check_stateless_reset/2 (only servers send this, so only clients store it).
+    PeerCIDPool = maybe_store_initial_reset_token(TransportParams, State),
+
     %% Store stream data limits in state for use when opening streams
     %% These tell us how much we can send on different stream types
     State#state{
@@ -11004,6 +11029,7 @@ apply_peer_transport_params_internal(TransportParams, State) ->
             peer_max_stream_data_bidi_local => MaxStreamDataBidiLocal,
             peer_max_stream_data_uni => MaxStreamDataUni
         }),
+        peer_cid_pool = PeerCIDPool,
         peer_active_cid_limit = PeerCIDLimit,
         %% Connection-level send limit
         max_data_remote = MaxDataRemote,
@@ -11015,6 +11041,30 @@ apply_peer_transport_params_internal(TransportParams, State) ->
         %% Migration disabled by peer (RFC 9000 Section 18.2)
         peer_disable_migration = PeerDisableMigration
     }.
+
+%% Record the peer's transport-parameter stateless_reset_token (RFC 9000 §10.3)
+%% against our current DCID (the peer's initial source CID), as a sequence-0
+%% entry in the peer CID pool. This is what lets check_stateless_reset/2 match a
+%% reset for the initial connection ID — a steady connection never receives a
+%% NEW_CONNECTION_ID frame, so without this the token is never stored.
+maybe_store_initial_reset_token(TransportParams, #state{dcid = DCID, peer_cid_pool = Pool}) ->
+    case maps:get(stateless_reset_token, TransportParams, undefined) of
+        Token when is_binary(Token), byte_size(Token) =:= 16, is_binary(DCID) ->
+            case lists:keyfind(0, #cid_entry.seq_num, Pool) of
+                false ->
+                    Entry = #cid_entry{
+                        seq_num = 0,
+                        cid = DCID,
+                        stateless_reset_token = Token,
+                        status = active
+                    },
+                    [Entry | Pool];
+                _ ->
+                    Pool
+            end;
+        _ ->
+            Pool
+    end.
 
 %% @doc Handle RETIRE_CONNECTION_ID frame from peer.
 %% Marks the specified CID in our local pool as retired.
@@ -11310,6 +11360,17 @@ test_spin_state_for(Role, Enabled) ->
 -spec test_state_with_secret(binary() | undefined) -> #state{}.
 test_state_with_secret(Secret) ->
     #state{stateless_reset_secret = Secret}.
+
+%% Minimal client #state{} for stateless-reset recognition tests: a current DCID
+%% and an explicit peer CID pool.
+-spec test_state_for_reset(binary(), [#cid_entry{}], binary() | undefined) -> #state{}.
+test_state_for_reset(DCID, PeerCIDPool, Secret) ->
+    #state{
+        role = client,
+        dcid = DCID,
+        peer_cid_pool = PeerCIDPool,
+        stateless_reset_secret = Secret
+    }.
 
 %% Minimal #state{} scoped to role for frame-dispatch tests.
 -spec test_state_for_role(client | server) -> #state{}.

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -60,7 +60,7 @@
 ]).
 
 -ifdef(TEST).
--export([send_packet/6]).
+-export([send_packet/6, compute_stateless_reset_token/2, build_stateless_reset/2]).
 -endif.
 
 -include("quic.hrl").
@@ -975,25 +975,28 @@ handle_unknown_packet(
         reset_secret = Secret
     }
 ) ->
-    %% RFC 9000 Section 10.3.3: Don't send reset if packet might be a reset
-    case is_potential_stateless_reset(Packet) of
+    %% RFC 9000 §10.3: reply to a 1-RTT (short-header) packet we cannot route to
+    %% any connection with a stateless reset, so a peer whose connection state we
+    %% have lost (e.g. after a restart) tears the connection down and reconnects
+    %% instead of retransmitting into a black hole until its idle timer fires.
+    %%
+    %% Constraints (RFC 9000 §10.3.3):
+    %%   * Only short-header packets — long-header (handshake) packets are part of
+    %%     connection setup and are handled elsewhere.
+    %%   * Only packets larger than 21 bytes, so the reset can be made strictly
+    %%     smaller than the trigger (build_stateless_reset/2). This both avoids
+    %%     amplification and bounds any reset loop: each reply shrinks until it is
+    %%     too small to trigger another, so the exchange terminates.
+    %%   * Only when a reset secret is configured, so the token is verifiable by a
+    %%     peer that received it during the original handshake.
+    TriggerSize = byte_size(Packet),
+    case is_short_header_packet(Packet) andalso TriggerSize > 21 andalso is_binary(Secret) of
         true ->
-            %% Don't respond to avoid reset loops
-            ok;
+            Token = compute_stateless_reset_token(Secret, DCID),
+            ResetPacket = build_stateless_reset(Token, TriggerSize),
+            send_packet(Socket, SocketState, Backend, IP, Port, ResetPacket);
         false ->
-            %% RFC 9000 Section 10.3.3: Reset must be smaller than triggering packet
-            %% and at least 21 bytes (minimum QUIC packet size)
-            TriggerSize = byte_size(Packet),
-            case TriggerSize > 21 of
-                true ->
-                    %% Generate and send stateless reset
-                    Token = compute_stateless_reset_token(Secret, DCID),
-                    ResetPacket = build_stateless_reset(Token, TriggerSize),
-                    send_packet(Socket, SocketState, Backend, IP, Port, ResetPacket);
-                false ->
-                    %% Packet too small to respond with reset
-                    ok
-            end
+            ok
     end.
 
 %% Decide whether a freshly arrived Initial gets a Retry, spawns a
@@ -1121,12 +1124,12 @@ send_packet(Socket, _SocketState, gen_udp, IP, Port, Packet) ->
 %% Check if a packet might be a stateless reset
 %% RFC 9000 Section 10.3: A reset looks like a short header packet
 %% ending with a 16-byte token
-is_potential_stateless_reset(<<0:1, _:7, _Rest/binary>> = Packet) ->
-    %% Short header - could be a stateless reset
-    %% A stateless reset is at least 21 bytes (1 header + 4 random + 16 token)
-    byte_size(Packet) >= 21;
-is_potential_stateless_reset(_) ->
-    %% Long header packets are not stateless resets
+%% RFC 9000 §17.3: a short header has the most-significant bit of the first byte
+%% clear (long headers set it). 1-RTT packets and stateless resets use short
+%% headers; Initial/Handshake/Retry/0-RTT use long headers.
+is_short_header_packet(<<0:1, _/bitstring>>) ->
+    true;
+is_short_header_packet(_) ->
     false.
 
 %% Compute stateless reset token from secret and CID

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -667,6 +667,8 @@ encode_transport_param(initial_scid, Value) ->
     encode_tp(?TP_INITIAL_SCID, Value);
 encode_transport_param(retry_scid, Value) ->
     encode_tp(?TP_RETRY_SCID, Value);
+encode_transport_param(stateless_reset_token, Value) ->
+    encode_tp(?TP_STATELESS_RESET_TOKEN, Value);
 encode_transport_param(preferred_address, #preferred_address{} = PA) ->
     encode_tp(?TP_PREFERRED_ADDRESS, encode_preferred_address(PA));
 encode_transport_param(max_datagram_frame_size, Value) when Value > 0 ->

--- a/test/quic_connection_tests.erl
+++ b/test/quic_connection_tests.erl
@@ -779,3 +779,94 @@ make_test_session_ticket(ServerName) ->
         cipher = aes_128_gcm,
         alpn = <<"h3">>
     }.
+
+%%====================================================================
+%% Stateless reset recognition (RFC 9000 §10.3)
+%%
+%% A connection must recognise a stateless reset for its initial connection ID
+%% so that, after the peer (server) loses connection state and restarts, the
+%% client tears the dead connection down promptly instead of waiting for its
+%% idle timer. The server advertises a stateless_reset_token transport param for
+%% its initial SCID; the client stores it against that CID; the restarted
+%% listener, sharing the secret, derives the same token and replies with a
+%% stateless reset that the client then recognises.
+%%====================================================================
+
+%% The peer's transport-parameter reset token is stored against our DCID as a
+%% sequence-0 peer CID pool entry.
+store_initial_reset_token_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    Token = crypto:strong_rand_bytes(16),
+    State = quic_connection:test_state_for_reset(DCID, [], undefined),
+    Pool = quic_connection:maybe_store_initial_reset_token(
+        #{stateless_reset_token => Token}, State
+    ),
+    ?assertMatch(
+        [#cid_entry{seq_num = 0, cid = DCID, stateless_reset_token = Token, status = active}],
+        Pool
+    ).
+
+%% No token in the transport params leaves the pool untouched.
+store_initial_reset_token_absent_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    State = quic_connection:test_state_for_reset(DCID, [], undefined),
+    ?assertEqual([], quic_connection:maybe_store_initial_reset_token(#{}, State)).
+
+%% An existing sequence-0 entry is not duplicated.
+store_initial_reset_token_idempotent_test() ->
+    DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+    Existing = #cid_entry{
+        seq_num = 0, cid = DCID, stateless_reset_token = <<9:128>>, status = active
+    },
+    State = quic_connection:test_state_for_reset(DCID, [Existing], undefined),
+    Pool = quic_connection:maybe_store_initial_reset_token(
+        #{stateless_reset_token => crypto:strong_rand_bytes(16)}, State
+    ),
+    ?assertEqual([Existing], Pool).
+
+%% Token derivation is identical on both sides (connection advertises, listener
+%% recomputes after restart): both are HMAC-SHA256(secret, CID)[0:16].
+reset_token_derivation_parity_test() ->
+    Secret = crypto:strong_rand_bytes(32),
+    CID = <<10, 11, 12, 13, 14, 15, 16, 17>>,
+    Advertised = quic_connection:generate_stateless_reset_token(
+        CID, quic_connection:test_state_with_secret(Secret)
+    ),
+    Recomputed = quic_listener:compute_stateless_reset_token(Secret, CID),
+    ?assertEqual(Advertised, Recomputed).
+
+%% End-to-end: a stateless reset built by a restarted listener (same secret) for
+%% the connection's initial CID is recognised by the client that stored the
+%% advertised token.
+recognize_stateless_reset_after_restart_test() ->
+    Secret = crypto:strong_rand_bytes(32),
+    DCID = <<10, 11, 12, 13, 14, 15, 16, 17>>,
+    %% Server advertised this token; client stores it against the initial DCID.
+    Advertised = quic_connection:generate_stateless_reset_token(
+        DCID, quic_connection:test_state_with_secret(Secret)
+    ),
+    Pool = quic_connection:maybe_store_initial_reset_token(
+        #{stateless_reset_token => Advertised},
+        quic_connection:test_state_for_reset(DCID, [], undefined)
+    ),
+    State = quic_connection:test_state_for_reset(DCID, Pool, undefined),
+    %% Restarted listener derives the token and builds a real reset packet.
+    ListenerToken = quic_listener:compute_stateless_reset_token(Secret, DCID),
+    Reset = quic_listener:build_stateless_reset(ListenerToken, 1200),
+    ?assertEqual({error, stateless_reset}, quic_connection:check_stateless_reset(Reset, State)).
+
+%% A short-header packet whose trailing bytes are not a known token is a plain
+%% decryption failure, not a stateless reset.
+reject_non_reset_packet_test() ->
+    Secret = crypto:strong_rand_bytes(32),
+    DCID = <<10, 11, 12, 13, 14, 15, 16, 17>>,
+    Advertised = quic_connection:generate_stateless_reset_token(
+        DCID, quic_connection:test_state_with_secret(Secret)
+    ),
+    Pool = quic_connection:maybe_store_initial_reset_token(
+        #{stateless_reset_token => Advertised},
+        quic_connection:test_state_for_reset(DCID, [], undefined)
+    ),
+    State = quic_connection:test_state_for_reset(DCID, Pool, undefined),
+    Bogus = <<64, (crypto:strong_rand_bytes(40))/binary>>,
+    ?assertEqual({error, decryption_failed}, quic_connection:check_stateless_reset(Bogus, State)).

--- a/test/quic_transport_params_tests.erl
+++ b/test/quic_transport_params_tests.erl
@@ -24,6 +24,15 @@ encode_original_dcid_test() ->
     {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
     ?assertEqual(DCID, maps:get(original_dcid, Decoded)).
 
+encode_stateless_reset_token_test() ->
+    %% stateless_reset_token (0x02) - 16 bytes, server-sent (RFC 9000 §10.3)
+    Token = crypto:strong_rand_bytes(16),
+    Params = #{stateless_reset_token => Token},
+    Encoded = quic_tls:encode_transport_params(Params),
+    ?assert(byte_size(Encoded) > 0),
+    {ok, Decoded} = quic_tls:decode_transport_params(Encoded),
+    ?assertEqual(Token, maps:get(stateless_reset_token, Decoded)).
+
 encode_max_idle_timeout_test() ->
     %% max_idle_timeout (0x01)
     Params = #{max_idle_timeout => 30000},


### PR DESCRIPTION
A connection that loses its peer's state (e.g. a server that restarts) could not tell the peer to stop using the dead connection: the peer kept sending 1-RTT packets until its idle timer fired (tens of seconds), and the restarted listener silently dropped them. The pieces for RFC 9000 §10.3 stateless reset existed but were not wired up end to end. Complete them:

  * quic_tls: encode the stateless_reset_token transport parameter (it had a decoder but no encoder, so it was silently dropped on the wire).
  * quic_connection (server): advertise a stateless_reset_token for our initial SCID, derived from the connection's stateless_reset_secret, when a secret is configured.
  * quic_connection (client): store the peer's transport-parameter reset token against our current DCID as a sequence-0 peer-CID-pool entry, so check_stateless_reset/2 can match it — a steady connection never receives a NEW_CONNECTION_ID frame, so this was the only way to learn the initial CID's token.
  * quic_listener: reply to an unroutable short-header packet with a stateless reset (derived from the listener secret + the packet's DCID) instead of suppressing it. Bounded to short-header packets >21 bytes so the reset is strictly smaller than the trigger (RFC 9000 §10.3.3), which prevents amplification and terminates any reset loop.

Token derivation matches on both sides (HMAC-SHA256(secret, CID)[0:16]), so a listener that shares the secret across restarts resets a connection the client recognises. eunit covers the transport-param roundtrip, client-side token storage, cross-module derivation parity, and end-to-end reset recognition.