### PR TITLE
Client socket backend: GRO receive and train-sized owner messages

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1732,6 +1732,10 @@ idle(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     %% Flush batched packets and timers after processing incoming data
     FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
     check_state_transition(idle, FlushedState);
+idle(info, {udp_batch, Socket, _IP, _Port, Packets}, #state{socket = Socket} = State) ->
+    NewState = handle_packets_batch(Packets, State),
+    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    check_state_transition(idle, FlushedState);
 %% Server receives packets from listener
 idle(info, {quic_packet, Data, _RemoteAddr}, #state{role = server} = State) ->
     NewState = handle_packet(Data, State),
@@ -1823,6 +1827,10 @@ handshaking({call, From}, {send_data, StreamId, Data, Fin}, #state{early_keys = 
 handshaking(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     NewState = handle_packet(Data, State),
     %% Flush batched packets and timers after processing incoming data
+    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    check_state_transition(handshaking, FlushedState);
+handshaking(info, {udp_batch, Socket, _IP, _Port, Packets}, #state{socket = Socket} = State) ->
+    NewState = handle_packets_batch(Packets, State),
     FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
     check_state_transition(handshaking, FlushedState);
 %% Server receives packets from listener
@@ -2189,6 +2197,15 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
     State1 = State#state{current_packet_source = {IP, Port}},
     NewState = handle_packet(Data, State1),
     %% Clear packet source and flush
+    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    FinalState = FlushedState#state{current_packet_source = undefined},
+    check_state_transition(connected, FinalState);
+%% Client receives a whole GRO train from the receiver process as one
+%% message; processing it in one pass amortizes the per-event flushes
+%% over the train.
+connected(info, {udp_batch, Socket, IP, Port, Packets}, #state{socket = Socket} = State) ->
+    State1 = State#state{current_packet_source = {IP, Port}},
+    NewState = handle_packets_batch(Packets, State1),
     FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -182,6 +182,8 @@ open_for_send(RemoteIP, Opts) ->
     Backend = maps:get(backend, Opts, DetectedBackend),
     DetectedGSO = maps:get(gso, Capabilities, false),
     GSOSupported = maps:get(gso, Opts, DetectedGSO),
+    DetectedGRO = maps:get(gro, Capabilities, false),
+    GROSupported = maps:get(gro, Opts, DetectedGRO),
 
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
@@ -192,6 +194,7 @@ open_for_send(RemoteIP, Opts) ->
         socket ->
             open_send_socket_backend(Family, Opts, #{
                 gso_supported => GSOSupported,
+                gro_supported => GROSupported,
                 batching_enabled => BatchingEnabled,
                 max_batch => MaxBatch,
                 gso_size => GSOSize
@@ -682,9 +685,18 @@ stop_client_receiver(Pid) when is_pid(Pid) ->
 %% exit signals from the linked owner are processed promptly rather
 %% than blocking forever in the NIF.
 client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
-    case socket:recvfrom(Socket, 0, [], 100) of
-        {ok, {#{addr := IP, port := Port}, Data}} ->
-            Owner ! {udp, Socket, IP, Port, Data},
+    %% recv_gro splits GRO-coalesced trains and sizes the read buffer
+    %% for a maximal train; a plain recvfrom with the default 8 KiB
+    %% buffer would silently truncate coalesced input. A multi-packet
+    %% train goes to the owner as ONE message so the mailbox holds
+    %% trains, not packets, and the whole train is processed in one
+    %% receive pass.
+    case recv_gro(Socket, 100) of
+        {ok, {IP, Port}, [Single]} ->
+            Owner ! {udp, Socket, IP, Port, Single},
+            client_recv_loop(SocketState, Owner);
+        {ok, {IP, Port}, Packets} ->
+            Owner ! {udp_batch, Socket, IP, Port, Packets},
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -818,13 +830,19 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
     %% fallback sends, which stalled handshakes and mis-segmented
     %% coalesced Initial+Handshake flights against gen_udp servers.
     GSOEnabled = maps:get(gso_supported, BatchConfig, false),
+    %% Enable GRO so a GSO-batching peer's trains arrive as one
+    %% recvmsg with a UDP_GRO cmsg instead of one syscall per segment;
+    %% recv_gro/2 already handles both shapes.
+    GROEnabled = maybe_enable_gro(Socket, #{
+        gro_supported => maps:get(gro_supported, BatchConfig, false)
+    }),
     State = #socket_state{
         socket = Socket,
         backend = socket,
         owns_socket = true,
         gso_supported = GSOEnabled,
+        gro_enabled = GROEnabled,
         gso_size = maps:get(gso_size, BatchConfig),
-        gro_enabled = false,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
     },
@@ -1186,8 +1204,11 @@ extra_socket_family(Extra) ->
 %%====================================================================
 
 recv_gro(Socket, Timeout) ->
-    %% Receive with GRO - may get coalesced packets
-    case socket:recvmsg(Socket, 0, 128, [], Timeout) of
+    %% Receive with GRO - may get coalesced packets. The buffer must
+    %% hold a maximally coalesced train (64 KiB): passing 0 uses the
+    %% OTP default read buffer (8 KiB) and recvmsg silently truncates
+    %% any larger train, discarding every segment past the first few.
+    case socket:recvmsg(Socket, 65535, 128, [], Timeout) of
         {ok, #{addr := #{addr := IP, port := Port}, iov := [Data], ctrl := Ctrl}} ->
             %% Check for GRO segment size in control messages
             case extract_gro_segment_size(Ctrl) of


### PR DESCRIPTION
The opt-in client socket backend never enabled `UDP_GRO`, so a GSO-batching peer's trains were segmented back into one `recvfrom` per datagram. That `recvfrom` also passed buffer size 0, whose 8 KiB default silently truncates any train that does arrive coalesced (`recv_gro` had the same latent truncation via `recvmsg(_, 0, ...)`).

This PR:
- enables GRO on the client socket when the platform supports it (per-socket `UDP_GRO`, detected the same way as the listener path),
- reads with `recv_gro` and a train-sized 64 KiB buffer,
- forwards a multi-packet train to the connection as a single `{udp_batch, ...}` message, processed in one receive pass — mirroring the listener's batched `{quic_packets, ...}` delivery.

The connection mailbox then holds trains instead of packets, and per-event flushes amortize over the train.

Measured on loopback bulk transfer (socket backend both ends, 4 MB x 64 streams): ~90 MB/s -> ~260 MB/s, with the win coming from ~46x fewer receive syscalls and messages.

Full eunit (2263), lint, xref and dialyzer pass.