### PR TITLE
Faster handshake retransmission cadence

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -214,9 +214,12 @@
 %% so it can flush the deferred flight. Backoff doubles from the base up
 %% to the cap. Localhost handshakes complete well under the base, so the
 %% timer is cancelled by the state change and never fires.
--define(HS_RTX_BASE_MS, 500).
--define(HS_RTX_MAX_MS, 4000).
--define(HS_RTX_MAX_ATTEMPTS, 8).
+%% 200 ms base keeps a lossy handshake moving at something closer to
+%% PTO cadence on low-RTT paths; 12 attempts bound the total effort to
+%% roughly half a minute before the connect timeout owns the outcome.
+-define(HS_RTX_BASE_MS, 200).
+-define(HS_RTX_MAX_MS, 3000).
+-define(HS_RTX_MAX_ATTEMPTS, 12).
 
 %% Max send queue size in bytes (16 MB default) - prevents memory exhaustion from queued data
 -define(MAX_SEND_QUEUE_BYTES, 16777216).


### PR DESCRIPTION
The handshake flight retransmit ran at a fixed 500 ms base backoff with 8 attempts, giving up after roughly 23 seconds. On low-RTT paths under loss that is 5 to 15 times slower than PTO cadence; in the interop runner's handshakecorruption case it meant ~15 seconds per handshake, and only 19 of 50 handshakes completed within the case's budget. A few percent of handshakes under 30% loss failed outright by exhausting the attempts.

200 ms base with 12 attempts (capped at 3000 ms) tracks lossy handshakes much more closely while still backing off exponentially, and the total effort stays bounded to roughly half a minute before the connect timeout owns the outcome. With this change handshakecorruption went from 19 of 50 to all 50 within budget, and together with #249, #250 and #252 both handshakeloss and handshakecorruption pass.

Full eunit passes.
