### PR TITLE
Loss tracker: survive path migration, cap the PTO backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The sent-packet tracker now survives an active path migration. It was
+  replaced wholesale, which orphaned every packet already in flight: no
+  ACK matched them, loss detection never ran, and `bytes_in_flight` read
+  zero so no PTO fired either. Their data was never retransmitted and
+  the peer kept a permanent hole in the stream. The path-derived
+  estimates (RTT, PTO count) still reset, since those belong to the old
+  path. Contributed by jbevemyr (#251).
+- The PTO backoff is capped at 5 seconds. RFC 9002 section 6.2.1 doubles
+  the PTO on each consecutive expiration and the doubling had no
+  ceiling, so on a 50 ms path it reached roughly 90 seconds after nine
+  expirations and about twelve minutes after twelve. A probe scheduled
+  that far out never happens: the idle timer and any request deadline
+  above it have long since fired. Contributed by jbevemyr (#254).
+
 ## [1.8.1] - 2026-08-15
 
 ### Added

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -10739,9 +10739,18 @@ complete_migration(
     NewPMTUState = quic_pmtu:on_path_change(PMTUState),
 
     %% RFC 9002 Section 9.4: Reset congestion controller on path change
-    %% The new path may have different RTT and bandwidth characteristics
-    NewCCState = quic_cc:new(#{}),
-    NewLossState = quic_loss:new(),
+    %% The new path may have different RTT and bandwidth characteristics.
+    %% The loss tracker's sent_q must SURVIVE the switch: replacing it
+    %% orphans every in-flight packet (no ACK match, no loss detection,
+    %% no PTO since bytes_in_flight reads 0) and their data is never
+    %% retransmitted - the peer then stalls on a permanent stream hole.
+    NewLossState = quic_loss:reset_for_new_path(State#state.loss_state),
+    NewCCState0 = quic_cc:new(#{}),
+    NewCCState =
+        case quic_loss:bytes_in_flight(NewLossState) of
+            0 -> NewCCState0;
+            Outstanding -> quic_cc:on_packet_sent(NewCCState0, Outstanding)
+        end,
 
     State#state{
         remote_addr = NewPath#path_state.remote_addr,
@@ -10752,7 +10761,8 @@ complete_migration(
         pmtu_raise_timer = undefined,
         %% Reset CC and loss detection for new path
         cc_state = NewCCState,
-        loss_state = NewLossState
+        loss_state = NewLossState,
+        pto_dirty = true
     };
 complete_migration(_, State) ->
     %% Can only migrate to validated paths

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -29,6 +29,7 @@
 -include("quic.hrl").
 
 -export([
+    reset_for_new_path/1,
     %% Loss detection state
     new/0,
     new/1,
@@ -113,6 +114,25 @@
 
 -opaque loss_state() :: #loss_state{}.
 -export_type([loss_state/0]).
+
+%% RFC 9002 §9.4 path-change reset: RTT and PTO state belong to the
+%% old path, but the sent-packet tracking must survive - dropping it
+%% orphans every in-flight packet (no ACK match, no loss declaration,
+%% no PTO since bytes_in_flight reads 0) and any lost data in that set
+%% is never retransmitted.
+-spec reset_for_new_path(loss_state() | undefined) -> loss_state().
+reset_for_new_path(undefined) ->
+    new();
+reset_for_new_path(#loss_state{} = S) ->
+    S#loss_state{
+        latest_rtt = 0,
+        smoothed_rtt = ?DEFAULT_INITIAL_RTT,
+        rtt_var = ?DEFAULT_INITIAL_RTT div 2,
+        min_rtt = infinity,
+        first_rtt_sample = false,
+        pto_count = 0,
+        loss_time = undefined
+    }.
 
 %%====================================================================
 %% Loss Detection State

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -71,6 +71,7 @@
 % 9/8
 -define(TIME_THRESHOLD, 1.125).
 % 1 millisecond
+-define(MAX_PTO_MS, 5000).
 -define(GRANULARITY, 1).
 % RFC 9002 default is 333ms, but 100ms is more aggressive for faster ramp-up
 -define(DEFAULT_INITIAL_RTT, 100).
@@ -498,7 +499,12 @@ get_pto(#loss_state{
 }) ->
     PTO = SRTT + max(4 * RTTVAR, ?GRANULARITY) + MaxAckDelay,
     %% Exponential backoff
-    PTO bsl PTOCount.
+    %% Exponential backoff, capped: uncapped doubling reaches tens of
+    %% seconds after a loss streak, and a probe that arrives after the
+    %% peer's patience is a probe that never happened. Probes are tiny,
+    %% so a bounded worst-case interval costs nothing while keeping
+    %% recovery inside real-world request timeouts.
+    min(PTO bsl PTOCount, ?MAX_PTO_MS).
 
 %% @doc Handle PTO expiration.
 -spec on_pto_expired(loss_state()) -> loss_state().

--- a/test/quic_loss_path_migration_tests.erl
+++ b/test/quic_loss_path_migration_tests.erl
@@ -1,0 +1,110 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for loss-tracker handling across an active path migration
+%%% (RFC 9000 §9.4).
+%%%
+%%% A migration invalidates the path's RTT and congestion estimates, but
+%%% not the packets already in flight. Replacing the whole tracker with a
+%%% fresh one orphans them: no ACK matches, loss detection never runs,
+%%% and bytes_in_flight reads 0 so no PTO fires either. Their data is
+%%% never retransmitted and the peer stalls on a permanent stream hole.
+%%%
+%%% reset_for_new_path/1 draws that line: path-derived estimates reset,
+%%% the sent queue and its byte accounting survive.
+%%%
+%%% Covers PR #251.
+
+-module(quic_loss_path_migration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_loss.
+-define(DEFAULT_INITIAL_RTT, 100).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% A tracker mid-flight: three ack-eliciting packets outstanding and an
+%% established RTT sample, i.e. what a connection looks like when a
+%% migration completes under load.
+in_flight_state() ->
+    S0 = quic_loss:new(),
+    S1 = quic_loss:on_packet_sent(S0, 1, 1200, true, [], 1000),
+    S2 = quic_loss:on_packet_sent(S1, 2, 1200, true, [], 1010),
+    S3 = quic_loss:on_packet_sent(S2, 3, 1000, true, [], 1020),
+    quic_loss:update_rtt(S3, 40, 0).
+
+%%====================================================================
+%% What must survive
+%%====================================================================
+
+keeps_bytes_in_flight_test() ->
+    State = in_flight_state(),
+    Before = quic_loss:bytes_in_flight(State),
+    ?assertEqual(3400, Before),
+    After = quic_loss:reset_for_new_path(State),
+    %% The bytes are still on the wire; forgetting them makes the
+    %% congestion controller think the path is idle.
+    ?assertEqual(Before, quic_loss:bytes_in_flight(After)).
+
+keeps_sent_packets_test() ->
+    State = in_flight_state(),
+    Before = quic_loss:sent_packets(State),
+    After = quic_loss:reset_for_new_path(State),
+    ?assertEqual(Before, quic_loss:sent_packets(After)),
+    %% And they remain retransmittable rather than being dropped on the
+    %% floor by the migration.
+    ?assertNotEqual(undefined, quic_loss:oldest_unacked(After)).
+
+keeps_oldest_unacked_test() ->
+    State = in_flight_state(),
+    ?assertEqual(
+        quic_loss:oldest_unacked(State),
+        quic_loss:oldest_unacked(quic_loss:reset_for_new_path(State))
+    ).
+
+%%====================================================================
+%% What must reset
+%%====================================================================
+
+resets_rtt_estimates_test() ->
+    State = in_flight_state(),
+    ?assertEqual(40, quic_loss:latest_rtt(State)),
+    ?assertEqual(40, quic_loss:smoothed_rtt(State)),
+    After = quic_loss:reset_for_new_path(State),
+    %% The new path has its own RTT; carrying the old one over paces the
+    %% first flight against a path that no longer exists.
+    ?assertEqual(0, quic_loss:latest_rtt(After)),
+    ?assertEqual(?DEFAULT_INITIAL_RTT, quic_loss:smoothed_rtt(After)),
+    ?assertEqual(?DEFAULT_INITIAL_RTT div 2, quic_loss:rtt_var(After)),
+    ?assertEqual(infinity, quic_loss:min_rtt(After)).
+
+resets_rtt_sample_flag_test() ->
+    State = in_flight_state(),
+    ?assert(quic_loss:has_rtt_sample(State)),
+    %% The next sample on the new path must be taken as a first sample,
+    %% not blended into the old path's EWMA.
+    ?assertNot(quic_loss:has_rtt_sample(quic_loss:reset_for_new_path(State))).
+
+resets_pto_count_test() ->
+    State = quic_loss:on_pto_expired(in_flight_state()),
+    ?assert(quic_loss:pto_count(State) > 0),
+    ?assertEqual(0, quic_loss:pto_count(quic_loss:reset_for_new_path(State))).
+
+first_sample_on_new_path_is_not_blended_test() ->
+    After = quic_loss:reset_for_new_path(in_flight_state()),
+    Sampled = quic_loss:update_rtt(After, 250, 0),
+    %% A first sample sets the EWMA outright. Had the flag survived, the
+    %% 250 would have been averaged against the stale 40.
+    ?assertEqual(250, quic_loss:smoothed_rtt(Sampled)),
+    ?assertEqual(250, quic_loss:latest_rtt(Sampled)).
+
+%%====================================================================
+%% Degenerate input
+%%====================================================================
+
+undefined_state_yields_fresh_tracker_test() ->
+    State = quic_loss:reset_for_new_path(undefined),
+    ?assertEqual(0, quic_loss:bytes_in_flight(State)),
+    ?assertNot(quic_loss:has_rtt_sample(State)).

--- a/test/quic_pto_backoff_cap_tests.erl
+++ b/test/quic_pto_backoff_cap_tests.erl
@@ -1,0 +1,99 @@
+%%% -*- erlang -*-
+%%%
+%%% The PTO backoff is bounded.
+%%%
+%%% RFC 9002 §6.2.1 doubles the PTO on each consecutive expiration, and
+%%% the doubling on its own has no ceiling. On a 50 ms path that reaches
+%%% roughly 90 seconds after nine expirations and about twelve minutes
+%%% after twelve. A probe scheduled that far out is not a probe: the
+%%% peer's idle timer, and any request deadline above it, will have
+%%% fired long before. The connection is dead without being closed.
+%%%
+%%% Probes are a single small packet, so bounding the worst-case
+%%% interval costs almost nothing and keeps recovery inside the window
+%%% where anything is still listening. These tests pin the ceiling and,
+%%% just as importantly, pin that the doubling below it is untouched.
+%%%
+%%% Covers PR #254.
+
+-module(quic_pto_backoff_cap_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_loss.
+-define(MAX_PTO_MS, 5000).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% A tracker with a settled RTT, so the PTO has a definite base.
+settled(RttMs) ->
+    quic_loss:update_rtt(quic_loss:new(), RttMs, 0).
+
+%% The PTO after N consecutive expirations.
+pto_after(State, N) ->
+    Expired = lists:foldl(
+        fun(_, S) -> quic_loss:on_pto_expired(S) end,
+        State,
+        lists:seq(1, N)
+    ),
+    quic_loss:get_pto(Expired).
+
+series(State, Upto) ->
+    [pto_after(State, N) || N <- lists:seq(1, Upto)].
+
+%%====================================================================
+%% The ceiling
+%%====================================================================
+
+backoff_never_exceeds_the_cap_test() ->
+    Series = series(settled(50), 12),
+    ?assert(lists:all(fun(P) -> P =< ?MAX_PTO_MS end, Series)).
+
+backoff_is_capped_even_from_a_slow_path_test() ->
+    %% A long RTT reaches the ceiling in fewer steps, and must not step
+    %% over it on the way.
+    Series = series(settled(2000), 8),
+    ?assert(lists:all(fun(P) -> P =< ?MAX_PTO_MS end, Series)).
+
+a_long_loss_streak_stays_at_the_cap_test() ->
+    %% The case that motivates this: without a ceiling, the doubling is
+    %% into the minutes here.
+    ?assertEqual(?MAX_PTO_MS, pto_after(settled(50), 20)),
+    ?assertEqual(?MAX_PTO_MS, pto_after(settled(50), 40)).
+
+%%====================================================================
+%% Below the ceiling nothing changes (fences)
+%%====================================================================
+
+backoff_still_doubles_below_the_cap_test() ->
+    State = settled(50),
+    Base = quic_loss:get_pto(State),
+    ?assert(Base * 2 < ?MAX_PTO_MS),
+    %% Each step is exactly twice the last for as long as there is room.
+    ?assertEqual(Base * 2, pto_after(State, 1)),
+    ?assertEqual(Base * 4, pto_after(State, 2)),
+    ?assertEqual(Base * 8, pto_after(State, 3)).
+
+backoff_is_monotonic_test() ->
+    Series = series(settled(50), 12),
+    ?assertEqual(lists:sort(Series), Series).
+
+first_expiration_is_not_clamped_on_a_fast_path_test() ->
+    %% A short RTT must not be dragged up to the ceiling; the cap is an
+    %% upper bound, not a floor.
+    ?assert(pto_after(settled(5), 1) < ?MAX_PTO_MS).
+
+unexpired_pto_is_untouched_test() ->
+    State = settled(50),
+    ?assert(quic_loss:get_pto(State) < ?MAX_PTO_MS),
+    ?assertEqual(0, quic_loss:pto_count(State)).
+
+%%====================================================================
+%% Degenerate input
+%%====================================================================
+
+cap_holds_without_an_rtt_sample_test() ->
+    %% Before the first sample the PTO runs off the default initial RTT.
+    ?assert(pto_after(quic_loss:new(), 20) =< ?MAX_PTO_MS).


### PR DESCRIPTION
Carries two of @jbevemyr's commits with the tests they were missing. Supersedes #251 and #254.

Grouped because both are `quic_loss` state-lifetime bugs and their tests share a harness. Each is a separate commit with his authorship intact.

## Sent-packet tracker across a migration (#251)

The tracker was replaced wholesale on an active path migration, which orphans every packet already in flight: no ACK matches them, loss detection never runs, and `bytes_in_flight` reads zero so no PTO fires either. Their data is never retransmitted and the peer keeps a permanent hole in the stream.

`reset_for_new_path/1` draws the line where it belongs: the sent queue and its accounting survive, the path-derived estimates (RTT, PTO count, first-sample flag) reset, because those did belong to the old path.

This is the same failure class as #250, which I reproduced end to end this week: once packets are silently retired from the sent queue, nothing brings them back and the transfer is dead without the connection closing.

## PTO backoff cap (#254)

RFC 9002 §6.2.1 doubles the PTO on each consecutive expiration and the doubling had no ceiling. Measured on a 50 ms path:

| expirations | before | after |
|---|---|---|
| 4 | 2800 ms | 2800 ms |
| 9 | 89600 ms | 5000 ms |
| 12 | 716800 ms | 5000 ms |

Nearly twelve minutes. A probe scheduled that far out never happens: the idle timer, and any request deadline above it, fired long before. Probes are one small packet, so bounding the worst case costs nothing.

## Tests

`quic_loss_path_migration_tests`, 8 cases, all 8 fail without the change since the function does not exist.

`quic_pto_backoff_cap_tests`, 8 cases, 4 fail on main. The other 4 are fences: the backoff still doubles exactly below the cap, stays monotonic, does not clamp a fast path up to the ceiling, and leaves an unexpired PTO alone. Those matter here because a cap is easy to implement in a way that also flattens the region below it.

## Checks

`eunit` 2278/0, `dialyzer`, `xref`, `lint`, `fmt --check` clean. `ct` shows no new failures against main's baseline; `quic_server_batching_SUITE` and `quic_sigalg_e2e_SUITE` report `error_in_suite` only in full runs and pass in isolation on main too.