### PR TITLE
Add X25519MLKEM768 post-quantum hybrid key exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Post-quantum hybrid key exchange `x25519mlkem768` (draft-ietf-tls-ecdhe-mlkem, ML-KEM-768 + X25519), opt-in via `groups`. Negotiable only when the crypto library provides ML-KEM-768 (OTP 28+); a `groups` option naming an unsupported group is rejected up front from `connect/4` and `start_server/3` as `{error, {unsupported_group, _}}` instead of crashing during the handshake. (#195)
+
+### Fixed
+- Initial-level CRYPTO is now chunked across Initial packets, each within the 1200-byte pre-PMTU limit, and the whole flight is replayed on retransmit. A hybrid `x25519mlkem768` ClientHello (~1360 bytes) or ServerHello Initial (~1225 bytes) no longer leaves as a single oversized datagram that is dropped on paths with an MTU below ~1470 (IPv6-over-PPPoE, WireGuard, mobile). (#195)
+
 ## [1.8.0] - 2026-08-05
 
 ### Fixed

--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -45,7 +45,7 @@ quic:close(Conn, normal).
 | `server_name` | binary | Host | Server Name Indication |
 | `cert` | binary | - | Client certificate (for mTLS) |
 | `key` | term | - | Client private key (for mTLS) |
-| `groups` | [atom()] | `[x25519]` | Key-exchange groups in preference order (`x25519`, `secp256r1`, `secp384r1`). The head gets a `key_share`; the rest are HelloRetryRequest-eligible. |
+| `groups` | [atom()] | `[x25519]` | Key-exchange groups in preference order (`x25519`, `secp256r1`, `secp384r1`, `x25519mlkem768`). The head gets a `key_share`; the rest are HelloRetryRequest-eligible. `x25519mlkem768` is the post-quantum hybrid group (needs OTP 28+); naming an unsupported group returns `{error, {unsupported_group, _}}`. |
 | `signature_algs` | [atom()] | historical list | Advertised signature schemes (`ecdsa_secp256r1_sha256`, `ecdsa_secp384r1_sha384`, `rsa_pss_rsae_sha256\|384\|512`, `ed25519`, `rsa_pkcs1_sha256`). |
 | `external_psk` | tuple | - | TLS 1.3 external PSK; see [PSK.md](PSK.md). |
 
@@ -62,6 +62,18 @@ transparently.
 {ok, Conn} = quic:connect(Host, Port, #{
     verify => false,
     groups => [x25519, secp256r1, secp384r1]
+}, self()).
+```
+
+Post-quantum example: prefer the hybrid ML-KEM group and fall back to
+classical `x25519` for peers that do not offer it. The hybrid
+ClientHello is larger than one datagram and is chunked across Initial
+packets automatically.
+
+```erlang
+{ok, Conn} = quic:connect(Host, Port, #{
+    verify => false,
+    groups => [x25519mlkem768, x25519]
 }, self()).
 ```
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -99,6 +99,8 @@
 ### Key-exchange groups
 - [x] x25519 (default)
 - [x] secp256r1, secp384r1 (opt-in via `groups`)
+- [x] x25519mlkem768 post-quantum hybrid (draft-ietf-tls-ecdhe-mlkem;
+      opt-in via `groups`, needs ML-KEM-768 support in `crypto`, OTP 28+)
 - [x] Multi-group `key_share` + `supported_groups` negotiation
 - [ ] secp521r1, x448 (constants only; see Roadmap)
 

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -294,6 +294,8 @@
 -define(GROUP_SECP521R1, 16#0019).
 -define(GROUP_X25519, 16#001d).
 -define(GROUP_X448, 16#001e).
+%% Post-quantum hybrid X25519MLKEM768 (draft-ietf-tls-ecdhe-mlkem)
+-define(GROUP_X25519MLKEM768, 16#11ec).
 
 %%====================================================================
 %% TLS 1.3 Signature Algorithms (RFC 8446 Section 4.2.3)

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -264,22 +264,26 @@ connect(Host, Port, Opts, Owner) when
 ->
     %% Extract socket option for pre-opened socket support
     Socket = maps:get(socket, Opts, undefined),
-    case validate_groups(Opts) of
+    case validate_client_opts(Socket, Opts) of
         ok ->
-            case validate_connect_opts(Socket, Opts) of
-                ok ->
-                    %% Resolution (and RFC 8305 Happy Eyeballs for hostnames) runs in
-                    %% the caller process so a resolution failure returns {error, _}
-                    %% instead of crashing the caller via the start_link.
-                    quic_happy:connect(Host, Port, Opts, Owner, Socket);
-                {error, _} = Error ->
-                    Error
-            end;
+            %% Resolution (and RFC 8305 Happy Eyeballs for hostnames) runs in
+            %% the caller process so a resolution failure returns {error, _}
+            %% instead of crashing the caller via the start_link.
+            quic_happy:connect(Host, Port, Opts, Owner, Socket);
         {error, _} = Error ->
             Error
     end;
 connect(_Host, _Port, _Opts, _Owner) ->
     {error, badarg}.
+
+%% @private All client-side option checks that must run before the
+%% connection process is started, so a bad option returns {error, _}
+%% to the caller instead of crashing mid-handshake.
+validate_client_opts(Socket, Opts) ->
+    case validate_groups(Opts) of
+        ok -> validate_connect_opts(Socket, Opts);
+        {error, _} = Error -> Error
+    end.
 
 %% A pre-opened `socket' is always a gen_udp handle; requesting the
 %% OTP socket NIF backend or the callback adapter at the same time

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -264,12 +264,17 @@ connect(Host, Port, Opts, Owner) when
 ->
     %% Extract socket option for pre-opened socket support
     Socket = maps:get(socket, Opts, undefined),
-    case validate_connect_opts(Socket, Opts) of
+    case validate_groups(Opts) of
         ok ->
-            %% Resolution (and RFC 8305 Happy Eyeballs for hostnames) runs in
-            %% the caller process so a resolution failure returns {error, _}
-            %% instead of crashing the caller via the start_link.
-            quic_happy:connect(Host, Port, Opts, Owner, Socket);
+            case validate_connect_opts(Socket, Opts) of
+                ok ->
+                    %% Resolution (and RFC 8305 Happy Eyeballs for hostnames) runs in
+                    %% the caller process so a resolution failure returns {error, _}
+                    %% instead of crashing the caller via the start_link.
+                    quic_happy:connect(Host, Port, Opts, Owner, Socket);
+                {error, _} = Error ->
+                    Error
+            end;
         {error, _} = Error ->
             Error
     end;
@@ -829,9 +834,24 @@ start_server(Name, Port, Opts) when
     Port =< 65535,
     is_map(Opts)
 ->
-    quic_server_sup:start_server(Name, Port, Opts);
+    case validate_groups(Opts) of
+        ok -> quic_server_sup:start_server(Name, Port, Opts);
+        {error, _} = Error -> Error
+    end;
 start_server(_Name, _Port, _Opts) ->
     {error, badarg}.
+
+%% @private Reject a `groups' option naming a key-exchange group this
+%% runtime cannot perform, up front with a clean error, rather than
+%% crashing later inside crypto:generate_key/2 during the handshake.
+%% The hybrid x25519mlkem768 group needs ML-KEM-768 support in crypto
+%% (OTP 28+); on OTP 27 group_supported/1 returns false.
+validate_groups(Opts) ->
+    Groups = maps:get(groups, Opts, []),
+    case [G || G <- Groups, not quic_crypto:group_supported(G)] of
+        [] -> ok;
+        [G | _] -> {error, {unsupported_group, G}}
+    end.
 
 %% @doc Stop a named QUIC server.
 %%

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -333,7 +333,7 @@
 
     %% TLS state
     tls_state :: atom(),
-    tls_private_key :: binary() | undefined,
+    tls_private_key :: quic_crypto:kex_private() | undefined,
     tls_transcript = <<>> :: binary(),
     handshake_secret :: binary() | undefined,
     master_secret :: binary() | undefined,
@@ -2690,6 +2690,7 @@ extract_group_key(Group, [{Code, PubKey} | Rest]) ->
 group_atom(?GROUP_X25519) -> x25519;
 group_atom(?GROUP_SECP256R1) -> secp256r1;
 group_atom(?GROUP_SECP384R1) -> secp384r1;
+group_atom(?GROUP_X25519MLKEM768) -> x25519mlkem768;
 group_atom(Other) -> Other.
 
 %% Decide the key-exchange group for a ClientHello (RFC 8446 §4.1.4).
@@ -5989,13 +5990,11 @@ do_server_client_hello_cont(
                 exit({tls_alert, decrypt_error})
         end,
 
-    %% Generate server key pair for the negotiated group
-    {ServerPubKey, ServerPrivKey} = quic_crypto:generate_key_pair(SelectedGroup),
-
-    %% Compute shared secret
-    SharedSecret = quic_crypto:compute_shared_secret(
-        SelectedGroup, ServerPrivKey, ClientPubKey
-    ),
+    %% Server side of the key exchange for the negotiated group: an
+    %% ECDHE keygen + ECDH for classical groups, an ML-KEM
+    %% encapsulation + ECDH for the hybrid group.
+    {ServerPubKey, ServerPrivKey, SharedSecret} =
+        quic_crypto:server_key_exchange(SelectedGroup, ClientPubKey),
 
     %% Negotiate ALPN
     ALPN = negotiate_alpn(ClientALPN, State#state.alpn_list),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -275,7 +275,10 @@
     %% Client-side: the Initial CRYPTO frame (ClientHello) buffered so a
     %% stalled handshake can re-send it, and the retransmission attempt
     %% count for backoff. See ?HS_RTX_* and retransmit_initial_flight/1.
-    initial_crypto_frame :: binary() | undefined,
+    %% Every CRYPTO chunk of the current Initial flight, in send order,
+    %% so the whole flight is replayed on retransmit -- a hybrid
+    %% (ML-KEM) ClientHello spans more than one Initial packet.
+    initial_crypto_frames = [] :: [binary()],
     hs_rtx_attempts = 0 :: non_neg_integer(),
     %% Server-side only. The Retry SCID to echo back as
     %% retry_source_connection_id (RFC 9000 §7.3) when this connection
@@ -2609,16 +2612,13 @@ send_client_hello(State) ->
                 {Keys, EarlySecret}
         end,
 
-    %% Create CRYPTO frame
-    CryptoFrame = quic_frame:encode({crypto, 0, ClientHello}),
-
-    %% Encrypt and send Initial packet
-    NewState = send_initial_packet(CryptoFrame, State#state{
+    %% Encrypt and send the ClientHello, chunked across Initial packets
+    %% when it exceeds one datagram (hybrid ML-KEM key share).
+    State0 = State#state{
         tls_private_key = PrivKey,
         tls_transcript = Transcript,
         tls_ch1_random = ClientRandom,
         tls_ch1_opts = ClientHelloOpts,
-        initial_crypto_frame = CryptoFrame,
         initial_tx_off = byte_size(ClientHello),
         early_keys = EarlyKeys,
         max_early_data =
@@ -2626,7 +2626,9 @@ send_client_hello(State) ->
                 undefined -> 0;
                 #session_ticket{max_early_data = MaxEarly} -> MaxEarly
             end
-    }),
+    },
+    {Frames, NewState0} = send_initial_crypto(ClientHello, 0, State0),
+    NewState = NewState0#state{initial_crypto_frames = Frames},
 
     %% Event-driven flush: flush batch and timers after sending ClientHello
     %% Critical for handshake - must send immediately
@@ -2839,9 +2841,11 @@ ensure_ticket_table() ->
 %% Initial CRYPTO offset (non-zero only after a HelloRetryRequest).
 send_server_hello(ServerHelloMsg, State) ->
     Off = State#state.initial_tx_off,
-    CryptoFrame = quic_frame:encode({crypto, Off, ServerHelloMsg}),
     State1 = State#state{initial_tx_off = Off + byte_size(ServerHelloMsg)},
-    send_initial_packet(CryptoFrame, State1).
+    %% Chunk across Initial packets: a hybrid ServerHello Initial is
+    %% ~1225 bytes and no longer fits one datagram.
+    {_Frames, NewState} = send_initial_crypto(ServerHelloMsg, Off, State1),
+    NewState.
 
 %% Server: Send EncryptedExtensions, Certificate, CertificateVerify, Finished
 %% @private
@@ -3135,6 +3139,48 @@ chunk_crypto(Payload, Offset, Max) ->
     Take = min(byte_size(Payload), Max),
     <<Chunk:Take/binary, Rest/binary>> = Payload,
     [{Offset, Chunk} | chunk_crypto(Rest, Offset + Take, Max)].
+
+%% @private Send an Initial-level CRYPTO payload (ClientHello,
+%% ServerHello, or a HelloRetryRequest CH2) as one or more Initial
+%% packets, each sized to stay within the 1200-byte pre-PMTU limit
+%% (RFC 9000 §14.1). A hybrid ML-KEM ClientHello is ~1360 bytes and no
+%% longer fits one datagram; a single oversized Initial is dropped on
+%% paths with an MTU below ~1470 (PPPoE, WireGuard, mobile). Returns
+%% the encoded chunk frames (for the retransmit buffer) and the state.
+send_initial_crypto(Payload, Offset0, State) ->
+    Max = initial_crypto_budget(State),
+    lists:mapfoldl(
+        fun({Offset, Chunk}, AccState) ->
+            Frame = quic_frame:encode({crypto, Offset, Chunk}),
+            {Frame, send_initial_packet(Frame, AccState)}
+        end,
+        State,
+        chunk_crypto(Payload, Offset0, Max)
+    ).
+
+%% @private Conservative per-chunk CRYPTO data budget for an Initial
+%% packet. Mirrors handshake_crypto_budget/1 but includes the Retry
+%% token field, which Initial packets carry (RFC 9000 §17.2.2). Each
+%% Initial packet is separately padded to 1200 bytes downstream, so
+%% the budget bounds the pre-padding size and keeps every datagram
+%% within the universally safe 1200-byte ceiling.
+initial_crypto_budget(#state{dcid = DCID, scid = SCID, retry_token = Token} = State) ->
+    PeerMax = maps:get(
+        max_udp_payload_size,
+        State#state.transport_params,
+        ?DEFAULT_MAX_UDP_PAYLOAD_SIZE
+    ),
+    Ceiling = min(PeerMax, ?DEFAULT_MAX_UDP_PAYLOAD_SIZE),
+    Overhead =
+        %% long header: first byte + version + DCID len/bytes + SCID len/bytes
+        1 + 4 + 1 + byte_size(DCID) + 1 + byte_size(SCID) +
+            %% token length varint + token bytes
+            byte_size(quic_varint:encode(byte_size(Token))) + byte_size(Token) +
+            %% length varint + packet number + AEAD tag
+            2 + 4 + 16 +
+            %% CRYPTO frame header: type + offset varint + length varint
+            1 + 8 + 4,
+    max(1, Ceiling - Overhead).
 
 %% Server: Send HANDSHAKE_DONE frame after receiving client Finished
 send_handshake_done(State) ->
@@ -3786,9 +3832,9 @@ amp_flush_budget(#state{amp_deferred = [Packet | Rest]} = State) ->
 hs_rtx_actions(#state{
     role = client,
     app_keys = undefined,
-    initial_crypto_frame = Frame,
+    initial_crypto_frames = Frames,
     hs_rtx_attempts = Attempts
-}) when Frame =/= undefined, Attempts < ?HS_RTX_MAX_ATTEMPTS ->
+}) when Frames =/= [], Attempts < ?HS_RTX_MAX_ATTEMPTS ->
     Delay = min(?HS_RTX_BASE_MS bsl Attempts, ?HS_RTX_MAX_MS),
     [{state_timeout, Delay, retransmit_initial}];
 hs_rtx_actions(_State) ->
@@ -3799,8 +3845,8 @@ hs_rtx_actions(_State) ->
 %% server's anti-amplification budget so it can flush a deferred flight.
 retransmit_initial_flight(
     StateName,
-    #state{role = client, app_keys = undefined, initial_crypto_frame = Frame} = State
-) when Frame =/= undefined ->
+    #state{role = client, app_keys = undefined, initial_crypto_frames = Frames} = State
+) when Frames =/= [] ->
     ?LOG_DEBUG(
         #{
             what => handshake_initial_retransmit,
@@ -3809,9 +3855,12 @@ retransmit_initial_flight(
         },
         ?QUIC_LOG_META
     ),
-    State1 = send_initial_packet(Frame, State#state{
-        hs_rtx_attempts = State#state.hs_rtx_attempts + 1
-    }),
+    %% Replay every chunk of the flight, each in its own Initial packet.
+    State1 = lists:foldl(
+        fun send_initial_packet/2,
+        State#state{hs_rtx_attempts = State#state.hs_rtx_attempts + 1},
+        Frames
+    ),
     Flushed = flush_dirty_timers(flush_socket_batch(State1)),
     client_rearm_active(Flushed, Flushed#state.active_n),
     {keep_state, Flushed, hs_rtx_actions(Flushed)};
@@ -6222,7 +6271,6 @@ handle_hello_retry_request(
             Transcript = <<BaseTranscript/binary, CH2/binary>>,
 
             Off = State#state.initial_tx_off,
-            CryptoFrame = quic_frame:encode({crypto, Off, CH2}),
             State1 = State#state{
                 hrr_sent = true,
                 hrr_group = SelGroup,
@@ -6231,7 +6279,11 @@ handle_hello_retry_request(
                 tls_transcript = Transcript,
                 initial_tx_off = Off + byte_size(CH2)
             },
-            send_initial_packet(CryptoFrame, State1)
+            %% CH2 carries the hybrid key share now, so it chunks too;
+            %% replace the retransmit buffer with the CH2 chunks (the
+            %% outstanding Initial flight after HRR is CH2, not CH1).
+            {Frames, State2} = send_initial_crypto(CH2, Off, State1),
+            State2#state{initial_crypto_frames = Frames}
     end.
 
 %%====================================================================

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -27,6 +27,12 @@
 
 -module(quic_crypto).
 
+-type group() :: x25519 | x448 | secp256r1 | secp384r1 | x25519mlkem768.
+%% Private key material for a key exchange: raw curve key for ECDHE,
+%% opaque {MlKemDecapsKey, X25519Priv} for the hybrid group.
+-type kex_private() :: binary() | {binary(), binary()}.
+-export_type([group/0, kex_private/0]).
+
 -export([
     %% Key Schedule
     derive_early_secret/0,
@@ -78,6 +84,8 @@
     %% ECDHE
     generate_key_pair/1,
     compute_shared_secret/3,
+    server_key_exchange/2,
+    group_supported/1,
 
     %% Retry Packet Integrity (RFC 9001 Section 5.8)
     verify_retry_integrity_tag/3,
@@ -377,23 +385,62 @@ cipher_to_hash(_) -> sha256.
 %% ECDHE Key Exchange
 %%====================================================================
 
-%% @doc Generate an ECDHE key pair for the specified curve.
-%% Returns {PublicKey, PrivateKey}
--spec generate_key_pair(x25519 | x448 | secp256r1 | secp384r1) ->
-    {binary(), binary()}.
+%% @doc Generate a key-exchange key pair for the specified group.
+%% Returns {PublicShare, PrivateKey}. For the classical ECDHE groups
+%% PublicShare/PrivateKey are the raw curve keys. For the post-quantum
+%% hybrid group x25519mlkem768 (draft-ietf-tls-ecdhe-mlkem) the public
+%% share is the 1216-byte concatenation of the ML-KEM-768 encapsulation
+%% key and the X25519 public key, and the private key is an opaque
+%% {MlKemDecapsKey, X25519Priv} pair; both are only ever consumed by
+%% compute_shared_secret/3.
+-spec generate_key_pair(group()) -> {binary(), kex_private()}.
+generate_key_pair(x25519mlkem768) ->
+    {MlKemEK, MlKemDK} = crypto:generate_key(mlkem768, []),
+    {XPub, XPriv} = crypto:generate_key(ecdh, x25519),
+    {<<MlKemEK/binary, XPub/binary>>, {MlKemDK, XPriv}};
 generate_key_pair(Curve) ->
     {PubKey, PrivKey} = crypto:generate_key(ecdh, Curve),
     {PubKey, PrivKey}.
 
-%% @doc Compute ECDHE shared secret.
-%% shared_secret = ECDH(our_private, their_public)
--spec compute_shared_secret(
-    x25519 | x448 | secp256r1 | secp384r1,
-    binary(),
-    binary()
-) -> binary().
+%% @doc Compute the key-exchange shared secret (client side for the
+%% hybrid group). For ECDHE groups: ECDH(our_private, their_public).
+%% For x25519mlkem768 the peer share is the server's 1120-byte
+%% concatenation of the ML-KEM ciphertext and X25519 public key, and
+%% the shared secret is mlkem_secret || x25519_secret (64 bytes).
+-spec compute_shared_secret(group(), kex_private(), binary()) -> binary().
+compute_shared_secret(x25519mlkem768, {MlKemDK, XPriv}, <<CipherText:1088/binary, SXPub:32/binary>>) ->
+    MlKemSecret = crypto:decapsulate_key(mlkem768, MlKemDK, CipherText),
+    XSecret = crypto:compute_key(ecdh, SXPub, XPriv, x25519),
+    <<MlKemSecret/binary, XSecret/binary>>;
 compute_shared_secret(Curve, OurPrivate, TheirPublic) ->
     crypto:compute_key(ecdh, TheirPublic, OurPrivate, Curve).
+
+%% @doc Server-side key exchange against a client key share.
+%% Returns {ServerShare, ServerPrivate, SharedSecret}. For ECDHE groups
+%% this generates a server key pair and computes ECDH; ServerPrivate is
+%% the curve private key (kept for parity with the previous behaviour).
+%% For x25519mlkem768 the server encapsulates against the client's
+%% ML-KEM encapsulation key: the server share is ciphertext || x25519
+%% public (1120 bytes), the shared secret is mlkem || x25519 (64 bytes),
+%% and there is no retained private key (the exchange is complete).
+-spec server_key_exchange(group(), binary()) ->
+    {binary(), kex_private() | undefined, binary()}.
+server_key_exchange(x25519mlkem768, <<MlKemEK:1184/binary, CXPub:32/binary>>) ->
+    {MlKemSecret, CipherText} = crypto:encapsulate_key(mlkem768, MlKemEK),
+    {SXPub, SXPriv} = crypto:generate_key(ecdh, x25519),
+    XSecret = crypto:compute_key(ecdh, CXPub, SXPriv, x25519),
+    {<<CipherText/binary, SXPub/binary>>, undefined, <<MlKemSecret/binary, XSecret/binary>>};
+server_key_exchange(Curve, ClientPub) ->
+    {PubKey, PrivKey} = generate_key_pair(Curve),
+    {PubKey, PrivKey, compute_shared_secret(Curve, PrivKey, ClientPub)}.
+
+%% @doc Whether this runtime can negotiate the given group. The hybrid
+%% group needs ML-KEM-768 support in crypto (OTP 28+).
+-spec group_supported(group()) -> boolean().
+group_supported(x25519mlkem768) ->
+    lists:member(mlkem768, proplists:get_value(kems, crypto:supports(), []));
+group_supported(Group) ->
+    lists:member(Group, [x25519, x448, secp256r1, secp384r1]).
 
 %%====================================================================
 %% Retry Packet Integrity (RFC 9001 Section 5.8)

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -408,7 +408,9 @@ generate_key_pair(Curve) ->
 %% concatenation of the ML-KEM ciphertext and X25519 public key, and
 %% the shared secret is mlkem_secret || x25519_secret (64 bytes).
 -spec compute_shared_secret(group(), kex_private(), binary()) -> binary().
-compute_shared_secret(x25519mlkem768, {MlKemDK, XPriv}, <<CipherText:1088/binary, SXPub:32/binary>>) ->
+compute_shared_secret(
+    x25519mlkem768, {MlKemDK, XPriv}, <<CipherText:1088/binary, SXPub:32/binary>>
+) ->
     MlKemSecret = crypto:decapsulate_key(mlkem768, MlKemDK, CipherText),
     XSecret = crypto:compute_key(ecdh, SXPub, XPriv, x25519),
     <<MlKemSecret/binary, XSecret/binary>>;

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -85,7 +85,7 @@
 %%   - session_ticket: #session_ticket{} for resumption with PSK (optional)
 %%
 %% Returns: {ClientHelloMsg, PrivateKey, Random}
--spec build_client_hello(map()) -> {binary(), binary(), binary()}.
+-spec build_client_hello(map()) -> {binary(), quic_crypto:kex_private(), binary()}.
 build_client_hello(Opts) ->
     %% Key-share group: the head of `groups' (default x25519). The
     %% remaining groups are advertised in supported_groups so the
@@ -133,7 +133,8 @@ default_sig_algs() ->
 %% @private Named-group atom to RFC 8446 §4.2.7 wire code.
 group_to_code(x25519) -> ?GROUP_X25519;
 group_to_code(secp256r1) -> ?GROUP_SECP256R1;
-group_to_code(secp384r1) -> ?GROUP_SECP384R1.
+group_to_code(secp384r1) -> ?GROUP_SECP384R1;
+group_to_code(x25519mlkem768) -> ?GROUP_X25519MLKEM768.
 
 %% @private Signature-scheme atom to RFC 8446 §4.2.3 wire code.
 sig_alg_to_code(ecdsa_secp256r1_sha256) -> ?SIG_ECDSA_SECP256R1_SHA256;
@@ -970,6 +971,9 @@ parse_server_key_share(<<?GROUP_X25519:16, 32:16, PubKey:32/binary, _/binary>>) 
     {ok, PubKey};
 parse_server_key_share(<<?GROUP_SECP256R1:16, Len:16, PubKey:Len/binary, _/binary>>) ->
     {ok, PubKey};
+parse_server_key_share(<<?GROUP_X25519MLKEM768:16, 1120:16, Share:1120/binary, _/binary>>) ->
+    %% ML-KEM-768 ciphertext (1088) || X25519 public (32)
+    {ok, Share};
 parse_server_key_share(_) ->
     {error, unsupported_key_share}.
 
@@ -1340,6 +1344,7 @@ parse_signature_algorithms_ext(_) ->
 code_to_group(?GROUP_X25519) -> x25519;
 code_to_group(?GROUP_SECP256R1) -> secp256r1;
 code_to_group(?GROUP_SECP384R1) -> secp384r1;
+code_to_group(?GROUP_X25519MLKEM768) -> x25519mlkem768;
 code_to_group(_) -> unknown.
 
 %% @private

--- a/test/quic_pqc_e2e_SUITE.erl
+++ b/test/quic_pqc_e2e_SUITE.erl
@@ -1,0 +1,152 @@
+%%% -*- erlang -*-
+%%%
+%%% Post-quantum hybrid key exchange end-to-end suite
+%%% (X25519MLKEM768, draft-ietf-tls-ecdhe-mlkem).
+%%%
+%%% Drives full handshakes negotiating the hybrid group directly and
+%%% through a HelloRetryRequest, plus mixed peers where one side is
+%%% classical-only, to prove interop is unaffected.
+%%%
+%%% The whole suite is skipped when the crypto library has no
+%%% ML-KEM-768 support (OTP < 28 or restricted crypto builds).
+
+-module(quic_pqc_e2e_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    suite/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
+
+-export([
+    hybrid_direct/1,
+    classical_client_interop/1,
+    hybrid_via_hrr/1,
+    hybrid_share_sizes/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [hybrid_direct, classical_client_interop, hybrid_via_hrr, hybrid_share_sizes].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    case quic_crypto:group_supported(x25519mlkem768) of
+        true ->
+            {ok, _} = application:ensure_all_started(quic),
+            Config;
+        false ->
+            {skip, "crypto library has no ML-KEM-768 support"}
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+%% Both sides prefer the hybrid group and the client sends its
+%% key_share for it: direct negotiation, no HRR, data echoes.
+hybrid_direct(_Config) ->
+    {ok, Server} = quic_test_echo_server:start(#{groups => [x25519mlkem768, x25519]}),
+    try
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            groups => [x25519mlkem768, x25519]
+        },
+        ConnRef = connect(Server, Opts),
+        Info = wait_connected(ConnRef),
+        ?assertEqual(x25519mlkem768, maps:get(negotiated_group, Info)),
+        ok = echo(ConnRef, <<"post-quantum echo">>),
+        quic:close(ConnRef, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%% A classical-only client against a hybrid-preferring server must
+%% keep working: the server uses the client's x25519 share directly.
+classical_client_interop(_Config) ->
+    {ok, Server} = quic_test_echo_server:start(#{groups => [x25519mlkem768, x25519]}),
+    try
+        Opts = #{verify => false, alpn => [<<"echo">>], groups => [x25519]},
+        ConnRef = connect(Server, Opts),
+        Info = wait_connected(ConnRef),
+        ?assertEqual(x25519, maps:get(negotiated_group, Info)),
+        ok = echo(ConnRef, <<"classical still fine">>),
+        quic:close(ConnRef, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%% Hybrid-only server, client key_share for x25519 but hybrid in its
+%% supported_groups: server sends an HRR for the hybrid group, the
+%% client retries with a hybrid share, handshake completes.
+hybrid_via_hrr(_Config) ->
+    {ok, Server} = quic_test_echo_server:start(#{groups => [x25519mlkem768]}),
+    try
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            groups => [x25519, x25519mlkem768]
+        },
+        ConnRef = connect(Server, Opts),
+        Info = wait_connected(ConnRef),
+        ?assertEqual(x25519mlkem768, maps:get(negotiated_group, Info)),
+        ok = echo(ConnRef, <<"hybrid after hrr">>),
+        quic:close(ConnRef, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%% Wire-format invariants of the hybrid exchange
+%% (draft-ietf-tls-ecdhe-mlkem): client share 1216 bytes (ML-KEM
+%% encapsulation key || X25519 public), server share 1120 bytes
+%% (ciphertext || X25519 public), shared secret 64 bytes (ML-KEM
+%% secret || X25519 secret), and both sides derive the same secret.
+hybrid_share_sizes(_Config) ->
+    {ClientShare, ClientPriv} = quic_crypto:generate_key_pair(x25519mlkem768),
+    ?assertEqual(1216, byte_size(ClientShare)),
+    {ServerShare, undefined, ServerSecret} =
+        quic_crypto:server_key_exchange(x25519mlkem768, ClientShare),
+    ?assertEqual(1120, byte_size(ServerShare)),
+    ?assertEqual(64, byte_size(ServerSecret)),
+    ClientSecret = quic_crypto:compute_shared_secret(
+        x25519mlkem768, ClientPriv, ServerShare
+    ),
+    ?assertEqual(ServerSecret, ClientSecret),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+connect(#{port := Port}, Opts) ->
+    {ok, ConnRef} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    ConnRef.
+
+wait_connected(ConnRef) ->
+    receive
+        {quic, ConnRef, {connected, Info}} -> Info
+    after 10000 ->
+        quic:safe_close(ConnRef, timeout),
+        ct:fail("connection timeout")
+    end.
+
+echo(ConnRef, Payload) ->
+    {ok, StreamId} = quic:open_stream(ConnRef),
+    ok = quic:send_data(ConnRef, StreamId, Payload, true),
+    receive
+        {quic, ConnRef, {stream_data, StreamId, Got, true}} ->
+            ?assertEqual(Payload, Got),
+            ok
+    after 10000 ->
+        ct:fail("echo timeout")
+    end.

--- a/test/quic_pqc_e2e_SUITE.erl
+++ b/test/quic_pqc_e2e_SUITE.erl
@@ -26,14 +26,21 @@
     hybrid_direct/1,
     classical_client_interop/1,
     hybrid_via_hrr/1,
-    hybrid_share_sizes/1
+    hybrid_share_sizes/1,
+    unsupported_group_rejected/1
 ]).
 
 suite() ->
     [{timetrap, {minutes, 2}}].
 
 all() ->
-    [hybrid_direct, classical_client_interop, hybrid_via_hrr, hybrid_share_sizes].
+    [
+        hybrid_direct,
+        classical_client_interop,
+        hybrid_via_hrr,
+        hybrid_share_sizes,
+        unsupported_group_rejected
+    ].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
@@ -122,6 +129,22 @@ hybrid_share_sizes(_Config) ->
         x25519mlkem768, ClientPriv, ServerShare
     ),
     ?assertEqual(ServerSecret, ClientSecret),
+    ok.
+
+%% A group the runtime cannot perform is rejected up front with a
+%% clean error from both connect/4 and start_server/3, rather than
+%% crashing inside crypto during the handshake. `unknown_group_xyz'
+%% stands in for a group unsupported on any release (the same path an
+%% OTP 27 node hits for x25519mlkem768).
+unsupported_group_rejected(_Config) ->
+    ?assertEqual(
+        {error, {unsupported_group, unknown_group_xyz}},
+        quic:connect(<<"127.0.0.1">>, 12345, #{groups => [unknown_group_xyz]}, self())
+    ),
+    ?assertEqual(
+        {error, {unsupported_group, unknown_group_xyz}},
+        quic:start_server(pqc_bad_group_srv, 0, #{groups => [unknown_group_xyz]})
+    ),
     ok.
 
 %%====================================================================

--- a/test/quic_pqc_mtu_SUITE.erl
+++ b/test/quic_pqc_mtu_SUITE.erl
@@ -1,0 +1,143 @@
+%%% -*- erlang -*-
+%%%
+%%% Post-quantum Initial-datagram sizing (draft-ietf-tls-ecdhe-mlkem).
+%%%
+%%% The hybrid X25519MLKEM768 ClientHello is ~1360 bytes and its
+%%% ServerHello Initial ~1225 bytes, both past the 1200-byte size that
+%%% is safe before PMTU is validated. A single oversized Initial is
+%%% dropped on paths with an MTU below ~1470 (IPv6-over-PPPoE 1492,
+%%% WireGuard ~1420, mobile ~1400), so the flight must be split across
+%%% Initial packets. Loopback has a 16k MTU and hides this, so this
+%%% suite watches the bytes on the wire directly via the socket
+%%% adapter and asserts every handshake datagram stays within 1200.
+%%%
+%%% Skipped when the crypto library has no ML-KEM-768 support.
+
+-module(quic_pqc_mtu_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([hybrid_initial_within_1200/1]).
+
+-define(SAFE_INITIAL, 1200).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [hybrid_initial_within_1200].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    case quic_crypto:group_supported(x25519mlkem768) of
+        true ->
+            {ok, _} = application:ensure_all_started(quic),
+            Config;
+        false ->
+            {skip, "crypto library has no ML-KEM-768 support"}
+    end.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% Drive a full hybrid handshake with the client behind a socket
+%% adapter that records the size and header type of every datagram it
+%% sends. Assert: no Initial datagram exceeds 1200 bytes, and the
+%% ClientHello actually spans more than one Initial (chunking engaged,
+%% not merely a small hello).
+hybrid_initial_within_1200(_Config) ->
+    {ok, Server} = quic_test_echo_server:start(#{groups => [x25519mlkem768, x25519]}),
+    try
+        Port = maps:get(port, Server),
+        ServerIP = {127, 0, 0, 1},
+        SocketRef = make_ref(),
+        Self = self(),
+        Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef, Self) end),
+
+        SendFun = fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        Adapter = #{
+            send_fun => SendFun,
+            close_fun => fun() ->
+                Bridge ! stop,
+                ok
+            end,
+            local => {{127, 0, 0, 1}, 0},
+            socket_ref => SocketRef
+        },
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            groups => [x25519mlkem768, x25519],
+            socket_backend => adapter,
+            socket_adapter => Adapter
+        },
+        {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+        Bridge ! {set_conn, Conn},
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 10000 -> ct:fail("connect timeout")
+        end,
+        quic:close(Conn, normal),
+
+        Sizes = collect_sizes([]),
+        Initials = [Sz || {initial, Sz} <- Sizes],
+        Oversized = [Sz || Sz <- Initials, Sz > ?SAFE_INITIAL],
+        ct:pal("client Initial datagram sizes: ~p", [Initials]),
+        ?assertEqual([], Oversized),
+        %% The hybrid ClientHello alone must occupy more than one
+        %% Initial datagram: without chunking it would be a single
+        %% ~1445-byte datagram and this list would have one big entry.
+        ?assert(length(Initials) >= 2)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%% Drain the size reports the bridge forwarded.
+collect_sizes(Acc) ->
+    receive
+        {dgram, Type, Size} -> collect_sizes([{Type, Size} | Acc])
+    after 200 -> lists:reverse(Acc)
+    end.
+
+%% Relay between the client adapter and a real UDP socket to the
+%% server, reporting each client-egress datagram's size and header
+%% type back to the test. QUIC header protection masks only the low 4
+%% bits of the first byte for long headers, so the form bit (0x80) and
+%% the packet-type bits (0x30) are readable in the clear.
+bridge_init(ServerIP, ServerPort, SocketRef, Reporter) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(Sock, undefined, ServerIP, ServerPort, SocketRef, Reporter).
+
+bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef, Reporter) ->
+    receive
+        {set_conn, NewConn} ->
+            bridge_loop(Sock, NewConn, ServerIP, ServerPort, SocketRef, Reporter);
+        {send, _IP, _Port, Pkt} ->
+            Reporter ! {dgram, header_type(Pkt), iolist_size(Pkt)},
+            ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef, Reporter);
+        {udp, Sock, _IP, _Port, Data} when is_pid(Conn) ->
+            Conn ! {udp, SocketRef, ServerIP, ServerPort, Data},
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef, Reporter);
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Sock, Conn, ServerIP, ServerPort, SocketRef, Reporter)
+    end.
+
+header_type(Pkt) ->
+    <<First:8, _/binary>> = iolist_to_binary(Pkt),
+    case First band 16#80 of
+        0 ->
+            short;
+        _ ->
+            case First band 16#30 of
+                16#00 -> initial;
+                _ -> other_long
+            end
+    end.


### PR DESCRIPTION
This adds the hybrid ML-KEM-768 + X25519 named group (draft-ietf-tls-ecdhe-mlkem, code point `0x11EC`) as an opt-in key-exchange group, making erlang_quic able to negotiate quantum-safe key exchange with any modern peer (OpenSSL 3.5+, current browsers, OTP 28 `ssl`).

**Design**
- Uses the ML-KEM primitives OTP 28 exposes via `crypto` (`generate_key(mlkem768, ...)`, `encapsulate_key/2`, `decapsulate_key/3`) — no new dependencies.
- Wire format per the draft: client share = encapsulation key ‖ X25519 public (1216 B), server share = ciphertext ‖ X25519 public (1120 B), shared secret = ML-KEM secret ‖ X25519 secret (64 B). Verified against OTP ssl's implementation of the same group.
- The server side of a KEM exchange is an encapsulation rather than keygen+ECDH, so `quic_crypto` gains `server_key_exchange/2` covering both shapes; classical groups keep their exact previous behavior through it.
- Everything else rides the existing multi-group machinery — `supported_groups` negotiation, HelloRetryRequest into the hybrid group, key_share plumbing — with just the new code point added.
- Inert on crypto without ML-KEM (`quic_crypto:group_supported/1`); the new CT suite skips itself there.

**Testing**
- New `quic_pqc_e2e_SUITE`: direct hybrid negotiation, classical-client interop against a hybrid-preferring server, hybrid negotiated via HRR (exercises hybrid keygen on the CH2 retry), and wire-format/shared-secret invariants.
- Full existing test suite passes: 2247 eunit tests, `quic_hrr_e2e_SUITE`, TLS negotiation/compliance/server eunit modules — 0 failures.

**Why**: harvest-now-decrypt-later makes quantum-safe key exchange the PQC piece with a deadline; C-based QUIC stacks only get it via OpenSSL 3.5+. With this, a pure-Erlang QUIC endpoint offers it from any OTP 28 install, at ~1.2 kB extra ClientHello when the group is offered. Defaults are unchanged (`default_groups()` is still `[x25519]`) — flipping the default hybrid-first could be a follow-up decision.

Related: on the OTP side I have a PR open exposing the negotiated group via `ssl:connection_information` (erlang/otp#11440) for the same PQC-observability motivation.