### PR TITLE
Fix async-send data loss and a send-queue ordering deadlock

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8476,7 +8476,15 @@ queue_stream_data(
     } = State,
     Where
 ) ->
-    DataSize = iolist_size(Data),
+    %% Normalise to a binary: consumers like
+    %% dequeue_small_stream_frame_tuple/1 hand the entry's data straight
+    %% to quic_frame:encode/1, which requires a binary.
+    DataBin =
+        case is_binary(Data) of
+            true -> Data;
+            false -> iolist_to_binary(Data)
+        end,
+    DataSize = byte_size(DataBin),
     NewQueueBytes = QueueBytes + DataSize,
     case NewQueueBytes > ?MAX_SEND_QUEUE_BYTES of
         true ->
@@ -8494,7 +8502,7 @@ queue_stream_data(
         false ->
             Urgency = get_stream_urgency(StreamId, Streams),
             %% Cache DataSize in entry to avoid repeated iolist_size calls
-            Entry = {stream_data, StreamId, Offset, Data, Fin, DataSize},
+            Entry = {stream_data, StreamId, Offset, DataBin, Fin, DataSize},
             NewPQ =
                 case Where of
                     back -> pqueue_in(Entry, Urgency, PQ);

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8209,14 +8209,23 @@ do_send_datagram(
 %% subsequent chunking reuses the same binary via sub-binary slices and
 %% downstream helpers can rely on the binary invariant without re-flattening.
 send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State) ->
+    send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, back).
+
+%% Where selects the queue position when a congestion/pacing block forces
+%% the unsent remainder back onto the send queue: `back' for fresh sends
+%% (their offset is highest, so appending keeps per-stream offset order),
+%% `front' when draining the queue (the popped entry's remainder must go
+%% back in front of higher-offset entries, or a later flow-control block
+%% at the head strands it behind them, leaving a permanent data hole).
+send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, Where) ->
     DataBin =
         case is_binary(Data) of
             true -> Data;
             false -> iolist_to_binary(Data)
         end,
-    send_stream_data_fragmented_tracked(StreamId, Offset, DataBin, Fin, State, 0).
+    send_stream_fragments(StreamId, Offset, DataBin, Fin, State, 0, Where).
 
-send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, BytesSentSoFar) when
+send_stream_fragments(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where) when
     is_binary(Data)
 ->
     %% Calculate max chunk size based on current PMTU
@@ -8225,15 +8234,17 @@ send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, BytesSen
 
     case DataSize =< MaxChunkSize of
         true ->
-            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where);
         false ->
             %% Data is already a flat binary; chunk via sub-binary slices.
-            send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize)
+            send_stream_chunked(
+                StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize, Where
+            )
     end.
 
 %% @doc Send stream data that fits in a single packet.
 %% Data is a binary (normalised by send_stream_data_fragmented_tracked/5).
-send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) when
+send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where) when
     is_binary(Data)
 ->
     #state{cc_state = CCState, pacing_enabled = PacingEnabled, streams = Streams} = State,
@@ -8265,7 +8276,7 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) wh
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     PacedState = maybe_set_pacing_timer(Delay, QueuedState),
                     {PacedState, BytesSentSoFar};
@@ -8285,7 +8296,7 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) wh
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     {QueuedState, BytesSentSoFar};
                 {error, send_queue_full} ->
@@ -8325,7 +8336,7 @@ cwnd_only_check(CCState, Size, Urgency) ->
 %% send_stream_data_fragmented_tracked/6. For a 10 MB upload this cuts
 %% thousands of get_stream_urgency/2 / get_max_stream_data_per_packet/1
 %% calls and record-pattern matches out of the hot send loop.
-send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize) ->
+send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize, Where) ->
     Urgency = get_stream_urgency(StreamId, State#state.streams),
     PacketSize = MaxChunkSize + ?PACKET_OVERHEAD,
     %% Pre-compute the stream-frame header parts that stay constant
@@ -8336,7 +8347,7 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
     LengthVarint = quic_varint:encode(MaxChunkSize),
     HeaderPrefix =
         <<(?FRAME_STREAM bor ?STREAM_FLAG_OFF bor ?STREAM_FLAG_LEN):8, StreamIdVarint/binary>>,
-    Ctx = {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint},
+    Ctx = {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where},
     send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx).
 
 %% Inner chunked-send loop. Cached values in `Ctx' never change within a
@@ -8344,17 +8355,17 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
 %% `send_stream_single_packet/6' so a partial last chunk gets a correctly
 %% sized packet (Length != MaxChunkSize) and can also carry a FIN.
 send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, _HeaderPrefix, _LengthVarint} = Ctx,
+    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, _HeaderPrefix, _LengthVarint, Where} = Ctx,
     DataSize = byte_size(Data),
     case DataSize =< MaxChunkSize of
         true ->
-            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where);
         false ->
             send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx)
     end.
 
 send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint} = Ctx,
+    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where} = Ctx,
     #state{cc_state = CCState, pacing_enabled = PacingEnabled} = State,
     Check =
         case PacingEnabled of
@@ -8387,7 +8398,7 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     PacedState = maybe_set_pacing_timer(Delay, QueuedState),
                     {PacedState, BytesSentSoFar};
@@ -8409,7 +8420,7 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     % Return bytes sent so far
                     {QueuedState, BytesSentSoFar};
@@ -8448,6 +8459,9 @@ queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
 
 %% Entry format: {stream_data, StreamId, Offset, Data, Fin, DataSize}
 %% DataSize is cached to avoid repeated iolist_size calls
+queue_stream_data(StreamId, Offset, Data, Fin, State) ->
+    queue_stream_data(StreamId, Offset, Data, Fin, State, back).
+
 queue_stream_data(
     StreamId,
     Offset,
@@ -8459,7 +8473,8 @@ queue_stream_data(
         send_queue_bytes = QueueBytes,
         send_queue_count = QueueCount,
         send_queue_version = Version
-    } = State
+    } = State,
+    Where
 ) ->
     DataSize = iolist_size(Data),
     NewQueueBytes = QueueBytes + DataSize,
@@ -8480,7 +8495,11 @@ queue_stream_data(
             Urgency = get_stream_urgency(StreamId, Streams),
             %% Cache DataSize in entry to avoid repeated iolist_size calls
             Entry = {stream_data, StreamId, Offset, Data, Fin, DataSize},
-            NewPQ = pqueue_in(Entry, Urgency, PQ),
+            NewPQ =
+                case Where of
+                    back -> pqueue_in(Entry, Urgency, PQ);
+                    front -> pqueue_in_front(Entry, Urgency, PQ)
+                end,
             NewVersion = Version + 1,
             {ok, State#state{
                 send_queue = NewPQ,
@@ -8612,7 +8631,7 @@ process_send_queue_entry(
                 send_queue_bytes = DecrementedQueueBytes,
                 send_queue_count = DecrementedQueueCount
             },
-            case send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State1) of
+            case send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State1, front) of
                 {error, send_queue_full} ->
                     ?LOG_WARNING(
                         #{
@@ -8662,6 +8681,16 @@ process_send_queue_entry(
 pqueue_in(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
     Bucket = element(Urgency + 1, PQ),
     NewBucket = queue:in(Entry, Bucket),
+    setelement(Urgency + 1, PQ, NewBucket).
+
+%% Insert at the front of the urgency bucket. Used when a drain pops an
+%% entry and must put back an unsent remainder: appending it at the back
+%% would order it behind higher-offset entries of the same stream, and a
+%% later stream-flow-control block at the head then strands it forever
+%% (the peer cannot extend the window across the resulting data hole).
+pqueue_in_front(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
+    Bucket = element(Urgency + 1, PQ),
+    NewBucket = queue:in_r(Entry, Bucket),
     setelement(Urgency + 1, PQ, NewBucket).
 
 %% Remove and return highest priority (lowest urgency) entry
@@ -9475,6 +9504,9 @@ defer_retransmit_frames(Frames, State) ->
 %% Queue a lost STREAM frame for retransmission. Exempt from flow control and
 %% data_sent (those were counted on the original send); bytes/count/version are
 %% updated like queue_stream_data/5 so the drain and reclaim-gate scans see it.
+%% Front-inserted: retransmits fill receiver-side holes, so they must not sit
+%% behind a flow-control-blocked head whose window can only grow once the hole
+%% is filled.
 enqueue_retransmit_stream(StreamId, Offset, Data, Fin, State) ->
     #state{
         send_queue = PQ,
@@ -9487,7 +9519,7 @@ enqueue_retransmit_stream(StreamId, Offset, Data, Fin, State) ->
     Urgency = get_stream_urgency(StreamId, Streams),
     Entry = {retransmit_stream, StreamId, Offset, Data, Fin, DataSize},
     State#state{
-        send_queue = pqueue_in(Entry, Urgency, PQ),
+        send_queue = pqueue_in_front(Entry, Urgency, PQ),
         send_queue_bytes = QueueBytes + DataSize,
         send_queue_count = QueueCount + 1,
         send_queue_version = Version + 1

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2501,6 +2501,33 @@ handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
     {keep_state, State};
+%% Async sends can arrive before the state machine reaches `connected':
+%% the owner is told `connected' a flight before the server confirms, and
+%% send_data_async is fire-and-forget so the caller cannot retry. Queue
+%% them like the synchronous handshaking-state path does (flushed by
+%% send_pending_data/2 on entering `connected'); falling through to the
+%% catch-all below silently loses the data.
+handle_common_event(
+    cast,
+    {send_data_async, StreamId, Data, Fin},
+    StateName,
+    #state{pending_data = Pending} = State
+) ->
+    case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
+        true ->
+            ?LOG_WARNING(
+                #{
+                    what => async_send_dropped_pending_limit,
+                    state => StateName,
+                    stream_id => StreamId
+                },
+                ?QUIC_LOG_META
+            ),
+            {keep_state, State};
+        false ->
+            NewPending = Pending ++ [{StreamId, Data, Fin}],
+            {keep_state, State#state{pending_data = NewPending}}
+    end;
 %% Return error for unhandled calls to prevent timeout
 handle_common_event({call, From}, _Request, StateName, State) ->
     {keep_state, State, [{reply, From, {error, {invalid_state, StateName}}}]};
@@ -7825,8 +7852,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.12: DATA_BLOCKED reports the connection data limit
                             BlockedFrame = {data_blocked, MaxDataRemote},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, connection}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {_, false} ->
                             %% Stream-level flow control blocked
                             %% RFC 9000: Don't queue data beyond flow control limits.
@@ -7843,8 +7870,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.13: STREAM_DATA_BLOCKED reports the stream data limit
                             BlockedFrame = {stream_data_blocked, StreamId, SendMaxData},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, {stream, StreamId}}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {true, true} ->
                             %% Flow control allows sending
                             %% Fragment and send data - congestion control may partially
@@ -8394,6 +8421,31 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
 %% Queue stream data when congestion window is full
 %% Uses bucket-based priority queue for O(1) insert (RFC 9218)
 %% Returns {ok, State} | {error, send_queue_full} if queue limit exceeded
+%% Flow-control-blocked sends are queued rather than dropped and are
+%% retried by process_send_queue/1 when MAX_DATA / MAX_STREAM_DATA
+%% arrives. Returning an error here silently loses data for
+%% send_data_async callers, which have no way to retry: the send offset
+%% stays untouched, so later sends close the gap at the QUIC layer while
+%% the application stream is missing a chunk. The offset is advanced
+%% when queueing so subsequent sends on the stream order consistently
+%% behind this entry; QUIC reassembly is offset-based, so transmission
+%% order across entries does not matter.
+queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
+    case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+        {ok, QState} ->
+            case maps:find(StreamId, QState#state.streams) of
+                {ok, Stream} ->
+                    NewStream = Stream#stream_state{send_offset = Offset + DataSize},
+                    {ok, QState#state{
+                        streams = maps:put(StreamId, NewStream, QState#state.streams)
+                    }};
+                error ->
+                    {ok, QState}
+            end;
+        {error, send_queue_full} = Error ->
+            Error
+    end.
+
 %% Entry format: {stream_data, StreamId, Offset, Data, Fin, DataSize}
 %% DataSize is cached to avoid repeated iolist_size calls
 queue_stream_data(


### PR DESCRIPTION
Two related data-loss/deadlock bugs in the send path, found while running this library as the QUIC client against an msquic server under sustained bulk load with `{return, async}`-style fire-and-forget sends.

## 1. Async sends silently dropped (`d2bdd4b`)

`send_data_async/4` is fire-and-forget, but two paths returned errors that no caller can see:

- **Flow-control blocked** (connection or stream level): `do_send_data` returned `{error, {flow_control_blocked, _}}` and dropped the payload. The stream's `send_offset` advances on the next send, so the peer sees a clean, contiguous stream with a chunk of application data simply missing — silent corruption rather than a visible failure. Fixed by queueing the data on the send queue (the DATA_BLOCKED / STREAM_DATA_BLOCKED frame is still emitted) and letting `process_send_queue/1` retry when MAX_DATA / MAX_STREAM_DATA arrives. `send_offset` is advanced at queue time so later sends order behind the queued entry; reassembly is offset-based, so cross-entry transmission order stays correct.

- **Cast arriving before `connected`**: the owner learns `connected` a flight before the server's confirmation transitions the state machine, so an immediate `send_data_async` could hit `handshaking` and fall into the catch-all, which dropped it. Queued into `pending_data` like the synchronous handshaking-state clause (flushed on entering `connected`).

## 2. Requeue ordering deadlock (`caa5dd5`)

When a send-queue drain pops an entry and congestion control or pacing blocks mid-entry, the unsent remainder was re-queued at the **back** of its urgency bucket — behind higher-offset entries of the same stream. The drain then transmits those higher offsets, the receiver buffers them out of order behind the hole, and once the queue head reaches the stream flow-control limit the drain stops permanently: the peer cannot extend a window that tracks contiguous delivery (stuck at the hole), and the only entry that could fill the hole is unreachable behind the blocked head. The connection deadlocks with the sender showing `in_flight = 0` and everything acked.

We caught this on the wire against msquic: a single entry-sized hole (e.g. `[133426,137580)`) never transmitted, ~126 KB beyond it delivered and buffered, and the peer's frozen `MAX_STREAM_DATA` grant equal to hole base + receive window exactly (264498 = 133426 + 131072).

Fix: a `pqueue_in_front/3` primitive; drain remainders are front-inserted, preserving per-stream offset order (fresh sends keep appending at the back — their offset is always highest). Lost-frame retransmits (`enqueue_retransmit_stream`) are front-inserted for the same reason: they exist to fill receiver-side holes, so they must not queue behind a flow-control-blocked head whose window can only grow once the hole is filled.

## Validation

- `rebar3 eunit` 2263/2263, `dialyzer`, `xref`, `lint`, `fmt --check` all clean.
- Application-level soak (volga event streaming, this library as client vs msquic 2.4 server, multi-MB topic replication): the bulk-transfer stall reproduced ~100% before, 5/5 clean runs after.

Independent of #203/#204 (applies directly to main); the fixes also compose with the coalescing branch.
