### PR TITLE
Own the session-ticket table in the server registry

### DIFF
--- a/src/quic_server_registry.erl
+++ b/src/quic_server_registry.erl
@@ -176,6 +176,21 @@ init([]) ->
         protected,
         {read_concurrency, true}
     ]),
+    %% The session-ticket table must outlive the connection that happens
+    %% to create it: with a connection process as owner it vanished when
+    %% that connection ended, so a client resuming after the issuing
+    %% connection was gone always fell back to a full handshake. The
+    %% registry is permanent, so own it here; quic_connection's
+    %% ensure_ticket_table/0 stays as a fallback for embedded use.
+    case ets:whereis(quic_server_tickets) of
+        undefined ->
+            _ = ets:new(quic_server_tickets, [
+                named_table, public, ordered_set, {read_concurrency, true}
+            ]),
+            ok;
+        _ ->
+            ok
+    end,
     {ok, #state{}}.
 
 handle_call({register, Name, Pid, Port, Opts}, _From, State = #state{monitors = Monitors}) ->


### PR DESCRIPTION
The global ticket table was created lazily by whichever connection first touched it, and ETS tables die with their owner. As soon as that connection ended the table vanished, taking every stored ticket with it, and the next resuming client fell back to a full handshake.

The failure hid easily: a client that reconnects immediately, while the issuing connection is still draining, finds the table alive and resumes fine. quiche's interop client waits a few seconds between connections and reliably lost its ticket.

Create the table in `quic_server_registry`'s init, which lives for the whole application. The lazy creation in `quic_connection` stays as a fallback for uses that run without the quic application's supervision.