### PR TITLE
Derive the GSO segment size from the batch

### DIFF
--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -402,8 +402,11 @@
 %% UDP Packet Batching (GSO/GRO on Linux)
 %% Maximum packets to batch before auto-flush
 -define(DEFAULT_MAX_BATCH_PACKETS, 64).
-%% Default GSO segment size (QUIC packet size for batching)
--define(DEFAULT_GSO_SEGMENT_SIZE, 1200).
+%% Kernel limits on a single UDP_SEGMENT write: UDP_MAX_SEGMENTS
+%% segments, and a payload that still fits a 16-bit UDP length. A batch
+%% larger than either is split across writes.
+-define(MAX_GSO_SEGMENTS, 64).
+-define(MAX_GSO_PAYLOAD, 65535).
 
 %%====================================================================
 %% Records

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2122,7 +2122,7 @@ connected(
     %% Return packet counts for liveness detection (net_kernel uses
     %% recv count to verify peer is alive) plus send-path batching
     %% counters for benchmarks and tests.
-    {Flushes, Coalesced} = send_batch_counters(SocketState),
+    {Flushes, Coalesced, GSOFlushes} = send_batch_counters(SocketState),
     Stats = #{
         packets_received => PacketsRecv,
         packets_sent => PacketsSent,
@@ -2131,7 +2131,8 @@ connected(
         ack_sent => AckSent,
         retransmits => Retransmits,
         batch_flushes => Flushes,
-        packets_coalesced => Coalesced
+        packets_coalesced => Coalesced,
+        gso_flushes => GSOFlushes
     },
     {keep_state, State, [{reply, From, {ok, Stats}}]};
 connected({call, From}, get_peer_transport_params, #state{transport_params = TP} = State) ->
@@ -9768,10 +9769,14 @@ send_gso_supported(SocketState) ->
     maps:get(gso_supported, quic_socket:info(SocketState)).
 
 send_batch_counters(undefined) ->
-    {0, 0};
+    {0, 0, 0};
 send_batch_counters(SocketState) ->
     Info = quic_socket:info(SocketState),
-    {maps:get(batch_flushes, Info), maps:get(packets_coalesced, Info)}.
+    {
+        maps:get(batch_flushes, Info),
+        maps:get(packets_coalesced, Info),
+        maps:get(gso_flushes, Info)
+    }.
 
 %% Normalize ALPN list - handles binary, list of binaries, list of strings
 normalize_alpn_list(undefined) ->

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -93,8 +93,10 @@
     owns_socket = true :: boolean(),
     %% GSO support detected and enabled
     gso_supported = false :: boolean(),
-    %% GSO segment size for batching
-    gso_size = ?DEFAULT_GSO_SEGMENT_SIZE :: non_neg_integer(),
+    %% Segment size of the most recent GSO flush, 0 before the first
+    %% one. Derived per flush from the batch: packet sizes follow the
+    %% current max datagram size, so there is no fixed value to configure.
+    gso_size = 0 :: non_neg_integer(),
     %% GRO enabled for receive
     gro_enabled = false :: boolean(),
     %% Batching enabled
@@ -110,9 +112,12 @@
     %% Observability counters: bumped on successful flush only. Skip
     %% immediate (unbatched) sends so packets_coalesced strictly measures
     %% the batching win. batch_flushes counts each flush that actually
-    %% transmitted something.
+    %% transmitted something. gso_flushes counts the subset that went
+    %% out segmented by the kernel, so a batch that only accumulated
+    %% cannot be mistaken for offload.
     batch_flushes = 0 :: non_neg_integer(),
-    packets_coalesced = 0 :: non_neg_integer()
+    packets_coalesced = 0 :: non_neg_integer(),
+    gso_flushes = 0 :: non_neg_integer()
 }).
 
 %% Packet can be:
@@ -144,7 +149,6 @@ open(Port, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     case Backend of
         socket ->
@@ -152,14 +156,12 @@ open(Port, Opts) ->
                 gso_supported => GSOSupported,
                 gro_supported => GROSupported,
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             });
         gen_udp ->
             open_genudp_backend(Port, Opts, #{
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             })
     end.
 
@@ -186,21 +188,18 @@ open_for_send(RemoteIP, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     case Backend of
         socket ->
             open_send_socket_backend(Family, Opts, #{
                 gso_supported => GSOSupported,
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             });
         gen_udp ->
             open_send_genudp_backend(Family, Opts, #{
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             })
     end.
 
@@ -218,13 +217,11 @@ open_server_send({LocalIP, LocalPort}, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     BatchConfig = #{
         gso_supported => GSOSupported,
         batching_enabled => BatchingEnabled,
-        max_batch => MaxBatch,
-        gso_size => GSOSize
+        max_batch => MaxBatch
     },
 
     case Backend of
@@ -256,13 +253,12 @@ configure_server_send_socket(Socket, LocalIP, LocalPort, Family, Opts, BatchConf
     SockAddr = #{family => Family, addr => LocalIP, port => LocalPort},
     case socket:bind(Socket, SockAddr) of
         ok ->
-            GSOEnabled = maybe_enable_gso(Socket, BatchConfig),
+            GSOEnabled = maybe_enable_gso(BatchConfig),
             State = #socket_state{
                 socket = Socket,
                 backend = socket,
                 owns_socket = true,
                 gso_supported = GSOEnabled,
-                gso_size = maps:get(gso_size, BatchConfig),
                 gro_enabled = false,
                 batching_enabled = maps:get(batching_enabled, BatchConfig),
                 max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -328,7 +324,8 @@ gso_supported(#socket_state{gso_supported = Supported}) ->
         batching_enabled := boolean(),
         max_batch_packets := pos_integer(),
         batch_flushes := non_neg_integer(),
-        packets_coalesced := non_neg_integer()
+        packets_coalesced := non_neg_integer(),
+        gso_flushes := non_neg_integer()
     }.
 info(#socket_state{
     backend = Backend,
@@ -338,7 +335,8 @@ info(#socket_state{
     batching_enabled = Batching,
     max_batch_packets = MaxBatch,
     batch_flushes = Flushes,
-    packets_coalesced = Coalesced
+    packets_coalesced = Coalesced,
+    gso_flushes = GSOFlushes
 }) ->
     #{
         backend => Backend,
@@ -348,7 +346,8 @@ info(#socket_state{
         batching_enabled => Batching,
         max_batch_packets => MaxBatch,
         batch_flushes => Flushes,
-        packets_coalesced => Coalesced
+        packets_coalesced => Coalesced,
+        gso_flushes => GSOFlushes
     }.
 
 %% @doc Build a socket_state backed by caller-supplied callbacks instead
@@ -401,14 +400,12 @@ wrap(Socket, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     State = #socket_state{
         socket = Socket,
         backend = gen_udp,
         owns_socket = false,
         gso_supported = false,
-        gso_size = GSOSize,
         gro_enabled = false,
         batching_enabled = BatchingEnabled,
         max_batch_packets = MaxBatch
@@ -429,14 +426,12 @@ new_sender(Socket, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     State = #socket_state{
         socket = Socket,
         backend = Backend,
         owns_socket = false,
         gso_supported = GSOSupported andalso (Backend =:= socket),
-        gso_size = GSOSize,
         gro_enabled = false,
         batching_enabled = BatchingEnabled,
         max_batch_packets = MaxBatch
@@ -522,28 +517,59 @@ flush(#socket_state{batch_count = Count, batch_addr = undefined} = State) ->
 flush(#socket_state{gso_supported = true, batch_count = 1} = State) ->
     %% Single-packet batch has no segmentation work; direct send.
     flush_individual(State);
-flush(#socket_state{gso_supported = true, batch_buffer = Buffer, gso_size = GSO} = State) ->
-    %% UDP_SEGMENT requires every segment except the last to be
-    %% exactly gso_size. Handshake flights coalesce Initial-padded-to-
+flush(#socket_state{gso_supported = true, batch_buffer = Buffer} = State) ->
+    %% UDP_SEGMENT requires every segment except the last to be exactly
+    %% the segment size. Handshake flights coalesce Initial-padded-to-
     %% 1200 with a ~400 byte Handshake packet; a naive GSO split
     %% mis-aligns those boundaries and the client cannot decode. When
     %% the batch is not uniform, fall through to individual sends.
-    case gso_batch_uniform(Buffer, GSO) of
-        true -> flush_gso(State);
+    case gso_segment_size(Buffer) of
+        {ok, SegmentSize} -> flush_gso(State, SegmentSize);
         false -> flush_individual(State)
     end;
 flush(#socket_state{} = State) ->
     %% Fallback path - send packets individually
     flush_individual(State).
 
-%% Batch buffer is stored newest-first (head was last added). For GSO
-%% correctness we need all packets EXCEPT the last-transmitted one
-%% (which is the head of the buffer) to be exactly gso_size. The
-%% last-transmitted packet may be shorter.
-gso_batch_uniform([], _GSO) ->
-    true;
-gso_batch_uniform([_Last | Earlier], GSO) ->
-    lists:all(fun(P) -> iolist_size(P) =:= GSO end, Earlier).
+%% Batch buffer is stored newest-first (head was last added). The
+%% segment size is whatever the earlier packets agree on, not a
+%% configured constant: 1-RTT packets are sized from the current max
+%% datagram size, so a fixed value never matches them and the batch
+%% would always fall through to individual sends. The last-transmitted
+%% packet (head of the buffer) may be shorter, but never longer, or the
+%% kernel would split it in two.
+-spec gso_segment_size([packet_view()]) -> {ok, pos_integer()} | false.
+gso_segment_size([]) ->
+    false;
+gso_segment_size([_Single]) ->
+    false;
+gso_segment_size([Last | [First | Rest]]) ->
+    SegmentSize = iolist_size(First),
+    Uniform =
+        SegmentSize > 0 andalso
+            iolist_size(Last) =< SegmentSize andalso
+            lists:all(fun(P) -> iolist_size(P) =:= SegmentSize end, Rest),
+    case Uniform of
+        true -> {ok, SegmentSize};
+        false -> false
+    end.
+
+%% One sendmsg carries at most UDP_MAX_SEGMENTS segments and at most
+%% 64 KB of payload, so a full batch of full-size packets needs more
+%% than one write.
+gso_segments_per_write(SegmentSize) ->
+    max(1, min(?MAX_GSO_SEGMENTS, ?MAX_GSO_PAYLOAD div SegmentSize)).
+
+%% Split a packet list into groups of at most Size. Only the final
+%% packet may be short, so it lands in the final group and every other
+%% group stays uniform.
+chunk_packets([], _Size) ->
+    [];
+chunk_packets(Packets, Size) when length(Packets) =< Size ->
+    [Packets];
+chunk_packets(Packets, Size) ->
+    {Head, Tail} = lists:split(Size, Packets),
+    [Head | chunk_packets(Tail, Size)].
 
 %% @doc Receive packets from the socket.
 %% On Linux with GRO, may return multiple coalesced packets.
@@ -767,22 +793,20 @@ build_socket_state(Socket, BatchConfig) ->
         socket = Socket,
         backend = socket,
         gso_supported = GSOEnabled,
-        gso_size = maps:get(gso_size, BatchConfig),
         gro_enabled = GROEnabled,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
     },
     {ok, State}.
 
-%% Retained for open_server_send's separate-socket path, which still
-%% uses a dedicated socket where a socket-level UDP_SEGMENT is safe
-%% (it is a send-only socket, never used for short handshake packets).
-maybe_enable_gso(Socket, #{gso_supported := true, gso_size := Size}) ->
-    case socket:setopt_native(Socket, {udp, ?UDP_SEGMENT}, <<Size:32/native>>) of
-        ok -> true;
-        {error, _} -> false
-    end;
-maybe_enable_gso(_, _) ->
+%% GSO is requested per message through the UDP_SEGMENT cmsg in
+%% flush_gso/2, never as a socket-level setsockopt: a socket-level
+%% UDP_SEGMENT segments every outbound datagram at that size, including
+%% short handshake packets, fallback sends, and any 1-RTT packet larger
+%% than the configured value, which the peer then cannot decode.
+maybe_enable_gso(#{gso_supported := true}) ->
+    true;
+maybe_enable_gso(_) ->
     false.
 
 maybe_enable_gro(Socket, #{gro_supported := true}) ->
@@ -823,7 +847,6 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
         backend = socket,
         owns_socket = true,
         gso_supported = GSOEnabled,
-        gso_size = maps:get(gso_size, BatchConfig),
         gro_enabled = false,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -893,7 +916,6 @@ build_genudp_state(Socket, BatchConfig) ->
         socket = Socket,
         backend = gen_udp,
         gso_supported = false,
-        gso_size = maps:get(gso_size, BatchConfig),
         gro_enabled = false,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -925,46 +947,57 @@ flush_gso(
     #socket_state{
         socket = Socket,
         batch_buffer = Buffer,
-        batch_addr = {IP, Port},
-        gso_size = SegmentSize
-    } = State
+        batch_addr = {IP, Port}
+    } = State,
+    SegmentSize
 ) ->
     %% Pass the batch as a multi-iov to socket:sendmsg/2. The kernel
     %% treats concatenated iov buffers as a single logical payload and
     %% segments at SegmentSize byte boundaries via the UDP_SEGMENT
     %% cmsg, so the wire bytes are identical to the old flatten-first
-    %% shape. We save a full user-space copy per flush (up to ~76 KB
-    %% at a 64-packet batch of 1200-byte segments).
+    %% shape. We save a full user-space copy per flush.
     Packets = lists:reverse(Buffer),
-    PacketIov = [normalize_packet(P) || P <- Packets],
-    Msg = #{
-        addr => #{family => family(IP), addr => IP, port => Port},
-        iov => PacketIov,
-        ctrl => [#{level => udp, type => ?UDP_SEGMENT, data => <<SegmentSize:16/native>>}]
-    },
-
-    case socket:sendmsg(Socket, Msg) of
+    Dest = #{family => family(IP), addr => IP, port => Port},
+    Chunks = chunk_packets(Packets, gso_segments_per_write(SegmentSize)),
+    case send_gso_chunks(Socket, Dest, SegmentSize, Chunks) of
         ok ->
-            {ok, record_flush(State)};
-        {ok, RestData} ->
-            flush_gso_partial(State, IP, Port, PacketIov, RestData);
+            {ok, record_gso_flush(State, SegmentSize)};
+        {partial, Sent, RestData, Unsent} ->
+            flush_gso_partial(State, IP, Port, SegmentSize, Sent, RestData, Unsent);
         {error, Reason} ->
             ?LOG_WARNING(#{what => gso_send_error, reason => Reason}),
             {error, Reason, clear_batch(State)}
     end.
 
+send_gso_chunks(_Socket, _Dest, _SegmentSize, []) ->
+    ok;
+send_gso_chunks(Socket, Dest, SegmentSize, [Chunk | Rest]) ->
+    PacketIov = [normalize_packet(P) || P <- Chunk],
+    Msg = #{
+        addr => Dest,
+        iov => PacketIov,
+        ctrl => [#{level => udp, type => ?UDP_SEGMENT, data => <<SegmentSize:16/native>>}]
+    },
+    case socket:sendmsg(Socket, Msg) of
+        ok -> send_gso_chunks(Socket, Dest, SegmentSize, Rest);
+        {ok, RestData} -> {partial, PacketIov, RestData, Rest};
+        {error, _} = Error -> Error
+    end.
+
 %% Partial GSO send: log, disable GSO on this socket, and retry the
-%% remaining bytes segment-by-segment.
-flush_gso_partial(State, IP, Port, PacketIov, RestData) ->
-    TotalBytes = iolist_size(PacketIov),
+%% unsent bytes segment-by-segment. `Unsent' holds whole chunks the
+%% kernel never saw, which must go out too or their packets are lost.
+flush_gso_partial(State, IP, Port, SegmentSize, Sent, RestData, Unsent) ->
+    TotalBytes = iolist_size(Sent),
     Remaining = iolist_size(RestData),
     ?LOG_WARNING(#{
         what => gso_partial_send,
         sent => TotalBytes - Remaining,
-        remaining => Remaining
+        remaining => Remaining + iolist_size(Unsent)
     }),
     State1 = clear_batch(State#socket_state{gso_supported = false}),
-    send_remaining_individually(State1, IP, Port, RestData).
+    Leftover = [RestData | [normalize_packet(P) || Chunk <- Unsent, P <- Chunk]],
+    send_remaining_individually(State1, IP, Port, SegmentSize, Leftover).
 
 flush_individual(#socket_state{backend = socket} = State) ->
     flush_individual_socket(State);
@@ -1036,7 +1069,7 @@ send_packets_genudp(Socket, IP, Port, [Packet | Rest], Sent) ->
 %% Send remaining data after GSO partial write (RestData is iolist)
 %% Split into segment-sized packets to preserve QUIC datagram boundaries
 send_remaining_individually(
-    #socket_state{socket = Socket, gso_size = SegmentSize} = State, IP, Port, RestData
+    #socket_state{socket = Socket} = State, IP, Port, SegmentSize, RestData
 ) ->
     Dest = #{family => family(IP), addr => IP, port => Port},
     Data = iolist_to_binary(RestData),
@@ -1163,6 +1196,13 @@ record_flush(
         batch_flushes = Flushes + 1,
         packets_coalesced = Coalesced + Count
     }.
+
+%% As record_flush/1, for a batch the kernel segmented. Records the
+%% segment size that went on the wire so `info/1' reports what was
+%% actually used rather than a configured guess.
+record_gso_flush(#socket_state{gso_flushes = GSOFlushes} = State, SegmentSize) ->
+    State1 = record_flush(State),
+    State1#socket_state{gso_flushes = GSOFlushes + 1, gso_size = SegmentSize}.
 
 %% Get address family
 family({_, _, _, _}) -> inet;

--- a/test/quic_server_batching_SUITE.erl
+++ b/test/quic_server_batching_SUITE.erl
@@ -176,20 +176,26 @@ server_download_uses_gso_on_linux(Config) ->
 
                 Flushes = maps:get(batch_flushes, Delta),
                 Coalesced = maps:get(packets_coalesced, Delta),
+                GSOFlushes = maps:get(gso_flushes, Delta),
                 Ratio =
                     case Flushes of
                         0 -> 0.0;
                         _ -> Coalesced / Flushes
                     end,
                 ct:log(
-                    "GSO delta: flushes=~p coalesced=~p ratio=~.2f",
-                    [Flushes, Coalesced, float(Ratio)]
+                    "GSO delta: flushes=~p coalesced=~p gso_flushes=~p ratio=~.2f",
+                    [Flushes, Coalesced, GSOFlushes, float(Ratio)]
                 ),
                 %% On Linux + GSO the download-path batches should
                 %% coalesce significantly. A ratio > 1.5 proves real
                 %% coalescing on top of the Coalesced > Flushes check.
                 ?assert(Coalesced > Flushes),
-                ?assert(Ratio > 1.5)
+                ?assert(Ratio > 1.5),
+                %% Coalescing alone only proves packets were batched:
+                %% both flush paths bump those counters. gso_flushes
+                %% counts the batches the kernel actually segmented, so
+                %% this is what fails if the GSO path stops running.
+                ?assert(GSOFlushes > 0)
             after
                 stop_server(Srv)
             end,
@@ -297,7 +303,7 @@ stats_delta(After, Before) ->
     maps:from_list(
         [
             {K, maps:get(K, After, 0) - maps:get(K, Before, 0)}
-         || K <- [packets_sent, batch_flushes, packets_coalesced]
+         || K <- [packets_sent, batch_flushes, packets_coalesced, gso_flushes]
         ]
     ).
 

--- a/test/quic_socket_tests.erl
+++ b/test/quic_socket_tests.erl
@@ -333,6 +333,10 @@ info_reports_config_and_counters_test() ->
     ?assertEqual(0, maps:get(packets_coalesced, Info)),
     ?assertEqual(true, maps:get(batching_enabled, Info)),
     ?assertEqual(16, maps:get(max_batch_packets, Info)),
+    %% Segment size is per-flush telemetry now, not configuration: it
+    %% reports what the kernel was told, and there has been no flush.
+    ?assertEqual(0, maps:get(gso_size, Info)),
+    ?assertEqual(0, maps:get(gso_flushes, Info)),
 
     ok = quic_socket:close(State).
 
@@ -367,6 +371,9 @@ batch_counters_advance_on_flush_test() ->
     Info = quic_socket:info(S4),
     ?assertEqual(1, maps:get(batch_flushes, Info)),
     ?assertEqual(3, maps:get(packets_coalesced, Info)),
+    %% A batch that went out packet by packet must not be reported as
+    %% offloaded; batch_flushes alone cannot tell the two apart.
+    ?assertEqual(0, maps:get(gso_flushes, Info)),
 
     ok = quic_socket:close(S4).
 


### PR DESCRIPTION
Fixes #196.

The GSO path never ran: the uniformity check compared every packet against a `gso_size` that no caller sets, so it stayed at the 1200 default while 1-RTT packets follow the current max datagram size. Deriving the size from the batch is the only value that can be right.

That alone is not enough to turn it on. `flush_gso/1` also read the segment size from the record rather than from the batch, so making the check pass still told the kernel to cut at 1200 in the middle of 1398-byte packets, which is the `idle_timeout` reported in the issue. The listener path also set a socket-level `UDP_SEGMENT`, which segments every datagram including handshake packets; GSO is now requested per message only, as `build_socket_state` already documented.

CI could not catch any of this because `batch_flushes` and `packets_coalesced` advance on the individual path too, so the download test's ratio measured batching rather than offload. `gso_flushes` counts only the batches the kernel segmented, and the Linux job now asserts it advanced.

@jbevemyr this is your report; if you can retest on your setup that would be welcome, since the maintainer's machine cannot exercise the path.