### PR TITLE
Scale the pacing burst allowance with the pacing rate

### DIFF
--- a/src/quic_cc_newreno.erl
+++ b/src/quic_cc_newreno.erl
@@ -812,7 +812,7 @@ update_mtu(#cc_state{max_datagram_size = OldMDS, minimum_window = OldMinWin} = S
     NewMinimumWindow = max(2 * NewMTU, (OldMinWin * NewMTU) div OldMDS),
 
     %% Update pacing_max_burst (12 * max_datagram_size)
-    NewPacingMaxBurst = 12 * NewMTU,
+    NewPacingMaxBurst = max(12 * NewMTU, 2 * State#cc_state.pacing_rate),
 
     ?LOG_DEBUG(
         #{
@@ -904,7 +904,17 @@ update_pacing_rate(#cc_state{cwnd = Cwnd} = State, SmoothedRTT) when SmoothedRTT
     %% Update HyStart++ RTT tracking
     State1 = update_hystart_rtt(State, SmoothedRTT),
 
-    State1#cc_state{pacing_rate = PacingRate};
+    %% The burst allowance must cover at least a couple of timer
+    %% granularities' worth of tokens at the paced rate: pacing wakeups
+    %% (send_after) have ~1 ms resolution, so a fixed 12-packet bucket
+    %% caps throughput at 12 packets per wakeup whenever the sender
+    %% outruns the incoming ACK clock, regardless of the configured
+    %% rate. 2 ms of rate keeps micro-bursts bounded (same idea as
+    %% Linux fq's pacing quantum) while letting a 1 ms clock sustain
+    %% the rate.
+    MaxBurst = max(12 * State1#cc_state.max_datagram_size, 2 * PacingRate),
+
+    State1#cc_state{pacing_rate = PacingRate, pacing_max_burst = MaxBurst};
 update_pacing_rate(State, _SmoothedRTT) ->
     %% No valid RTT yet, keep current state
     State.


### PR DESCRIPTION
pacing_max_burst is a fixed 12 packets while pacing wakeups (send_after) have ~1 ms timer resolution. Whenever the sender outruns the incoming ACK clock, the pacing timer becomes the only wakeup source, and the 12-packet bucket then caps throughput at 12 packets per wakeup (~17 KB/ms) regardless of the computed pacing rate. On a fast LAN this pins bulk transfers to a small fraction of the paced rate; we measured a hard plateau far below both the pacing rate and the congestion window, with the token bucket permanently empty.

This scales the allowance to 2 ms of the paced rate, floored at the old 12 * max_datagram_size. Micro-bursts stay bounded (the same idea as Linux fq's pacing quantum) while a 1 ms clock can sustain the configured rate. On RTTs above a few milliseconds the ACK clock dominates and behavior is unchanged.

On loopback this roughly doubles single-stream bulk throughput in our benchmarks. Full eunit passes.

Related to the performance series (#203-#218) but independent: applies directly to main.