### PR TITLE
Stop the keep-alive PING spin on connections with a quiet peer

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2455,12 +2455,21 @@ handle_common_event(
             %% no PING needed.
             {keep_state, set_keep_alive_timer(State#state{keep_alive_timer = undefined})};
         false ->
-            %% Idle for a full interval: send a PING. Being ack-eliciting, it
-            %% refreshes last_activity if it is the first such packet since our
-            %% last receive (RFC 9000 §10.1); re-arm a full interval.
+            %% Idle for a full interval: send a PING, then wait a full
+            %% interval before the next one.
+            %%
+            %% The re-arm must count from now, not from last_activity:
+            %% last_activity only moves on the FIRST ack-eliciting packet
+            %% sent since the last receive (RFC 9000 §10.1), so on a
+            %% connection whose peer stays quiet every later PING leaves it
+            %% untouched. Deriving the delay from it then yields
+            %% max(0, past + interval - now) = 0, the timer fires straight
+            %% back, and the connection spins sending PINGs at timer-wheel
+            %% rate (measured: ~930/s per connection, 46k/s across 50 idle
+            %% connections) until the peer happens to send something.
             State1 = send_keep_alive_ping(State#state{keep_alive_timer = undefined}),
             State2 = flush_dirty_timers(flush_socket_batch(State1)),
-            {keep_state, set_keep_alive_timer(State2)}
+            {keep_state, arm_keep_alive_timer(State2, State2#state.keep_alive_interval)}
     end;
 handle_common_event(info, {keep_alive_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale keep-alive timer (ref doesn't match or wrong state)
@@ -9686,15 +9695,19 @@ set_keep_alive_timer(#state{keep_alive_interval = disabled} = State) ->
 set_keep_alive_timer(
     #state{
         keep_alive_interval = Interval,
-        keep_alive_timer = OldTimer,
         last_activity = LastActivity
     } = State
 ) ->
-    cancel_timer(OldTimer),
     %% Lazy re-arm against last_activity (same model as the idle timer):
     %% full interval on the initial arm, the remainder on a spurious fire.
     Now = erlang:monotonic_time(millisecond),
-    Delay = max(0, (LastActivity + Interval) - Now),
+    arm_keep_alive_timer(State, max(0, (LastActivity + Interval) - Now)).
+
+%% Arm the keep-alive timer with an explicit delay.
+arm_keep_alive_timer(#state{keep_alive_interval = disabled} = State, _Delay) ->
+    State#state{keep_alive_timer = undefined};
+arm_keep_alive_timer(#state{keep_alive_timer = OldTimer} = State, Delay) ->
+    cancel_timer(OldTimer),
     Ref = make_ref(),
     erlang:send_after(Delay, self(), {keep_alive_timeout, Ref}),
     State#state{keep_alive_timer = Ref}.


### PR DESCRIPTION
A connection whose peer stays quiet spins sending keep-alive PINGs at timer-wheel rate.

`set_keep_alive_timer/1` re-arms from `last_activity`:

```erlang
Delay = max(0, (LastActivity + Interval) - Now)
```

but `last_activity` only moves on the *first* ack-eliciting packet sent since the last receive, which is the RFC 9000 §10.1 idle-timer rule and is correctly implemented in `send_app_packet_internal`:

```erlang
RestartIdle = AckEliciting andalso (not State#state.ack_eliciting_since_recv),
```

So on a connection where the peer sends nothing, the first PING sets `last_activity` and the `ack_eliciting_since_recv` flag. Every subsequent PING leaves `last_activity` untouched, the delay computes as `max(0, past + interval - now)` = 0, the timer fires straight back, and the loop continues until the peer happens to send something. Each iteration drags the whole send path along: packet build, header protection, loss tracking, PTO re-arm, keep-alive re-arm, socket batch flush.

What makes it hard to spot: pacing blocks most of the spun PINGs before they reach the wire, so the datagram counters look normal while the CPU burns building packets that get dropped. It is invisible to sampling profilers too, since every sample lands on `gen_statem:loop`. We found it with `erlang:trace_pattern(..., [call_count])`, which showed it immediately.

Measured on a control tower holding 50 mostly-idle connections, 10 second window:

| | before | after |
|---|---|---|
| calls to `send_keep_alive_ping` | 465,145 | ~500 |
| total calls across quic modules | 15,907,186 | 2,792 |
| process CPU for the whole run | 58.6 s | 24.9 s (two runs, identical) |

That is ~930 PINGs per second per connection against the intended 1/s, and it accounted for roughly half of all CPU the QUIC stack used in that workload. For reference, the msquic-based stack we compare against uses 24.2 s on the same run, so this single fix took us from a 2.4x CPU premium to parity (1.03x).

Bulk throughput is unchanged either way: during a transfer `last_activity` keeps moving, so the spin never starts. It only ever hits connections whose peer is quiet, which is the common shape for server push, telemetry collection, and anything where the client rarely speaks.

**The fix**: after sending a PING, arm the timer a full interval from *now* rather than from `last_activity`. The lazy `last_activity` re-arm stays for the no-PING branch, where it is correct. `set_keep_alive_timer/1` now delegates to a new `arm_keep_alive_timer/2` that takes an explicit delay, so both paths share the cancel/arm logic.

Full eunit suite clean on this branch (2263 tests, 0 failures).
