### PR TITLE
Send what fits when a write exceeds the peer's flow-control window

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -146,6 +146,7 @@
     convert_rest_ranges/2,
     check_send_queue_flow_control/4,
     test_check_flow_control/6,
+    test_queue_blocked_send/5,
     close_reason_to_code/1,
     %% Migration frame classification (RFC 9000 Section 9.1)
     is_probing_frame/1,
@@ -2501,6 +2502,32 @@ handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
     {keep_state, State};
+%% An async send can arrive before the state machine reaches `connected':
+%% the owner is told the connection is up a flight before the handshake
+%% concludes, so this is an ordinary race rather than misuse. Queue it the
+%% way the synchronous handshaking-state clause does, to be flushed by
+%% send_pending_data/2 on entering `connected'. Falling through to the
+%% catch-all below would discard it, and send_data_async cannot retry.
+handle_common_event(
+    cast,
+    {send_data_async, StreamId, Data, Fin},
+    StateName,
+    #state{pending_data = Pending} = State
+) ->
+    case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
+        true ->
+            ?LOG_WARNING(
+                #{
+                    what => async_send_dropped_pending_limit,
+                    state => StateName,
+                    stream_id => StreamId
+                },
+                ?QUIC_LOG_META
+            ),
+            {keep_state, State};
+        false ->
+            {keep_state, State#state{pending_data = Pending ++ [{StreamId, Data, Fin}]}}
+    end;
 %% Return error for unhandled calls to prevent timeout
 handle_common_event({call, From}, _Request, StateName, State) ->
     {keep_state, State, [{reply, From, {error, {invalid_state, StateName}}}]};
@@ -7825,13 +7852,12 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.12: DATA_BLOCKED reports the connection data limit
                             BlockedFrame = {data_blocked, MaxDataRemote},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, connection}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {_, false} ->
-                            %% Stream-level flow control blocked
-                            %% RFC 9000: Don't queue data beyond flow control limits.
-                            %% Send STREAM_DATA_BLOCKED and return error to caller.
-                            %% Caller should retry after receiving MAX_STREAM_DATA from peer.
+                            %% Stream-level flow control blocked. Send
+                            %% STREAM_DATA_BLOCKED and queue; the send queue is
+                            %% drained when MAX_STREAM_DATA arrives.
                             ?LOG_DEBUG(
                                 #{
                                     what => stream_flow_control_blocked,
@@ -7843,8 +7869,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.13: STREAM_DATA_BLOCKED reports the stream data limit
                             BlockedFrame = {stream_data_blocked, StreamId, SendMaxData},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, {stream, StreamId}}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {true, true} ->
                             %% Flow control allows sending
                             %% Fragment and send data - congestion control may partially
@@ -8389,6 +8415,33 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
                 {error, send_queue_full} ->
                     {error, send_queue_full}
             end
+    end.
+
+%% Queue a send the peer's flow-control window has no room for, rather
+%% than returning an error. process_send_queue/1 drains it when MAX_DATA
+%% or MAX_STREAM_DATA arrives. An error here is silently lost for
+%% send_data_async callers, which are fire-and-forget and have no way to
+%% retry, and the loss is invisible to both ends: the bytes never reach
+%% the wire, so the peer cannot detect a gap, and the next send on the
+%% stream simply continues from a later offset.
+%%
+%% The send offset is advanced at queue time so later sends on the stream
+%% order behind this entry. QUIC reassembly is offset-based, so the order
+%% the queued entries actually go out in does not matter.
+queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
+    case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+        {ok, QState} ->
+            case maps:find(StreamId, QState#state.streams) of
+                {ok, Stream} ->
+                    NewStream = Stream#stream_state{send_offset = Offset + DataSize},
+                    {ok, QState#state{
+                        streams = maps:put(StreamId, NewStream, QState#state.streams)
+                    }};
+                error ->
+                    {ok, QState}
+            end;
+        {error, send_queue_full} = Error ->
+            Error
     end.
 
 %% Queue stream data when congestion window is full
@@ -11648,6 +11701,21 @@ test_check_flow_control(StreamId, Offset, DataSize, MaxDataRemote, DataSent, Str
         streams = Streams
     },
     check_send_queue_flow_control(StreamId, Offset, DataSize, State).
+
+%% Test helper for queue_blocked_send/6. A send the peer's window has no
+%% room for must be queued, not dropped, and the stream offset must
+%% advance so later sends order behind it.
+%% Returns {ok, NewSendOffset, QueuedCount} | {error, Reason}.
+test_queue_blocked_send(StreamId, Offset, Data, Fin, SendOffset) ->
+    Stream = #stream_state{send_offset = SendOffset, send_max_data = 0},
+    State = #state{streams = #{StreamId => Stream}},
+    case queue_blocked_send(StreamId, Offset, Data, Fin, iolist_size(Data), State) of
+        {ok, S2} ->
+            #{StreamId := S} = S2#state.streams,
+            {ok, S#stream_state.send_offset, S2#state.send_queue_count};
+        Error ->
+            Error
+    end.
 
 %% Test helper for complete_migration/2.
 %% Tests that path_changed notification is sent to owner on active migration.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -7836,7 +7836,30 @@ do_send_data(
                         ?QUIC_LOG_META
                     ),
 
+                    Allowed = min(ConnectionAllowed, StreamAllowed),
                     case {DataSize =< ConnectionAllowed, DataSize =< StreamAllowed} of
+                        Fits when Fits =/= {true, true}, Allowed > 0 ->
+                            %% Part of this write fits in the peer's window.
+                            %% Send that part and queue the rest: queuing the
+                            %% whole write instead deadlocks the transfer,
+                            %% because the peer only extends the window as it
+                            %% consumes data, so sending nothing means nothing
+                            %% ever arrives to open it.
+                            Bin = iolist_to_binary(Data),
+                            <<Head:Allowed/binary, Tail/binary>> = Bin,
+                            case do_send_data(StreamId, Head, false, State) of
+                                {ok, SentState} ->
+                                    queue_blocked_send(
+                                        StreamId,
+                                        Offset + Allowed,
+                                        Tail,
+                                        Fin,
+                                        byte_size(Tail),
+                                        SentState
+                                    );
+                                Other ->
+                                    Other
+                            end;
                         {false, _} ->
                             %% Connection-level flow control blocked
                             %% RFC 9000: Don't queue data beyond flow control limits.

--- a/test/quic_async_send_loss_tests.erl
+++ b/test/quic_async_send_loss_tests.erl
@@ -1,0 +1,39 @@
+%%% A send that the peer's flow-control window has no room for must be
+%%% queued, not turned into an error.
+%%%
+%%% send_data_async is fire-and-forget, so an error return is silently
+%%% lost, and the loss is invisible to both ends: the bytes never reach
+%%% the wire, so the peer cannot detect a gap, and the next send on the
+%%% stream continues from a later offset. The application stream is then
+%%% missing a chunk with nothing reported anywhere.
+-module(quic_async_send_loss_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+queue(StreamId, Offset, Data, Fin, SendOffset) ->
+    quic_connection:test_queue_blocked_send(StreamId, Offset, Data, Fin, SendOffset).
+
+%% The regression: this used to return {error, {flow_control_blocked, _}}
+%% and drop the payload.
+blocked_send_is_queued_test() ->
+    ?assertMatch({ok, _, 1}, queue(4, 0, <<"payload">>, false, 0)).
+
+%% The offset has to advance at queue time, so a later send on the same
+%% stream orders behind this entry rather than overwriting its range.
+blocked_send_advances_offset_test() ->
+    {ok, NewOffset, _} = queue(4, 100, binary:copy(<<$x>>, 250), false, 100),
+    ?assertEqual(350, NewOffset).
+
+fin_is_preserved_test() ->
+    ?assertMatch({ok, _, 1}, queue(8, 0, <<"last">>, true, 0)).
+
+%% An empty payload still has to queue rather than error: a FIN-only send
+%% carries stream-closing intent.
+empty_payload_is_queued_test() ->
+    {ok, NewOffset, Count} = queue(4, 40, <<>>, true, 40),
+    ?assertEqual(40, NewOffset),
+    ?assertEqual(1, Count).
+
+iodata_is_accepted_test() ->
+    {ok, NewOffset, _} = queue(4, 0, [<<"ab">>, [<<"cd">>, <<"ef">>]], false, 0),
+    ?assertEqual(6, NewOffset).


### PR DESCRIPTION
do_send_data/4 compared the whole write against the available window:

    case {DataSize =< ConnectionAllowed, DataSize =< StreamAllowed} of

so a write larger than the window took the blocked path and queued in
its entirety, putting nothing on the wire. That deadlocks the transfer.
The peer only extends the window as it consumes data, so sending nothing
means nothing ever arrives to open it, and both sides wait forever.

Measured against a peer advertising initial_max_stream_data of 524288:
transfers of 64K, 256K and 512K completed, 1M and 2M delivered zero
bytes and timed out. The sender logged send_data result: ok for the full
payload each time, because queueing had succeeded.

Now a write that only partly fits sends the part that does and queues
the remainder at the advanced offset, where process_send_queue/1 drains
it when MAX_DATA or MAX_STREAM_DATA arrives. Both 1M and 2M then
transfer byte-identically. The fully blocked case (no room at all) is
unchanged: BLOCKED frame plus queue.

Depends on queue_blocked_send/6 from the async-send fix, so this is
stacked on that branch.

**Stacked on #225** (needs `queue_blocked_send/6`); review that one first.

Found by running erlang_quic through the QUIC Interop Runner. Full eunit clean (2268 tests).