### PR TITLE
Keep the sent-packet tracker across an active path migration

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -10739,9 +10739,18 @@ complete_migration(
     NewPMTUState = quic_pmtu:on_path_change(PMTUState),
 
     %% RFC 9002 Section 9.4: Reset congestion controller on path change
-    %% The new path may have different RTT and bandwidth characteristics
-    NewCCState = quic_cc:new(#{}),
-    NewLossState = quic_loss:new(),
+    %% The new path may have different RTT and bandwidth characteristics.
+    %% The loss tracker's sent_q must SURVIVE the switch: replacing it
+    %% orphans every in-flight packet (no ACK match, no loss detection,
+    %% no PTO since bytes_in_flight reads 0) and their data is never
+    %% retransmitted - the peer then stalls on a permanent stream hole.
+    NewLossState = quic_loss:reset_for_new_path(State#state.loss_state),
+    NewCCState0 = quic_cc:new(#{}),
+    NewCCState =
+        case quic_loss:bytes_in_flight(NewLossState) of
+            0 -> NewCCState0;
+            Outstanding -> quic_cc:on_packet_sent(NewCCState0, Outstanding)
+        end,
 
     State#state{
         remote_addr = NewPath#path_state.remote_addr,
@@ -10752,7 +10761,8 @@ complete_migration(
         pmtu_raise_timer = undefined,
         %% Reset CC and loss detection for new path
         cc_state = NewCCState,
-        loss_state = NewLossState
+        loss_state = NewLossState,
+        pto_dirty = true
     };
 complete_migration(_, State) ->
     %% Can only migrate to validated paths

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -29,6 +29,7 @@
 -include("quic.hrl").
 
 -export([
+    reset_for_new_path/1,
     %% Loss detection state
     new/0,
     new/1,
@@ -113,6 +114,25 @@
 
 -opaque loss_state() :: #loss_state{}.
 -export_type([loss_state/0]).
+
+%% RFC 9002 §9.4 path-change reset: RTT and PTO state belong to the
+%% old path, but the sent-packet tracking must survive - dropping it
+%% orphans every in-flight packet (no ACK match, no loss declaration,
+%% no PTO since bytes_in_flight reads 0) and any lost data in that set
+%% is never retransmitted.
+-spec reset_for_new_path(loss_state() | undefined) -> loss_state().
+reset_for_new_path(undefined) ->
+    new();
+reset_for_new_path(#loss_state{} = S) ->
+    S#loss_state{
+        latest_rtt = 0,
+        smoothed_rtt = ?DEFAULT_INITIAL_RTT,
+        rtt_var = ?DEFAULT_INITIAL_RTT div 2,
+        min_rtt = infinity,
+        first_rtt_sample = false,
+        pto_count = 0,
+        loss_time = undefined
+    }.
 
 %%====================================================================
 %% Loss Detection State


### PR DESCRIPTION
Active migration replaced the loss tracker with `quic_loss:new()`, orphaning every in-flight packet: no ACK can match them, loss detection never examines them, and PTO never fires for them since `bytes_in_flight` reads 0. Any lost data in that set was never retransmitted, and the peer stalled on a permanent stream hole until idle timeout.

RFC 9002 §9.4 resets congestion state on a path change, not the sent-packet tracking. This PR keeps sent_q and its byte accounting, resets the RTT estimate and PTO backoff (they belong to the old path), carries the outstanding bytes into the fresh congestion controller, and marks the PTO timer dirty so it re-arms for the surviving packets.

Reproducer: a 5 MiB transfer through a proxy that rebinds the client's source address and port every second (dead old bindings, as a NAT would). Previously the transfer died on idle timeout partway in; with the fix it completes, and the interop runner's `rebind-addr` case went from failing to passing.

Full eunit and dialyzer pass.