### PR TITLE
interop: buffer fragmented requests, poll for stream credit

### DIFF
--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -88,10 +88,11 @@ run_test(TestCase, RequestsStr, DownloadsDir) ->
             io:format("No requests specified~n"),
             halt(?EXIT_FAILURE);
         _ ->
-            Results = lists:map(
-                fun(Url) -> download_file(TestCase, Url, DownloadsDir) end,
-                Requests
-            ),
+            %% The runner asks for several files and requires them on ONE
+            %% connection: the transfer test counts handshakes and fails on
+            %% more than one, and multiplexing expects concurrent streams.
+            %% Connect once per host and reuse it for every path.
+            Results = download_all(TestCase, Requests, DownloadsDir),
 
             case lists:all(fun(R) -> R =:= ok end, Results) of
                 true ->
@@ -103,29 +104,92 @@ run_test(TestCase, RequestsStr, DownloadsDir) ->
             end
     end.
 
-download_file(TestCase, Url, DownloadsDir) ->
-    io:format("Downloading: ~s~n", [Url]),
+download_all(TestCase, Requests, DownloadsDir) ->
+    ByHost = lists:foldl(
+        fun(Url, Acc) ->
+            case parse_url(Url) of
+                {ok, Host, Port, Path} ->
+                    maps:update_with(
+                        {Host, Port}, fun(Ps) -> Ps ++ [Path] end, [Path], Acc
+                    );
+                error ->
+                    io:format("Invalid URL: ~s~n", [Url]),
+                    Acc
+            end
+        end,
+        #{},
+        Requests
+    ),
+    lists:append(
+        maps:fold(
+            fun({Host, Port}, Paths, Acc) ->
+                [download_from(TestCase, Host, Port, Paths, DownloadsDir) | Acc]
+            end,
+            [],
+            ByHost
+        )
+    ).
 
-    %% Parse URL
-    case parse_url(Url) of
-        {ok, Host, Port, Path} ->
-            %% Build connection options based on test case
-            Opts = build_opts(TestCase),
-
-            %% Connect
-            case quic:connect(Host, Port, Opts, self()) of
-                {ok, Conn} ->
-                    Result = wait_for_connection_and_download(
-                        Conn, Path, DownloadsDir, TestCase
-                    ),
+download_from(TestCase, Host, Port, Paths, DownloadsDir) ->
+    Opts = build_opts(TestCase),
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, Conn} ->
+            case wait_connected(Conn, TestCase) of
+                ok ->
+                    Results = [
+                        begin
+                            io:format("Downloading: https://~s:~p/~s~n", [Host, Port, Path]),
+                            request_path(Conn, Path, DownloadsDir)
+                        end
+                     || Path <- Paths
+                    ],
                     quic:close(Conn, normal),
-                    Result;
-                {error, Reason} ->
-                    io:format("Connection failed: ~p~n", [Reason]),
-                    error
+                    Results;
+                error ->
+                    quic:close(Conn, normal),
+                    [error || _ <- Paths]
             end;
-        error ->
-            io:format("Invalid URL: ~s~n", [Url]),
+        {error, Reason} ->
+            io:format("Connection failed: ~p~n", [Reason]),
+            [error || _ <- Paths]
+    end.
+
+wait_connected(Conn, TestCase) ->
+    receive
+        {quic, Conn, {connected, _Info}} ->
+            io:format("Connected~n"),
+            case TestCase of
+                "keyupdate" -> quic_connection:key_update(Conn);
+                _ -> ok
+            end,
+            ok;
+        {quic, Conn, {closed, Reason}} ->
+            io:format("Connection closed: ~p~n", [Reason]),
+            error;
+        {quic, Conn, {transport_error, Code, Msg}} ->
+            io:format("Transport error: ~p ~p~n", [Code, Msg]),
+            error
+    after 30000 ->
+        io:format("Connection timeout~n"),
+        error
+    end.
+
+%% Kept for the resumption/zerortt paths, which connect per attempt by
+%% design: one connection, one request.
+wait_for_connection_and_download(Conn, Path, DownloadsDir, TestCase) ->
+    case wait_connected(Conn, TestCase) of
+        ok -> request_path(Conn, Path, DownloadsDir);
+        error -> error
+    end.
+
+request_path(Conn, Path, DownloadsDir) ->
+    case quic:open_stream(Conn) of
+        {ok, StreamId} ->
+            Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
+            ok = quic:send_data(Conn, StreamId, Request, true),
+            receive_and_save(Conn, StreamId, Path, DownloadsDir);
+        {error, StreamErr} ->
+            io:format("Failed to open stream: ~p~n", [StreamErr]),
             error
     end.
 
@@ -157,42 +221,6 @@ build_opts(_) ->
         verify => false,
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
-
-wait_for_connection_and_download(Conn, Path, DownloadsDir, TestCase) ->
-    receive
-        {quic, Conn, {connected, _Info}} ->
-            io:format("Connected~n"),
-
-            %% Handle key update test case
-            case TestCase of
-                "keyupdate" ->
-                    %% Initiate key update before request
-                    quic_connection:key_update(Conn);
-                _ ->
-                    ok
-            end,
-
-            %% Open stream and send request
-            case quic:open_stream(Conn) of
-                {ok, StreamId} ->
-                    %% Send HTTP/0.9 style request (for hq-interop)
-                    Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(Conn, StreamId, Request, true),
-                    receive_and_save(Conn, StreamId, Path, DownloadsDir);
-                {error, StreamErr} ->
-                    io:format("Failed to open stream: ~p~n", [StreamErr]),
-                    error
-            end;
-        {quic, Conn, {closed, Reason}} ->
-            io:format("Connection closed: ~p~n", [Reason]),
-            error;
-        {quic, Conn, {transport_error, Code, Msg}} ->
-            io:format("Transport error: ~p ~p~n", [Code, Msg]),
-            error
-    after 30000 ->
-        io:format("Connection timeout~n"),
-        error
-    end.
 
 receive_and_save(Conn, StreamId, Path, DownloadsDir) ->
     %% Extract filename and open file for streaming writes

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -141,14 +141,8 @@ download_from(TestCase, Host, Port, Paths, DownloadsDir) ->
                     %% streams in flight at the same time; issuing them one
                     %% after another looks like a series of single-stream
                     %% transfers no matter how many files are requested.
-                    Streams = [
-                        begin
-                            io:format("Downloading: https://~s:~p/~s~n", [Host, Port, Path]),
-                            open_and_request(Conn, Path)
-                        end
-                     || Path <- Paths
-                    ],
-                    Results = collect_streams(Conn, Streams, DownloadsDir),
+                    io:format("Requesting ~p file(s)~n", [length(Paths)]),
+                    Results = collect_streams(Conn, Paths, DownloadsDir),
                     quic:close(Conn, normal),
                     Results;
                 error ->
@@ -228,28 +222,37 @@ build_opts(_) ->
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
 
-open_and_request(Conn, Path) ->
+%% Keep as many streams in flight as the peer's stream credit allows and
+%% refill as they finish. The multiplexing test asks for close to 2000
+%% files while the default bidi stream limit is 100, so opening them all
+%% up front fails all but the first hundred; the peer extends credit with
+%% MAX_STREAMS only as earlier streams close.
+collect_streams(Conn, Paths, DownloadsDir) ->
+    {Open, Pending} = fill_streams(Conn, Paths, #{}, DownloadsDir),
+    Done = collect_loop(Conn, Open, Pending, DownloadsDir, #{}, 180000),
+    [Result || {_StreamId, Result} <- maps:to_list(Done)].
+
+fill_streams(_Conn, [], Open, _DownloadsDir) ->
+    {Open, []};
+fill_streams(Conn, [Path | Rest] = Pending, Open, DownloadsDir) ->
     case quic:open_stream(Conn) of
         {ok, StreamId} ->
             Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
             case quic:send_data(Conn, StreamId, Request, true) of
-                ok -> {StreamId, Path};
-                Err -> {error, Path, Err}
+                ok ->
+                    fill_streams(
+                        Conn,
+                        Rest,
+                        Open#{StreamId => open_target(Path, DownloadsDir)},
+                        DownloadsDir
+                    );
+                _Err ->
+                    {Open, Pending}
             end;
-        {error, StreamErr} ->
-            {error, Path, StreamErr}
+        {error, _} ->
+            %% Out of stream credit for now; the rest wait for MAX_STREAMS.
+            {Open, Pending}
     end.
-
-%% Collect concurrently: one file handle per stream, fed by whichever
-%% stream_data arrives next, until every stream has seen its FIN.
-collect_streams(Conn, Streams, DownloadsDir) ->
-    Open = maps:from_list([
-        {Sid, open_target(Path, DownloadsDir)}
-     || {Sid, Path} <- Streams, is_integer(Sid)
-    ]),
-    Failed = [error || {error, _, _} <- Streams],
-    Done = collect_loop(Conn, Open, #{}, 120000),
-    Failed ++ [R || {_Sid, R} <- maps:to_list(Done)].
 
 open_target(Path, DownloadsDir) ->
     FilePath = filename:join(DownloadsDir, filename:basename(Path)),
@@ -258,9 +261,9 @@ open_target(Path, DownloadsDir) ->
         {error, Err} -> {error, FilePath, Err}
     end.
 
-collect_loop(_Conn, Open, Done, _Timeout) when map_size(Open) =:= 0 ->
+collect_loop(_Conn, Open, [], _DownloadsDir, Done, _Timeout) when map_size(Open) =:= 0 ->
     Done;
-collect_loop(Conn, Open, Done, Timeout) ->
+collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
     receive
         {quic, Conn, {stream_data, Sid, Data, Fin}} ->
             case maps:find(Sid, Open) of
@@ -271,25 +274,28 @@ collect_loop(Conn, Open, Done, Timeout) ->
                         true ->
                             file:close(Handle),
                             io:format("Saved: ~s (~p bytes)~n", [FilePath, NewWritten]),
+                            {Open2, Pending2} = fill_streams(
+                                Conn, Pending, maps:remove(Sid, Open), DownloadsDir
+                            ),
                             collect_loop(
-                                Conn,
-                                maps:remove(Sid, Open),
-                                Done#{Sid => ok},
-                                Timeout
+                                Conn, Open2, Pending2, DownloadsDir, Done#{Sid => ok}, Timeout
                             );
                         false ->
                             collect_loop(
                                 Conn,
                                 Open#{Sid => {Handle, FilePath, NewWritten}},
+                                Pending,
+                                DownloadsDir,
                                 Done,
                                 Timeout
                             )
                     end;
                 error ->
-                    collect_loop(Conn, Open, Done, Timeout)
+                    collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout)
             end;
         {quic, Conn, {stream_reset, Sid, _Code}} ->
-            collect_loop(Conn, maps:remove(Sid, Open), Done#{Sid => error}, Timeout);
+            {Open2, Pending2} = fill_streams(Conn, Pending, maps:remove(Sid, Open), DownloadsDir),
+            collect_loop(Conn, Open2, Pending2, DownloadsDir, Done#{Sid => error}, Timeout);
         {quic, Conn, {closed, _Reason}} ->
             close_remaining(Open, Done)
     after Timeout ->

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -229,8 +229,14 @@ build_opts(_) ->
 %% MAX_STREAMS only as earlier streams close.
 collect_streams(Conn, Paths, DownloadsDir) ->
     {Open, Pending} = fill_streams(Conn, Paths, #{}, DownloadsDir),
-    Done = collect_loop(Conn, Open, Pending, DownloadsDir, #{}, 180000),
-    [Result || {_StreamId, Result} <- maps:to_list(Done)].
+    Deadline = erlang:monotonic_time(millisecond) + 180000,
+    {Done, PendingLeft} = collect_loop(Conn, Open, Pending, DownloadsDir, #{}, Deadline),
+    case PendingLeft of
+        [] -> ok;
+        _ -> io:format("~p request(s) never got a stream~n", [length(PendingLeft)])
+    end,
+    [Result || {_StreamId, Result} <- maps:to_list(Done)] ++
+        [error || _ <- PendingLeft].
 
 fill_streams(_Conn, [], Open, _DownloadsDir) ->
     {Open, []};
@@ -261,9 +267,19 @@ open_target(Path, DownloadsDir) ->
         {error, Err} -> {error, FilePath, Err}
     end.
 
-collect_loop(_Conn, Open, [], _DownloadsDir, Done, _Timeout) when map_size(Open) =:= 0 ->
-    Done;
-collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
+collect_loop(_Conn, Open, [], _DownloadsDir, Done, _Deadline) when map_size(Open) =:= 0 ->
+    {Done, []};
+collect_loop(Conn, Open, Pending, DownloadsDir, Done, Deadline) ->
+    TimeLeft = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    %% With requests waiting for stream credit, poll: MAX_STREAMS
+    %% arriving at the connection process produces no message here, so
+    %% waiting only for stream events deadlocks when the last grant
+    %% lands after the last completion event has been handled.
+    Timeout =
+        case Pending of
+            [] -> TimeLeft;
+            _ -> min(200, TimeLeft)
+        end,
     receive
         {quic, Conn, {stream_data, Sid, Data, Fin}} ->
             case maps:find(Sid, Open) of
@@ -278,7 +294,7 @@ collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
                                 Conn, Pending, maps:remove(Sid, Open), DownloadsDir
                             ),
                             collect_loop(
-                                Conn, Open2, Pending2, DownloadsDir, Done#{Sid => ok}, Timeout
+                                Conn, Open2, Pending2, DownloadsDir, Done#{Sid => ok}, Deadline
                             );
                         false ->
                             collect_loop(
@@ -287,20 +303,26 @@ collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
                                 Pending,
                                 DownloadsDir,
                                 Done,
-                                Timeout
+                                Deadline
                             )
                     end;
                 error ->
-                    collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout)
+                    collect_loop(Conn, Open, Pending, DownloadsDir, Done, Deadline)
             end;
         {quic, Conn, {stream_reset, Sid, _Code}} ->
             {Open2, Pending2} = fill_streams(Conn, Pending, maps:remove(Sid, Open), DownloadsDir),
-            collect_loop(Conn, Open2, Pending2, DownloadsDir, Done#{Sid => error}, Timeout);
+            collect_loop(Conn, Open2, Pending2, DownloadsDir, Done#{Sid => error}, Deadline);
         {quic, Conn, {closed, _Reason}} ->
-            close_remaining(Open, Done)
+            {close_remaining(Open, Done), Pending}
     after Timeout ->
-        io:format("Stream timeout with ~p stream(s) outstanding~n", [map_size(Open)]),
-        close_remaining(Open, Done)
+        case TimeLeft > 0 andalso Pending =/= [] of
+            true ->
+                {Open2, Pending2} = fill_streams(Conn, Pending, Open, DownloadsDir),
+                collect_loop(Conn, Open2, Pending2, DownloadsDir, Done, Deadline);
+            false ->
+                io:format("Stream timeout with ~p stream(s) outstanding~n", [map_size(Open)]),
+                {close_remaining(Open, Done), Pending}
+        end
     end.
 
 close_remaining(Open, Done) ->

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -136,13 +136,19 @@ download_from(TestCase, Host, Port, Paths, DownloadsDir) ->
         {ok, Conn} ->
             case wait_connected(Conn, TestCase) of
                 ok ->
-                    Results = [
+                    %% Open every stream and send every request before
+                    %% collecting any of them. The multiplexing test wants the
+                    %% streams in flight at the same time; issuing them one
+                    %% after another looks like a series of single-stream
+                    %% transfers no matter how many files are requested.
+                    Streams = [
                         begin
                             io:format("Downloading: https://~s:~p/~s~n", [Host, Port, Path]),
-                            request_path(Conn, Path, DownloadsDir)
+                            open_and_request(Conn, Path)
                         end
                      || Path <- Paths
                     ],
+                    Results = collect_streams(Conn, Streams, DownloadsDir),
                     quic:close(Conn, normal),
                     Results;
                 error ->
@@ -221,6 +227,89 @@ build_opts(_) ->
         verify => false,
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
+
+open_and_request(Conn, Path) ->
+    case quic:open_stream(Conn) of
+        {ok, StreamId} ->
+            Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
+            case quic:send_data(Conn, StreamId, Request, true) of
+                ok -> {StreamId, Path};
+                Err -> {error, Path, Err}
+            end;
+        {error, StreamErr} ->
+            {error, Path, StreamErr}
+    end.
+
+%% Collect concurrently: one file handle per stream, fed by whichever
+%% stream_data arrives next, until every stream has seen its FIN.
+collect_streams(Conn, Streams, DownloadsDir) ->
+    Open = maps:from_list([
+        {Sid, open_target(Path, DownloadsDir)}
+     || {Sid, Path} <- Streams, is_integer(Sid)
+    ]),
+    Failed = [error || {error, _, _} <- Streams],
+    Done = collect_loop(Conn, Open, #{}, 120000),
+    Failed ++ [R || {_Sid, R} <- maps:to_list(Done)].
+
+open_target(Path, DownloadsDir) ->
+    FilePath = filename:join(DownloadsDir, filename:basename(Path)),
+    case file:open(FilePath, [write, binary, raw]) of
+        {ok, Handle} -> {Handle, FilePath, 0};
+        {error, Err} -> {error, FilePath, Err}
+    end.
+
+collect_loop(_Conn, Open, Done, _Timeout) when map_size(Open) =:= 0 ->
+    Done;
+collect_loop(Conn, Open, Done, Timeout) ->
+    receive
+        {quic, Conn, {stream_data, Sid, Data, Fin}} ->
+            case maps:find(Sid, Open) of
+                {ok, {Handle, FilePath, Written}} ->
+                    ok = file:write(Handle, Data),
+                    NewWritten = Written + byte_size(Data),
+                    case Fin of
+                        true ->
+                            file:close(Handle),
+                            io:format("Saved: ~s (~p bytes)~n", [FilePath, NewWritten]),
+                            collect_loop(
+                                Conn,
+                                maps:remove(Sid, Open),
+                                Done#{Sid => ok},
+                                Timeout
+                            );
+                        false ->
+                            collect_loop(
+                                Conn,
+                                Open#{Sid => {Handle, FilePath, NewWritten}},
+                                Done,
+                                Timeout
+                            )
+                    end;
+                error ->
+                    collect_loop(Conn, Open, Done, Timeout)
+            end;
+        {quic, Conn, {stream_reset, Sid, _Code}} ->
+            collect_loop(Conn, maps:remove(Sid, Open), Done#{Sid => error}, Timeout);
+        {quic, Conn, {closed, _Reason}} ->
+            close_remaining(Open, Done)
+    after Timeout ->
+        io:format("Stream timeout with ~p stream(s) outstanding~n", [map_size(Open)]),
+        close_remaining(Open, Done)
+    end.
+
+close_remaining(Open, Done) ->
+    maps:fold(
+        fun
+            (Sid, {Handle, FilePath, _}, Acc) when is_pid(Handle) orelse is_tuple(Handle) ->
+                file:close(Handle),
+                file:delete(FilePath),
+                Acc#{Sid => error};
+            (Sid, _, Acc) ->
+                Acc#{Sid => error}
+        end,
+        Done,
+        Open
+    ).
 
 receive_and_save(Conn, StreamId, Path, DownloadsDir) ->
     %% Extract filename and open file for streaming writes

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -144,50 +144,52 @@ decode_key_entry('PrivateKeyInfo', Der) ->
 decode_key_entry(Type, _Der) ->
     error({unsupported_key_type, Type}).
 
-spawn_handler(ConnPid, Conn, WwwDir, TestCase) ->
+spawn_handler(ConnPid, _DCID, WwwDir, TestCase) ->
+    %% The arity-2 connection_handler is called as Fun(ConnPid, DCID); the
+    %% connection handle in every quic message and API call is the pid.
     HandlerPid = spawn(fun() ->
-        connection_handler(ConnPid, Conn, WwwDir, TestCase)
+        connection_handler(ConnPid, WwwDir, TestCase)
     end),
     {ok, HandlerPid}.
 
-connection_handler(ConnPid, Conn, WwwDir, TestCase) ->
+connection_handler(Conn, WwwDir, TestCase) ->
     io:format("Handler started, waiting for messages...~n"),
     %% Wait for stream data
     receive
         {quic, Conn, {connected, Info}} ->
             io:format("Handler got connected: ~p~n", [Info]),
-            connection_handler(ConnPid, Conn, WwwDir, TestCase);
+            connection_handler(Conn, WwwDir, TestCase);
         {quic, Conn, {stream_opened, StreamId}} ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
-            handle_stream(ConnPid, Conn, StreamId, WwwDir, TestCase);
+            handle_stream(Conn, StreamId, WwwDir, TestCase);
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             io:format(
                 "Handler got stream_data: stream=~p size=~p fin=~p~n",
                 [StreamId, byte_size(Data), Fin]
             ),
             %% Handle request
-            handle_request(ConnPid, Conn, StreamId, Data, WwwDir, TestCase);
+            handle_request(Conn, StreamId, Data, WwwDir, TestCase);
         {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
         Other ->
             io:format("Handler got unexpected: ~p~n", [Other]),
-            connection_handler(ConnPid, Conn, WwwDir, TestCase)
+            connection_handler(Conn, WwwDir, TestCase)
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
     end.
 
-handle_stream(_ConnPid, Conn, StreamId, WwwDir, TestCase) ->
+handle_stream(Conn, StreamId, WwwDir, TestCase) ->
     %% Wait for request on this stream
     receive
         {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
-            handle_request(undefined, Conn, StreamId, Data, WwwDir, TestCase)
+            handle_request(Conn, StreamId, Data, WwwDir, TestCase)
     after 30000 ->
         ok
     end.
 
-handle_request(_ConnPid, Conn, StreamId, Data, WwwDir, TestCase) ->
+handle_request(Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),
     %% Parse simple HTTP/0.9 request: "GET /path\r\n"
     case parse_request(Data) of

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -161,49 +161,45 @@ spawn_handler(ConnPid, _DCID, WwwDir, TestCase) ->
 
 connection_handler(Conn, WwwDir, TestCase) ->
     io:format("Handler started, waiting for messages...~n"),
-    %% Wait for stream data
+    connection_handler(Conn, WwwDir, TestCase, #{}).
+
+%% A request may arrive split across several STREAM frames, so buffer per
+%% stream until FIN before parsing. Serving each fragment as if it were a
+%% whole request answered twice on one stream: two responses, two FINs at
+%% different offsets, and a correct peer kills the connection with
+%% FINAL_SIZE_ERROR.
+connection_handler(Conn, WwwDir, TestCase, Bufs) ->
     receive
         {quic, Conn, {connected, Info}} ->
             io:format("Handler got connected: ~p~n", [Info]),
-            connection_handler(Conn, WwwDir, TestCase);
+            connection_handler(Conn, WwwDir, TestCase, Bufs);
         {quic, Conn, {stream_opened, StreamId}} ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
-            handle_stream(Conn, StreamId, WwwDir, TestCase);
+            connection_handler(Conn, WwwDir, TestCase, Bufs);
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            io:format(
-                "Handler got stream_data: stream=~p size=~p fin=~p~n",
-                [StreamId, byte_size(Data), Fin]
-            ),
-            %% Handle request
-            handle_request(Conn, StreamId, Data, WwwDir, TestCase);
+            Acc = [maps:get(StreamId, Bufs, []) | Data],
+            case Fin of
+                true ->
+                    Request = iolist_to_binary(Acc),
+                    _ = serve_request(Conn, StreamId, Request, WwwDir, TestCase),
+                    connection_handler(
+                        Conn, WwwDir, TestCase, maps:remove(StreamId, Bufs)
+                    );
+                false ->
+                    connection_handler(
+                        Conn, WwwDir, TestCase, Bufs#{StreamId => Acc}
+                    )
+            end;
         {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
         Other ->
             io:format("Handler got unexpected: ~p~n", [Other]),
-            connection_handler(Conn, WwwDir, TestCase)
+            connection_handler(Conn, WwwDir, TestCase, Bufs)
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
     end.
-
-handle_stream(Conn, StreamId, WwwDir, TestCase) ->
-    %% Wait for the request on this stream, then resume the handler loop.
-    receive
-        {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
-            handle_request(Conn, StreamId, Data, WwwDir, TestCase)
-    after 30000 ->
-        connection_handler(Conn, WwwDir, TestCase)
-    end.
-
-%% Serve one request, then go back to waiting: a client may issue several
-%% requests on the same connection, and the interop runner's transfer and
-%% multiplexing tests require exactly that. Returning here instead ended
-%% the handler process after the first file and tore the connection down,
-%% so a second request met {invalid_state,draining}.
-handle_request(Conn, StreamId, Data, WwwDir, TestCase) ->
-    _ = serve_request(Conn, StreamId, Data, WwwDir, TestCase),
-    connection_handler(Conn, WwwDir, TestCase).
 
 serve_request(Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -188,15 +188,24 @@ connection_handler(Conn, WwwDir, TestCase) ->
     end.
 
 handle_stream(Conn, StreamId, WwwDir, TestCase) ->
-    %% Wait for request on this stream
+    %% Wait for the request on this stream, then resume the handler loop.
     receive
         {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
             handle_request(Conn, StreamId, Data, WwwDir, TestCase)
     after 30000 ->
-        ok
+        connection_handler(Conn, WwwDir, TestCase)
     end.
 
+%% Serve one request, then go back to waiting: a client may issue several
+%% requests on the same connection, and the interop runner's transfer and
+%% multiplexing tests require exactly that. Returning here instead ended
+%% the handler process after the first file and tore the connection down,
+%% so a second request met {invalid_state,draining}.
 handle_request(Conn, StreamId, Data, WwwDir, TestCase) ->
+    _ = serve_request(Conn, StreamId, Data, WwwDir, TestCase),
+    connection_handler(Conn, WwwDir, TestCase).
+
+serve_request(Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),
     %% Parse simple HTTP/0.9 request: "GET /path\r\n"
     case parse_request(Data) of

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -124,15 +124,22 @@ build_server_opts(TestCase, Cert, Key, WwwDir) ->
 
 %% Decode PEM-encoded private key to internal format
 decode_private_key(PemData) ->
-    case public_key:pem_decode(PemData) of
-        [{Type, Der, not_encrypted}] ->
+    %% A key file may carry more than the key: `openssl ecparam -genkey',
+    %% which is how the interop runner generates its certificates, emits
+    %% EC PARAMETERS ahead of EC PRIVATE KEY. Pick the key entry out of
+    %% the list rather than insisting the file holds exactly one.
+    case [E || {Type, _, _} = E <- public_key:pem_decode(PemData), is_key_entry(Type)] of
+        [{Type, Der, _} | _] ->
             decode_key_entry(Type, Der);
-        [{Type, Der, _Cipher}] ->
-            %% Encrypted key - not supported yet
-            decode_key_entry(Type, Der);
-        _ ->
+        [] ->
             error(invalid_private_key)
     end.
+
+is_key_entry('RSAPrivateKey') -> true;
+is_key_entry('DSAPrivateKey') -> true;
+is_key_entry('ECPrivateKey') -> true;
+is_key_entry('PrivateKeyInfo') -> true;
+is_key_entry(_) -> false.
 
 decode_key_entry('RSAPrivateKey', Der) ->
     public_key:der_decode('RSAPrivateKey', Der);

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -177,19 +177,8 @@ connection_handler(Conn, WwwDir, TestCase, Bufs) ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
             connection_handler(Conn, WwwDir, TestCase, Bufs);
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            Acc = [maps:get(StreamId, Bufs, []) | Data],
-            case Fin of
-                true ->
-                    Request = iolist_to_binary(Acc),
-                    _ = serve_request(Conn, StreamId, Request, WwwDir, TestCase),
-                    connection_handler(
-                        Conn, WwwDir, TestCase, maps:remove(StreamId, Bufs)
-                    );
-                false ->
-                    connection_handler(
-                        Conn, WwwDir, TestCase, Bufs#{StreamId => Acc}
-                    )
-            end;
+            Bufs1 = buffer_stream_data(Conn, WwwDir, TestCase, Bufs, StreamId, Data, Fin),
+            connection_handler(Conn, WwwDir, TestCase, Bufs1);
         {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
@@ -199,6 +188,17 @@ connection_handler(Conn, WwwDir, TestCase, Bufs) ->
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
+    end.
+
+buffer_stream_data(Conn, WwwDir, TestCase, Bufs, StreamId, Data, Fin) ->
+    Acc = [maps:get(StreamId, Bufs, []) | Data],
+    case Fin of
+        true ->
+            Request = iolist_to_binary(Acc),
+            _ = serve_request(Conn, StreamId, Request, WwwDir, TestCase),
+            maps:remove(StreamId, Bufs);
+        false ->
+            Bufs#{StreamId => Acc}
     end.
 
 serve_request(Conn, StreamId, Data, WwwDir, TestCase) ->


### PR DESCRIPTION
Two interop-harness fixes found running the multiplexing case, one per role.

**Server** (first commit): the handler treated every `stream_data` delivery as a complete request. A request split across STREAM frames was served once per fragment: the first piece parsed as a plausible path (`parse_request` accepts a line without CRLF) and got a 404 with FIN, the rest got a 400 with a second FIN at a higher offset. Redeclaring the final size on one stream is a protocol violation, and picoquic rightly closed the whole connection with `FINAL_SIZE_ERROR` (0x6). Buffer per stream and parse on `fin=true`.

**Client** (second commit): `collect_loop` refilled from the pending list only on stream completion events. MAX_STREAMS arriving at the connection process produces no message to the owner, so when the last grant lands after the last completion has been handled the client sits in receive forever; against quic-go it stopped at exactly the initial 100 streams. Poll with a short timeout while requests wait for credit. Requests that never got a stream were also invisible in the result, so a run that fetched 100 files of 1999 still printed "All downloads successful"; they now count as failures.

With these plus #236, multiplexing passes with quic-go, ngtcp2 and picoquic clients against our server, and for our client against quic-go. The remaining multiplexing failures in the matrix are external: the quiche client keeps every dump file open until the connection ends and panics on EMFILE at ~1019 requests (also against quic-go), and the ngtcp2 server image aborts on a UBSan null-pointer check in std::format mid-run (also with a picoquic client).

Based on #228.