### PR TITLE
Send the sendable prefix of a flow-control-blocked queued entry

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8476,7 +8476,15 @@ queue_stream_data(
     } = State,
     Where
 ) ->
-    DataSize = iolist_size(Data),
+    %% Normalise to a binary: consumers like
+    %% dequeue_small_stream_frame_tuple/1 hand the entry's data straight
+    %% to quic_frame:encode/1, which requires a binary.
+    DataBin =
+        case is_binary(Data) of
+            true -> Data;
+            false -> iolist_to_binary(Data)
+        end,
+    DataSize = byte_size(DataBin),
     NewQueueBytes = QueueBytes + DataSize,
     case NewQueueBytes > ?MAX_SEND_QUEUE_BYTES of
         true ->
@@ -8494,7 +8502,7 @@ queue_stream_data(
         false ->
             Urgency = get_stream_urgency(StreamId, Streams),
             %% Cache DataSize in entry to avoid repeated iolist_size calls
-            Entry = {stream_data, StreamId, Offset, Data, Fin, DataSize},
+            Entry = {stream_data, StreamId, Offset, DataBin, Fin, DataSize},
             NewPQ =
                 case Where of
                     back -> pqueue_in(Entry, Urgency, PQ);

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8209,14 +8209,23 @@ do_send_datagram(
 %% subsequent chunking reuses the same binary via sub-binary slices and
 %% downstream helpers can rely on the binary invariant without re-flattening.
 send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State) ->
+    send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, back).
+
+%% Where selects the queue position when a congestion/pacing block forces
+%% the unsent remainder back onto the send queue: `back' for fresh sends
+%% (their offset is highest, so appending keeps per-stream offset order),
+%% `front' when draining the queue (the popped entry's remainder must go
+%% back in front of higher-offset entries, or a later flow-control block
+%% at the head strands it behind them, leaving a permanent data hole).
+send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, Where) ->
     DataBin =
         case is_binary(Data) of
             true -> Data;
             false -> iolist_to_binary(Data)
         end,
-    send_stream_data_fragmented_tracked(StreamId, Offset, DataBin, Fin, State, 0).
+    send_stream_fragments(StreamId, Offset, DataBin, Fin, State, 0, Where).
 
-send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, BytesSentSoFar) when
+send_stream_fragments(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where) when
     is_binary(Data)
 ->
     %% Calculate max chunk size based on current PMTU
@@ -8225,15 +8234,17 @@ send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, BytesSen
 
     case DataSize =< MaxChunkSize of
         true ->
-            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where);
         false ->
             %% Data is already a flat binary; chunk via sub-binary slices.
-            send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize)
+            send_stream_chunked(
+                StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize, Where
+            )
     end.
 
 %% @doc Send stream data that fits in a single packet.
 %% Data is a binary (normalised by send_stream_data_fragmented_tracked/5).
-send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) when
+send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where) when
     is_binary(Data)
 ->
     #state{cc_state = CCState, pacing_enabled = PacingEnabled, streams = Streams} = State,
@@ -8265,7 +8276,7 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) wh
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     PacedState = maybe_set_pacing_timer(Delay, QueuedState),
                     {PacedState, BytesSentSoFar};
@@ -8285,7 +8296,7 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) wh
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     {QueuedState, BytesSentSoFar};
                 {error, send_queue_full} ->
@@ -8325,7 +8336,7 @@ cwnd_only_check(CCState, Size, Urgency) ->
 %% send_stream_data_fragmented_tracked/6. For a 10 MB upload this cuts
 %% thousands of get_stream_urgency/2 / get_max_stream_data_per_packet/1
 %% calls and record-pattern matches out of the hot send loop.
-send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize) ->
+send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize, Where) ->
     Urgency = get_stream_urgency(StreamId, State#state.streams),
     PacketSize = MaxChunkSize + ?PACKET_OVERHEAD,
     %% Pre-compute the stream-frame header parts that stay constant
@@ -8336,7 +8347,7 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
     LengthVarint = quic_varint:encode(MaxChunkSize),
     HeaderPrefix =
         <<(?FRAME_STREAM bor ?STREAM_FLAG_OFF bor ?STREAM_FLAG_LEN):8, StreamIdVarint/binary>>,
-    Ctx = {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint},
+    Ctx = {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where},
     send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx).
 
 %% Inner chunked-send loop. Cached values in `Ctx' never change within a
@@ -8344,17 +8355,17 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
 %% `send_stream_single_packet/6' so a partial last chunk gets a correctly
 %% sized packet (Length != MaxChunkSize) and can also carry a FIN.
 send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, _HeaderPrefix, _LengthVarint} = Ctx,
+    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, _HeaderPrefix, _LengthVarint, Where} = Ctx,
     DataSize = byte_size(Data),
     case DataSize =< MaxChunkSize of
         true ->
-            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where);
         false ->
             send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx)
     end.
 
 send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint} = Ctx,
+    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where} = Ctx,
     #state{cc_state = CCState, pacing_enabled = PacingEnabled} = State,
     Check =
         case PacingEnabled of
@@ -8387,7 +8398,7 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     PacedState = maybe_set_pacing_timer(Delay, QueuedState),
                     {PacedState, BytesSentSoFar};
@@ -8409,7 +8420,7 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     % Return bytes sent so far
                     {QueuedState, BytesSentSoFar};
@@ -8448,6 +8459,9 @@ queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
 
 %% Entry format: {stream_data, StreamId, Offset, Data, Fin, DataSize}
 %% DataSize is cached to avoid repeated iolist_size calls
+queue_stream_data(StreamId, Offset, Data, Fin, State) ->
+    queue_stream_data(StreamId, Offset, Data, Fin, State, back).
+
 queue_stream_data(
     StreamId,
     Offset,
@@ -8459,7 +8473,8 @@ queue_stream_data(
         send_queue_bytes = QueueBytes,
         send_queue_count = QueueCount,
         send_queue_version = Version
-    } = State
+    } = State,
+    Where
 ) ->
     DataSize = iolist_size(Data),
     NewQueueBytes = QueueBytes + DataSize,
@@ -8480,7 +8495,11 @@ queue_stream_data(
             Urgency = get_stream_urgency(StreamId, Streams),
             %% Cache DataSize in entry to avoid repeated iolist_size calls
             Entry = {stream_data, StreamId, Offset, Data, Fin, DataSize},
-            NewPQ = pqueue_in(Entry, Urgency, PQ),
+            NewPQ =
+                case Where of
+                    back -> pqueue_in(Entry, Urgency, PQ);
+                    front -> pqueue_in_front(Entry, Urgency, PQ)
+                end,
             NewVersion = Version + 1,
             {ok, State#state{
                 send_queue = NewPQ,
@@ -8612,7 +8631,7 @@ process_send_queue_entry(
                 send_queue_bytes = DecrementedQueueBytes,
                 send_queue_count = DecrementedQueueCount
             },
-            case send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State1) of
+            case send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State1, front) of
                 {error, send_queue_full} ->
                     ?LOG_WARNING(
                         #{
@@ -8662,6 +8681,16 @@ process_send_queue_entry(
 pqueue_in(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
     Bucket = element(Urgency + 1, PQ),
     NewBucket = queue:in(Entry, Bucket),
+    setelement(Urgency + 1, PQ, NewBucket).
+
+%% Insert at the front of the urgency bucket. Used when a drain pops an
+%% entry and must put back an unsent remainder: appending it at the back
+%% would order it behind higher-offset entries of the same stream, and a
+%% later stream-flow-control block at the head then strands it forever
+%% (the peer cannot extend the window across the resulting data hole).
+pqueue_in_front(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
+    Bucket = element(Urgency + 1, PQ),
+    NewBucket = queue:in_r(Entry, Bucket),
     setelement(Urgency + 1, PQ, NewBucket).
 
 %% Remove and return highest priority (lowest urgency) entry
@@ -9475,6 +9504,9 @@ defer_retransmit_frames(Frames, State) ->
 %% Queue a lost STREAM frame for retransmission. Exempt from flow control and
 %% data_sent (those were counted on the original send); bytes/count/version are
 %% updated like queue_stream_data/5 so the drain and reclaim-gate scans see it.
+%% Front-inserted: retransmits fill receiver-side holes, so they must not sit
+%% behind a flow-control-blocked head whose window can only grow once the hole
+%% is filled.
 enqueue_retransmit_stream(StreamId, Offset, Data, Fin, State) ->
     #state{
         send_queue = PQ,
@@ -9487,7 +9519,7 @@ enqueue_retransmit_stream(StreamId, Offset, Data, Fin, State) ->
     Urgency = get_stream_urgency(StreamId, Streams),
     Entry = {retransmit_stream, StreamId, Offset, Data, Fin, DataSize},
     State#state{
-        send_queue = pqueue_in(Entry, Urgency, PQ),
+        send_queue = pqueue_in_front(Entry, Urgency, PQ),
         send_queue_bytes = QueueBytes + DataSize,
         send_queue_count = QueueCount + 1,
         send_queue_version = Version + 1

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8549,8 +8549,15 @@ process_send_queue(#state{send_queue = PQ} = State) ->
                     %% Flow control allows - dequeue and try to send
                     process_send_queue_entry(State);
                 {blocked, _Reason} ->
-                    %% Flow control blocked - leave in queue, wait for MAX_DATA
-                    State
+                    %% An entry larger than the current window still has a
+                    %% sendable prefix. Waiting for one grant big enough for
+                    %% the whole entry stalls against a peer that extends its
+                    %% window in small steps as it reads, because it sizes the
+                    %% grant to what it consumed, never to what we have queued.
+                    case split_blocked_head(State) of
+                        {ok, SplitState} -> process_send_queue_entry(SplitState);
+                        false -> State
+                    end
             end;
         {value, {retransmit_stream, _StreamId, _Offset, _Data, _Fin, DataSize}} ->
             %% Retransmits are exempt from flow control (bytes already counted),
@@ -8594,6 +8601,45 @@ check_send_queue_flow_control(StreamId, Offset, DataSize, #state{
                     ok
             end
     end.
+
+%% Replace a flow-control-blocked head entry with the prefix that fits plus
+%% the remainder, both at the front so stream order is preserved. Returns
+%% false when nothing fits, when the whole entry fits (the caller should not
+%% have been blocked), or for a zero-length FIN-only entry.
+split_blocked_head(#state{send_queue = PQ, send_queue_count = QueueCount} = State) ->
+    case pqueue_peek(PQ) of
+        {value, {stream_data, StreamId, Offset, Data, Fin, DataSize}} ->
+            case blocked_head_allowance(StreamId, Offset, State) of
+                Allowed when Allowed > 0, Allowed < DataSize ->
+                    {{value, _}, PQ1} = pqueue_out(PQ),
+                    <<Head:Allowed/binary, Tail/binary>> = Data,
+                    Urgency = get_stream_urgency(StreamId, State#state.streams),
+                    TailEntry =
+                        {stream_data, StreamId, Offset + Allowed, Tail, Fin, DataSize - Allowed},
+                    HeadEntry = {stream_data, StreamId, Offset, Head, false, Allowed},
+                    PQ2 = pqueue_in_front(TailEntry, Urgency, PQ1),
+                    PQ3 = pqueue_in_front(HeadEntry, Urgency, PQ2),
+                    {ok, State#state{send_queue = PQ3, send_queue_count = QueueCount + 1}};
+                _ ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+%% Bytes of the entry at Offset that both connection and stream windows admit.
+blocked_head_allowance(StreamId, Offset, #state{
+    max_data_remote = MaxDataRemote,
+    data_sent = DataSent,
+    streams = Streams
+}) ->
+    ConnectionAllowed = MaxDataRemote - DataSent,
+    StreamAllowed =
+        case maps:find(StreamId, Streams) of
+            {ok, #stream_state{send_max_data = SendMaxData}} -> SendMaxData - Offset;
+            error -> ConnectionAllowed
+        end,
+    min(ConnectionAllowed, StreamAllowed).
 
 %% Actually process the queue entry (called after flow control check passes)
 process_send_queue_entry(

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2501,6 +2501,33 @@ handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
     {keep_state, State};
+%% Async sends can arrive before the state machine reaches `connected':
+%% the owner is told `connected' a flight before the server confirms, and
+%% send_data_async is fire-and-forget so the caller cannot retry. Queue
+%% them like the synchronous handshaking-state path does (flushed by
+%% send_pending_data/2 on entering `connected'); falling through to the
+%% catch-all below silently loses the data.
+handle_common_event(
+    cast,
+    {send_data_async, StreamId, Data, Fin},
+    StateName,
+    #state{pending_data = Pending} = State
+) ->
+    case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
+        true ->
+            ?LOG_WARNING(
+                #{
+                    what => async_send_dropped_pending_limit,
+                    state => StateName,
+                    stream_id => StreamId
+                },
+                ?QUIC_LOG_META
+            ),
+            {keep_state, State};
+        false ->
+            NewPending = Pending ++ [{StreamId, Data, Fin}],
+            {keep_state, State#state{pending_data = NewPending}}
+    end;
 %% Return error for unhandled calls to prevent timeout
 handle_common_event({call, From}, _Request, StateName, State) ->
     {keep_state, State, [{reply, From, {error, {invalid_state, StateName}}}]};
@@ -7825,8 +7852,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.12: DATA_BLOCKED reports the connection data limit
                             BlockedFrame = {data_blocked, MaxDataRemote},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, connection}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {_, false} ->
                             %% Stream-level flow control blocked
                             %% RFC 9000: Don't queue data beyond flow control limits.
@@ -7843,8 +7870,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.13: STREAM_DATA_BLOCKED reports the stream data limit
                             BlockedFrame = {stream_data_blocked, StreamId, SendMaxData},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, {stream, StreamId}}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {true, true} ->
                             %% Flow control allows sending
                             %% Fragment and send data - congestion control may partially
@@ -8394,6 +8421,31 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
 %% Queue stream data when congestion window is full
 %% Uses bucket-based priority queue for O(1) insert (RFC 9218)
 %% Returns {ok, State} | {error, send_queue_full} if queue limit exceeded
+%% Flow-control-blocked sends are queued rather than dropped and are
+%% retried by process_send_queue/1 when MAX_DATA / MAX_STREAM_DATA
+%% arrives. Returning an error here silently loses data for
+%% send_data_async callers, which have no way to retry: the send offset
+%% stays untouched, so later sends close the gap at the QUIC layer while
+%% the application stream is missing a chunk. The offset is advanced
+%% when queueing so subsequent sends on the stream order consistently
+%% behind this entry; QUIC reassembly is offset-based, so transmission
+%% order across entries does not matter.
+queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
+    case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+        {ok, QState} ->
+            case maps:find(StreamId, QState#state.streams) of
+                {ok, Stream} ->
+                    NewStream = Stream#stream_state{send_offset = Offset + DataSize},
+                    {ok, QState#state{
+                        streams = maps:put(StreamId, NewStream, QState#state.streams)
+                    }};
+                error ->
+                    {ok, QState}
+            end;
+        {error, send_queue_full} = Error ->
+            Error
+    end.
+
 %% Entry format: {stream_data, StreamId, Offset, Data, Fin, DataSize}
 %% DataSize is cached to avoid repeated iolist_size calls
 queue_stream_data(


### PR DESCRIPTION
The send queue drain treats flow control as all-or-nothing: if the head entry does not fit entirely within the connection and stream windows, it stays queued until a grant arrives that covers the whole entry.

A peer that extends its window incrementally as the application reads never issues such a grant. It sizes each `MAX_STREAM_DATA` to what it just consumed, so against a multi-megabyte queued entry the window grows in steps far smaller than the entry and the transfer wedges permanently.

Found with the QUIC Interop Runner. A quic-go client downloading from our server stalled at exactly the last offset it had granted, while ngtcp2 passed the same case because it opens a large window up front. quic-go's qlog showed it was sending window extensions the whole time; we were declining to use them.

The fix splits the head entry, sending the prefix the windows admit and putting the remainder back. Both parts go in via `pqueue_in_front` so the stream stays in offset order. Appending the remainder at the back would place it behind higher-offset entries of the same stream and strand it, which is the hazard that helper already documents.

This is the drain-path counterpart of #230, which fixes the same all-or-nothing defect on the direct write path.

Result in the interop runner, quic-go client against our server:

| | before | after |
|---|---|---|
| transfer | fail, stalls at the granted offset | pass |
| multiplexing | fail | pass |
| keyupdate | fail | pass |

`erlang-quic` against itself still passes transfer, multiplexing and handshake, and eunit is clean (2263 tests).

Based on #205, which introduces `pqueue_in_front` and `process_send_queue_unbudgeted`.