### PR TITLE
Differentiate QUIC-conn exit reason on H3 connection teardown

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -598,8 +598,8 @@ bootstrapping(cast, close, State) ->
     {next_state, closing, State};
 bootstrapping(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-bootstrapping(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+bootstrapping(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 bootstrapping(
     info,
     {quic, QC, {early_data_rejected, StreamIds}},
@@ -707,8 +707,8 @@ early_data(cast, close, State) ->
     {next_state, closing, State};
 early_data(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-early_data(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+early_data(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 early_data(
     info,
     {quic, QC, {session_ticket, T}},
@@ -772,8 +772,8 @@ awaiting_quic(cast, close, State) ->
     {next_state, closing, State};
 awaiting_quic(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-awaiting_quic(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+awaiting_quic(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 awaiting_quic(
     info,
     {quic, QC, {session_ticket, T}},
@@ -870,8 +870,8 @@ h3_connecting(cast, close, State) ->
     {next_state, closing, State};
 h3_connecting(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-h3_connecting(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+h3_connecting(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 h3_connecting(
     info,
     {quic, QC, {session_ticket, T}},
@@ -1107,8 +1107,8 @@ connected(cast, close, State) ->
     {next_state, closing, State};
 connected(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-connected(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+connected(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 connected(info, {'DOWN', Ref, process, _Pid, _Reason}, #state{stream_handlers = Handlers} = State) ->
     %% Check if this is a stream handler going down
     case find_handler_by_ref(Ref, Handlers) of
@@ -1185,8 +1185,8 @@ goaway_sent(cast, close, State) ->
     {next_state, closing, State};
 goaway_sent(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-goaway_sent(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+goaway_sent(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 goaway_sent(
     info,
     {quic, QC, {session_ticket, T}},
@@ -1249,8 +1249,8 @@ goaway_received(cast, close, State) ->
     {next_state, closing, State};
 goaway_received(info, {'DOWN', Ref, process, _, _}, #state{owner_monitor = Ref} = State) ->
     {next_state, closing, State};
-goaway_received(info, {'DOWN', Ref, process, _, _}, #state{quic_ref = Ref} = State) ->
-    {stop, quic_closed, State};
+goaway_received(info, {'DOWN', Ref, process, _, Reason}, #state{quic_ref = Ref} = State) ->
+    handle_quic_down(Reason, State);
 goaway_received(
     info,
     {quic, QC, {session_ticket, T}},
@@ -1302,6 +1302,22 @@ closing(
     {keep_state_and_data, [{reply, From, quic:early_data_accepted(QC)}]};
 closing(_EventType, _Event, _State) ->
     keep_state_and_data.
+
+%%====================================================================
+%% Internal: QUIC connection DOWN
+%%====================================================================
+
+%% A cleanly closed QUIC connection must not crash the H3 process:
+%% only an abnormal QUIC exit is propagated as {quic_closed, Reason}.
+handle_quic_down(Reason, #state{owner = Owner} = State) ->
+    Owner ! {quic_h3, self(), closed},
+    case Reason of
+        normal -> {stop, normal, State};
+        shutdown -> {stop, normal, State};
+        {shutdown, _} -> {stop, normal, State};
+        noproc -> {stop, normal, State};
+        _ -> {stop, {quic_closed, Reason}, State}
+    end.
 
 %%====================================================================
 %% Internal: Critical Streams

--- a/test/quic_h3_close_tests.erl
+++ b/test/quic_h3_close_tests.erl
@@ -1,0 +1,152 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for how quic_h3_connection reacts to the underlying QUIC
+%%% connection process going DOWN: a clean QUIC exit (normal,
+%%% shutdown, {shutdown, _}) must stop the H3 process with `normal'
+%%% (no crash report, no abnormal link-EXIT to the owner), while an
+%%% abnormal QUIC exit stops it with {quic_closed, Reason}. In both
+%%% cases the owner receives {quic_h3, Conn, closed}.
+
+-module(quic_h3_close_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% logger handler callback
+-export([log/2]).
+
+setup() ->
+    meck:new(quic, [passthrough]),
+    meck:expect(quic, set_owner_sync, fun(_, _) -> ok end),
+    meck:expect(quic, close, fun(_) -> ok end),
+    meck:expect(quic, close, fun(_, _, _) -> ok end),
+    meck:expect(quic, datagram_max_size, fun(_) -> 0 end),
+    ok.
+
+teardown(_) ->
+    meck:unload(quic),
+    ok.
+
+quic_down_normal_is_graceful_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        Capture = install_capture(),
+        {FakeQuicConn, H3Conn, Mon} = start_client(),
+        FakeQuicConn ! {exit_with, normal},
+        expect_closed(H3Conn),
+        expect_down(Mon, normal),
+        assert_no_error_log(H3Conn),
+        remove_capture(Capture)
+    end}.
+
+quic_down_shutdown_is_graceful_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        Capture = install_capture(),
+        {FakeQuicConn, H3Conn, Mon} = start_client(),
+        FakeQuicConn ! {exit_with, {shutdown, drained}},
+        expect_closed(H3Conn),
+        expect_down(Mon, normal),
+        assert_no_error_log(H3Conn),
+        remove_capture(Capture)
+    end}.
+
+quic_down_abnormal_propagates_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        Capture = install_capture(),
+        {FakeQuicConn, H3Conn, Mon} = start_client(),
+        FakeQuicConn ! {exit_with, boom},
+        expect_closed(H3Conn),
+        expect_down(Mon, {quic_closed, boom}),
+        expect_error_log(H3Conn),
+        remove_capture(Capture)
+    end}.
+
+server_quic_down_normal_is_graceful_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        Capture = install_capture(),
+        FakeQuicConn = spawn(fun fake_quic_loop/0),
+        {ok, H3Conn} = gen_statem:start_link(
+            quic_h3_connection, {server, FakeQuicConn, #{}, self()}, []
+        ),
+        unlink(H3Conn),
+        Mon = monitor(process, H3Conn),
+        ?assertEqual(awaiting_quic, current_state(H3Conn)),
+        FakeQuicConn ! {exit_with, normal},
+        expect_closed(H3Conn),
+        expect_down(Mon, normal),
+        assert_no_error_log(H3Conn),
+        remove_capture(Capture)
+    end}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+start_client() ->
+    FakeQuicConn = spawn(fun fake_quic_loop/0),
+    {ok, H3Conn} = quic_h3_connection:start_link(FakeQuicConn, <<"example.com">>, 443, #{}),
+    unlink(H3Conn),
+    Mon = monitor(process, H3Conn),
+    ?assertEqual(bootstrapping, current_state(H3Conn)),
+    {FakeQuicConn, H3Conn, Mon}.
+
+fake_quic_loop() ->
+    receive
+        {exit_with, Reason} -> exit(Reason);
+        _ -> fake_quic_loop()
+    end.
+
+current_state(Pid) ->
+    {StateName, _StateData} = sys:get_state(Pid, 1000),
+    StateName.
+
+expect_closed(H3Conn) ->
+    receive
+        {quic_h3, H3Conn, closed} -> ok
+    after 1000 ->
+        error(no_closed_message)
+    end.
+
+expect_down(Mon, ExpectedReason) ->
+    receive
+        {'DOWN', Mon, process, _, Reason} ->
+            ?assertEqual(ExpectedReason, Reason)
+    after 1000 ->
+        error(no_down)
+    end.
+
+%%====================================================================
+%% Logger capture: forward every error-level event's origin pid so a
+%% test can assert whether the H3 process emitted a crash report.
+%%====================================================================
+
+log(#{level := error, meta := Meta}, #{config := #{pid := Pid}}) ->
+    Pid ! {error_log, maps:get(pid, Meta, undefined)};
+log(_Event, _Config) ->
+    ok.
+
+install_capture() ->
+    Id = list_to_atom(
+        "quic_h3_close_capture_" ++
+            integer_to_list(erlang:unique_integer([positive, monotonic]))
+    ),
+    ok = logger:add_handler(Id, ?MODULE, #{
+        level => error,
+        config => #{pid => self()}
+    }),
+    Id.
+
+remove_capture(Id) ->
+    logger:remove_handler(Id).
+
+assert_no_error_log(Pid) ->
+    receive
+        {error_log, Pid} -> error({unexpected_crash_report, Pid})
+    after 200 ->
+        ok
+    end.
+
+expect_error_log(Pid) ->
+    receive
+        {error_log, Pid} -> ok
+    after 1000 ->
+        error(no_crash_report)
+    end.


### PR DESCRIPTION
quic_h3_connection stopped with the bare atom quic_closed whenever the underlying QUIC connection went DOWN, regardless of the exit reason. Clean closes (idle timeout, graceful drain, shutdown) therefore emitted ERROR and CRASH reports and propagated an abnormal exit through links to non-trapping owners. This was the root cause of hackney's intermittent "tests were cancelled" eunit failures with pooled idle H3 connections and of the webtransport server-side teardown noise.

The DOWN handler now inspects the exit reason: normal, shutdown, {shutdown, _} and noproc stop the H3 process with normal, anything else stops it with {quic_closed, Reason}. The owner now also receives the {quic_h3, Conn, closed} notification on this path, which previously was only sent from the closing state.

Verified against hackney with the patched dep: 12 consecutive runs of the h3/wt suites, no cancellations.