### PR TITLE
Fix MAX_DATA update trigger to use remaining headroom

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -6687,9 +6687,12 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                     recv_max_data = NewMaxStreamData
                                 },
                                 MaxStreamDataFrame = {max_stream_data, StreamId, NewMaxStreamData},
-                                %% Update cached max stream recv window
+                                %% Cache the granted window *size* (not the
+                                %% absolute limit) for the connection-window
+                                %% multiplier below.
                                 NewCachedMax = max(
-                                    NewMaxStreamData, State1#state.fc_max_stream_recv_window
+                                    NewMaxStreamData - NewRecvOffset,
+                                    State1#state.fc_max_stream_recv_window
                                 ),
                                 State1a = State1#state{
                                     streams = maps:put(StreamId, UpdatedStream, Streams),
@@ -6701,12 +6704,16 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                 State1
                         end,
 
-                    %% Check if we need to send MAX_DATA for connection-level flow control
-                    %% Send when we've consumed more than 50% of our advertised connection window
-                    %% RTT-based auto-tuning with connection/stream multiplier enforcement
+                    %% Check if we need to send MAX_DATA for connection-level flow
+                    %% control. Trigger on remaining headroom (limit - received),
+                    %% like the per-stream update above: comparing cumulative
+                    %% received bytes against the absolute limit becomes
+                    %% permanently true once total received exceeds one window,
+                    %% spraying an ack-eliciting MAX_DATA on every packet.
                     MaxDataLocalVal = State2#state.max_data_local,
+                    ConnHeadroom = max(0, MaxDataLocalVal - NewDataReceivedVal),
                     State3 =
-                        case NewDataReceivedVal > (MaxDataLocalVal div 2) of
+                        case ConnHeadroom < (State2#state.fc_max_receive_window div 2) of
                             true ->
                                 Now2 = erlang:monotonic_time(millisecond),
                                 SmoothedRTT2 = quic_loss:smoothed_rtt(State2#state.loss_state),
@@ -6730,11 +6737,15 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                     InitialConnWindow,
                                     FastConsumption2
                                 ),
-                                %% Ensure connection window >= 1.5x largest stream window
+                                %% Ensure connection window >= 1.5x largest stream
+                                %% window. MaxStreamWindow is a window size; anchor
+                                %% it at the delivered offset to compare limits.
                                 MaxStreamWindow = get_max_stream_recv_window(State2),
-                                MinConnWindow = trunc(
-                                    MaxStreamWindow * ?CONNECTION_FLOW_CONTROL_MULTIPLIER
-                                ),
+                                MinConnWindow =
+                                    NewDataReceivedVal +
+                                        trunc(
+                                            MaxStreamWindow * ?CONNECTION_FLOW_CONTROL_MULTIPLIER
+                                        ),
                                 NewMaxData = max(BaseNewMaxData, MinConnWindow),
                                 MaxDataFrame = {max_data, NewMaxData},
                                 State2a = send_frame(MaxDataFrame, State2),


### PR DESCRIPTION
The connection-level flow control update fired when cumulative bytes received exceeded half the absolute limit (`data_received > max_data_local div 2`). Since the limit slides forward as `received + window`, that condition becomes *permanently true* once a connection has received more than one `max_receive_window` of data: from that point every received packet triggers an ack-eliciting MAX_DATA frame.

On a 200 MiB single-stream transfer this produced ~66k MAX_DATA frames, each of which the peer also had to ACK — the reverse-path chatter roughly halved bulk throughput (and explains why throughput degraded with transfer size: 50 MiB transfers stay mostly under one window and don't hit it).

This PR:

* triggers the update on remaining headroom (`limit - received < window/2`), mirroring the per-stream MAX_STREAM_DATA check;
* fixes the connection/stream window multiplier to compare like quantities: `fc_max_stream_recv_window` now caches the granted window *size* rather than an absolute stream offset, and the 1.5x minimum is anchored at the delivered offset. Previously the minimum was computed from an absolute stream limit, which inflated the connection limit to ~1.5x of all data ever received and effectively unbounded the receiver-memory cap that connection flow control exists to provide.

Measured effect (loopback, single stream, 200 MiB): 8–16 MiB/s → 28–31 MiB/s; peer ACK count for the transfer drops from ~66k to ~57.