### PR TITLE
Use the negotiated cipher when unprotecting short headers

### DIFF
--- a/src/quic_aead.erl
+++ b/src/quic_aead.erl
@@ -46,6 +46,7 @@
     unprotect_long_packet/7,
     %% 2-stage short header receive API (for key-phase handling)
     unprotect_short_header/4,
+    unprotect_short_header/5,
     decrypt_short_payload/8
 ]).
 
@@ -475,7 +476,18 @@ unprotect_packet_common(Cipher, Key, IV, HP, Header, EncryptedPayload, LargestRe
 -spec unprotect_short_header(binary(), binary(), binary(), non_neg_integer()) ->
     {ok, 0 | 1, 1..4, non_neg_integer(), binary()} | {error, term()}.
 unprotect_short_header(HP, Header, EncryptedPayload, PNOffset) ->
-    case unprotect_header(HP, Header, EncryptedPayload, PNOffset) of
+    %% Guesses the cipher from the HP key length, which cannot tell
+    %% AES-256-GCM from ChaCha20-Poly1305. Prefer the /5 variant.
+    unprotect_short_header(cipher_for_key(HP), HP, Header, EncryptedPayload, PNOffset).
+
+%% @doc Like unprotect_short_header/4 but with the cipher given by the
+%% caller, which is required when ChaCha20-Poly1305 is negotiated: its
+%% 32-byte HP key is indistinguishable from AES-256-GCM's, and the two
+%% mask constructions are unrelated.
+-spec unprotect_short_header(cipher(), binary(), binary(), binary(), non_neg_integer()) ->
+    {ok, 0 | 1, 1..4, non_neg_integer(), binary()} | {error, term()}.
+unprotect_short_header(Cipher, HP, Header, EncryptedPayload, PNOffset) ->
+    case unprotect_header(Cipher, HP, Header, EncryptedPayload, PNOffset) of
         {error, Reason} ->
             {error, {header_unprotect_failed, Reason}};
         {UnprotectedHeader, PNLen} ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4362,11 +4362,14 @@ decode_short_header_packet(Data, State) ->
 %% Decrypt an application (1-RTT) packet with key phase handling
 %% Uses 2-stage API: unprotect header to get key_phase, then decrypt with selected keys
 decrypt_app_packet(Header, EncryptedPayload, CurrentKeys, State) ->
-    #crypto_keys{hp = HP} = CurrentKeys,
+    %% The cipher must come from the negotiated keys: inferring it from
+    %% the HP key length mistakes ChaCha20-Poly1305 for AES-256-GCM and
+    %% drops every received 1-RTT packet on such connections.
+    #crypto_keys{hp = HP, cipher = HpCipher} = CurrentKeys,
     PNOffset = byte_size(Header),
 
     %% Stage 1: Unprotect header to get key_phase and PN info
-    case quic_aead:unprotect_short_header(HP, Header, EncryptedPayload, PNOffset) of
+    case quic_aead:unprotect_short_header(HpCipher, HP, Header, EncryptedPayload, PNOffset) of
         {error, Reason} ->
             {error, Reason};
         {ok, KeyPhase, PNLen, TruncatedPN, UnprotectedHeader} ->

--- a/test/quic_aead_tests.erl
+++ b/test/quic_aead_tests.erl
@@ -267,6 +267,38 @@ header_protection_roundtrip_short_test() ->
     ?assertEqual(PNLen, UnprotPNLen),
     ?assertEqual(Header, Unprotected).
 
+%% RFC 9001 Appendix A.5: ChaCha20-Poly1305 short header packet.
+%% The HP key is 32 bytes, so the cipher cannot be inferred from its
+%% length; the caller has to supply it or the AES-256 mask is used.
+rfc9001_chacha20_short_header_test() ->
+    Key = hexstr_to_bin(
+        "c6d98ff3441c3fe1b2182094f69caa2e"
+        "d4b716b65488960a7a984979fb23e1c8"
+    ),
+    IV = hexstr_to_bin("e0459b3474bdd0e44a41c144"),
+    HP = hexstr_to_bin(
+        "25a282b9e82f06f21f488917a4fc8f1b"
+        "73573685608597d0efcb076b0ab7a7a4"
+    ),
+    Packet = hexstr_to_bin("4cfe4189655e5cd55c41f69080575d7999c25a5bfb"),
+
+    %% Zero-length DCID: the header before the PN is just the first byte
+    <<Header:1/binary, EncryptedPayload/binary>> = Packet,
+    {ok, KeyPhase, PNLen, TruncPN, UnprotHdr} =
+        quic_aead:unprotect_short_header(
+            chacha20_poly1305, HP, Header, EncryptedPayload, 1
+        ),
+    ?assertEqual(0, KeyPhase),
+    ?assertEqual(3, PNLen),
+    ?assertEqual(49140, TruncPN),
+    ?assertEqual(hexstr_to_bin("4200bff4"), UnprotHdr),
+
+    {ok, PN, Plaintext} = quic_aead:decrypt_short_payload(
+        chacha20_poly1305, Key, IV, UnprotHdr, PNLen, TruncPN, EncryptedPayload, 654360563
+    ),
+    ?assertEqual(654360564, PN),
+    ?assertEqual(<<16#01>>, Plaintext).
+
 %%====================================================================
 %% Helper Functions
 %%====================================================================


### PR DESCRIPTION
decrypt_app_packet removed header protection via `unprotect_short_header/4`, which guesses the cipher from the HP key length. AES-256-GCM and ChaCha20-Poly1305 both use 32-byte HP keys, so on a ChaCha20 connection the guess lands on AES-256 and the computed mask is unrelated to the real one. The recovered packet number and length are garbage, AEAD open fails, and every received 1-RTT packet is silently dropped.

The failure is invisible until interop: the long-header path passes the cipher explicitly, so the handshake completes, and the send path also knows the cipher, so the peer decrypts our packets fine. The connection then sits in a one-way conversation until it idles out. Found with the QUIC Interop Runner, where the chacha20 case failed against every other implementation.

Add `unprotect_short_header/5` taking the cipher and pass the one from the negotiated keys; `/4` stays as a delegating wrapper.

The RFC 9001 Appendix A.5 ChaCha20-Poly1305 short-header vector is added as a regression test; it fails against the old inference path (the old code recovers header `4972AF` where the RFC expects `4200BFF4`).

Verified with the interop runner: with this fix the chacha20 case passes with quic-go, ngtcp2 and picoquic clients against our server. (The client role needs one more fix — the ClientHello offers a hardcoded cipher list — which comes separately as it builds on #232.)