### PR TITLE
Follow a peer address change immediately, validate in the background

### DIFF
--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -10389,7 +10389,19 @@ initiate_peer_path_validation(NewAddr, IsNATRebinding, DataSize, State) ->
         is_nat_rebinding = false
     },
 
+    %% RFC 9000 §9.3: follow the highest-numbered non-probing packet
+    %% immediately (the caller gates on non-probing) and validate in the
+    %% background. Waiting for PATH_RESPONSE before moving the data path
+    %% stalls the connection for a full validation round trip per
+    %% rebinding; under frequent NAT rebinds the old binding is already
+    %% dead and everything sent there is lost, so the transfer dies on
+    %% idle timeout. The §9.3 unvalidated-address send cap is not
+    %% enforced on the 1-RTT path here; noted as a deliberate trade
+    %% (spoofing needs the connection ID, the old path is probed per
+    %% §9.3.2, and a failed validation resets so the true peer's next
+    %% packet re-triggers).
     State1 = State#state{
+        remote_addr = NewAddr,
         pending_peer_validation = NewPathState,
         old_path_validation = OldPathState,
         migration_state = validating_peer


### PR DESCRIPTION
RFC 9000 section 9.3: an endpoint changes the address it sends to in response to the highest-numbered non-probing packet from a new peer address, and may send there before path validation completes. The server held all data on the old path until PATH_RESPONSE arrived; under frequent NAT rebinding the old binding is already dead, everything sent there is lost, and with rebinds faster than a validation round trip the connection starves until idle timeout.

This PR switches remote_addr as soon as validation is initiated. The PATH_CHALLENGE on the new path and the section 9.3.2 old-path probe continue unchanged, and a failed validation resets to idle so the true peer's next packet re-triggers. The section 9.3 unvalidated-address send cap is not enforced on the 1-RTT path; this is noted in a comment as a deliberate trade (spoofing requires the connection ID, and the old path is probed).

Reproducer: a 5 MiB transfer through a proxy that rebinds the client's source address and port with strict NAT semantics (the old binding dies, as a real NAT). At 1 s rebind intervals the sent-queue preservation fix in #251 suffices; at 300, 100 and 50 ms intervals the transfer died on idle timeout in every run, and with this change it completes at full pace in all three. The interop runner's rebind-port, rebind-addr, handshakeloss and blackhole cases stay green, and full eunit passes.

Builds on #251.
