### PR TITLE
Give up on an unresponsive peer with a disconnect timeout

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -491,6 +491,13 @@
     keep_alive_interval :: non_neg_integer() | disabled,
     keep_alive_timer :: reference() | undefined,
 
+    %% Give up on an unresponsive peer: close the connection when
+    %% ack-eliciting data has been in flight with no ACK for this long
+    %% (RFC 9000 permits idle-timeout-only, but a stateless-reset-blind
+    %% peer then lingers for the whole idle timeout; msquic uses a 16 s
+    %% disconnect timeout for the same reason).
+    disconnect_timeout = 16000 :: pos_integer() | infinity,
+
     %% Pacing (RFC 9002 Section 7.7)
     pacing_timer :: reference() | undefined,
     pacing_enabled = true :: boolean(),
@@ -1172,6 +1179,7 @@ init({server, Opts}) ->
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeout,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeout),
+        disconnect_timeout = disconnect_timeout_opt(Opts),
         keep_alive_timer = undefined,
         last_activity = erlang:monotonic_time(millisecond),
         cc_state = CCState,
@@ -1551,6 +1559,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeoutClient,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeoutClient),
+        disconnect_timeout = disconnect_timeout_opt(Opts),
         keep_alive_timer = undefined,
         last_activity = erlang:monotonic_time(millisecond),
         cc_state = CCState,
@@ -2410,9 +2419,28 @@ handle_common_event(cast, handle_timeout, _StateName, State) ->
 handle_common_event(info, {pto_timeout, Ref}, StateName, #state{pto_timer = Ref} = State) when
     Ref =/= undefined andalso (StateName =:= connected orelse StateName =:= handshaking)
 ->
-    %% Handle PTO timeout - send probe packet
-    NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
-    {keep_state, NewState};
+    case disconnect_timeout_expired(State) of
+        true ->
+            %% The peer has not acknowledged anything for the whole
+            %% disconnect timeout while we had data in flight: declare
+            %% it dead instead of probing until the idle timeout. This
+            %% is how a client escapes a restarted peer whose stateless
+            %% resets it cannot recognise.
+            ?LOG_NOTICE(
+                #{
+                    what => disconnect_timeout,
+                    in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
+                    pto_count => quic_loss:pto_count(State#state.loss_state)
+                },
+                ?QUIC_LOG_META
+            ),
+            NewState = initiate_close(disconnect_timeout, State#state{pto_timer = undefined}),
+            {next_state, draining, NewState};
+        false ->
+            %% Handle PTO timeout - send probe packet
+            NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
+            {keep_state, NewState}
+    end;
 handle_common_event(info, {pto_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale PTO timer (ref doesn't match or wrong state)
     {keep_state, State};
@@ -9667,6 +9695,26 @@ query_local_addr(Socket) ->
     case inet:sockname(Socket) of
         {ok, Sockname} -> Sockname;
         {error, _} -> undefined
+    end.
+
+disconnect_timeout_expired(#state{disconnect_timeout = infinity}) ->
+    false;
+disconnect_timeout_expired(#state{disconnect_timeout = DT, loss_state = LossState}) ->
+    quic_loss:bytes_in_flight(LossState) > 0 andalso
+        case quic_loss:last_progress(LossState) of
+            undefined ->
+                false;
+            T ->
+                erlang:monotonic_time(millisecond) - T >= DT
+        end.
+
+%% Disconnect-timeout option: how long ack-eliciting data may stay in
+%% flight without any ACK before the peer is declared dead.
+disconnect_timeout_opt(Opts) ->
+    case maps:get(disconnect_timeout, Opts, 16000) of
+        infinity -> infinity;
+        T when is_integer(T), T >= 1000 -> T;
+        _ -> 16000
     end.
 
 calculate_keep_alive_interval(Opts, IdleTimeout) ->

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -61,6 +61,7 @@
     %% Queries
     sent_packets/1,
     bytes_in_flight/1,
+    last_progress/1,
     pto_count/1,
     oldest_unacked/1,
     has_rtt_sample/1
@@ -100,6 +101,12 @@
     %% Loss detection
     loss_time = undefined :: non_neg_integer() | undefined,
     time_of_last_ack = undefined :: non_neg_integer() | undefined,
+
+    %% When the current outstanding burst started: set whenever an
+    %% ack-eliciting packet is sent while nothing was in flight. Used
+    %% together with time_of_last_ack as the anchor for the disconnect
+    %% timeout, so a fresh send after a quiet period cannot trip it.
+    outstanding_since = undefined :: non_neg_integer() | undefined,
 
     %% PTO
     pto_count = 0 :: non_neg_integer(),
@@ -191,12 +198,18 @@ on_packet_sent(
             true -> InFlight + Size;
             false -> InFlight
         end,
+    OutstandingSince =
+        case AckEliciting andalso InFlight =:= 0 of
+            true -> Now;
+            false -> State#loss_state.outstanding_since
+        end,
     %% NOTE: pto_count is NOT reset here per RFC 9002.
     %% PTO count is only reset when receiving an ACK (in on_ack_received).
     %% Resetting on send would break exponential backoff for probe retransmissions.
     State#loss_state{
         sent_q = queue:in(SentPacket, Q),
-        bytes_in_flight = NewInFlight
+        bytes_in_flight = NewInFlight,
+        outstanding_since = OutstandingSince
     }.
 
 %% @doc Process an ACK frame.
@@ -523,6 +536,14 @@ bytes_in_flight(#loss_state{bytes_in_flight = B}) -> B.
 %% @doc Get current PTO count.
 -spec pto_count(loss_state()) -> non_neg_integer().
 pto_count(#loss_state{pto_count = C}) -> C.
+
+%% @doc Latest sign of forward progress for the disconnect timeout: the
+%% last received ACK, or the start of the current outstanding burst,
+%% whichever is later. undefined until either has happened.
+-spec last_progress(loss_state()) -> non_neg_integer() | undefined.
+last_progress(#loss_state{time_of_last_ack = undefined, outstanding_since = O}) -> O;
+last_progress(#loss_state{time_of_last_ack = A, outstanding_since = undefined}) -> A;
+last_progress(#loss_state{time_of_last_ack = A, outstanding_since = O}) -> max(A, O).
 
 %% @doc Get the oldest unacked packet (for PTO probe selection).
 %% Returns {ok, #sent_packet{}} or none. Head of the sent queue is

--- a/test/quic_server_e2e_SUITE.erl
+++ b/test/quic_server_e2e_SUITE.erl
@@ -30,7 +30,8 @@
     listener_start_stop/1,
     listener_get_port/1,
     server_connection_batches_by_default/1,
-    server_connection_batching_opt_out/1
+    server_connection_batching_opt_out/1,
+    disconnect_timeout_on_unresponsive_peer/1
 ]).
 
 %%====================================================================
@@ -49,7 +50,8 @@ groups() ->
             listener_start_stop,
             listener_get_port,
             server_connection_batches_by_default,
-            server_connection_batching_opt_out
+            server_connection_batching_opt_out,
+            disconnect_timeout_on_unresponsive_peer
         ]}
     ].
 
@@ -177,6 +179,50 @@ server_connection_batching_opt_out(Config) ->
         ?assertEqual(false, maps:get(send_batching_enabled, Info)),
         ?assertEqual(false, maps:get(send_gso_supported, Info)),
         quic:close(Conn)
+    after
+        quic_test_echo_server:stop(Echo)
+    end,
+    Config.
+
+%% A peer that stops responding while we have data in flight must be
+%% declared dead by the disconnect timeout, well before the idle
+%% timeout. A restarted peer's stateless resets are unrecognisable
+%% (issue #202), so without this the connection lingers for the whole
+%% idle timeout.
+disconnect_timeout_on_unresponsive_peer(Config) ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    #{name := Name, port := Port} = Echo,
+    try
+        Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+            disconnect_timeout => 2000,
+            idle_timeout => 60000
+        }),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, Opts, self()),
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 5000 ->
+            ct:fail("client handshake timed out")
+        end,
+        {ok, [ServerPid | _]} = quic:get_server_connections(Name),
+        %% Freeze the server side: packets pile up in its mailbox but
+        %% nothing is processed or acknowledged.
+        ok = sys:suspend(ServerPid),
+        {ok, Sid} = quic:open_stream(Conn),
+        ok = quic:send_data(Conn, Sid, <<"are you there?">>, false),
+        T0 = erlang:monotonic_time(millisecond),
+        Reason =
+            receive
+                {quic, Conn, {closed, R}} -> R
+            after 20000 ->
+                ct:fail("connection not closed by disconnect timeout")
+            end,
+        Elapsed = erlang:monotonic_time(millisecond) - T0,
+        ct:log("closed after ~b ms with reason ~p", [Elapsed, Reason]),
+        %% Must fire on the 2 s disconnect timeout (plus PTO cadence),
+        %% far below the 60 s idle timeout.
+        ?assertEqual(disconnect_timeout, Reason),
+        ?assert(Elapsed < 15000),
+        ok = sys:resume(ServerPid)
     after
         quic_test_echo_server:stop(Echo)
     end,


### PR DESCRIPTION
Fixes #202.

A connection whose peer stops responding while ack-eliciting data is in flight previously lived until the idle timeout, sending PTO probes into the void the whole time. The common way to get such a peer is a restart: RFC 9000 stateless resets require the exact token, and peers that derive reset tokens from per-process state (msquic does) send resets the surviving side can never recognise - so it correctly ignores them and hangs for the full idle timeout, tens of seconds of blackout for the application. msquic escapes the same situation with its 16 s disconnect timeout.

This adds the same mechanism:

- When a PTO fires with data in flight and the last forward progress is more than `disconnect_timeout` ms ago, the connection closes and the owner is notified with reason `disconnect_timeout`.
- Forward progress = the last received ACK **or** the start of the current outstanding burst (tracked in `quic_loss` as `outstanding_since`, set when an ack-eliciting packet is sent while nothing was in flight) - so a fresh send after a long quiet period cannot trip the timeout with a stale ACK timestamp.
- New connection option `disconnect_timeout`, default 16000 ms, `infinity` disables and restores the old behaviour. Idle connections are unaffected: with nothing in flight the check never applies.

Includes an e2e test that freezes the server-side connection process and asserts the client closes with reason `disconnect_timeout` in ~3 s (2 s timeout + PTO cadence) instead of waiting out a 60 s idle timeout.

`rebar3 eunit` 2263/2263, `ct --suite=quic_server_e2e_SUITE` 5/5, `dialyzer`, `fmt --check` clean.