### PR TITLE
GRO: accept the int-sized UDP_GRO cmsg payload

### DIFF
--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -1208,7 +1208,14 @@ recv_gro(Socket, Timeout) ->
 
 extract_gro_segment_size([]) ->
     undefined;
-extract_gro_segment_size([#{level := udp, type := ?UDP_GRO, data := <<Size:16/native>>} | _]) ->
+extract_gro_segment_size([
+    #{level := udp, type := ?UDP_GRO, data := <<Size:16/native, _/binary>>} | _
+]) ->
+    %% The kernel's UDP_GRO cmsg payload is an int (4 bytes); matching
+    %% exactly 2 bytes made every lookup fail, so a GRO-coalesced buffer
+    %% was passed up unsplit as one giant datagram and dropped by the
+    %% QUIC layer (short-header packets cannot be re-split). Accept the
+    %% int and read the low 16 bits.
     Size;
 extract_gro_segment_size([_ | Rest]) ->
     extract_gro_segment_size(Rest).


### PR DESCRIPTION
The one-line fix from the #196 retest, as its own PR: `extract_gro_segment_size/1` matched exactly two bytes of cmsg data, but the kernel delivers the segment size as a native int, so the match always failed and GRO-coalesced buffers were passed up unsplit (and dropped - a short-header packet consumes the rest of the datagram, so merged 1-RTT flights cannot be recovered). Verified end to end in the #196 setup: the previously 0/7-failing netem transfer path went 8/8 with this fix on top of #200. Independent of #200 (the parse bug exists regardless), but only observable once a peer's GSO actually engages.