### PR TITLE
Give up on an unresponsive peer with a disconnect timeout

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -497,6 +497,10 @@
     %% peer then lingers for the whole idle timeout; msquic uses a 16 s
     %% disconnect timeout for the same reason).
     disconnect_timeout = 16000 :: pos_integer() | infinity,
+    %% Dedicated timer for the above. Checking it only when a PTO happened
+    %% to fire made the effective timeout the next PTO after the deadline,
+    %% and PTO backoff doubles, so a nominal 16 s took 24 s or more.
+    disconnect_timer :: reference() | undefined,
 
     %% Pacing (RFC 9002 Section 7.7)
     pacing_timer :: reference() | undefined,
@@ -1777,7 +1781,7 @@ idle(EventType, EventContent, State) ->
 handshaking(enter, idle, State) ->
     %% Continue handshake; (re)arm the client Initial-retransmission timer
     %% (no-op for the server).
-    {keep_state, State, hs_rtx_actions(State)};
+    {keep_state, arm_disconnect_timer(State), hs_rtx_actions(State)};
 handshaking(state_timeout, retransmit_initial, State) ->
     retransmit_initial_flight(handshaking, State);
 handshaking({call, From}, get_ref, #state{conn_ref = Ref} = State) ->
@@ -1899,7 +1903,7 @@ connected(
         server -> ok
     end,
     %% Send any data that was queued before connection established
-    State1 = State#state{pending_data = []},
+    State1 = arm_disconnect_timer(State#state{pending_data = []}),
     State2 = send_pending_data(Pending, State1),
     %% RFC 9000 Section 9.6: Client validates server's preferred address
     State3 =
@@ -2421,26 +2425,27 @@ handle_common_event(info, {pto_timeout, Ref}, StateName, #state{pto_timer = Ref}
 ->
     case disconnect_timeout_expired(State) of
         true ->
-            %% The peer has not acknowledged anything for the whole
-            %% disconnect timeout while we had data in flight: declare
-            %% it dead instead of probing until the idle timeout. This
-            %% is how a client escapes a restarted peer whose stateless
-            %% resets it cannot recognise.
-            ?LOG_NOTICE(
-                #{
-                    what => disconnect_timeout,
-                    in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
-                    pto_count => quic_loss:pto_count(State#state.loss_state)
-                },
-                ?QUIC_LOG_META
-            ),
-            NewState = initiate_close(disconnect_timeout, State#state{pto_timer = undefined}),
-            {next_state, draining, NewState};
+            {next_state, draining, declare_peer_dead(State#state{pto_timer = undefined})};
         false ->
             %% Handle PTO timeout - send probe packet
             NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
             {keep_state, NewState}
     end;
+handle_common_event(
+    info, {disconnect_check, Ref}, StateName, #state{disconnect_timer = Ref} = State
+) when
+    Ref =/= undefined andalso (StateName =:= connected orelse StateName =:= handshaking)
+->
+    State1 = State#state{disconnect_timer = undefined},
+    case disconnect_timeout_expired(State1) of
+        true ->
+            {next_state, draining, declare_peer_dead(State1)};
+        false ->
+            {keep_state, arm_disconnect_timer(State1)}
+    end;
+handle_common_event(info, {disconnect_check, _StaleRef}, _StateName, State) ->
+    %% Stale disconnect timer (ref doesn't match or wrong state)
+    {keep_state, State};
 handle_common_event(info, {pto_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale PTO timer (ref doesn't match or wrong state)
     {keep_state, State};
@@ -9707,6 +9712,49 @@ disconnect_timeout_expired(#state{disconnect_timeout = DT, loss_state = LossStat
             T ->
                 erlang:monotonic_time(millisecond) - T >= DT
         end.
+
+%% The disconnect timeout elapsed with ack-eliciting data in flight and
+%% no ACK: declare the peer dead instead of probing until the idle
+%% timeout. This is how a client escapes a restarted peer whose stateless
+%% resets it cannot recognise.
+declare_peer_dead(State) ->
+    ?LOG_NOTICE(
+        #{
+            what => disconnect_timeout,
+            in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
+            pto_count => quic_loss:pto_count(State#state.loss_state)
+        },
+        ?QUIC_LOG_META
+    ),
+    initiate_close(disconnect_timeout, cancel_disconnect_timer(State)).
+
+cancel_disconnect_timer(#state{disconnect_timer = undefined} = State) ->
+    State;
+cancel_disconnect_timer(#state{disconnect_timer = Ref} = State) ->
+    cancel_timer(Ref),
+    State#state{disconnect_timer = undefined}.
+
+%% Arm the disconnect check at the deadline itself. Lazy, like the idle
+%% timer: a fire that finds the deadline moved re-arms the remainder.
+%% The delay is never zero, so this cannot spin the way a re-arm derived
+%% from a stale timestamp would.
+arm_disconnect_timer(#state{disconnect_timeout = infinity} = State) ->
+    cancel_disconnect_timer(State);
+arm_disconnect_timer(#state{disconnect_timeout = DT, loss_state = LossState} = State) ->
+    Delay =
+        case quic_loss:last_progress(LossState) of
+            undefined ->
+                DT;
+            T ->
+                case quic_loss:bytes_in_flight(LossState) > 0 of
+                    true -> max(1, (T + DT) - erlang:monotonic_time(millisecond));
+                    false -> DT
+                end
+        end,
+    State1 = cancel_disconnect_timer(State),
+    Ref = make_ref(),
+    erlang:send_after(Delay, self(), {disconnect_check, Ref}),
+    State1#state{disconnect_timer = Ref}.
 
 %% Disconnect-timeout option: how long ack-eliciting data may stay in
 %% flight without any ACK before the peer is declared dead.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -491,6 +491,13 @@
     keep_alive_interval :: non_neg_integer() | disabled,
     keep_alive_timer :: reference() | undefined,
 
+    %% Give up on an unresponsive peer: close the connection when
+    %% ack-eliciting data has been in flight with no ACK for this long
+    %% (RFC 9000 permits idle-timeout-only, but a stateless-reset-blind
+    %% peer then lingers for the whole idle timeout; msquic uses a 16 s
+    %% disconnect timeout for the same reason).
+    disconnect_timeout = 16000 :: pos_integer() | infinity,
+
     %% Pacing (RFC 9002 Section 7.7)
     pacing_timer :: reference() | undefined,
     pacing_enabled = true :: boolean(),
@@ -1172,6 +1179,7 @@ init({server, Opts}) ->
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeout,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeout),
+        disconnect_timeout = disconnect_timeout_opt(Opts),
         keep_alive_timer = undefined,
         last_activity = erlang:monotonic_time(millisecond),
         cc_state = CCState,
@@ -1551,6 +1559,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeoutClient,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeoutClient),
+        disconnect_timeout = disconnect_timeout_opt(Opts),
         keep_alive_timer = undefined,
         last_activity = erlang:monotonic_time(millisecond),
         cc_state = CCState,
@@ -2410,9 +2419,28 @@ handle_common_event(cast, handle_timeout, _StateName, State) ->
 handle_common_event(info, {pto_timeout, Ref}, StateName, #state{pto_timer = Ref} = State) when
     Ref =/= undefined andalso (StateName =:= connected orelse StateName =:= handshaking)
 ->
-    %% Handle PTO timeout - send probe packet
-    NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
-    {keep_state, NewState};
+    case disconnect_timeout_expired(State) of
+        true ->
+            %% The peer has not acknowledged anything for the whole
+            %% disconnect timeout while we had data in flight: declare
+            %% it dead instead of probing until the idle timeout. This
+            %% is how a client escapes a restarted peer whose stateless
+            %% resets it cannot recognise.
+            ?LOG_NOTICE(
+                #{
+                    what => disconnect_timeout,
+                    in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
+                    pto_count => quic_loss:pto_count(State#state.loss_state)
+                },
+                ?QUIC_LOG_META
+            ),
+            NewState = initiate_close(disconnect_timeout, State#state{pto_timer = undefined}),
+            {next_state, draining, NewState};
+        false ->
+            %% Handle PTO timeout - send probe packet
+            NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
+            {keep_state, NewState}
+    end;
 handle_common_event(info, {pto_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale PTO timer (ref doesn't match or wrong state)
     {keep_state, State};
@@ -9667,6 +9695,26 @@ query_local_addr(Socket) ->
     case inet:sockname(Socket) of
         {ok, Sockname} -> Sockname;
         {error, _} -> undefined
+    end.
+
+disconnect_timeout_expired(#state{disconnect_timeout = infinity}) ->
+    false;
+disconnect_timeout_expired(#state{disconnect_timeout = DT, loss_state = LossState}) ->
+    quic_loss:bytes_in_flight(LossState) > 0 andalso
+        case quic_loss:last_progress(LossState) of
+            undefined ->
+                false;
+            T ->
+                erlang:monotonic_time(millisecond) - T >= DT
+        end.
+
+%% Disconnect-timeout option: how long ack-eliciting data may stay in
+%% flight without any ACK before the peer is declared dead.
+disconnect_timeout_opt(Opts) ->
+    case maps:get(disconnect_timeout, Opts, 16000) of
+        infinity -> infinity;
+        T when is_integer(T), T >= 1000 -> T;
+        _ -> 16000
     end.
 
 calculate_keep_alive_interval(Opts, IdleTimeout) ->

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -61,6 +61,7 @@
     %% Queries
     sent_packets/1,
     bytes_in_flight/1,
+    last_progress/1,
     pto_count/1,
     oldest_unacked/1,
     has_rtt_sample/1
@@ -100,6 +101,12 @@
     %% Loss detection
     loss_time = undefined :: non_neg_integer() | undefined,
     time_of_last_ack = undefined :: non_neg_integer() | undefined,
+
+    %% When the current outstanding burst started: set whenever an
+    %% ack-eliciting packet is sent while nothing was in flight. Used
+    %% together with time_of_last_ack as the anchor for the disconnect
+    %% timeout, so a fresh send after a quiet period cannot trip it.
+    outstanding_since = undefined :: non_neg_integer() | undefined,
 
     %% PTO
     pto_count = 0 :: non_neg_integer(),
@@ -191,12 +198,18 @@ on_packet_sent(
             true -> InFlight + Size;
             false -> InFlight
         end,
+    OutstandingSince =
+        case AckEliciting andalso InFlight =:= 0 of
+            true -> Now;
+            false -> State#loss_state.outstanding_since
+        end,
     %% NOTE: pto_count is NOT reset here per RFC 9002.
     %% PTO count is only reset when receiving an ACK (in on_ack_received).
     %% Resetting on send would break exponential backoff for probe retransmissions.
     State#loss_state{
         sent_q = queue:in(SentPacket, Q),
-        bytes_in_flight = NewInFlight
+        bytes_in_flight = NewInFlight,
+        outstanding_since = OutstandingSince
     }.
 
 %% @doc Process an ACK frame.
@@ -523,6 +536,14 @@ bytes_in_flight(#loss_state{bytes_in_flight = B}) -> B.
 %% @doc Get current PTO count.
 -spec pto_count(loss_state()) -> non_neg_integer().
 pto_count(#loss_state{pto_count = C}) -> C.
+
+%% @doc Latest sign of forward progress for the disconnect timeout: the
+%% last received ACK, or the start of the current outstanding burst,
+%% whichever is later. undefined until either has happened.
+-spec last_progress(loss_state()) -> non_neg_integer() | undefined.
+last_progress(#loss_state{time_of_last_ack = undefined, outstanding_since = O}) -> O;
+last_progress(#loss_state{time_of_last_ack = A, outstanding_since = undefined}) -> A;
+last_progress(#loss_state{time_of_last_ack = A, outstanding_since = O}) -> max(A, O).
 
 %% @doc Get the oldest unacked packet (for PTO probe selection).
 %% Returns {ok, #sent_packet{}} or none. Head of the sent queue is

--- a/test/quic_server_e2e_SUITE.erl
+++ b/test/quic_server_e2e_SUITE.erl
@@ -30,7 +30,8 @@
     listener_start_stop/1,
     listener_get_port/1,
     server_connection_batches_by_default/1,
-    server_connection_batching_opt_out/1
+    server_connection_batching_opt_out/1,
+    disconnect_timeout_on_unresponsive_peer/1
 ]).
 
 %%====================================================================
@@ -49,7 +50,8 @@ groups() ->
             listener_start_stop,
             listener_get_port,
             server_connection_batches_by_default,
-            server_connection_batching_opt_out
+            server_connection_batching_opt_out,
+            disconnect_timeout_on_unresponsive_peer
         ]}
     ].
 
@@ -177,6 +179,50 @@ server_connection_batching_opt_out(Config) ->
         ?assertEqual(false, maps:get(send_batching_enabled, Info)),
         ?assertEqual(false, maps:get(send_gso_supported, Info)),
         quic:close(Conn)
+    after
+        quic_test_echo_server:stop(Echo)
+    end,
+    Config.
+
+%% A peer that stops responding while we have data in flight must be
+%% declared dead by the disconnect timeout, well before the idle
+%% timeout. A restarted peer's stateless resets are unrecognisable
+%% (issue #202), so without this the connection lingers for the whole
+%% idle timeout.
+disconnect_timeout_on_unresponsive_peer(Config) ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    #{name := Name, port := Port} = Echo,
+    try
+        Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+            disconnect_timeout => 2000,
+            idle_timeout => 60000
+        }),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, Opts, self()),
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 5000 ->
+            ct:fail("client handshake timed out")
+        end,
+        {ok, [ServerPid | _]} = quic:get_server_connections(Name),
+        %% Freeze the server side: packets pile up in its mailbox but
+        %% nothing is processed or acknowledged.
+        ok = sys:suspend(ServerPid),
+        {ok, Sid} = quic:open_stream(Conn),
+        ok = quic:send_data(Conn, Sid, <<"are you there?">>, false),
+        T0 = erlang:monotonic_time(millisecond),
+        Reason =
+            receive
+                {quic, Conn, {closed, R}} -> R
+            after 20000 ->
+                ct:fail("connection not closed by disconnect timeout")
+            end,
+        Elapsed = erlang:monotonic_time(millisecond) - T0,
+        ct:log("closed after ~b ms with reason ~p", [Elapsed, Reason]),
+        %% Must fire on the 2 s disconnect timeout (plus PTO cadence),
+        %% far below the 60 s idle timeout.
+        ?assertEqual(disconnect_timeout, Reason),
+        ?assert(Elapsed < 15000),
+        ok = sys:resume(ServerPid)
     after
         quic_test_echo_server:stop(Echo)
     end,


### PR DESCRIPTION
This is a feature proposal rather than a bug fix, so the default is the part worth arguing about. See the note at the end.

### The gap

When a peer disappears without closing, the only thing that ends the connection is the idle timeout. That is correct per RFC 9000, but it is a long time to hold a connection that is provably dead, and there is a case where it is worse than just slow: a peer that restarts and sends stateless resets we cannot recognise. We keep probing, it keeps resetting, and nothing resolves until the idle timeout expires. With `idle_timeout` set generously, or `infinity`, the connection never goes away at all.

msquic solves this with a 16 second disconnect timeout, and this takes the same approach: if ack-eliciting data has been in flight with no ACK at all for the timeout, declare the peer dead and close instead of probing on.

### Two commits

**1. The timeout itself.** `quic_loss` gains `last_progress/1`, the time of the last ACK that made forward progress. `quic_connection` closes with `disconnect_timeout` when data has been in flight past that point for longer than the configured window. Configurable via the `disconnect_timeout` option, `infinity` to disable.

**2. Checking it on its own timer.** The first version evaluated the condition only when a `pto_timeout` happened to fire, which turns out to be a poor sampling point: PTO backoff doubles on every retransmission, so by the time a peer has gone quiet the probe interval is seconds wide and the deadline is discovered well past it. Measured against 50 hard-killed peers, a nominal 16 s timeout fired after 24.4 s, where msquic noticed the same peers in 15.7 s. The timeout was not wrong, its sampling was.

The check now runs on a dedicated timer armed at `last_progress + disconnect_timeout`, re-armed lazily when a fire finds the deadline has moved. The delay is never zero, so it cannot spin the way a re-arm derived from a stale timestamp can: with data in flight and the deadline not reached the remainder is positive, and with nothing in flight a full interval is armed. Cost is one timer per connection firing at most once per interval while idle, against the keep-alive timer's once per second. The PTO path keeps its check, where it is now just an early exit.

On a control tower with 50 connections this removed 19.6 s from the phase where the peer process is killed and the server has to notice.

### About the default

The branch defaults to 16000 ms, which is what we ship and what msquic uses. That does change behaviour for existing users: a path that blackholes for 20 seconds survives today and would not after this. If you would rather keep it purely additive, say so and I will default it to `infinity` so it only applies when asked for. I do not have a strong view on which is right for upstream, only that the choice should be explicit rather than a side effect.

Full eunit suite clean on this branch (2263 tests, 0 failures).
