### PR TITLE
Cap retained ACK ranges per PN space (RFC 9000 §13.2.4)

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -234,6 +234,15 @@
 %% ACK traffic for RTT-sample granularity.
 -define(ACK_PACKET_TOLERANCE, 2).
 
+%% Max ACK ranges retained per PN space (RFC 9000 §13.2.4 allows the
+%% receiver to limit these). Under burst loss an unbounded list
+%% fragments into hundreds of ranges, and since every outgoing ACK
+%% encodes the full list (and the peer decodes it), ACK processing
+%% cost grows O(ranges) per packet on both ends. Packets below the
+%% lowest retained range are retransmitted by the peer and dropped
+%% here as duplicates.
+-define(MAX_ACK_RANGES, 64).
+
 %% Max receive buffer size in bytes (32 MB total across all streams) - protects against malicious peers
 -define(MAX_RECV_BUFFER_BYTES, 33554432).
 
@@ -7327,12 +7336,21 @@ update_pn_space_recv(PN, PNSpace, Now) ->
             L -> L
         end,
     %% Add to ack_ranges maintaining descending order and merging adjacent ranges
-    NewRanges = add_to_ack_ranges(PN, Ranges),
+    NewRanges = cap_ack_ranges(add_to_ack_ranges(PN, Ranges)),
     PNSpace#pn_space{
         largest_recv = NewLargest,
         recv_time = Now,
         ack_ranges = NewRanges
     }.
+
+%% Drop the lowest ranges beyond ?MAX_ACK_RANGES (list is descending).
+cap_ack_ranges([_, _ | Tail] = Ranges) when Tail =/= [] ->
+    case length(Ranges) > ?MAX_ACK_RANGES of
+        true -> lists:sublist(Ranges, ?MAX_ACK_RANGES);
+        false -> Ranges
+    end;
+cap_ack_ranges(Ranges) ->
+    Ranges.
 
 %% Add a packet number to ACK ranges, maintaining descending order by Start
 %% and merging adjacent/overlapping ranges


### PR DESCRIPTION
The per-PN-space `ack_ranges` list was unbounded. Under burst loss it fragments into hundreds of disjoint ranges, and since every outgoing ACK encodes the full list (and the peer decodes it), ACK processing cost grows O(ranges) per packet on **both** endpoints.

Profiled on a lossy loopback bulk transfer: ~270 ranges per ACK frame, kilobyte-sized ACK frames, and **57% of all connection-process CPU** spent in `encode_ack_ranges`/`decode_ack_ranges`/`ack_ranges_to_range_list` (6.6M calls for a 50 MiB transfer). The oversized ACKs also amplify the very congestion that caused the loss — a death spiral.

RFC 9000 §13.2.4 explicitly permits limiting retained ranges. This keeps the 64 highest ranges; packets below the lowest retained range are retransmitted by the peer if truly unacked, and discarded as duplicates otherwise. 64 is in line with other stacks (msquic caps its range tracking similarly).

The cap is applied at insertion (`update_pn_space_recv/3`), so encoding, decoding, and storage are all bounded by it.