### PR TITLE
Do not apply Initial/Handshake ACKs to the 1-RTT loss tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- ACKs arriving at the Initial or Handshake encryption level no longer
+  reach the 1-RTT loss tracker. Packet numbers restart per space
+  (RFC 9000 §12.3), so a Handshake-space ACK of packet numbers 0..N was
+  retiring the first N 1-RTT packets from the sent queue without the peer
+  having received them: nothing retransmitted them and the peer kept a
+  permanent hole in the stream. A path that drops a full window and then
+  returns (WiFi-to-cellular handover, VPN reconnect, NAT rebind) left the
+  transfer stalled for good. Contributed by jbevemyr (#250).
+
 ## [1.8.1] - 2026-08-15
 
 ### Added

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4554,6 +4554,15 @@ process_frame(_Level, ping, State) ->
     State;
 process_frame(Level, {crypto, Offset, Data}, State) ->
     buffer_crypto_data(Level, Offset, Data, State);
+process_frame(Level, {ack, _Ranges, _AckDelay, _ECN}, State) when Level =/= app ->
+    %% Initial/Handshake ACKs must never touch the loss tracker: only
+    %% 1-RTT packets are registered there, and packet numbers restart
+    %% per space, so a Handshake-space ACK of PN 0..N silently "acks"
+    %% the first N 1-RTT packets out of sent_q. If those carried data
+    %% the peer never received, nothing retransmits them and the peer
+    %% stalls on a permanent stream hole. Handshake flights have their
+    %% own retransmission machinery.
+    State;
 process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
     %% Process ACK - update loss detection and congestion control
     #state{loss_state = LossState, cc_state = CCState} = State,

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -184,7 +184,10 @@
     test_decimate_step/1,
     test_decimate_on_timer_fire/1,
     test_maybe_send_ack_app/2,
-    test_classify_recv_trigger/2
+    test_classify_recv_trigger/2,
+    %% Per-space ACK isolation (RFC 9000 Section 12.3)
+    test_state_with_loss/1,
+    test_loss_state/1
 ]).
 -endif.
 
@@ -11639,6 +11642,21 @@ test_state_for_server(RemoteAddr, Secret, ODCID) ->
 
 -spec test_close_reason(#state{}) -> term().
 test_close_reason(#state{close_reason = R}) -> R.
+
+%% Minimal #state{} carrying a caller-supplied loss tracker, for tests
+%% that need to observe what an incoming frame does to it.
+-spec test_state_with_loss(quic_loss:loss_state()) -> #state{}.
+test_state_with_loss(LossState) ->
+    #state{
+        role = client,
+        app_keys = undefined,
+        loss_state = LossState,
+        cc_state = quic_cc:new(#{})
+    }.
+
+%% Read the loss tracker back out without exposing the record.
+-spec test_loss_state(#state{}) -> quic_loss:loss_state().
+test_loss_state(#state{loss_state = L}) -> L.
 
 %% Test helper for check_send_queue_flow_control/3.
 %% Wraps the internal function to avoid exposing #state{} record.

--- a/test/quic_handshake_ack_isolation_tests.erl
+++ b/test/quic_handshake_ack_isolation_tests.erl
@@ -1,0 +1,132 @@
+%%% -*- erlang -*-
+%%%
+%%% ACKs are per packet-number space (RFC 9000 §12.3, RFC 9002 §A.10).
+%%%
+%%% Packet numbers restart at 0 in each space, so the same number means
+%%% a different packet in Initial, Handshake and 1-RTT. Only 1-RTT
+%%% packets are registered in the connection's loss tracker, so feeding
+%%% it a Handshake-space ACK of packet numbers 0..N acknowledges the
+%%% first N 1-RTT packets that were never acknowledged at all. They
+%%% leave the sent queue, nothing retransmits them, and the peer is left
+%%% with a permanent hole in the stream.
+%%%
+%%% These tests pin the isolation at the frame-dispatch boundary: an ACK
+%%% arriving at a non-application encryption level must leave the loss
+%%% tracker exactly as it found it, while an application-level ACK must
+%%% still be processed normally.
+%%%
+%%% The end-to-end consequence is covered by
+%%% quic_stranded_window_recovery_SUITE.
+
+-module(quic_handshake_ack_isolation_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PACKET_BYTES, 1200).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Three ack-eliciting 1-RTT packets in flight. The send times are real
+%% monotonic milliseconds because processing an application ACK arms the
+%% PTO timer, and a timestamp far in the past yields a negative delay.
+loss_with_three_inflight() ->
+    Now = erlang:monotonic_time(millisecond),
+    S0 = quic_loss:new(),
+    S1 = quic_loss:on_packet_sent(S0, 0, ?PACKET_BYTES, true, [], Now),
+    S2 = quic_loss:on_packet_sent(S1, 1, ?PACKET_BYTES, true, [], Now + 1),
+    quic_loss:on_packet_sent(S2, 2, ?PACKET_BYTES, true, [], Now + 2).
+
+state() ->
+    quic_connection:test_state_with_loss(loss_with_three_inflight()).
+
+%% An ACK frame in the shape process_frame/3 consumes. Each range is
+%% {LargestAcked, FirstRange} where FirstRange is a *count* of further
+%% packets below the largest, as on the wire (RFC 9000 §19.3), not the
+%% smallest packet number.
+ack(Ranges) ->
+    {ack, Ranges, 0, undefined}.
+
+%% Acknowledge all three packets, 0..2.
+ack_all() ->
+    ack([{2, 2}]).
+
+%% Everything about the tracker a stray ACK could disturb.
+snapshot(State) ->
+    L = quic_connection:test_loss_state(State),
+    #{
+        in_flight => quic_loss:bytes_in_flight(L),
+        sent => quic_loss:sent_packets(L),
+        oldest => quic_loss:oldest_unacked(L),
+        pto_count => quic_loss:pto_count(L)
+    }.
+
+%%====================================================================
+%% Premise
+%%====================================================================
+
+three_packets_are_in_flight_test() ->
+    #{in_flight := InFlight} = snapshot(state()),
+    %% Without this the isolation assertions below would hold vacuously.
+    ?assertEqual(3 * ?PACKET_BYTES, InFlight).
+
+%%====================================================================
+%% Non-application levels must not touch the tracker
+%%====================================================================
+
+handshake_ack_leaves_the_tracker_untouched_test() ->
+    Before = snapshot(state()),
+    After = snapshot(quic_connection:process_frame(handshake, ack_all(), state())),
+    ?assertEqual(Before, After).
+
+initial_ack_leaves_the_tracker_untouched_test() ->
+    Before = snapshot(state()),
+    After = snapshot(quic_connection:process_frame(initial, ack_all(), state())),
+    ?assertEqual(Before, After).
+
+handshake_ack_of_a_single_packet_leaves_it_in_flight_test() ->
+    %% The narrow case: one packet number that exists in both spaces.
+    After = snapshot(quic_connection:process_frame(handshake, ack([{0, 0}]), state())),
+    ?assertEqual(3 * ?PACKET_BYTES, maps:get(in_flight, After)).
+
+handshake_ack_beyond_the_tracker_is_harmless_test() ->
+    %% A Handshake space that outran the 1-RTT one must not be treated as
+    %% an invalid range against 1-RTT packets that were never sent.
+    After = snapshot(quic_connection:process_frame(handshake, ack([{99, 90}]), state())),
+    ?assertEqual(3 * ?PACKET_BYTES, maps:get(in_flight, After)).
+
+%%====================================================================
+%% Application level must still work
+%%====================================================================
+
+app_ack_is_processed_test() ->
+    %% The inverse case. If this passed too, the fix would have disabled
+    %% ACK processing altogether rather than scoping it.
+    After = snapshot(quic_connection:process_frame(app, ack_all(), state())),
+    ?assertEqual(0, maps:get(in_flight, After)),
+    ?assertEqual(none, maps:get(oldest, After)).
+
+app_ack_of_a_prefix_retires_only_that_prefix_test() ->
+    After = snapshot(quic_connection:process_frame(app, ack([{1, 1}]), state())),
+    %% Two of the three retire; the third is still outstanding.
+    ?assertEqual(?PACKET_BYTES, maps:get(in_flight, After)),
+    ?assertNotEqual(none, maps:get(oldest, After)).
+
+%%====================================================================
+%% Degenerate input (fences: these hold before and after the fix)
+%%====================================================================
+
+empty_ack_is_a_no_op_at_every_level_test() ->
+    Before = snapshot(state()),
+    [
+        ?assertEqual(Before, snapshot(quic_connection:process_frame(Level, ack([]), state())))
+     || Level <- [initial, handshake, app]
+    ].
+
+non_ack_frame_is_unaffected_test() ->
+    %% The new clause is guarded on ACK frames; a PING at handshake level
+    %% must still take its own path rather than being swallowed.
+    Before = snapshot(state()),
+    After = snapshot(quic_connection:process_frame(handshake, ping, state())),
+    ?assertEqual(Before, After).

--- a/test/quic_stranded_window_recovery_SUITE.erl
+++ b/test/quic_stranded_window_recovery_SUITE.erl
@@ -1,0 +1,221 @@
+%%% -*- erlang -*-
+%%%
+%%% Recovery after the whole send window is stranded.
+%%%
+%%% ACKs are per packet-number space (RFC 9000 §12.3) and packet numbers
+%%% restart at 0 in each space. Only 1-RTT packets are registered in the
+%%% connection's loss tracker, so a Handshake-space ACK of packet numbers
+%%% 0..N applied to that tracker retires the first N 1-RTT packets
+%%% without the peer ever having received them. They leave the sent
+%%% queue, so nothing retransmits them, and the stream keeps a permanent
+%%% hole.
+%%%
+%%% It takes a real outage to expose this. On a healthy path the 1-RTT
+%%% packets are acknowledged before any late handshake-level ACK can
+%%% retire them, which is why the control case below passes either way.
+%%%
+%%% The scenario here is a path that drops everything for long enough to
+%%% strand a full window, then comes back: a WiFi-to-cellular handover, a
+%%% VPN reconnect, a NAT rebind. The transfer has to complete once the
+%%% path returns.
+%%%
+%%% Frame-level coverage of the same fix is in
+%%% quic_handshake_ack_isolation_tests.
+
+-module(quic_stranded_window_recovery_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([control_plain_echo/1, recovers_after_the_window_is_stranded/1]).
+
+%% Several times the initial congestion window, so the send queue still
+%% holds most of it when the outage starts.
+-define(PAYLOAD_BYTES, 256 * 1024).
+%% Long enough for the window to fill and for loss detection to run.
+-define(BLACKHOLE_MS, 1500).
+%% Budget for the whole transfer once the path is back. Recovery takes
+%% well under a second when it works at all; this is deliberately loose
+%% so the case fails on a stall rather than on a slow machine.
+-define(RECOVER_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [control_plain_echo, recovers_after_the_window_is_stranded].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: the same transfer over the same harness with no outage. It
+%% passes with and without the fix, and tells a failure of the case
+%% below apart from a broken harness.
+control_plain_echo(_Config) ->
+    with_echo_server(fun(Conn) ->
+        {ok, StreamId} = quic:open_stream(Conn),
+        Payload = payload(),
+        ok = quic:send_data_async(Conn, StreamId, Payload, true),
+        Echoed = collect_echo(Conn, StreamId, ?RECOVER_MS, 0),
+        ?assertEqual(byte_size(Payload), Echoed)
+    end).
+
+recovers_after_the_window_is_stranded(_Config) ->
+    with_echo_server(fun(Conn, Bridge) ->
+        %% Drop everything the client sends, so the window fills with
+        %% packets that can never be acknowledged.
+        Bridge ! blackhole,
+        {ok, StreamId} = quic:open_stream(Conn),
+        Payload = payload(),
+        ok = quic:send_data_async(Conn, StreamId, Payload, true),
+        timer:sleep(?BLACKHOLE_MS),
+
+        Stranded = path_stats(Conn),
+        ct:pal("at the end of the outage: ~p", [Stranded]),
+        %% The premise: the window really is full. Without it the
+        %% assertion below would pass on a connection that simply had
+        %% nothing outstanding.
+        ?assert(maps:get(bytes_in_flight, Stranded) >= maps:get(cwnd, Stranded)),
+
+        Restored = erlang:monotonic_time(millisecond),
+        Bridge ! heal,
+        Echoed = collect_echo(Conn, StreamId, ?RECOVER_MS, 0),
+        Elapsed = erlang:monotonic_time(millisecond) - Restored,
+        ct:pal(
+            "echoed ~p of ~p bytes, ~p ms after the path returned~nfinal: ~p",
+            [Echoed, byte_size(Payload), Elapsed, path_stats(Conn)]
+        ),
+        ?assertEqual(byte_size(Payload), Echoed)
+    end).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+payload() ->
+    binary:copy(<<"x">>, ?PAYLOAD_BYTES).
+
+path_stats(Conn) ->
+    {ok, Stats} = quic:get_path_stats(Conn),
+    Stats.
+
+with_echo_server(Fun) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        {Conn, Bridge} = connect_through_bridge(maps:get(port, Server)),
+        case erlang:fun_info(Fun, arity) of
+            {arity, 1} -> Fun(Conn);
+            {arity, 2} -> Fun(Conn, Bridge)
+        end,
+        _ = quic:safe_close(Conn, normal),
+        ok
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%% Accumulate echoed bytes until the payload is back or the budget runs
+%% out. The budget covers the transfer as a whole, so a trickle that
+%% never finishes still fails.
+collect_echo(_Conn, _StreamId, Budget, Acc) when Budget =< 0 ->
+    Acc;
+collect_echo(_Conn, _StreamId, _Budget, Acc) when Acc >= ?PAYLOAD_BYTES ->
+    Acc;
+collect_echo(Conn, StreamId, Budget, Acc) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc + byte_size(Data));
+        {quic, Conn, _Other} ->
+            %% Session tickets and the like arrive on the same mailbox.
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc)
+    after Budget -> Acc
+    end.
+
+spent(Start) ->
+    max(1, erlang:monotonic_time(millisecond) - Start).
+
+connect_through_bridge(Port) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    receive
+        {quic, Conn, {connected, _}} -> {Conn, Bridge}
+    after 10000 -> ct:fail("connect timeout")
+    end.
+
+%% Relays between the client's socket adapter and a real UDP socket to
+%% the server. In blackhole mode client packets are dropped rather than
+%% forwarded; `heal' puts the path back. The server direction is never
+%% touched, so nothing else about the connection changes.
+bridge_init(ServerIP, ServerPort, SocketRef) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        blackhole => false,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        blackhole ->
+            bridge_loop(Bridge#{blackhole := true});
+        heal ->
+            bridge_loop(Bridge#{blackhole := false});
+        {send, _IP, _Port, Pkt} ->
+            case maps:get(blackhole, Bridge) of
+                true -> ok;
+                false -> ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt)
+            end,
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case maps:get(conn, Bridge) of
+                undefined ->
+                    bridge_loop(Bridge#{pending := [Data | maps:get(pending, Bridge)]});
+                Conn ->
+                    deliver(Bridge, Conn, Data),
+                    bridge_loop(Bridge)
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.


### PR DESCRIPTION
Carries @jbevemyr's commit from #250 with the tests it was missing. Supersedes #250.

## The bug

Packet numbers restart per space (RFC 9000 §12.3) and only 1-RTT packets are registered in the loss tracker, so a Handshake-space ACK of packet numbers 0..N retired the first N 1-RTT packets from `sent_q` without the peer ever having received them. Nothing retransmits them and the peer keeps a permanent hole in the stream.

It needs a real outage to show, which is why it survived: on a healthy path the 1-RTT packets are acknowledged before any late handshake-level ACK can retire them.

Measured on main, over the socket adapter, blackholing the client for 1.5s so a full window is stranded and then restoring the path:

- the client re-sends the whole payload after the path returns (225 packets, 276796 bytes at the bridge)
- the server echoes **0 of 262144 bytes in 20s**
- final state: `bytes_in_flight => 0`, `congested => false`, send queue empty, connection still up

The data is gone and the transfer never completes. With the fix it completes in ~250-550ms. Real paths that do this: WiFi-to-cellular handover, VPN reconnect, NAT rebind.

The new clause follows the `Level =/= app` idiom already used for `handshake_done`, `max_data`, `max_stream_data`, `max_streams` and `data_blocked`.

## Tests

`quic_handshake_ack_isolation_tests` pins the fix at the frame boundary. 4 of its 9 cases fail without it, including a handshake ACK that empties the tracker outright. The application-level cases are the inverse check: they fail if the fix ever turns into "stop processing ACKs".

`quic_stranded_window_recovery_SUITE` covers the consequence end to end, with a control case running the same transfer with no outage so a failure separates a real stall from a broken harness.

`test_state_with_loss/1` and `test_loss_state/1` join the existing `-ifdef(TEST)` export block.

## Checks

`eunit` 2271/0, `dialyzer`, `xref`, `lint`, `fmt --check` all clean. `ct` shows no new failures: the QPACK interop, `quic_h3_owner_SUITE` init and `quic_psk_e2e_SUITE` failures are all present on main too.
