### PR TITLE
Handle overlapping and duplicate chunks when reassembling

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -147,6 +147,9 @@
     check_send_queue_flow_control/4,
     test_check_flow_control/6,
     close_reason_to_code/1,
+    %% Out-of-order reassembly (RFC 9000 §2.2, §13.3)
+    extract_contiguous_data/2,
+    trim_reassembly_buffer/2,
     %% Migration frame classification (RFC 9000 Section 9.1)
     is_probing_frame/1,
     contains_non_probing_frame/1,
@@ -5219,8 +5222,9 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                 ?QUIC_CRYPTO_BUFFER_EXCEEDED, <<"crypto buffer exceeded">>, State
             );
         false ->
-            %% Add data to buffer
-            NewBuffer = maps:put(Offset, Data, Buffer),
+            %% Add data to buffer, keeping the longer chunk if the peer
+            %% already sent one at this offset.
+            NewBuffer = keep_longest_chunk(Offset, Data, Buffer),
             NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State#state.crypto_buffer),
 
             State1 = State#state{crypto_buffer = NewCryptoBuffer},
@@ -5253,7 +5257,21 @@ process_crypto_buffer(Level, State) ->
             %% Try to process more
             process_crypto_buffer(Level, State2);
         error ->
-            State
+            %% Nothing keyed exactly at ExpectedOffset, which does not mean a
+            %% gap: a peer may re-frame CRYPTO data it retransmits (RFC 9000
+            %% §13.3), so the bytes we need can sit inside a chunk that starts
+            %% earlier. Drop what is already consumed, re-key what straddles
+            %% the offset, then retry once. Storing the trimmed buffer also
+            %% stops duplicate retransmissions from accumulating against
+            %% ?MAX_CRYPTO_BUFFER_BYTES and closing a healthy connection.
+            Trimmed = trim_reassembly_buffer(Buffer, ExpectedOffset),
+            State1 = State#state{
+                crypto_buffer = maps:put(Level, Trimmed, State#state.crypto_buffer)
+            },
+            case maps:is_key(ExpectedOffset, Trimmed) of
+                true -> process_crypto_buffer(Level, State1);
+                false -> State1
+            end
     end.
 
 %% Process TLS handshake data from CRYPTO frames
@@ -6573,7 +6591,7 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                 {Data, EndOffset, RecvBuffer, Fin};
                             false ->
                                 %% Out-of-order or buffer has data: use buffer path
-                                UpdatedBuffer = maps:put(Offset, Data, RecvBuffer),
+                                UpdatedBuffer = keep_longest_chunk(Offset, Data, RecvBuffer),
                                 {ExtractedData, ExtractedOffset, ExtractedBuffer} =
                                     extract_contiguous_data(UpdatedBuffer, CurrentOffset),
                                 ExtractedFin =
@@ -6613,11 +6631,16 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                         end,
                     NewDataReceivedVal = DataReceived + NewBytesReceived,
 
-                    %% Update receive buffer bytes tracking
-                    %% Net change: add new bytes, subtract delivered bytes
-                    DeliveredBytes = byte_size(DeliverData),
+                    %% Update receive buffer bytes tracking from the buffer
+                    %% itself. The new-minus-delivered estimate drifts upward
+                    %% once retransmissions overlap, because the overlapping
+                    %% bytes count as new but are never delivered twice, and
+                    %% that drift would eventually trip the cap on a stream
+                    %% holding nothing.
                     NewRecvBufferBytes = max(
-                        0, RecvBufferBytes + NewBytesReceived - DeliveredBytes
+                        0,
+                        RecvBufferBytes - reassembly_buffer_bytes(RecvBuffer) +
+                            reassembly_buffer_bytes(NewBuffer)
                     ),
 
                     State1 = State#state{
@@ -6768,9 +6791,48 @@ extract_contiguous_data(Buffer, Offset, Acc) ->
             NextOffset = Offset + byte_size(Data),
             extract_contiguous_data(NewBuffer, NextOffset, <<Acc/binary, Data/binary>>);
         error ->
-            %% No data at this offset (gap in stream)
-            {Acc, Offset, Buffer}
+            %% Nothing keyed exactly at Offset, which does not mean a gap:
+            %% a peer may split or coalesce retransmitted data differently
+            %% (RFC 9000 §2.2, §13.3), so the bytes we want can sit inside
+            %% a chunk that starts earlier. Drop what is already delivered,
+            %% re-key what straddles Offset, then retry once.
+            Trimmed = trim_reassembly_buffer(Buffer, Offset),
+            case maps:is_key(Offset, Trimmed) of
+                true -> extract_contiguous_data(Trimmed, Offset, Acc);
+                false -> {Acc, Offset, Trimmed}
+            end
     end.
+
+%% Drop buffered chunks that end at or before Offset and trim those that
+%% straddle it, re-keying them to Offset. Keeps the longest chunk at each
+%% offset, so overlapping retransmissions collapse instead of accumulating.
+trim_reassembly_buffer(Buffer, Offset) ->
+    maps:fold(
+        fun(Off, Data, Acc) ->
+            End = Off + byte_size(Data),
+            if
+                End =< Offset ->
+                    Acc;
+                Off >= Offset ->
+                    keep_longest_chunk(Off, Data, Acc);
+                true ->
+                    Kept = binary:part(Data, Offset - Off, End - Offset),
+                    keep_longest_chunk(Offset, Kept, Acc)
+            end
+        end,
+        #{},
+        Buffer
+    ).
+
+keep_longest_chunk(Off, Data, Acc) ->
+    case Acc of
+        #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Acc;
+        _ -> Acc#{Off => Data}
+    end.
+
+%% Total bytes held in a reassembly buffer.
+reassembly_buffer_bytes(Buffer) ->
+    maps:fold(fun(_, Data, Acc) -> Acc + byte_size(Data) end, 0, Buffer).
 
 %% Get the maximum stream receive window across all streams.
 %% Used to ensure connection window >= 1.5x largest stream window.

--- a/test/quic_reassembly_tests.erl
+++ b/test/quic_reassembly_tests.erl
@@ -1,0 +1,126 @@
+%%% Out-of-order reassembly tests.
+%%%
+%%% RFC 9000 §2.2 and §13.3 let a peer split or coalesce data it
+%%% retransmits differently from the original send, so buffered chunks
+%%% can overlap and can repeat data already delivered. The reassembler
+%%% must therefore not assume a chunk starts exactly where the next
+%%% delivery does.
+-module(quic_reassembly_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Byte at absolute stream offset N, so assembled output can be checked
+%% against the offsets it claims to cover.
+chunk(Start, Len) ->
+    <<<<(B rem 256)>> || B <- lists:seq(Start, Start + Len - 1)>>.
+
+extract(Buffer, Offset) ->
+    quic_connection:extract_contiguous_data(Buffer, Offset).
+
+trim(Buffer, Offset) ->
+    quic_connection:trim_reassembly_buffer(Buffer, Offset).
+
+%%====================================================================
+%% Extraction
+%%====================================================================
+
+exact_chunks_are_joined_test() ->
+    Buffer = #{0 => chunk(0, 100), 100 => chunk(100, 100)},
+    ?assertEqual({chunk(0, 200), 200, #{}}, extract(Buffer, 0)).
+
+gap_stops_extraction_test() ->
+    Buffer = #{0 => chunk(0, 100), 200 => chunk(200, 100)},
+    ?assertEqual({chunk(0, 100), 100, #{200 => chunk(200, 100)}}, extract(Buffer, 0)).
+
+%% The regression: the second chunk starts inside the first, so nothing
+%% is keyed at the offset extraction reaches. Keying by exact offset
+%% left those bytes unreachable and stalled the stream for good.
+overlapping_chunks_do_not_stall_test() ->
+    Buffer = #{1000 => chunk(1000, 500), 1200 => chunk(1200, 500)},
+    ?assertEqual({chunk(1000, 700), 1700, #{}}, extract(Buffer, 1000)).
+
+%% Same shape one level deeper: a re-framed retransmission that overlaps
+%% two buffered chunks at once.
+overlap_spanning_two_chunks_test() ->
+    Buffer = #{
+        0 => chunk(0, 100),
+        50 => chunk(50, 300),
+        200 => chunk(200, 400)
+    },
+    ?assertEqual({chunk(0, 600), 600, #{}}, extract(Buffer, 0)).
+
+%% A chunk wholly contained in one already buffered adds nothing and
+%% must not truncate the delivery.
+contained_chunk_is_absorbed_test() ->
+    Buffer = #{0 => chunk(0, 500), 100 => chunk(100, 50)},
+    ?assertEqual({chunk(0, 500), 500, #{}}, extract(Buffer, 0)).
+
+%% Data below the delivery point was already handed to the owner. It has
+%% to be dropped rather than left to accumulate: it was never counted
+%% against the receive-buffer cap, so it grew unbounded and unnoticed.
+consumed_chunks_are_dropped_test() ->
+    Buffer = #{0 => chunk(0, 100), 100 => chunk(100, 100)},
+    ?assertEqual({<<>>, 500, #{}}, extract(Buffer, 500)).
+
+duplicate_below_offset_is_dropped_but_gap_kept_test() ->
+    Buffer = #{0 => chunk(0, 100), 900 => chunk(900, 10)},
+    ?assertEqual({<<>>, 500, #{900 => chunk(900, 10)}}, extract(Buffer, 500)).
+
+empty_buffer_test() ->
+    ?assertEqual({<<>>, 42, #{}}, extract(#{}, 42)).
+
+%%====================================================================
+%% Trimming
+%%====================================================================
+
+trim_drops_consumed_and_rekeys_straddling_test() ->
+    Buffer = #{100 => chunk(100, 500), 300 => chunk(300, 100)},
+    ?assertEqual(#{400 => chunk(400, 200)}, trim(Buffer, 400)).
+
+%% Two chunks that both trim to the same offset collapse to the longer
+%% one, so overlapping retransmissions cannot displace live data.
+trim_keeps_the_longer_chunk_test() ->
+    Buffer = #{100 => chunk(100, 500), 200 => chunk(200, 600)},
+    ?assertEqual(#{300 => chunk(300, 500)}, trim(Buffer, 300)).
+
+trim_is_idempotent_test() ->
+    Buffer = #{0 => chunk(0, 100), 50 => chunk(50, 300), 200 => chunk(200, 400)},
+    Once = trim(Buffer, 120),
+    ?assertEqual(Once, trim(Once, 120)).
+
+trim_leaves_future_chunks_untouched_test() ->
+    Buffer = #{800 => chunk(800, 100), 900 => chunk(900, 100)},
+    ?assertEqual(Buffer, trim(Buffer, 800)).
+
+%%====================================================================
+%% Randomised: any fragmentation of a known stream reassembles to it
+%%====================================================================
+
+random_fragmentations_reassemble_test() ->
+    Total = 4000,
+    Stream = chunk(0, Total),
+    lists:foreach(
+        fun(Seed) ->
+            rand:seed(exsplus, {Seed, Seed * 7 + 1, Seed * 13 + 3}),
+            Buffer = lists:foldl(
+                fun(_, Acc) ->
+                    Off = rand:uniform(Total) - 1,
+                    Len = rand:uniform(min(600, Total - Off)),
+                    add_chunk(Off, chunk(Off, Len), Acc)
+                end,
+                #{},
+                lists:seq(1, 60)
+            ),
+            %% Guarantee full coverage so the whole stream is contiguous.
+            Full = add_chunk(0, Stream, Buffer),
+            ?assertEqual({Seed, {Stream, Total, #{}}}, {Seed, extract(Full, 0)})
+        end,
+        lists:seq(1, 100)
+    ).
+
+%% Mirrors how the connection inserts: keep whichever chunk is longer.
+add_chunk(Off, Data, Buffer) ->
+    case Buffer of
+        #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Buffer;
+        _ -> Buffer#{Off => Data}
+    end.


### PR DESCRIPTION
Both reassembly buffers look up the next bytes by exact offset. `process_crypto_buffer/2` does `maps:find(ExpectedOffset, Buffer)` and `extract_contiguous_data/3` does `maps:take(Offset, Buffer)`. That assumes a chunk always starts precisely where the last delivery ended, which the protocol does not promise: RFC 9000 §2.2 permits overlapping STREAM frames, and §13.3 lets a peer split or coalesce data it retransmits differently from the original send.

### The stall

When a chunk straddles the delivery point, its key stays below that point and is never looked up again:

```
buffered: {1000 => 500 bytes} {1200 => 500 bytes}
deliver from 1000 -> takes key 1000, advances to 1500
                     looks for key 1500, finds nothing
                     bytes 1500..1699 are held forever
```

The stream stalls permanently. On the CRYPTO side the handshake does, which is the same end state as the split-header bug in #222: one side considers itself connected while the other waits for data it is already holding.

### The leak

Chunks below the delivery point had the mirror problem: extraction only ever removed exact matches, so they were kept forever.

On a stream they were inserted into the buffer but counted as zero new bytes, so they grew without being charged against `?MAX_RECV_BUFFER_BYTES` — unbounded memory the cap could not see. On the CRYPTO side they *were* charged, so accumulated duplicate retransmissions could reach `?MAX_CRYPTO_BUFFER_BYTES` and close a healthy connection with `CRYPTO_BUFFER_EXCEEDED`.

### The fix

Both paths now share `trim_reassembly_buffer/2`, applied when the exact lookup misses: chunks ending at or before the delivery point are dropped, a chunk straddling it is trimmed and re-keyed to that point, and extraction retries once. The fast path, an exact hit, is untouched, so in-order delivery costs nothing extra; only a miss pays the fold, and a miss is what used to mean "give up".

Insertion goes through `keep_longest_chunk/3`, because plain `maps:put` let a shorter retransmission at an offset displace a longer chunk already buffered and silently drop the tail.

Receive-buffer accounting is now derived from the buffer itself rather than from new-minus-delivered. With overlap the old estimate drifted upward, since overlapping bytes counted as new but were never delivered twice, and that drift would eventually trip the cap on a stream holding nothing.

### Tests

`test/quic_reassembly_tests.erl` covers exact joins, gaps, straddling overlap, overlap spanning two chunks, fully contained chunks, pruning of delivered and duplicate chunks, trim idempotence, and a randomised pass that fragments a known 4000 byte stream arbitrarily and requires it to reassemble byte-exactly.

6 of the 13 fail on the current code. Full eunit suite clean with the fix (2276 tests, 0 failures).
