### PR TITLE
Do not apply Initial/Handshake ACKs to the 1-RTT loss tracker

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4554,6 +4554,15 @@ process_frame(_Level, ping, State) ->
     State;
 process_frame(Level, {crypto, Offset, Data}, State) ->
     buffer_crypto_data(Level, Offset, Data, State);
+process_frame(Level, {ack, _Ranges, _AckDelay, _ECN}, State) when Level =/= app ->
+    %% Initial/Handshake ACKs must never touch the loss tracker: only
+    %% 1-RTT packets are registered there, and packet numbers restart
+    %% per space, so a Handshake-space ACK of PN 0..N silently "acks"
+    %% the first N 1-RTT packets out of sent_q. If those carried data
+    %% the peer never received, nothing retransmits them and the peer
+    %% stalls on a permanent stream hole. Handshake flights have their
+    %% own retransmission machinery.
+    State;
 process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
     %% Process ACK - update loss detection and congestion control
     #state{loss_state = LossState, cc_state = CCState} = State,


### PR DESCRIPTION
Only 1-RTT packets are registered in the loss tracker, but ACK frames from every packet-number space were processed against it, and packet numbers restart per space. A Handshake-space ACK of PN 0..N therefore silently acked the first N 1-RTT packets out of sent_q; if those carried data the peer never received, nothing retransmitted them, and the peer stalled on a permanent stream hole until idle timeout.

The overlap window is exactly connection start, where a server's first 1-RTT response packets share numbers with the client's Handshake ACKs, so the typical casualty is a small request/response exchange. Measured with a 30%-loss UDP proxy and 1 KiB request/response per connection: ~5% of exchanges wedged (93-97 of 100); with the fix, 148 of 150. Together with the probe exemption in #249 this took the interop runner's `handshakeloss`/`handshakecorruption` cases from hard failures to passing.

Full eunit passes.