### PR TITLE
Surface the QUIC failure reason to the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A client connection now reports a handshake failure to its owner as `{quic, Conn, {error, Reason}}`, tagged with the connection handle like every other owner event; it used to be tagged with the connection reference, which no owner matches on. `quic_h3:connect/3` passes the reason on, so a rejected certificate returns `{error, {certificate_invalid, _}}` instead of `{error, connect_timeout}`, and a Happy Eyeballs race that exhausts its addresses returns the last attempt's reason instead of `all_attempts_failed`.
+
 ## [1.7.1] - 2026-07-17
 
 ### Fixed

--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -416,7 +416,10 @@ Messages sent to the owner process:
 | `{quic, Conn, {stream_deadline, StreamId}}` | Stream deadline expired |
 | `{quic, Conn, {send_ready, StreamId}}` | Stream ready to write |
 | `{quic, Conn, {closed, Reason}}` | Connection closed |
+| `{quic, Conn, {error, Reason}}` | Handshake failed, e.g. `{certificate_invalid, _}` |
 | `{quic, Conn, {transport_error, Code, Reason}}` | Transport error |
+
+`Conn` is always the connection handle returned by `quic:connect/4`.
 
 ### Detecting stream closure
 

--- a/src/h3/quic_h3.erl
+++ b/src/h3/quic_h3.erl
@@ -317,7 +317,10 @@ maybe_wait_connected(H3Conn, Opts) ->
                     {ok, H3Conn};
                 {error, timeout} ->
                     quic_h3:close(H3Conn),
-                    {error, connect_timeout}
+                    {error, connect_timeout};
+                {error, Reason} ->
+                    quic_h3:close(H3Conn),
+                    {error, Reason}
             end;
         false ->
             {ok, H3Conn}
@@ -718,12 +721,14 @@ early_data_accepted(Conn) ->
 %% @doc Wait for H3 connection to be ready.
 %%
 %% Blocks until the connection is established and SETTINGS exchanged,
-%% or until the timeout expires.
+%% until the QUIC connection fails (the failure reason is returned, e.g.
+%% `{certificate_invalid, _}'), or until the timeout expires.
 %% @end
--spec wait_connected(conn(), timeout()) -> ok | {error, timeout}.
+-spec wait_connected(conn(), timeout()) -> ok | {error, timeout | term()}.
 wait_connected(Conn, Timeout) ->
     receive
-        {quic_h3, Conn, connected} -> ok
+        {quic_h3, Conn, connected} -> ok;
+        {quic_h3, Conn, {closed, Reason}} -> {error, Reason}
     after Timeout ->
         {error, timeout}
     end.

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -630,6 +630,10 @@ bootstrapping(info, {quic, QC, {stream_data, _, _, _}}, #state{quic_conn = QC}) 
     {keep_state_and_data, [postpone]};
 bootstrapping(info, {quic, QC, {new_stream, _, _}}, #state{quic_conn = QC}) ->
     {keep_state_and_data, [postpone]};
+bootstrapping(info, {quic, QC, {error, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
+bootstrapping(info, {quic, QC, {closed, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
 bootstrapping(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -728,6 +732,10 @@ early_data(
     #state{quic_conn = QC} = _State
 ) ->
     {keep_state_and_data, [{reply, From, quic:early_data_accepted(QC)}]};
+early_data(info, {quic, QC, {error, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
+early_data(info, {quic, QC, {closed, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
 early_data(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -793,6 +801,10 @@ awaiting_quic(
     #state{quic_conn = QC} = _State
 ) ->
     {keep_state_and_data, [{reply, From, quic:early_data_accepted(QC)}]};
+awaiting_quic(info, {quic, QC, {error, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
+awaiting_quic(info, {quic, QC, {closed, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
 awaiting_quic(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -891,6 +903,10 @@ h3_connecting(
     #state{quic_conn = QC} = _State
 ) ->
     {keep_state_and_data, [{reply, From, quic:early_data_accepted(QC)}]};
+h3_connecting(info, {quic, QC, {error, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
+h3_connecting(info, {quic, QC, {closed, Reason}}, #state{quic_conn = QC} = State) ->
+    handle_quic_failed(Reason, State);
 h3_connecting(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -1306,6 +1322,13 @@ closing(_EventType, _Event, _State) ->
 %%====================================================================
 %% Internal: QUIC connection DOWN
 %%====================================================================
+
+%% The QUIC connection reported a failure (bad certificate, TLS alert, peer
+%% close) before HTTP/3 came up. Pass the reason to the owner so a caller in
+%% `quic_h3:wait_connected/2' fails with it instead of timing out.
+handle_quic_failed(Reason, #state{owner = Owner} = State) ->
+    Owner ! {quic_h3, self(), {closed, Reason}},
+    {stop, normal, State}.
 
 %% A cleanly closed QUIC connection must not crash the H3 process:
 %% only an abnormal QUIC exit is propagated as {quic_closed, Reason}.

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -18,6 +18,8 @@
 %%%   <li>`{quic, Conn, {connected, Info}}' - Connection established</li>
 %%%   <li>`{quic, Conn, {stream_opened, StreamId}}' - Stream opened</li>
 %%%   <li>`{quic, Conn, {closed, Reason}}' - Connection closed</li>
+%%%   <li>`{quic, Conn, {error, Reason}}' - Handshake failed, e.g.
+%%%       `{certificate_invalid, _}'</li>
 %%%   <li>`{quic, Conn, {transport_error, Code, Reason}}' - Transport error</li>
 %%%   <li>`{quic, Conn, {stream_data, StreamId, Bin, Fin}}' - Data received</li>
 %%%   <li>`{quic, Conn, {stream_reset, StreamId, ErrorCode}}' - Stream reset</li>

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2888,9 +2888,9 @@ validate_client_psk_selection(_Idx, _Identity, _Secret, _Modes) ->
 %% @private
 %% Notify the connection owner of a handshake failure so quic:connect/4
 %% callers see {error, Reason} rather than a silent stall.
-notify_owner(Msg, #state{owner = Owner, conn_ref = Ref}) when is_pid(Owner) ->
+notify_owner(Msg, #state{owner = Owner}) when is_pid(Owner) ->
     try
-        Owner ! {quic, Ref, Msg},
+        Owner ! {quic, self(), Msg},
         ok
     catch
         _:_ -> ok

--- a/src/quic_happy.erl
+++ b/src/quic_happy.erl
@@ -132,7 +132,8 @@ coordinator_entry(Args) ->
         owner => maps:get(owner, Args),
         caller => maps:get(caller, Args),
         delay => maps:get(delay, Args),
-        attempts => #{}
+        attempts => #{},
+        last_error => undefined
     },
     %% Overall deadline. Messages to this process after it exits are dropped,
     %% so no explicit timer cancellation is needed.
@@ -143,7 +144,7 @@ loop(St) ->
     #{remaining := Remaining, attempts := Attempts} = St,
     case (map_size(Attempts) =:= 0) andalso (Remaining =:= []) of
         true ->
-            finish(St, {error, all_attempts_failed});
+            finish(St, {error, exhausted_reason(St)});
         false ->
             receive
                 {timeout, _Ref, next_attempt} ->
@@ -155,6 +156,10 @@ loop(St) ->
                         true -> on_connected(St, Pid, Info);
                         false -> loop(St)
                     end;
+                {quic, Pid, {error, Reason}} ->
+                    loop(note_error(St, Pid, Reason));
+                {quic, Pid, {closed, Reason}} ->
+                    loop(note_error(St, Pid, Reason));
                 {'DOWN', _MRef, process, Pid, _Reason} ->
                     loop(drop_attempt(St, Pid));
                 _Other ->
@@ -190,6 +195,18 @@ start_attempt({IP, _Fam}, #{port := Port, opts := Opts, attempts := Attempts} = 
             %% termination check / next timer handles progress.
             St
     end.
+
+%% Why an attempt gave up, kept so the caller sees the real reason (a bad
+%% certificate, a peer close) rather than only `all_attempts_failed'. The
+%% last one wins: the attempts race, and any of them explains the failure.
+note_error(#{attempts := Attempts} = St, Pid, Reason) ->
+    case maps:is_key(Pid, Attempts) of
+        true -> St#{last_error := Reason};
+        false -> St
+    end.
+
+exhausted_reason(#{last_error := undefined}) -> all_attempts_failed;
+exhausted_reason(#{last_error := Reason}) -> Reason.
 
 drop_attempt(#{attempts := Attempts} = St, Pid) ->
     case maps:take(Pid, Attempts) of

--- a/test/quic_close_tests.erl
+++ b/test/quic_close_tests.erl
@@ -185,18 +185,15 @@ draining_handles_owner_exit_test() ->
 %% Test that close triggers draining state and sends closed message
 close_sends_closed_message_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
-    Ref = gen_statem:call(Pid, get_ref),
 
     %% Close the connection (doesn't need to be connected to test close behavior)
     quic_connection:close(Pid, normal),
 
     %% Wait for the closed message - should be sent when entering draining
     receive
-        {quic, Ref, {closed, normal}} -> ok
-    after 500 ->
-        %% If we don't get the message, it might be because we're in idle state
-        %% which is fine - the test is about not crashing
-        ok
+        {quic, Pid, {closed, normal}} -> ok
+    after 1000 ->
+        error(no_closed_event)
     end,
 
     %% Wait for connection to finish
@@ -209,7 +206,6 @@ close_sends_closed_message_test() ->
 %% Test close/3 with custom error code and reason phrase
 close_with_app_error_code_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
-    Ref = gen_statem:call(Pid, get_ref),
 
     %% Close with custom application error code
     ErrorCode = 16#0100,
@@ -218,9 +214,9 @@ close_with_app_error_code_test() ->
 
     %% Wait for the closed message with the app_error reason
     receive
-        {quic, Ref, {closed, {app_error, ErrorCode, ReasonPhrase}}} -> ok
-    after 500 ->
-        ok
+        {quic, Pid, {closed, {app_error, ErrorCode, ReasonPhrase}}} -> ok
+    after 1000 ->
+        error(no_closed_event)
     end,
 
     timer:sleep(100).
@@ -228,15 +224,14 @@ close_with_app_error_code_test() ->
 %% Test close/3 API with zero error code (QUIC_NO_ERROR equivalent)
 close_with_zero_error_code_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
-    Ref = gen_statem:call(Pid, get_ref),
 
     %% Close with error code 0 (no error)
     quic_connection:close(Pid, {app_error, 0, <<>>}),
 
     receive
-        {quic, Ref, {closed, {app_error, 0, <<>>}}} -> ok
-    after 500 ->
-        ok
+        {quic, Pid, {closed, {app_error, 0, <<>>}}} -> ok
+    after 1000 ->
+        error(no_closed_event)
     end,
 
     timer:sleep(100).
@@ -244,16 +239,15 @@ close_with_zero_error_code_test() ->
 %% Test close/3 API with maximum valid 62-bit error code
 close_with_max_error_code_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
-    Ref = gen_statem:call(Pid, get_ref),
 
     %% Close with maximum 62-bit error code
     MaxErrorCode = (1 bsl 62) - 1,
     quic_connection:close(Pid, {app_error, MaxErrorCode, <<"max code">>}),
 
     receive
-        {quic, Ref, {closed, {app_error, MaxErrorCode, <<"max code">>}}} -> ok
-    after 500 ->
-        ok
+        {quic, Pid, {closed, {app_error, MaxErrorCode, <<"max code">>}}} -> ok
+    after 1000 ->
+        error(no_closed_event)
     end,
 
     timer:sleep(100).
@@ -272,15 +266,14 @@ quic_close_3_api_test() ->
 %% Test that close/2 with legacy {error, application_error} still works
 close_legacy_application_error_test() ->
     {ok, Pid} = quic_connection:start_link("127.0.0.1", 4433, #{}, self()),
-    Ref = gen_statem:call(Pid, get_ref),
 
     %% Close with legacy pattern (used in E2E tests)
     quic_connection:close(Pid, {error, application_error}),
 
     receive
-        {quic, Ref, {closed, {error, application_error}}} -> ok
-    after 500 ->
-        ok
+        {quic, Pid, {closed, {error, application_error}}} -> ok
+    after 1000 ->
+        error(no_closed_event)
     end,
 
     timer:sleep(100).

--- a/test/quic_h3_connect_error_tests.erl
+++ b/test/quic_h3_connect_error_tests.erl
@@ -1,0 +1,85 @@
+%%% -*- erlang -*-
+%%%
+%%% A QUIC connection that fails before HTTP/3 comes up (bad certificate,
+%%% TLS alert, peer close) must surface its reason to the caller. The H3
+%%% FSM used to drop those events in its pre-connected states, so
+%%% `quic_h3:connect/3' with `sync => true' returned `connect_timeout' and
+%%% the real reason was lost.
+
+-module(quic_h3_connect_error_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CERT_ERROR, {certificate_invalid, {hostname_mismatch, <<"example.com">>}}).
+
+setup() ->
+    meck:new(quic, [passthrough]),
+    meck:expect(quic, set_owner_sync, fun(_Conn, _NewOwner) -> ok end),
+    meck:expect(quic, close, fun(_) -> ok end),
+    meck:expect(quic, close, fun(_, _, _) -> ok end),
+    meck:expect(quic, safe_close, fun(_) -> ok end),
+    meck:expect(quic, safe_close, fun(_, _, _) -> ok end),
+    meck:expect(quic, datagram_max_size, fun(_) -> 0 end),
+    meck:expect(quic, has_early_keys, fun(_) -> false end),
+    meck:expect(quic, early_data_accepted, fun(_) -> unknown end),
+    ok.
+
+teardown(_) ->
+    meck:unload(quic),
+    ok.
+
+%% The failure is already in the caller's mailbox when connect/3 hands the
+%% connection to the H3 process (a certificate rejected during the
+%% handshake, before ownership moved).
+sync_connect_returns_failure_reason_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        FakeQuicConn = spawn_link(fun fake_quic_loop/0),
+        meck:expect(quic, connect, fun(_Host, _Port, _Opts, Owner) ->
+            Owner ! {quic, FakeQuicConn, {error, ?CERT_ERROR}},
+            {ok, FakeQuicConn}
+        end),
+        Result = quic_h3:connect(<<"example.com">>, 443, #{
+            sync => true, connect_timeout => 5000
+        }),
+        ?assertEqual({error, ?CERT_ERROR}, Result),
+        stop(FakeQuicConn)
+    end}.
+
+%% The failure arrives while the H3 process is already waiting on QUIC.
+late_failure_reaches_waiter_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        FakeQuicConn = spawn_link(fun fake_quic_loop/0),
+        meck:expect(quic, connect, fun(_Host, _Port, _Opts, _Owner) ->
+            {ok, FakeQuicConn}
+        end),
+        {ok, H3Conn} = quic_h3:connect(<<"example.com">>, 443, #{}),
+        H3Conn ! {quic, FakeQuicConn, {error, ?CERT_ERROR}},
+        ?assertEqual({error, ?CERT_ERROR}, quic_h3:wait_connected(H3Conn, 5000)),
+        stop(FakeQuicConn)
+    end}.
+
+%% A peer close before HTTP/3 is up carries its reason the same way.
+sync_connect_returns_close_reason_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        FakeQuicConn = spawn_link(fun fake_quic_loop/0),
+        meck:expect(quic, connect, fun(_Host, _Port, _Opts, Owner) ->
+            Owner ! {quic, FakeQuicConn, {closed, {peer_closed, transport, 296, 0, <<>>}}},
+            {ok, FakeQuicConn}
+        end),
+        Result = quic_h3:connect(<<"example.com">>, 443, #{
+            sync => true, connect_timeout => 5000
+        }),
+        ?assertEqual({error, {peer_closed, transport, 296, 0, <<>>}}, Result),
+        stop(FakeQuicConn)
+    end}.
+
+stop(Pid) ->
+    unlink(Pid),
+    exit(Pid, shutdown),
+    ok.
+
+fake_quic_loop() ->
+    receive
+        stop -> ok;
+        _ -> fake_quic_loop()
+    end.

--- a/test/quic_happy_tests.erl
+++ b/test/quic_happy_tests.erl
@@ -165,6 +165,53 @@ do_he_winner_dies_with_owner() ->
         quic_test_echo_server:stop(Srv)
     end.
 
+%% An attempt that reports why it gave up (a rejected certificate, a peer
+%% close) hands that reason to the caller once the race is exhausted, instead
+%% of the bare `all_attempts_failed'.
+he_reports_attempt_error_test_() ->
+    {timeout, 30, fun he_reports_attempt_error/0}.
+
+he_reports_attempt_error() ->
+    {ok, _} = application:ensure_all_started(quic),
+    Reason = {certificate_invalid, {hostname_mismatch, <<"example.com">>}},
+    Before = conn_children(),
+    %% Dead port: the attempt sits in the handshake, so it is alive and
+    %% tracked while we drive the coordinator.
+    {ok, Coord} = quic_happy:start_coordinator(#{
+        addrs => [{{127, 0, 0, 1}, inet}],
+        port => 1,
+        opts => #{verify => false},
+        owner => self(),
+        caller => self(),
+        delay => 100,
+        timeout => 10000
+    }),
+    try
+        Attempt = wait_new_child(Before, 50),
+        Coord ! {quic, Attempt, {error, Reason}},
+        exit(Attempt, kill),
+        receive
+            {quic_happy_result, Coord, Result} -> ?assertEqual({error, Reason}, Result)
+        after 5000 -> error(no_result)
+        end
+    after
+        exit(Coord, kill)
+    end.
+
+conn_children() ->
+    [P || {_, P, _, _} <- supervisor:which_children(quic_conn_sup), is_pid(P)].
+
+wait_new_child(_Before, 0) ->
+    error(no_attempt_started);
+wait_new_child(Before, N) ->
+    case conn_children() -- Before of
+        [Pid | _] ->
+            Pid;
+        [] ->
+            timer:sleep(20),
+            wait_new_child(Before, N - 1)
+    end.
+
 %% No server: every raced attempt fails, connect returns an error within
 %% the (shortened) overall timeout rather than hanging or dialing localhost.
 he_all_fail_test_() ->


### PR DESCRIPTION
A client that fails its handshake told nobody why. `notify_owner/2` tagged `{error, Reason}` with the connection *reference*, while every other owner event and the documented shape use the connection handle, so the H3 layer (which matches on the handle) dropped it in its catch-all clauses and the caller sat in `wait_connected/2` until it timed out. A rejected certificate came back as `{error, connect_timeout}`, and on the Happy Eyeballs path as `{error, all_attempts_failed}`.

Owner error events now carry the connection handle, the H3 FSM stops on a QUIC error or close it sees before HTTP/3 is up and passes the reason to its owner, and the Happy Eyeballs coordinator keeps the last reason an attempt reported rather than discarding it.

```erlang
quic_h3:connect("example.com", 443, #{sync => true}).
%% {error, {certificate_invalid, {hostname_mismatch, <<"example.com">>}}}
```

Behaviour change: an owner matching on `{quic, ConnRef, {error, _}}` must match on the connection handle instead. That form was undocumented and unreachable for `quic_h3`.