### PR TITLE
Stop sending MAX_STREAM_DATA for streams whose final size is known

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -6637,7 +6637,13 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                     %% advancing.
                     MaxWindowForStream = State#state.fc_max_receive_window,
                     Headroom = max(0, RecvMaxData - NewRecvOffset),
-                    WillSendMaxStreamData = Headroom < (MaxWindowForStream div 2),
+                    %% A stream whose final size is known can never use more
+                    %% credit (RFC 9000 §19.10), so widening its window only
+                    %% spends bytes: one frame per completed stream adds up
+                    %% in request/response traffic.
+                    WillSendMaxStreamData =
+                        Headroom < (MaxWindowForStream div 2) andalso
+                            NewStream#stream_state.final_size =:= undefined,
                     Threshold = RecvMaxData - (MaxWindowForStream div 2),
                     ?LOG_DEBUG(
                         #{


### PR DESCRIPTION
The receive-side window update triggered purely on headroom shrinking below half the maximum window. When the configured initial stream window is much smaller than `fc_max_receive_window`, that condition is true from the first delivered byte, so every completed stream got a parting MAX_STREAM_DATA it can never use: RFC 9000 §19.10 notes the frame is pointless once the final size is known.

In request/response traffic this is one wasted frame per stream. The interop zerortt case made it visible: the grader budgets the client's total 1-RTT bytes, and forty of these frames were a fifth of it.