### PR TITLE
Hibernate idle connection processes

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -711,7 +711,7 @@ start_link(Host, Port, Opts, Owner) ->
     gen_udp:socket() | undefined
 ) -> {ok, pid()} | {error, term()}.
 start_link(Host, Port, Opts, Owner, Socket) ->
-    gen_statem:start_link(?MODULE, [Host, Port, Opts, Owner, Socket], []).
+    gen_statem:start_link(?MODULE, [Host, Port, Opts, Owner, Socket], statem_opts(Opts)).
 
 %% @doc Initiate a connection to a QUIC server.
 %% This is a convenience wrapper that starts the process and initiates handshake.
@@ -734,7 +734,22 @@ connect(Host, Port, Opts, Owner) ->
 %% Called by quic_listener when a new connection is accepted.
 -spec start_server(map()) -> {ok, pid()} | {error, term()}.
 start_server(Opts) ->
-    gen_statem:start_link(?MODULE, {server, Opts}, []).
+    gen_statem:start_link(?MODULE, {server, Opts}, statem_opts(Opts)).
+
+%% An idle connection process never garbage-collects on its own, so the
+%% garbage produced by the handshake (~170 KiB measured) stays pinned to
+%% its heap indefinitely; with tens of thousands of mostly-idle
+%% connections that dominates the VM footprint. Hibernating after a
+%% quiet period runs a fullsweep GC and shrinks the process to a few
+%% KiB. Busy connections are unaffected (the timer only fires after
+%% `hibernate_after' ms without any event).
+statem_opts(Opts) ->
+    case maps:get(hibernate_after, Opts, 5000) of
+        infinity ->
+            [];
+        T when is_integer(T), T > 0 ->
+            [{hibernate_after, T}]
+    end.
 
 %% @doc Send data on a stream.
 -spec send_data(pid(), non_neg_integer(), iodata(), boolean()) ->


### PR DESCRIPTION
An idle gen_statem never garbage-collects on its own, so every connection keeps the garbage produced by its handshake pinned to the process heap indefinitely. Measured with 300 idle established connections per side (loopback, in-VM echo server): **~177 KiB per server connection** (~164 KiB client) sitting idle after the handshake, against ~7 KiB of live state. On a server holding tens of thousands of mostly-idle connections this dominates the VM footprint — roughly 9 GB of dead heap at 50k connections.

This starts the connection statem with `{hibernate_after, T}`: a connection with no event for T ms hibernates (fullsweep GC, stack released, heap compacted to live state). Measured effect on the same bench:

| | before | after |
|---|---|---|
| avg server conn process | 177.4 KiB | **7.7 KiB** (23x) |
| avg client conn process | 164.3 KiB | 7.0 KiB |
| VM growth, 600 idle conns | 117 MB | 12.5 MB |

Busy connections never reach the timer, so throughput is unaffected; a hibernated connection wakes on any event at microsecond cost. T comes from a new `hibernate_after` connection/server option (default 5000 ms, `infinity` disables).

`rebar3 eunit` 2263/2263, `dialyzer`, `fmt --check` clean; also validated under our application integration suites (bulk transfer and API tests green with the change).

Possible follow-up (not in this PR): the remaining ~7 KiB of live state still carries handshake-era fields — `initial_keys`/`handshake_keys` (RFC 9001 §4.9 says to discard these after the handshake), the CRYPTO reassembly buffer, and the Initial/Handshake packet-number spaces. Dropping them post-handshake would shave another ~2-3 KiB per connection and improve spec hygiene.