### PR TITLE
Keep the Initial packet number counting across a Retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A client that receives a Retry now keeps counting Initial packet numbers up (RFC 9000 §17.2.5.3) instead of restarting at 0, so the retried Initial is a new packet to the server rather than a replay of the one it answered with the Retry. The Initials sent before the Retry are dropped from loss detection rather than left charged as bytes in flight.
+
 ## [1.7.1] - 2026-07-17
 
 ### Fixed

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4171,10 +4171,14 @@ handle_valid_retry(RetryToken, ServerSCID, State) ->
     %% Return state with retry info, no frames to process
     {ok, retry_handled, [], <<>>, State5}.
 
-%% Reset the initial packet number space after a Retry
-reset_initial_pn_space(State) ->
+%% Clear the Initial packet number space after a Retry. RFC 9000 §17.2.5.3:
+%% the packet number keeps counting up, so the retried Initial is a new
+%% packet to the server rather than a replay of the one it answered with the
+%% Retry. Everything else in the space describes packets protected by the
+%% keys we just replaced.
+reset_initial_pn_space(#state{pn_initial = #pn_space{next_pn = NextPN}} = State) ->
     PNSpace = #pn_space{
-        next_pn = 0,
+        next_pn = NextPN,
         largest_acked = undefined,
         largest_recv = undefined,
         recv_time = undefined,
@@ -4183,7 +4187,11 @@ reset_initial_pn_space(State) ->
         loss_time = undefined,
         sent_packets = #{}
     },
-    State#state{pn_initial = PNSpace}.
+    %% RFC 9002 §6.2.1: the Initials sent before the Retry can be treated as
+    %% lost. Only Initials can have been sent at this point, so dropping the
+    %% loss state clears them all rather than leaving bytes charged in flight
+    %% for packets that can never be acknowledged.
+    State#state{pn_initial = PNSpace, loss_state = quic_loss:new()}.
 
 %% Check if a packet is a stateless reset (RFC 9000 Section 10.3)
 check_stateless_reset(Data, _State) when byte_size(Data) < 21 ->

--- a/test/h3_profile.erl
+++ b/test/h3_profile.erl
@@ -1,0 +1,108 @@
+%%% -*- erlang -*-
+%%%
+%%% Test-only HTTP/3 profiling harness (not part of the shipped app).
+%%%
+%%% Drives a sequential GET request/response loop against the in-process
+%%% H3 test server over one persistent connection, and measures it three
+%%% ways so a per-call-instrumentation artifact (fprof) can be told apart
+%%% from a real CPU cost (wall-clock / eprof):
+%%%
+%%%   - timer:tc wall-clock for the whole loop (ground truth),
+%%%   - eprof flat per-function time,
+%%%   - fprof call graph + own-time + call counts (the lens the original
+%%%     header-validation report used).
+%%%
+%%% Usage:
+%%%   rebar3 as test shell
+%%%   h3_profile:run().            %% default 2000 wall/eprof iters
+%%%   h3_profile:run(5000).
+%%%
+%%% Writes /tmp/h3_eprof.txt and /tmp/h3_fprof_analysis.txt.
+
+-module(h3_profile).
+
+-export([run/0, run/1]).
+
+-define(HOST, <<"127.0.0.1">>).
+
+run() -> run(2000).
+
+run(N) ->
+    {ok, _} = application:ensure_all_started(quic),
+    {ok, Server} = quic_test_h3_server:start(),
+    Port = maps:get(port, Server),
+    {ok, Conn} = quic_h3:connect(?HOST, Port, #{verify => false, sync => true}),
+
+    %% Warm up so the server-side connection processes exist before we
+    %% snapshot processes() for eprof.
+    ok = one_request(Conn),
+
+    io:format("~n=== wall-clock (no profiler) ===~n"),
+    {WallUs, ok} = timer:tc(fun() -> loop(Conn, N) end),
+    UsPerReq = WallUs div N,
+    ReqPerSec = (N * 1000000) div WallUs,
+    io:format("~p requests in ~p ms => ~p us/req, ~p req/s~n", [
+        N, WallUs div 1000, UsPerReq, ReqPerSec
+    ]),
+
+    io:format("~n=== eprof (flat time, all current processes) ===~n"),
+    run_eprof(Conn, N),
+
+    io:format("~n=== fprof (own-time + call counts) ===~n"),
+    %% fprof slows everything ~10-20x; use fewer iterations.
+    run_fprof(Conn, max(50, N div 10)),
+
+    quic_h3:close(Conn),
+    quic_test_h3_server:stop(Server),
+    io:format("~neprof: /tmp/h3_eprof.txt   fprof: /tmp/h3_fprof_analysis.txt~n"),
+    ok.
+
+run_eprof(Conn, N) ->
+    eprof:start(),
+    profiling = eprof:start_profiling(processes()),
+    loop(Conn, N),
+    eprof:stop_profiling(),
+    %% Total view across all profiled processes.
+    eprof:analyze(total, [{sort, time}]),
+    eprof:log("/tmp/h3_eprof.txt"),
+    eprof:analyze(total, [{sort, time}, {filter, [{time, 1000}]}]),
+    eprof:stop().
+
+run_fprof(Conn, N) ->
+    fprof:trace([start, {procs, all}]),
+    loop(Conn, N),
+    fprof:trace(stop),
+    fprof:profile(),
+    fprof:analyse([{dest, "/tmp/h3_fprof_analysis.txt"}, {totals, true}, {sort, own}]),
+    io:format("(fprof analysis written; top own-time functions in the file)~n").
+
+loop(_Conn, 0) ->
+    ok;
+loop(Conn, N) ->
+    ok = one_request(Conn),
+    loop(Conn, N - 1).
+
+one_request(Conn) ->
+    Headers = [
+        {<<":method">>, <<"GET">>},
+        {<<":scheme">>, <<"https">>},
+        {<<":path">>, <<"/test.txt">>},
+        {<<":authority">>, ?HOST},
+        {<<"user-agent">>, <<"h3-profile/1.0">>},
+        {<<"accept">>, <<"text/plain">>},
+        {<<"accept-encoding">>, <<"gzip, deflate, br">>}
+    ],
+    {ok, StreamId} = quic_h3:request(Conn, Headers),
+    drain(Conn, StreamId).
+
+drain(Conn, StreamId) ->
+    receive
+        {quic_h3, Conn, {response, StreamId, _S, _H}} -> drain(Conn, StreamId);
+        {quic_h3, Conn, {headers, StreamId, _S, _H}} -> drain(Conn, StreamId);
+        {quic_h3, Conn, {data, StreamId, _D, true}} -> ok;
+        {quic_h3, Conn, {data, StreamId, _D, false}} -> drain(Conn, StreamId);
+        {quic_h3, Conn, {trailers, StreamId, _T}} -> ok;
+        {quic_h3, Conn, {stream_end, StreamId}} -> ok
+    after 10000 ->
+        error({response_timeout, StreamId})
+    end.

--- a/test/quic_retry_pn_tests.erl
+++ b/test/quic_retry_pn_tests.erl
@@ -1,0 +1,80 @@
+%%% -*- erlang -*-
+%%%
+%%% RFC 9000 §17.2.5.3: a client MUST NOT reset the packet number for any
+%%% packet number space after processing a Retry. The retried Initial used to
+%%% go out as packet number 0 again, so a server that treats a repeated
+%%% Initial packet number as a duplicate drops it and the handshake stalls.
+
+-module(quic_retry_pn_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+retry_keeps_initial_pn_test_() ->
+    {timeout, 30, fun retry_keeps_initial_pn/0}.
+
+retry_keeps_initial_pn() ->
+    QlogDir = qlog_dir(),
+    {ok, Srv} = quic_test_echo_server:start(#{address_validation => always}),
+    try
+        #{port := Port} = Srv,
+        Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+            qlog => #{enabled => true, dir => QlogDir}
+        }),
+        {ok, Conn} = quic:connect({127, 0, 0, 1}, Port, Opts, self()),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> error(not_connected)
+            end,
+            %% Let the qlog writer flush the handshake events.
+            timer:sleep(300),
+            PNs = initial_packet_numbers(QlogDir),
+            %% Retry (address_validation => always) means at least two
+            %% Initials: the ClientHello and the retried one.
+            ?assert(length(PNs) >= 2),
+            ?assertEqual(lists:usort(PNs), PNs)
+        after
+            quic:safe_close(Conn)
+        end
+    after
+        quic_test_echo_server:stop(Srv),
+        del_dir(QlogDir)
+    end.
+
+qlog_dir() ->
+    Dir = filename:join(
+        "/tmp",
+        "quic_retry_pn_" ++ integer_to_list(erlang:unique_integer([positive, monotonic]))
+    ),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    Dir.
+
+%% Packet numbers of the Initial packets the client sent, in send order.
+%% Read off the qlog rather than the connection state: `packet_sent' is the
+%% only place the number a packet went out with is visible from a test.
+initial_packet_numbers(Dir) ->
+    Files = filelib:wildcard(filename:join(Dir, "*client*.qlog")),
+    lists:append([initial_packet_numbers_of(F) || F <- Files]).
+
+initial_packet_numbers_of(File) ->
+    {ok, Bin} = file:read_file(File),
+    %% Drop the space after each `:' so one matcher fits either spacing.
+    Compact = binary:replace(Bin, <<": ">>, <<":">>, [global]),
+    Lines = binary:split(Compact, <<"\n">>, [global, trim_all]),
+    [packet_number(L) || L <- Lines, is_initial_sent(L)].
+
+is_initial_sent(Line) ->
+    lists:all(
+        fun(Needle) -> binary:match(Line, Needle) =/= nomatch end,
+        [<<"\"quic:packet_sent\"">>, <<"\"packet_type\":\"initial\"">>]
+    ).
+
+packet_number(Line) ->
+    [_, Rest] = binary:split(Line, <<"\"packet_number\":">>),
+    [Digits | _] = binary:split(Rest, [<<",">>, <<"}">>]),
+    binary_to_integer(Digits).
+
+del_dir(Dir) ->
+    _ = [file:delete(F) || F <- filelib:wildcard(filename:join(Dir, "*"))],
+    _ = file:del_dir(Dir),
+    ok.

--- a/test/tcp_throughput_bench.erl
+++ b/test/tcp_throughput_bench.erl
@@ -1,0 +1,145 @@
+%%% -*- erlang -*-
+%%%
+%%% Plain TCP sink benchmark.
+%%%
+%%% Mirrors the shape of quic_throughput_bench:run_sink/1 so the MB/s
+%%% numbers are directly comparable: client opens one connection, sends
+%%% a 4-byte length header followed by N bytes, waits for the server to
+%%% signal "received it all" via a 1-byte completion marker, closes.
+%%% Elapsed time is end-to-end.
+%%%
+%%% Plain gen_tcp only (no TLS). Buffer sizes match the QUIC bench so
+%%% the comparison isn't skewed by kernel buffer tuning.
+%%%
+%%% Usage:
+%%%   tcp_throughput_bench:run().                         % 10 MB default
+%%%   tcp_throughput_bench:run(#{data_size => 50*1024*1024}).
+%%%
+
+-module(tcp_throughput_bench).
+
+-export([run/0, run/1]).
+
+-define(DEFAULT_PORT, 14434).
+-define(DEFAULT_DATA_SIZE, 10 * 1024 * 1024).
+-define(BUF_SIZE, 7 * 1024 * 1024).
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+run() -> run(#{}).
+
+run(Opts) ->
+    DataSize = maps:get(data_size, Opts, ?DEFAULT_DATA_SIZE),
+    Port = maps:get(port, Opts, ?DEFAULT_PORT),
+
+    io:format("~n=== TCP Sink Benchmark ===~n"),
+    io:format("Data size: ~.2f MB~n", [DataSize / 1048576]),
+
+    {ok, Server} = start_server(Port),
+    Result =
+        try
+            run_client(Port, DataSize)
+        after
+            stop_server(Server)
+        end,
+
+    io:format("Result: ~.2f MB/s (~p ms)~n", [
+        maps:get(mb_per_sec, Result),
+        maps:get(duration_ms, Result)
+    ]),
+    Result.
+
+%%====================================================================
+%% Server
+%%====================================================================
+
+start_server(Port) ->
+    ListenOpts = [
+        binary,
+        {packet, 0},
+        {active, false},
+        {reuseaddr, true},
+        {nodelay, true},
+        {recbuf, ?BUF_SIZE},
+        {sndbuf, ?BUF_SIZE}
+    ],
+    {ok, LSock} = gen_tcp:listen(Port, ListenOpts),
+    Pid = spawn_link(fun() -> accept_loop(LSock) end),
+    {ok, {Pid, LSock}}.
+
+accept_loop(LSock) ->
+    case gen_tcp:accept(LSock) of
+        {ok, Sock} ->
+            Pid = spawn(fun() ->
+                receive
+                    go -> sink(Sock)
+                end
+            end),
+            ok = gen_tcp:controlling_process(Sock, Pid),
+            Pid ! go,
+            accept_loop(LSock);
+        {error, _} ->
+            ok
+    end.
+
+sink(Sock) ->
+    %% Read 4-byte big-endian length prefix, then exactly that many bytes.
+    {ok, <<N:32>>} = gen_tcp:recv(Sock, 4, 30000),
+    ok = drain_n(Sock, N),
+    _ = gen_tcp:send(Sock, <<0>>),
+    gen_tcp:close(Sock),
+    ok.
+
+drain_n(_Sock, 0) ->
+    ok;
+drain_n(Sock, Remaining) ->
+    %% Ask for whatever the kernel has; 0 = whatever's available.
+    case gen_tcp:recv(Sock, 0, 30000) of
+        {ok, Data} ->
+            drain_n(Sock, Remaining - byte_size(Data));
+        {error, Reason} ->
+            error({drain_failed, Reason, Remaining})
+    end.
+
+stop_server({Pid, LSock}) ->
+    unlink(Pid),
+    gen_tcp:close(LSock),
+    exit(Pid, shutdown).
+
+%%====================================================================
+%% Client
+%%====================================================================
+
+run_client(Port, DataSize) ->
+    ConnectOpts = [
+        binary,
+        {packet, 0},
+        {active, false},
+        {nodelay, true},
+        {recbuf, ?BUF_SIZE},
+        {sndbuf, ?BUF_SIZE}
+    ],
+    {ok, Sock} = gen_tcp:connect("127.0.0.1", Port, ConnectOpts),
+    Data = crypto:strong_rand_bytes(DataSize),
+
+    T0 = erlang:monotonic_time(microsecond),
+    ok = gen_tcp:send(Sock, <<DataSize:32>>),
+    ok = gen_tcp:send(Sock, Data),
+
+    %% Wait for the 1-byte completion marker.
+    {ok, <<_>>} = gen_tcp:recv(Sock, 1, 60000),
+    T1 = erlang:monotonic_time(microsecond),
+
+    gen_tcp:close(Sock),
+
+    DurationUs = max(1, T1 - T0),
+    MBps = (DataSize / 1048576) / (DurationUs / 1000000),
+
+    #{
+        status => ok,
+        data_size => DataSize,
+        duration_ms => DurationUs div 1000,
+        mb_per_sec => MBps
+    }.


### PR DESCRIPTION
RFC 9000 §17.2.5.3 says a client MUST NOT reset the packet number for any packet number space after processing a Retry. `reset_initial_pn_space/1` restarted at 0, so the retried Initial reused a packet number the server had already seen in that space and a server that dedupes on it drops the packet, stalling the handshake with no error anywhere. It also broke the loss detector's assumption that its sent queue is ordered by packet number.

The Initial number now continues where it left off. The rest of the space is still cleared, since it describes packets protected by the keys the Retry replaced, and the loss state is dropped with it: only Initials can have been sent at that point and RFC 9002 §6.2.1 lets them be treated as lost, so their bytes stop counting as in flight for packets that can never be acknowledged.

The test races a client against a listener with `address_validation => always` and reads the Initial packet numbers back off the client's qlog.