### PR TITLE
0-RTT: only the client sends it, and lost 0-RTT data is resent

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1799,26 +1799,33 @@ handshaking({call, From}, open_stream, #state{early_keys = _EarlyKeys} = State) 
 handshaking(
     {call, From},
     {send_data, StreamId, Data, Fin},
-    #state{
-        early_keys = undefined,
-        pending_data = Pending
-    } = State
+    #state{role = client, early_keys = EarlyKeys} = State
+) when EarlyKeys =/= undefined ->
+    %% Send as 0-RTT data. 0-RTT sending is a client-only affair (RFC
+    %% 9000 §17.2.3): a server also holds early keys, but only for
+    %% receiving. Answering early data before the handshake completes
+    %% must not go out in a 0-RTT packet the client can never decrypt,
+    %% so the server queues below and the data goes out 1-RTT on
+    %% connected.
+    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
+        {ok, NewState} ->
+            {keep_state, NewState, [{reply, From, ok}]};
+        {error, Reason} ->
+            {keep_state, State, [{reply, From, {error, Reason}}]}
+    end;
+handshaking(
+    {call, From},
+    {send_data, StreamId, Data, Fin},
+    #state{pending_data = Pending} = State
 ) ->
-    %% No early keys, queue the data for later (with limit to prevent memory exhaustion)
+    %% No usable send keys yet, queue the data for later (with limit to
+    %% prevent memory exhaustion)
     case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
         true ->
             {keep_state, State, [{reply, From, {error, pending_data_limit}}]};
         false ->
             NewPending = Pending ++ [{StreamId, Data, Fin}],
             {keep_state, State#state{pending_data = NewPending}, [{reply, From, ok}]}
-    end;
-handshaking({call, From}, {send_data, StreamId, Data, Fin}, #state{early_keys = _} = State) ->
-    %% Send as 0-RTT data
-    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            {keep_state, NewState, [{reply, From, ok}]};
-        {error, Reason} ->
-            {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
 handshaking(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     NewState = handle_packet(Data, State),
@@ -7907,7 +7914,7 @@ do_send_zero_rtt_data(
             Payload = quic_frame:encode(Frame),
 
             %% Send as 0-RTT packet
-            NewState = send_zero_rtt_packet(Payload, EarlyKeys, State),
+            NewState = send_zero_rtt_packet(Payload, [Frame], EarlyKeys, State),
 
             %% Update stream state and track early data sent
             NewStreamState = StreamState#stream_state{
@@ -7934,7 +7941,7 @@ do_send_zero_rtt_data(
 
 %% Send a 0-RTT packet (long header, type 1)
 %% RFC 9001 Section 5.3: 0-RTT packets use early traffic keys
-send_zero_rtt_packet(Payload, EarlyKeys, State) ->
+send_zero_rtt_packet(Payload, Frames, EarlyKeys, State) ->
     #state{
         scid = SCID,
         dcid = DCID,
@@ -7970,12 +7977,25 @@ send_zero_rtt_packet(Payload, EarlyKeys, State) ->
     ),
     NewSocketState = send_and_take_socket_state(Packet, State),
 
+    %% 0-RTT shares the application PN space, so it must be tracked for
+    %% loss detection like any 1-RTT packet: a dropped 0-RTT request was
+    %% otherwise never retransmitted and the stream hung forever (RFC
+    %% 9001 §4.1.1 expects lost 0-RTT data to be resent).
+    Now = erlang:monotonic_time(millisecond),
+    NewLossState = quic_loss:on_packet_sent(
+        State#state.loss_state, PN, byte_size(Packet), true, Frames, Now
+    ),
+    NewCCState = quic_cc:on_packet_sent(State#state.cc_state, byte_size(Packet)),
+
     %% Update PN space and packet counter
     NewPNSpace = PNSpace#pn_space{next_pn = PN + 1},
     State#state{
         pn_app = NewPNSpace,
         packets_sent = State#state.packets_sent + 1,
-        socket_state = NewSocketState
+        socket_state = NewSocketState,
+        loss_state = NewLossState,
+        cc_state = NewCCState,
+        pto_dirty = true
     }.
 
 %% Reset local state for all streams that carried 0-RTT data when the
@@ -9498,6 +9518,12 @@ handle_pto_timeout(#state{loss_state = LossState} = State) ->
 
 %% Send a probe packet for PTO
 %% PTO probes are allowed to use control_allowance per RFC 9002
+%% App-space PTO can fire before 1-RTT keys exist when tracked 0-RTT
+%% packets are outstanding. Handshake-space recovery drives progress
+%% until the keys arrive; sending nothing here avoids building an app
+%% packet without keys.
+send_probe_packet(#state{app_keys = undefined} = State) ->
+    State;
 send_probe_packet(State) ->
     case get_oldest_unacked_frames(State) of
         {ok, Frames} ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1704,12 +1704,25 @@ idle({call, From}, open_unidirectional_stream, #state{early_keys = _EarlyKeys} =
         {error, Reason} ->
             {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
-%% 0-RTT: Allow sending data in idle state if early keys are available
+%% 0-RTT sending is client-only (RFC 9000 §17.2.3), here as in the
+%% handshaking state: a server handler answering early data delivered
+%% before the handshake completes must queue, or the response goes out
+%% as a 0-RTT packet the client can never decrypt.
+idle(
+    {call, From},
+    {send_data, StreamId, Data, Fin},
+    #state{role = client, early_keys = EarlyKeys} = State
+) when EarlyKeys =/= undefined ->
+    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
+        {ok, NewState} ->
+            {keep_state, NewState, [{reply, From, ok}]};
+        {error, Reason} ->
+            {keep_state, State, [{reply, From, {error, Reason}}]}
+    end;
 idle(
     {call, From},
     {send_data, StreamId, Data, Fin},
     #state{
-        early_keys = undefined,
         pending_data = Pending
     } = State
 ) ->
@@ -1719,13 +1732,6 @@ idle(
         false ->
             NewPending = Pending ++ [{StreamId, Data, Fin}],
             {keep_state, State#state{pending_data = NewPending}, [{reply, From, ok}]}
-    end;
-idle({call, From}, {send_data, StreamId, Data, Fin}, #state{early_keys = _} = State) ->
-    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            {keep_state, NewState, [{reply, From, ok}]};
-        {error, Reason} ->
-            {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
 idle(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     NewState = handle_packet(Data, State),
@@ -7909,12 +7915,13 @@ do_send_zero_rtt_data(
             DataBin = iolist_to_binary(Data),
             Offset = StreamState#stream_state.send_offset,
 
-            %% Build STREAM frame
-            Frame = {stream, StreamId, Offset, DataBin, Fin},
-            Payload = quic_frame:encode(Frame),
-
-            %% Send as 0-RTT packet
-            NewState = send_zero_rtt_packet(Payload, [Frame], EarlyKeys, State),
+            %% A write larger than one packet must be split like any
+            %% 1-RTT send; a single oversized 0-RTT packet leaves as one
+            %% IP-fragmented datagram, which QUIC forbids (RFC 9000 §14).
+            MaxChunk = get_max_stream_data_per_packet(State),
+            NewState = send_zero_rtt_chunks(
+                StreamId, Offset, DataBin, Fin, MaxChunk, EarlyKeys, State
+            ),
 
             %% Update stream state and track early data sent
             NewStreamState = StreamState#stream_state{
@@ -7938,6 +7945,18 @@ do_send_zero_rtt_data(
         error ->
             {error, unknown_stream}
     end.
+
+%% Split a 0-RTT write into per-packet STREAM frames, FIN on the last.
+send_zero_rtt_chunks(StreamId, Offset, Data, Fin, MaxChunk, EarlyKeys, State) when
+    byte_size(Data) =< MaxChunk
+->
+    Frame = {stream, StreamId, Offset, Data, Fin},
+    send_zero_rtt_packet(quic_frame:encode(Frame), [Frame], EarlyKeys, State);
+send_zero_rtt_chunks(StreamId, Offset, Data, Fin, MaxChunk, EarlyKeys, State) ->
+    <<Chunk:MaxChunk/binary, Rest/binary>> = Data,
+    Frame = {stream, StreamId, Offset, Chunk, false},
+    State1 = send_zero_rtt_packet(quic_frame:encode(Frame), [Frame], EarlyKeys, State),
+    send_zero_rtt_chunks(StreamId, Offset + MaxChunk, Rest, Fin, MaxChunk, EarlyKeys, State1).
 
 %% Send a 0-RTT packet (long header, type 1)
 %% RFC 9001 Section 5.3: 0-RTT packets use early traffic keys


### PR DESCRIPTION
Two 0-RTT defects, both found with the interop runner's zerortt case.

**The handshaking-state send path chose 0-RTT whenever early keys were present, for either role.** A server also holds early keys, but only for receiving: a handler answering early data before the handshake completed had its response encrypted as a 0-RTT packet, which RFC 9000 §17.2.3 reserves for the client and which the client can never decrypt. The response vanished and the client eventually re-requested in 1-RTT. The server now queues such writes like any other pre-handshake data; they go out as 1-RTT when the connection completes.

**0-RTT packets were sent without being registered with loss detection**: `next_pn` was bumped and the datagram written, nothing else. A dropped 0-RTT request was never retransmitted, so its stream hung forever. Blasting forty requests into the simulator's 25-packet queue reliably lost several this way, every run. 0-RTT shares the application number space, so the packets are now registered there like any 1-RTT send; loss recovery then re-frames them into 1-RTT automatically. An app-space PTO can now fire before 1-RTT keys exist, so the probe path sits out until the keys arrive; handshake-space recovery drives progress meanwhile.