### PR TITLE
Accept all supported groups by default on the server

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1136,7 +1136,11 @@ init({server, Opts}) ->
             psk_callback => maps:get(psk_callback, Opts, undefined),
             psks => maps:get(psks, Opts, undefined)
         },
-        tls_groups = maps:get(groups, Opts, [x25519]),
+        %% Accept every group the crypto layer supports: a preference
+        %% list holding only x25519 forced a HelloRetryRequest round
+        %% trip on any client whose key_share leads with another group
+        %% (picoquic shares P-256 first).
+        tls_groups = maps:get(groups, Opts, [x25519, secp256r1, secp384r1]),
         tls_sig_algs = maps:get(signature_algs, Opts, undefined),
         alpn_list = normalize_alpn_list(ALPNList),
         pn_initial = PNSpace,


### PR DESCRIPTION
The server's default group preference held only x25519, so a client whose key_share leads with another curve was sent a HelloRetryRequest even though the crypto layer speaks secp256r1 and secp384r1 just fine. picoquic shares P-256 first, which put an HRR round trip — a full extra RTT — in front of every connection from it, and dragged the rarely-exercised HRR path into flows that did not need it (the HRR + compatible-version-negotiation interaction in #243 was found this way).

Default to every classical group the crypto layer supports. Clients that share x25519 are picked directly as before; an explicit `groups` option still restricts the set.