### PR TITLE
Buffer handshake messages whose header is split across CRYPTO frames

### DIFF
--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -919,8 +919,11 @@ decode_handshake_message(<<Type:8, Length:24, Body:Length/binary, Rest/binary>>)
     {ok, {Type, Body}, Rest};
 decode_handshake_message(<<_Type:8, Length:24, Data/binary>>) when byte_size(Data) < Length ->
     {error, incomplete};
+%% Fewer than 4 bytes: the message header itself is split across CRYPTO
+%% frames. There is no invalid framing at this layer, only insufficient
+%% data; malformed content is rejected by the per-message parsers.
 decode_handshake_message(_) ->
-    {error, invalid}.
+    {error, incomplete}.
 
 %%====================================================================
 %% Internal Functions

--- a/test/quic_tls_compliance_tests.erl
+++ b/test/quic_tls_compliance_tests.erl
@@ -480,3 +480,21 @@ verify_resumption_binder_fails_closed_without_offset_test() ->
             crypto:strong_rand_bytes(32), aes_128_gcm, <<"ch">>, undefined, <<"binder">>
         )
     ).
+
+%% A CRYPTO frame may end anywhere, including inside the four-byte
+%% handshake message header. Every short prefix must report `incomplete'
+%% so the caller buffers it and waits: reporting `invalid' made the
+%% server discard a split client Finished and wedge the handshake.
+split_handshake_header_is_incomplete_test() ->
+    Body = binary:copy(<<$v>>, 32),
+    Msg = <<?TLS_FINISHED:8, 32:24, Body/binary>>,
+    lists:foreach(
+        fun(N) ->
+            ?assertEqual(
+                {N, {error, incomplete}},
+                {N, quic_tls:decode_handshake_message(binary:part(Msg, 0, N))}
+            )
+        end,
+        lists:seq(0, byte_size(Msg) - 1)
+    ),
+    ?assertEqual({ok, {?TLS_FINISHED, Body}, <<>>}, quic_tls:decode_handshake_message(Msg)).


### PR DESCRIPTION
A handshake message whose four-byte header is split across two CRYPTO frames is silently discarded, and the connection wedges for good.

`quic_tls:decode_handshake_message/1`:

```erlang
decode_handshake_message(<<Type:8, Length:24, Body:Length/binary, Rest/binary>>) ->
    {ok, {Type, Body}, Rest};
decode_handshake_message(<<_Type:8, Length:24, Data/binary>>) when byte_size(Data) < Length ->
    {error, incomplete};
decode_handshake_message(_) ->
    {error, invalid}.
```

The `incomplete` clause binds `Type:8, Length:24` before its guard can run, so it only matches once at least four bytes have arrived. A shorter prefix, which is exactly the case where the header itself straddles a CRYPTO frame boundary, falls through to the catch-all and is reported as `invalid`.

That distinction matters, because the only caller treats the two differently. `quic_connection:process_tls_messages/3` buffers on `incomplete` and waits for more data, but on any other error it drops the bytes and returns the state unchanged:

```erlang
{error, incomplete} ->
    State#state{tls_buffer = maps:put(Level, Data, State#state.tls_buffer)};
{error, _Err} ->
    State
```

A CRYPTO frame may end at any offset, so a peer that segments its flight to fit the datagram size can split the header. When it lands on the client's Finished the server throws it away, stays in `handshaking` forever and keeps retransmitting its own flight, while the client considers the handshake complete and starts sending 1-RTT application data. Nothing recovers: the client has no reason to resend Finished, and the server has no way to ask for it.

With logging added at that branch, the server side shows

```
[tls message decode failed] reason=invalid size=2 head=<<20,0>> level=handshake role=server
[server handshake flight retransmit] attempt=1..4
```

where 20 is `?TLS_FINISHED` and the two bytes are the type plus the first length byte.

**The fix** is to treat a short prefix as insufficient rather than malformed. There is no invalid framing at this layer, only insufficient data; malformed content is still rejected by the per-message parsers:

```erlang
decode_handshake_message(<<_Type:8, Length:24, Data/binary>>) when byte_size(Data) < Length ->
    {error, incomplete};
decode_handshake_message(_) ->
    {error, incomplete}.
```

Includes a regression test covering every prefix length of a Finished message.

### Impact

We hit this on a control tower accepting 50 concurrent connections, where 1 to 3 per run wedged this way. It is easy to miss because the client reports a successful connect and the failure only surfaces much later, as an application-level timeout on the server followed by the peer falling back to TCP.

Measured on that test, before and after, against the msquic-based stack we compare with:

| phase | msquic | before | after |
|---|---|---|---|
| wait for 50 connections, first pass | 2.4 s | 35.2 s | 2.4 s |
| wait for 50 connections, second pass | 0.2 s | 32.8 s | 0.2 s |
| connections still on QUIC (of 50) | 50 | 47 | 50 |
| whole test, wall clock | 213 s | 291 s | 222 s |

Both connection phases are now at parity, no connection falls back to TCP any more, and the wall-clock gap for the whole test drops from 78 s to 9 s.

Full eunit suite clean (2284 tests, 0 failures).
