### PR TITLE
h3: end the message body at stream end, not at a frame boundary

### DIFF
--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -2542,17 +2542,40 @@ handle_request_stream_data(
     Combined = <<Buffer/binary, Data/binary>>,
 
     case process_request_frames(StreamId, Combined, Fin, Stream, State) of
+        {ok, Rest, _Stream1, _State1} when Fin, Rest =/= <<>> ->
+            %% Stream ended inside an H3 frame: truncated (RFC 9114 §7.1).
+            {error, {connection_error, ?H3_FRAME_ERROR, <<"stream ended mid-frame">>}};
         {ok, Rest, Stream1, State1} ->
+            %% RFC 9114 §4.1: the message ends when the stream ends, not at
+            %% a frame boundary. A peer that sends its FIN in a bare final
+            %% QUIC frame (quic-go does) otherwise leaves the application
+            %% waiting for a fin-marked delivery that never comes.
+            {Stream2, State2} =
+                case Fin of
+                    true -> finish_request_stream(StreamId, Stream1, State1);
+                    false -> {Stream1, State1}
+                end,
             Buffers1 =
                 case Rest of
                     <<>> -> maps:remove(StreamId, Buffers);
                     _ -> Buffers#{StreamId => Rest}
                 end,
-            Streams1 = Streams#{StreamId => Stream1},
-            {ok, State1#state{streams = Streams1, stream_buffers = Buffers1}};
+            Streams1 = Streams#{StreamId => Stream2},
+            {ok, State2#state{streams = Streams1, stream_buffers = Buffers1}};
         {error, Reason} ->
             {error, Reason, State}
     end.
+
+%% The stream's FIN arrived after the last complete frame. If the body
+%% was already closed by a fin-marked frame delivery this is a no-op;
+%% an open body gets its final empty fin-marked delivery here.
+finish_request_stream(
+    StreamId, #h3_stream{frame_state = expecting_data} = Stream, State
+) ->
+    State1 = notify_stream_data(StreamId, <<>>, true, State),
+    {Stream#h3_stream{frame_state = complete, state = half_closed_remote}, State1};
+finish_request_stream(_StreamId, Stream, State) ->
+    {Stream, State}.
 
 process_request_frames(StreamId, Data, Fin, Stream, #state{quic_conn = QuicConn} = State) ->
     case quic_h3_frame:decode(Data) of

--- a/test/quic_h3_event_forwarding_tests.erl
+++ b/test/quic_h3_event_forwarding_tests.erl
@@ -234,6 +234,44 @@ wait_settings_received(Pid, Timeout) ->
             ok
     end.
 
+%%====================================================================
+%% Body end signalled by bare stream FIN (RFC 9114 §4.1)
+%%====================================================================
+
+%% quic-go ends the response body with an empty final QUIC frame rather
+%% than fin-marking the last DATA chunk. The message ends at stream end,
+%% so the owner must still get a fin-marked delivery.
+bare_fin_ends_body_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        meck:expect(quic, set_stream_priority, fun(_, _, _, _) -> ok end),
+        meck:expect(quic, reset_stream, fun(_, _, _) -> ok end),
+        FakeQuicConn = spawn_link(fun fake_quic_loop/0),
+        {ok, H3Conn} = start_client_h3(FakeQuicConn),
+        drive_to_connected(H3Conn, FakeQuicConn),
+        {ok, StreamId} = quic_h3_connection:request(H3Conn, [
+            {<<":method">>, <<"GET">>},
+            {<<":scheme">>, <<"https">>},
+            {<<":path">>, <<"/f">>},
+            {<<":authority">>, <<"example.com">>}
+        ]),
+        RespHeaders = quic_h3_frame:encode(
+            {headers, quic_qpack:encode([{<<":status">>, <<"200">>}])}
+        ),
+        Body = <<"hello h3 body">>,
+        RespData = quic_h3_frame:encode({data, Body}),
+        H3Conn ! {quic, FakeQuicConn, {stream_data, StreamId, RespHeaders, false}},
+        H3Conn ! {quic, FakeQuicConn, {stream_data, StreamId, RespData, false}},
+        %% The peer's FIN arrives on its own, after the last complete frame.
+        H3Conn ! {quic, FakeQuicConn, {stream_data, StreamId, <<>>, true}},
+        receive
+            {quic_h3, H3Conn, {response, StreamId, 200, _}} -> ok
+        after 500 -> erlang:error(no_response)
+        end,
+        assert_owner_message({data, StreamId, Body, false}, H3Conn, 500),
+        assert_owner_message({data, StreamId, <<>>, true}, H3Conn, 500),
+        stop_h3(H3Conn, FakeQuicConn)
+    end}.
+
 drive_to_connected(H3Conn, FakeQuicConn) ->
     ok = quic_h3_connection:prime(H3Conn),
     wait_state(H3Conn, early_data, 500),


### PR DESCRIPTION
A request-stream FIN that arrived in a bare final QUIC frame — after the last complete H3 frame rather than fin-marking its final chunk — was silently absorbed: the frame parser saw an empty buffer, returned "need more", and no fin-marked delivery ever reached the application. The body sat complete in the owner's hands with no way to know it had ended.

RFC 9114 §4.1 ends the message when the stream ends. quic-go's server sends its FIN exactly this way, so every eq-client H3 download from quic-go hung until timeout; implementations that fin-mark the last DATA chunk (including our own server) masked the gap — which made this a fun one to find: the interop http3 case passed against ngtcp2, quiche and picoquic and failed only against quic-go.

On a FIN with a cleanly drained buffer the stream now gets a final empty fin-marked delivery, unless a fin-marked frame already closed the body. A FIN arriving with a partial frame still buffered is now a connection error (`H3_FRAME_ERROR`, stream ended mid-frame) instead of silence, per RFC 9114 §7.1.

The regression test drives the client FSM with a fake QUIC connection: HEADERS, one complete DATA frame without fin, then a bare FIN; it fails against the old code.

With this (plus an interop-harness http3 case that comes separately), the interop runner's http3 test passes for erlang-quic in both roles against quic-go, ngtcp2, quiche and picoquic.