### PR TITLE
Fix silent GRO train truncation in the receive path

### DIFF
--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -682,9 +682,14 @@ stop_client_receiver(Pid) when is_pid(Pid) ->
 %% exit signals from the linked owner are processed promptly rather
 %% than blocking forever in the NIF.
 client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
-    case socket:recvfrom(Socket, 0, [], 100) of
-        {ok, {#{addr := IP, port := Port}, Data}} ->
-            Owner ! {udp, Socket, IP, Port, Data},
+    %% recv_gro splits GRO-coalesced trains and sizes the read buffer
+    %% for a maximal train. A plain recvfrom here had two problems:
+    %% the default 8 KiB buffer silently truncates coalesced input,
+    %% and an unsplit train is one datagram of which the QUIC layer
+    %% can only parse the first packet.
+    case recv_gro(Socket, 100) of
+        {ok, {IP, Port}, Packets} ->
+            [Owner ! {udp, Socket, IP, Port, Data} || Data <- Packets],
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -1186,8 +1191,11 @@ extra_socket_family(Extra) ->
 %%====================================================================
 
 recv_gro(Socket, Timeout) ->
-    %% Receive with GRO - may get coalesced packets
-    case socket:recvmsg(Socket, 0, 128, [], Timeout) of
+    %% Receive with GRO - may get coalesced packets. The buffer must
+    %% hold a maximally coalesced train (64 KiB): passing 0 uses the
+    %% OTP default read buffer (8 KiB) and recvmsg silently TRUNCATES
+    %% any larger train, discarding every segment past the first few.
+    case socket:recvmsg(Socket, 65535, 128, [], Timeout) of
         {ok, #{addr := #{addr := IP, port := Port}, iov := [Data], ctrl := Ctrl}} ->
             %% Check for GRO segment size in control messages
             case extract_gro_segment_size(Ctrl) of


### PR DESCRIPTION
`recv_gro` called `socket:recvmsg` with a buffer size of 0, which uses the OTP default read buffer (8 KiB). A GRO-coalesced train can be up to 64 KiB; `recvmsg` silently truncates anything larger — for every large train only the first ~6 packets survived and the remaining ~40 were discarded with **no error, no counter, no log**.

The effect is vicious: the loss rate scales with how well GSO/GRO is working on the sending side, so the better the batching performs, the more packets vanish. Bulk throughput collapses through loss recovery while every observable counter (kernel rcvbuf errors, decrypt failures, drop counters) reads zero. Diagnosed by elimination: sender loss-tracking said ~11k packets/200 MiB unacked, receiver gap-jump counting said they never arrived, and every layer in between measured clean — leaving only the recvmsg boundary.

The client receiver (`client_recv_loop`) had the same zero-sized buffer and additionally never split GRO trains at all (plain `recvfrom`): a coalesced train was forwarded as a single datagram, of which the QUIC layer can only parse the first packet (short headers cannot be re-split — same class of issue as #204). It now goes through `recv_gro`.

After this fix, retransmit counts on a lossy bulk run match actual receiver-side drops exactly (previously ~8x inflated by the invisible truncation losses).