### PR TITLE
Handle SHA-384 suites in the Finished verification path

### DIFF
--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -586,9 +586,10 @@ parse_certificate_verify(_) ->
 %% @doc Parse Finished message.
 -spec parse_finished(binary()) -> {ok, binary()} | {error, term()}.
 parse_finished(VerifyData) when byte_size(VerifyData) >= 32 ->
-    %% SHA-256 produces 32 bytes
-    <<Data:32/binary, _/binary>> = VerifyData,
-    {ok, Data};
+    %% The verify_data length depends on the negotiated hash (32 for
+    %% SHA-256, 48 for SHA-384), so return the whole body and let
+    %% verification compare.
+    {ok, VerifyData};
 parse_finished(_) ->
     {error, invalid_finished}.
 
@@ -609,14 +610,21 @@ build_finished(VerifyData) ->
 verify_finished(ReceivedVerifyData, TrafficSecret, TranscriptHash) ->
     FinishedKey = quic_crypto:derive_finished_key(TrafficSecret),
     ExpectedVerifyData = quic_crypto:compute_finished_verify(FinishedKey, TranscriptHash),
-    crypto:hash_equals(ReceivedVerifyData, ExpectedVerifyData).
+    hash_equals(ReceivedVerifyData, ExpectedVerifyData).
 
 %% @doc Verify a Finished message with cipher-specific hash.
 -spec verify_finished(binary(), binary(), binary(), atom()) -> boolean().
 verify_finished(ReceivedVerifyData, TrafficSecret, TranscriptHash, Cipher) ->
     FinishedKey = quic_crypto:derive_finished_key(Cipher, TrafficSecret),
     ExpectedVerifyData = quic_crypto:compute_finished_verify(Cipher, FinishedKey, TranscriptHash),
-    crypto:hash_equals(ReceivedVerifyData, ExpectedVerifyData).
+    hash_equals(ReceivedVerifyData, ExpectedVerifyData).
+
+%% crypto:hash_equals/2 raises badarg on length mismatch; a wrong-length
+%% verify_data is a verification failure, not a crash.
+hash_equals(A, B) when byte_size(A) =:= byte_size(B) ->
+    crypto:hash_equals(A, B);
+hash_equals(_, _) ->
+    false.
 
 %%====================================================================
 %% Transport Parameters
@@ -1571,7 +1579,7 @@ verify_psk_binder(Secret, Cipher, TruncatedHash, OfferedBinder) ->
     Expected = quic_crypto:compute_psk_binder(
         Cipher, EarlySecret, TruncatedHash, external
     ),
-    crypto:hash_equals(Expected, OfferedBinder).
+    hash_equals(Expected, OfferedBinder).
 
 %% @doc Verify a resumption PSK binder against a parsed ClientHello.
 %% `Secret' is the resumption PSK, `PskBindersInfo' is the `psk_binders'
@@ -1586,7 +1594,7 @@ verify_resumption_binder(Secret, Cipher, FullClientHello, PskBindersInfo, Offere
     Expected = quic_crypto:compute_psk_binder(
         Cipher, EarlySecret, TruncatedHash, resumption
     ),
-    crypto:hash_equals(Expected, OfferedBinder);
+    hash_equals(Expected, OfferedBinder);
 verify_resumption_binder(_Secret, _Cipher, _FullClientHello, _PskBindersInfo, _OfferedBinder) ->
     %% Missing binder offset info — cannot verify, fail closed.
     false.

--- a/test/quic_tls_negotiation_tests.erl
+++ b/test/quic_tls_negotiation_tests.erl
@@ -189,3 +189,22 @@ unsupported_scheme_errors_test() ->
         {unsupported_signature_scheme, _},
         quic_tls:build_certificate_verify(16#FFFF, Key, crypto:hash(sha256, <<"x">>))
     ).
+
+%% SHA-384 suites use 48-byte verify_data; parse_finished must not
+%% truncate it and verify_finished must not badarg on length mismatch.
+sha384_finished_roundtrip_test() ->
+    Secret = crypto:strong_rand_bytes(48),
+    Transcript = crypto:strong_rand_bytes(48),
+    Key = quic_crypto:derive_finished_key(aes_256_gcm, Secret),
+    VerifyData = quic_crypto:compute_finished_verify(aes_256_gcm, Key, Transcript),
+    ?assertEqual(48, byte_size(VerifyData)),
+    ?assertEqual({ok, VerifyData}, quic_tls:parse_finished(VerifyData)),
+    ?assert(quic_tls:verify_finished(VerifyData, Secret, Transcript, aes_256_gcm)).
+
+wrong_length_finished_is_false_not_badarg_test() ->
+    Secret = crypto:strong_rand_bytes(48),
+    Transcript = crypto:strong_rand_bytes(48),
+    Key = quic_crypto:derive_finished_key(aes_256_gcm, Secret),
+    VerifyData = quic_crypto:compute_finished_verify(aes_256_gcm, Key, Transcript),
+    <<Truncated:32/binary, _/binary>> = VerifyData,
+    ?assertNot(quic_tls:verify_finished(Truncated, Secret, Transcript, aes_256_gcm)).


### PR DESCRIPTION
`parse_finished` truncated verify_data to 32 bytes (SHA-256 hard-coded) while `verify_finished/4` computes the full-length HMAC for the negotiated cipher. Any server that selects `TLS_AES_256_GCM_SHA384` (msquic does by OpenSSL default preference) therefore crashed the client with `badarg` from `crypto:hash_equals/2` on every Finished message, and the handshake could never complete.

This was masked while the ClientHello offered only `TLS_AES_128_GCM_SHA256`; once the offer includes `aes_256_gcm` (#235) a SHA-384 selection becomes reachable.

Fix:
- `parse_finished` returns the whole message body instead of truncating to 32 bytes.
- `verify_finished/3,4` and the PSK binder checks compare lengths before `crypto:hash_equals/2`, so a wrong-length verify_data or binder (the binder is attacker-controlled wire data) is a verification failure instead of a process crash.

Repro: connect an eq client with `ciphers => [aes_256_gcm]` to any eq or msquic server; before this change the connection never reaches `connected`. Regression tests included; full eunit, lint and xref pass.