### PR TITLE
Connect to servers behind a wildcard certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The client hostname check now applies the RFC 6125 HTTPS rules, so a leftmost-label wildcard SAN such as `*.example.com` matches `host.example.com`. Servers behind a wildcard-only certificate, `www.google.com` among them, were rejected with `{certificate_invalid, {hostname_mismatch, _}}` and, through `quic_h3:connect/3`, surfaced as a connect timeout. (#188)
 ## [1.7.1] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - The client hostname check now applies the RFC 6125 HTTPS rules, so a leftmost-label wildcard SAN such as `*.example.com` matches `host.example.com`. Servers behind a wildcard-only certificate, `www.google.com` among them, were rejected with `{certificate_invalid, {hostname_mismatch, _}}` and, through `quic_h3:connect/3`, surfaced as a connect timeout. (#188)
+- A Happy Eyeballs winner now hands its owner every event it delivered before reporting `connected`. A server that sends its HTTP/3 SETTINGS in the same flight as the handshake had that data dropped by the coordinator, so `quic_h3:connect/3` waited for SETTINGS that never arrived and returned `connect_timeout` for a multi-address host. (#188)
 ## [1.7.1] - 2026-07-17
 
 ### Fixed

--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -470,6 +470,10 @@ end.
 #{verify => false}
 ```
 
+The name in `server_name` (or the host you passed to `quic:connect/4`) is
+matched against the certificate under the RFC 6125 HTTPS rules: a `*.example.com`
+SAN matches `host.example.com`, but not `example.com` and not `a.b.example.com`.
+
 ### 2. Connection Pooling
 
 ```erlang

--- a/docs/features.md
+++ b/docs/features.md
@@ -261,7 +261,7 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `datagram_recv_queue_len` - Bounded receive queue for inbound datagrams (default: `infinity`; drops oldest on overflow, tracked via `datagram_stats/1`)
 - `reset_stream_at` - Enable RESET_STREAM_AT extension (default: false)
 - `alpn` - ALPN protocols list
-- `verify` - Server certificate verification on the client (default: `true`; verifies the CertificateVerify signature, the chain, and the hostname). Set `false` to accept any certificate, e.g. a self-signed test server.
+- `verify` - Server certificate verification on the client (default: `true`; verifies the CertificateVerify signature, the chain, and the hostname). The hostname check follows the RFC 6125 HTTPS rules, so a leftmost-label wildcard SAN such as `*.example.com` matches `host.example.com`. Set `false` to accept any certificate, e.g. a self-signed test server.
 - `cacerts` - Trust anchors for client chain validation, as a list of DER-encoded certificates (default: the operating system trust store)
 - `preferred_ipv4` - Server preferred IPv4 address
 - `preferred_ipv6` - Server preferred IPv6 address

--- a/src/quic_cert.erl
+++ b/src/quic_cert.erl
@@ -179,9 +179,13 @@ verify_hostname(Leaf, ServerName) when is_binary(ServerName) ->
         false -> {error, {hostname_mismatch, ServerName}}
     end.
 
+%% The `https' match fun applies the RFC 6125 §6.4.3 wildcard rules, which
+%% OTP's default match fun leaves out: without it a leftmost-label wildcard
+%% (`*.example.com') never matches, so wildcard-only servers are rejected.
 safe_verify_hostname(Leaf, RefId) ->
     try
-        public_key:pkix_verify_hostname(Leaf, [RefId])
+        MatchFun = public_key:pkix_verify_hostname_match_fun(https),
+        public_key:pkix_verify_hostname(Leaf, [RefId], [{match_fun, MatchFun}])
     catch
         _:_ -> false
     end.

--- a/src/quic_happy.erl
+++ b/src/quic_happy.erl
@@ -132,7 +132,8 @@ coordinator_entry(Args) ->
         owner => maps:get(owner, Args),
         caller => maps:get(caller, Args),
         delay => maps:get(delay, Args),
-        attempts => #{}
+        attempts => #{},
+        backlog => #{}
     },
     %% Overall deadline. Messages to this process after it exits are dropped,
     %% so no explicit timer cancellation is needed.
@@ -155,6 +156,8 @@ loop(St) ->
                         true -> on_connected(St, Pid, Info);
                         false -> loop(St)
                     end;
+                {quic, Pid, _} = Msg ->
+                    loop(buffer_owner_msg(St, Pid, Msg));
                 {'DOWN', _MRef, process, Pid, _Reason} ->
                     loop(drop_attempt(St, Pid));
                 _Other ->
@@ -191,28 +194,44 @@ start_attempt({IP, _Fam}, #{port := Port, opts := Opts, attempts := Attempts} = 
             St
     end.
 
-drop_attempt(#{attempts := Attempts} = St, Pid) ->
+drop_attempt(#{attempts := Attempts, backlog := Backlog} = St, Pid) ->
     case maps:take(Pid, Attempts) of
         {MRef, Rest} ->
             _ = erlang:demonitor(MRef, [flush]),
-            St#{attempts := Rest};
+            St#{attempts := Rest, backlog := maps:remove(Pid, Backlog)};
         error ->
+            St
+    end.
+
+%% Owner events an attempt delivers before it reports `connected' (a server
+%% that opens its HTTP/3 control stream in the same flight as the handshake
+%% sends SETTINGS here). They belong to the winner's owner, so hold them per
+%% attempt instead of discarding, and drop them with the attempt that loses.
+%% The peer's initial flow-control window bounds what can pile up.
+buffer_owner_msg(#{attempts := Attempts, backlog := Backlog} = St, Pid, Msg) ->
+    case maps:is_key(Pid, Attempts) of
+        true ->
+            Buffered = maps:get(Pid, Backlog, []),
+            St#{backlog := maps:put(Pid, [Msg | Buffered], Backlog)};
+        false ->
             St
     end.
 
 %% First attempt to finish its handshake wins. Hand it to the real owner
 %% (re-delivers {connected}); the remaining attempts are still owned by this
 %% coordinator and self-close on owner-DOWN when we exit below.
-on_connected(#{owner := Owner, caller := Caller} = St, Pid, _Info) ->
+on_connected(#{owner := Owner, caller := Caller, backlog := Backlog} = St, Pid, _Info) ->
     %% set_owner_sync is a gen_statem:call; a winner that died between
     %% {connected} and here raises, and we continue the race.
     try quic_connection:set_owner_sync(Pid, Owner) of
         ok ->
             %% The connection handshaked while we owned it, so any peer data
             %% it already delivered (e.g. the server's HTTP/3 control stream
-            %% and SETTINGS) is sitting in our mailbox and would be lost when
-            %% we exit. set_owner_sync re-delivers {connected} but not that
-            %% backlog, so hand it to the new owner in order.
+            %% and SETTINGS) was buffered here or is still sitting in our
+            %% mailbox, and would be lost when we exit. set_owner_sync
+            %% re-delivers {connected} but not that backlog, so hand it to the
+            %% new owner in order.
+            [Owner ! M || M <- lists:reverse(maps:get(Pid, Backlog, []))],
             forward_quic_backlog(Pid, Owner),
             Caller ! {quic_happy_result, self(), {ok, Pid}},
             ok

--- a/test/quic_cert_tests.erl
+++ b/test/quic_cert_tests.erl
@@ -51,6 +51,58 @@ validate_server_test_() ->
             []
     end.
 
+%% Regression (#188): a wildcard-only certificate (`*.example.test', no
+%% exact SAN) is what most large sites serve, www.google.com included.
+%% The hostname check used to reject every one of them.
+wildcard_hostname_test_() ->
+    case gen_cert("/CN=*.example.test", "subjectAltName=DNS:*.example.test") of
+        {ok, Leaf, _Key} ->
+            [
+                {"leftmost-label wildcard matches",
+                    ?_assertEqual(
+                        ok,
+                        quic_cert:validate_server(Leaf, [], [Leaf], <<"host.example.test">>)
+                    )},
+                {"wildcard does not match the bare domain",
+                    ?_assertMatch(
+                        {error, {hostname_mismatch, _}},
+                        quic_cert:validate_server(Leaf, [], [Leaf], <<"example.test">>)
+                    )},
+                {"wildcard does not span labels",
+                    ?_assertMatch(
+                        {error, {hostname_mismatch, _}},
+                        quic_cert:validate_server(Leaf, [], [Leaf], <<"a.b.example.test">>)
+                    )},
+                {"unrelated domain is still rejected",
+                    ?_assertMatch(
+                        {error, {hostname_mismatch, _}},
+                        quic_cert:validate_server(Leaf, [], [Leaf], <<"host.evil.test">>)
+                    )}
+            ];
+        {error, _} ->
+            []
+    end.
+
+%% An IP-literal server name keeps matching on iPAddress SANs; the
+%% wildcard match fun only applies to dNSName reference ids.
+ip_literal_hostname_test_() ->
+    case gen_cert("/CN=localhost", "subjectAltName=DNS:localhost,IP:127.0.0.1") of
+        {ok, Leaf, _Key} ->
+            [
+                {"IP literal matches an iPAddress SAN",
+                    ?_assertEqual(
+                        ok, quic_cert:validate_server(Leaf, [], [Leaf], <<"127.0.0.1">>)
+                    )},
+                {"other IP literal is rejected",
+                    ?_assertMatch(
+                        {error, {hostname_mismatch, _}},
+                        quic_cert:validate_server(Leaf, [], [Leaf], <<"127.0.0.2">>)
+                    )}
+            ];
+        {error, _} ->
+            []
+    end.
+
 %% Regression: a server commonly sends an extra or cross-signed cert
 %% above the cert that actually chains to a trust anchor (e.g.
 %% cloudflare.com over Google Trust Services with the Mozilla NSS /

--- a/test/quic_happy_tests.erl
+++ b/test/quic_happy_tests.erl
@@ -165,6 +165,59 @@ do_he_winner_dies_with_owner() ->
         quic_test_echo_server:stop(Srv)
     end.
 
+%% Regression (#188): owner events an attempt delivers before it reports
+%% `connected' (a server that sends its HTTP/3 SETTINGS in the same flight as
+%% the handshake) used to be discarded by the coordinator's catch-all receive,
+%% so the H3 layer never saw SETTINGS and its connect timed out.
+he_pre_connected_backlog_test_() ->
+    {timeout, 30, fun he_pre_connected_backlog/0}.
+
+he_pre_connected_backlog() ->
+    {ok, _} = application:ensure_all_started(quic),
+    Before = conn_children(),
+    %% Dead port: the attempt stays in the handshake, so it is alive and
+    %% tracked while we drive the coordinator.
+    {ok, Coord} = quic_happy:start_coordinator(#{
+        addrs => [{{127, 0, 0, 1}, inet}],
+        port => 1,
+        opts => #{verify => false},
+        owner => self(),
+        caller => self(),
+        delay => 100,
+        timeout => 10000
+    }),
+    try
+        Attempt = wait_new_child(Before, 50),
+        Early = {quic, Attempt, {stream_data, 3, <<"early-settings">>, false}},
+        Coord ! Early,
+        Coord ! {quic, Attempt, {connected, #{}}},
+        receive
+            Early -> ok
+        after 5000 -> error(pre_connected_backlog_lost)
+        end,
+        receive
+            {quic_happy_result, Coord, Result} -> ?assertEqual({ok, Attempt}, Result)
+        after 5000 -> error(no_result)
+        end,
+        quic:safe_close(Attempt)
+    after
+        exit(Coord, kill)
+    end.
+
+conn_children() ->
+    [P || {_, P, _, _} <- supervisor:which_children(quic_conn_sup), is_pid(P)].
+
+wait_new_child(_Before, 0) ->
+    error(no_attempt_started);
+wait_new_child(Before, N) ->
+    case conn_children() -- Before of
+        [Pid | _] ->
+            Pid;
+        [] ->
+            timer:sleep(20),
+            wait_new_child(Before, N - 1)
+    end.
+
 %% No server: every raced attempt fails, connect returns an error within
 %% the (shortened) overall timeout rather than hanging or dialing localhost.
 he_all_fail_test_() ->


### PR DESCRIPTION
`quic_h3:connect("www.google.com", 443, #{sync => true})` timed out. Two defects, both on the client path.

The hostname check called `public_key:pkix_verify_hostname/2` without a match fun, and OTP's default one skips the RFC 6125 wildcard rule. Google's QUIC endpoint serves a wildcard leaf (`*.google.com`, no exact SAN), so the chain validated and the name did not: `{certificate_invalid, {hostname_mismatch, <<"www.google.com">>}}`. Every server behind a wildcard-only certificate was unreachable with `verify` on. The check now passes `public_key:pkix_verify_hostname_match_fun(https)`, which only stops false rejections: a leftmost-label wildcard still does not match the bare domain or span labels.

With that fixed the hostname form still timed out. The Happy Eyeballs coordinator's catch-all receive dropped `{quic, _, _}` events an attempt delivered before it reported `connected`, and Google sends its HTTP/3 control stream and SETTINGS in the same flight as the handshake. The H3 layer waits for SETTINGS to report connected, so it never did. The coordinator now buffers those events per attempt and hands the winner's to the new owner, alongside the mailbox drain that was already there.

```erlang
{ok, Conn} = quic_h3:connect("www.google.com", 443, #{sync => true}).
```

Fixes #188.