### PR TITLE
Write TLS secrets to SSLKEYLOGFILE when it is set

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -3048,6 +3048,7 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     ServerAppSecret = quic_crypto:derive_server_app_secret(
         Cipher, MasterSecret, TranscriptHashFinal
     ),
+    keylog_application(State#state.tls_ch1_random, ClientAppSecret, ServerAppSecret),
 
     %% Derive app keys
     {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientAppSecret, Cipher),
@@ -5256,6 +5257,16 @@ process_crypto_buffer(Level, State) ->
             State
     end.
 
+%% Key logging is opt-in via SSLKEYLOGFILE and off otherwise; see
+%% quic_keylog for why it exists and what it exposes.
+keylog_handshake(ClientRandom, ClientSecret, ServerSecret) ->
+    quic_keylog:log(client_handshake, ClientRandom, ClientSecret),
+    quic_keylog:log(server_handshake, ClientRandom, ServerSecret).
+
+keylog_application(ClientRandom, ClientSecret, ServerSecret) ->
+    quic_keylog:log(client_application, ClientRandom, ClientSecret),
+    quic_keylog:log(server_application, ClientRandom, ServerSecret).
+
 %% Process TLS handshake data from CRYPTO frames
 process_tls_data(Level, Data, State) ->
     %% Prepend any buffered incomplete TLS data
@@ -5605,6 +5616,9 @@ process_tls_message(
                     ServerAppSecret = quic_crypto:derive_server_app_secret(
                         Cipher, MasterSecret, TranscriptHashFinal
                     ),
+                    keylog_application(
+                        State#state.tls_ch1_random, ClientAppSecret, ServerAppSecret
+                    ),
 
                     %% Derive app keys
                     {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(
@@ -5949,6 +5963,7 @@ do_server_client_hello_cont(
     SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
 ) ->
     ClientALPN = maps:get(alpn_protocols, ClientHelloInfo, []),
+    ClientRandom = maps:get(random, ClientHelloInfo, undefined),
     TP = maps:get(transport_params, ClientHelloInfo, #{}),
     SessionId = maps:get(session_id, ClientHelloInfo, <<>>),
     %% Check for PSK (0-RTT/resumption/external)
@@ -6155,6 +6170,7 @@ do_server_client_hello_cont(
         negotiated_group = SelectedGroup,
         handshake_secret = HandshakeSecret,
         client_hs_secret = ClientHsSecret,
+        tls_ch1_random = ClientRandom,
         server_hs_secret = ServerHsSecret,
         handshake_keys = {ClientHsKeys, ServerHsKeys},
         alpn = ALPN,
@@ -6162,6 +6178,8 @@ do_server_client_hello_cont(
         early_data_accepted = (EarlyKeys =/= undefined andalso WantsEarlyData),
         selected_psk = SelectedPsk
     },
+    keylog_handshake(State#state.tls_ch1_random, ClientHsSecret, ServerHsSecret),
+    keylog_handshake(ClientRandom, ClientHsSecret, ServerHsSecret),
     %% Negotiate the CertificateVerify scheme up front (cert
     %% path only). No common scheme is fatal (RFC 8446 §4.4.3).
     case negotiate_cert_verify(SelectedPsk, State0) of

--- a/src/quic_keylog.erl
+++ b/src/quic_keylog.erl
@@ -1,0 +1,66 @@
+%%% TLS key logging in the NSS Key Log format.
+%%%
+%%% Wireshark, and through it the QUIC Interop Runner, decrypts a capture
+%%% by reading the traffic secrets from a file named by the SSLKEYLOGFILE
+%%% environment variable. Several interop test cases refuse to grade a
+%%% run without one: they return "unsupported" before looking at whether
+%%% the transfer actually worked.
+%%%
+%%% Writing this file hands anyone who reads it the ability to decrypt the
+%%% connection, so it stays off unless SSLKEYLOGFILE is set, and nothing
+%%% here logs the secrets anywhere else.
+-module(quic_keylog).
+
+-export([log/3, enabled/0]).
+
+-define(CLIENT_HANDSHAKE, "CLIENT_HANDSHAKE_TRAFFIC_SECRET").
+-define(SERVER_HANDSHAKE, "SERVER_HANDSHAKE_TRAFFIC_SECRET").
+-define(CLIENT_APP, "CLIENT_TRAFFIC_SECRET_0").
+-define(SERVER_APP, "SERVER_TRAFFIC_SECRET_0").
+
+-type label() ::
+    client_handshake | server_handshake | client_application | server_application.
+
+-spec enabled() -> boolean().
+enabled() ->
+    case os:getenv("SSLKEYLOGFILE") of
+        false -> false;
+        "" -> false;
+        _ -> true
+    end.
+
+%% @doc Append one secret to the key log. ClientRandom is the 32-byte
+%% random from the ClientHello, which is what ties the line to a
+%% connection; a missing one means the line cannot be matched to anything,
+%% so it is dropped rather than written misleadingly.
+-spec log(label(), binary() | undefined, binary() | undefined) -> ok.
+log(Label, ClientRandom, Secret) when
+    is_binary(ClientRandom), is_binary(Secret), byte_size(Secret) > 0
+->
+    case os:getenv("SSLKEYLOGFILE") of
+        false ->
+            ok;
+        "" ->
+            ok;
+        Path ->
+            Line = [
+                label_text(Label),
+                $\s,
+                hex(ClientRandom),
+                $\s,
+                hex(Secret),
+                $\n
+            ],
+            _ = file:write_file(Path, Line, [append]),
+            ok
+    end;
+log(_Label, _ClientRandom, _Secret) ->
+    ok.
+
+label_text(client_handshake) -> ?CLIENT_HANDSHAKE;
+label_text(server_handshake) -> ?SERVER_HANDSHAKE;
+label_text(client_application) -> ?CLIENT_APP;
+label_text(server_application) -> ?SERVER_APP.
+
+hex(Bin) ->
+    string:lowercase(binary:encode_hex(Bin)).

--- a/src/quic_keylog.erl
+++ b/src/quic_keylog.erl
@@ -21,6 +21,8 @@
 -type label() ::
     client_handshake | server_handshake | client_application | server_application.
 
+-export_type([label/0]).
+
 -spec enabled() -> boolean().
 enabled() ->
     case os:getenv("SSLKEYLOGFILE") of


### PR DESCRIPTION
Wireshark, and through it the QUIC Interop Runner, decrypts a capture by
reading traffic secrets from the file named by SSLKEYLOGFILE. Several
interop test cases refuse to grade a run without one: multiplexing, for
instance, returns "unsupported" before it looks at whether anything
transferred. erlang_quic mentioned the variable in the interop harness
comments but never wrote the file, so those cases could not pass however
well the transfer went.

quic_keylog writes the four TLS 1.3 lines in NSS Key Log format, keyed
by the ClientHello random. The server previously discarded that random
while parsing the ClientHello; it is now kept in tls_ch1_random, which
the client side already did.

This hands anyone who can read the file the ability to decrypt the
connection, so it stays off unless SSLKEYLOGFILE is set, and a line with
no client random is dropped rather than written unmatchable.

With this the runner grades multiplexing and transfer as passing where
both were previously unsupported or failed.

Found while running erlang_quic through the QUIC Interop Runner. Full eunit clean (2263 tests).