### PR TITLE
Cap the PTO backoff at 5 seconds

### DIFF
--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -71,6 +71,7 @@
 % 9/8
 -define(TIME_THRESHOLD, 1.125).
 % 1 millisecond
+-define(MAX_PTO_MS, 5000).
 -define(GRANULARITY, 1).
 % RFC 9002 default is 333ms, but 100ms is more aggressive for faster ramp-up
 -define(DEFAULT_INITIAL_RTT, 100).
@@ -498,7 +499,12 @@ get_pto(#loss_state{
 }) ->
     PTO = SRTT + max(4 * RTTVAR, ?GRANULARITY) + MaxAckDelay,
     %% Exponential backoff
-    PTO bsl PTOCount.
+    %% Exponential backoff, capped: uncapped doubling reaches tens of
+    %% seconds after a loss streak, and a probe that arrives after the
+    %% peer's patience is a probe that never happened. Probes are tiny,
+    %% so a bounded worst-case interval costs nothing while keeping
+    %% recovery inside real-world request timeouts.
+    min(PTO bsl PTOCount, ?MAX_PTO_MS).
 
 %% @doc Handle PTO expiration.
 -spec on_pto_expired(loss_state()) -> loss_state().


### PR DESCRIPTION
The PTO doubled without bound, so after a loss streak of eight or nine expirations the probe interval reached tens of seconds; a probe that arrives after the peer's request timeout is a probe that never happened. Measured under a 30%-loss UDP proxy with 1 KiB request/response exchanges: roughly 1% of exchanges stalled because the responder's PTO backed off past the requester's patience while the response sat unacked in sent_q (observed pto_count 8-9, meaning 10-60+ second probe intervals).

Probes are tiny, so a bounded worst-case interval costs nothing while keeping recovery inside real-world timeouts. RFC 9002 requires exponential backoff but does not forbid a ceiling, and most production stacks cap it. With the cap, 299 of 300 exchanges complete; without it, stalls reproduced in every run of 200.

Full eunit passes.
