### PR TITLE
Retransmission congestion policy: exempt PTO probes, bind loss retransmissions to cwnd (RFC 9002 §7)

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -166,6 +166,8 @@
     maybe_store_initial_reset_token/2,
     check_stateless_reset/2,
     test_state_for_reset/3,
+    %% Retransmission congestion policy (RFC 9002 §7)
+    retransmit_cc_allowed/3,
     %% NEW_TOKEN frame dispatch (RFC 9000 §8.1.3)
     process_frame/3,
     test_state_for_role/1,
@@ -9388,12 +9390,7 @@ send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = 
     Payload = iolist_to_binary([quic_frame:encode(F) || F <- Frames]),
     PacketSize = byte_size(Payload) + 50,
 
-    Allowed =
-        case Mode of
-            probe -> true;
-            normal -> quic_cc:can_send_control(CCState, PacketSize)
-        end,
-    case Allowed of
+    case retransmit_cc_allowed(Mode, CCState, PacketSize) of
         true ->
             send_app_packet_internal(Payload, Frames, State#state{retransmits = R + 1});
         false ->
@@ -9414,6 +9411,16 @@ send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = 
             ),
             defer_retransmit_frames(Frames, State)
     end.
+
+%% RFC 9002 §7: an endpoint MUST NOT exceed cwnd "unless the packet is
+%% sent on a PTO timer expiration or when entering a recovery period".
+%% A PTO probe is exempt outright; an ordinary loss retransmission
+%% stays bound by the congestion window proper, not by the more
+%% lenient control allowance.
+retransmit_cc_allowed(probe, _CCState, _PacketSize) ->
+    true;
+retransmit_cc_allowed(normal, CCState, PacketSize) ->
+    quic_cc:can_send(CCState, PacketSize).
 
 %% Split CC-deferred lost frames: stream data into FC-exempt retransmit_stream
 %% queue entries (retried by process_send_queue/1), control frames into

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -9374,14 +9374,26 @@ filter_reset_stream_at_data(Frames, #state{streams = Streams}) ->
 %% Send frames for retransmission with congestion control check
 send_retransmit_frames_cc([], State) ->
     State;
-send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = State) ->
+send_retransmit_frames_cc(Frames, State) ->
+    send_retransmit_frames_cc(Frames, State, normal).
+
+%% Mode `probe' (PTO) is exempt from congestion control per RFC 9002
+%% §7.5. Gating probes on the control allowance deadlocks a full
+%% window: bytes_in_flight sits at or just above cwnd, every PTO probe
+%% is denied, no probe means no ACK, no ACK means loss detection never
+%% runs, and the connection stalls until idle timeout with a full
+%% sent_q. Mode `normal' (loss retransmission) stays subject to cwnd.
+send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = State, Mode) ->
     %% Encode all frames and check size
     Payload = iolist_to_binary([quic_frame:encode(F) || F <- Frames]),
     PacketSize = byte_size(Payload) + 50,
 
-    %% Check if CC allows sending this retransmission
-    %% Use can_send_control to allow small overage for retransmissions
-    case quic_cc:can_send_control(CCState, PacketSize) of
+    Allowed =
+        case Mode of
+            probe -> true;
+            normal -> quic_cc:can_send_control(CCState, PacketSize)
+        end,
+    case Allowed of
         true ->
             send_app_packet_internal(Payload, Frames, State#state{retransmits = R + 1});
         false ->
@@ -9501,8 +9513,8 @@ handle_pto_timeout(#state{loss_state = LossState} = State) ->
 send_probe_packet(State) ->
     case get_oldest_unacked_frames(State) of
         {ok, Frames} ->
-            %% Retransmit oldest data as probe with CC check
-            send_retransmit_frames_cc(Frames, State);
+            %% Retransmit oldest data as the probe, cwnd-exempt
+            send_retransmit_frames_cc(Frames, State, probe);
         none ->
             %% No data to retransmit, send PING (always allowed as control)
             Payload = quic_frame:encode(ping),

--- a/test/quic_retransmit_cc_policy_tests.erl
+++ b/test/quic_retransmit_cc_policy_tests.erl
@@ -1,0 +1,57 @@
+%%% -*- erlang -*-
+%%%
+%%% Congestion policy for retransmitted frames (RFC 9002 §7).
+%%%
+%%% "An endpoint MUST NOT send a packet if it would cause bytes_in_flight
+%%% to be larger than the congestion window, unless the packet is sent on
+%%% a PTO timer expiration or when entering recovery." That is two rules:
+%%% a PTO probe is exempt from the congestion window outright, and an
+%%% ordinary loss retransmission stays bound by it.
+%%%
+%%% Gating probes deadlocks a full window: bytes_in_flight sits at or
+%%% just above cwnd, every probe is denied, no probe means no ACK, and
+%%% loss detection never runs. Exempting loss retransmissions instead
+%%% would burst a full sent_q past the window during recovery.
+%%%
+%%% These tests pin the policy at the retransmit_cc_allowed/3 decision
+%%% point for both modes, over both a full and an open window.
+
+-module(quic_retransmit_cc_policy_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PACKET, 1200).
+
+%% A congestion state with no room: keep charging full packets until
+%% even one more no longer fits under cwnd.
+full_window() ->
+    fill(quic_cc:new()).
+
+fill(CC) ->
+    case quic_cc:can_send(CC, ?PACKET) of
+        true -> fill(quic_cc:on_packet_sent(CC, ?PACKET));
+        false -> CC
+    end.
+
+probe_is_exempt_above_cwnd_test() ->
+    CC = full_window(),
+    ?assertNot(quic_cc:can_send(CC, ?PACKET)),
+    ?assert(quic_connection:retransmit_cc_allowed(probe, CC, ?PACKET)).
+
+loss_retransmission_is_refused_above_cwnd_test() ->
+    CC = full_window(),
+    ?assertNot(quic_connection:retransmit_cc_allowed(normal, CC, ?PACKET)).
+
+loss_retransmission_passes_an_open_window_test() ->
+    CC = quic_cc:new(),
+    ?assert(quic_connection:retransmit_cc_allowed(normal, CC, ?PACKET)).
+
+%% The loss gate is the congestion window proper, not the more lenient
+%% control allowance: a state the control gate would wave through is
+%% still refused once cwnd is spent.
+loss_gate_is_cwnd_not_the_control_allowance_test() ->
+    CC = full_window(),
+    case quic_cc:can_send_control(CC, ?PACKET) of
+        true -> ?assertNot(quic_connection:retransmit_cc_allowed(normal, CC, ?PACKET));
+        false -> ok
+    end.


### PR DESCRIPTION
RFC 9002 §7.5: probe packets are not limited by the congestion window. The probe path went through `can_send_control` (cwnd + 1200-byte allowance), so once `bytes_in_flight` sat at or just above cwnd, every PTO probe was denied. No probe means no ACK, no ACK means loss detection never runs, and the connection deadlocks with a full sent_q until idle timeout.

Deterministic reproducer: a 10 MiB transfer through a UDP proxy that blacks out both directions for 2 s mid-transfer. The in-flight window is lost, `bytes_in_flight` fills cwnd exactly, and every subsequent PTO probe is refused: the transfer died on idle timeout in every run. With the exemption it completes in ~4.5 s. This also turned the interop runner's `blackhole` case from a hard fail into a pass.

Loss retransmissions (mode `normal`) stay subject to cwnd as before. Full eunit passes.