### PR TITLE
Recover a lost client Finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A client whose Finished is lost now recovers. The
+  Certificate(+CertificateVerify)+Finished flight goes out at the
+  Handshake level, and once the client state machine left `handshaking'
+  nothing retransmitted it: handshake-space packets are not in the 1-RTT
+  loss tracker and the handshake retransmit timer only runs in that
+  state. The client considered itself connected and sent 1-RTT data the
+  server could not act on before handshake completion, while the server
+  replayed its own flight against ACK-only answers, until the connection
+  died on the idle timer. The flight is now retained until
+  HANDSHAKE_DONE and resent from the PTO and on a duplicate
+  handshake-level CRYPTO at offset 0. A write that exceeds the peer's
+  flow-control limit also sends the part that fits rather than nothing,
+  which is what lets the recovered connection drain its queue.
+  Contributed by jbevemyr (#252, #230, #225).
+
 ## [1.8.1] - 2026-08-15
 
 ### Added

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -146,6 +146,7 @@
     convert_rest_ranges/2,
     check_send_queue_flow_control/4,
     test_check_flow_control/6,
+    test_queue_blocked_send/5,
     close_reason_to_code/1,
     %% Migration frame classification (RFC 9000 Section 9.1)
     is_probing_frame/1,
@@ -2501,6 +2502,32 @@ handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
     {keep_state, State};
+%% An async send can arrive before the state machine reaches `connected':
+%% the owner is told the connection is up a flight before the handshake
+%% concludes, so this is an ordinary race rather than misuse. Queue it the
+%% way the synchronous handshaking-state clause does, to be flushed by
+%% send_pending_data/2 on entering `connected'. Falling through to the
+%% catch-all below would discard it, and send_data_async cannot retry.
+handle_common_event(
+    cast,
+    {send_data_async, StreamId, Data, Fin},
+    StateName,
+    #state{pending_data = Pending} = State
+) ->
+    case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
+        true ->
+            ?LOG_WARNING(
+                #{
+                    what => async_send_dropped_pending_limit,
+                    state => StateName,
+                    stream_id => StreamId
+                },
+                ?QUIC_LOG_META
+            ),
+            {keep_state, State};
+        false ->
+            {keep_state, State#state{pending_data = Pending ++ [{StreamId, Data, Fin}]}}
+    end;
 %% Return error for unhandled calls to prevent timeout
 handle_common_event({call, From}, _Request, StateName, State) ->
     {keep_state, State, [{reply, From, {error, {invalid_state, StateName}}}]};
@@ -7825,13 +7852,12 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.12: DATA_BLOCKED reports the connection data limit
                             BlockedFrame = {data_blocked, MaxDataRemote},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, connection}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {_, false} ->
-                            %% Stream-level flow control blocked
-                            %% RFC 9000: Don't queue data beyond flow control limits.
-                            %% Send STREAM_DATA_BLOCKED and return error to caller.
-                            %% Caller should retry after receiving MAX_STREAM_DATA from peer.
+                            %% Stream-level flow control blocked. Send
+                            %% STREAM_DATA_BLOCKED and queue; the send queue is
+                            %% drained when MAX_STREAM_DATA arrives.
                             ?LOG_DEBUG(
                                 #{
                                     what => stream_flow_control_blocked,
@@ -7843,8 +7869,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.13: STREAM_DATA_BLOCKED reports the stream data limit
                             BlockedFrame = {stream_data_blocked, StreamId, SendMaxData},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, {stream, StreamId}}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {true, true} ->
                             %% Flow control allows sending
                             %% Fragment and send data - congestion control may partially
@@ -8389,6 +8415,33 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
                 {error, send_queue_full} ->
                     {error, send_queue_full}
             end
+    end.
+
+%% Queue a send the peer's flow-control window has no room for, rather
+%% than returning an error. process_send_queue/1 drains it when MAX_DATA
+%% or MAX_STREAM_DATA arrives. An error here is silently lost for
+%% send_data_async callers, which are fire-and-forget and have no way to
+%% retry, and the loss is invisible to both ends: the bytes never reach
+%% the wire, so the peer cannot detect a gap, and the next send on the
+%% stream simply continues from a later offset.
+%%
+%% The send offset is advanced at queue time so later sends on the stream
+%% order behind this entry. QUIC reassembly is offset-based, so the order
+%% the queued entries actually go out in does not matter.
+queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
+    case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+        {ok, QState} ->
+            case maps:find(StreamId, QState#state.streams) of
+                {ok, Stream} ->
+                    NewStream = Stream#stream_state{send_offset = Offset + DataSize},
+                    {ok, QState#state{
+                        streams = maps:put(StreamId, NewStream, QState#state.streams)
+                    }};
+                error ->
+                    {ok, QState}
+            end;
+        {error, send_queue_full} = Error ->
+            Error
     end.
 
 %% Queue stream data when congestion window is full
@@ -11648,6 +11701,21 @@ test_check_flow_control(StreamId, Offset, DataSize, MaxDataRemote, DataSent, Str
         streams = Streams
     },
     check_send_queue_flow_control(StreamId, Offset, DataSize, State).
+
+%% Test helper for queue_blocked_send/6. A send the peer's window has no
+%% room for must be queued, not dropped, and the stream offset must
+%% advance so later sends order behind it.
+%% Returns {ok, NewSendOffset, QueuedCount} | {error, Reason}.
+test_queue_blocked_send(StreamId, Offset, Data, Fin, SendOffset) ->
+    Stream = #stream_state{send_offset = SendOffset, send_max_data = 0},
+    State = #state{streams = #{StreamId => Stream}},
+    case queue_blocked_send(StreamId, Offset, Data, Fin, iolist_size(Data), State) of
+        {ok, S2} ->
+            #{StreamId := S} = S2#state.streams,
+            {ok, S#stream_state.send_offset, S2#state.send_queue_count};
+        Error ->
+            Error
+    end.
 
 %% Test helper for complete_migration/2.
 %% Tests that path_changed notification is sent to owner on active migration.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -7836,7 +7836,30 @@ do_send_data(
                         ?QUIC_LOG_META
                     ),
 
+                    Allowed = min(ConnectionAllowed, StreamAllowed),
                     case {DataSize =< ConnectionAllowed, DataSize =< StreamAllowed} of
+                        Fits when Fits =/= {true, true}, Allowed > 0 ->
+                            %% Part of this write fits in the peer's window.
+                            %% Send that part and queue the rest: queuing the
+                            %% whole write instead deadlocks the transfer,
+                            %% because the peer only extends the window as it
+                            %% consumes data, so sending nothing means nothing
+                            %% ever arrives to open it.
+                            Bin = iolist_to_binary(Data),
+                            <<Head:Allowed/binary, Tail/binary>> = Bin,
+                            case do_send_data(StreamId, Head, false, State) of
+                                {ok, SentState} ->
+                                    queue_blocked_send(
+                                        StreamId,
+                                        Offset + Allowed,
+                                        Tail,
+                                        Fin,
+                                        byte_size(Tail),
+                                        SentState
+                                    );
+                                Other ->
+                                    Other
+                            end;
                         {false, _} ->
                             %% Connection-level flow control blocked
                             %% RFC 9000: Don't queue data beyond flow control limits.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -362,6 +362,10 @@
     initial_tx_off = 0 :: non_neg_integer(),
     %% Client-side: CH1 random + build opts, needed to rebuild CH2
     tls_ch1_random :: binary() | undefined,
+    %% Client-side: the Certificate(+CertificateVerify)+Finished payload,
+    %% retained until HANDSHAKE_DONE so a lost Finished can be resent -
+    %% nothing else retransmits it once the statem has left `handshaking'.
+    client_hs_flight = undefined :: undefined | binary(),
     tls_ch1_opts :: map() | undefined,
     %% Negotiated values surfaced in the connected event
     negotiated_group :: atom() | undefined,
@@ -4693,7 +4697,9 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
     end;
 %% HANDSHAKE_DONE: Server confirms handshake complete
 %% RFC 9000 Section 19.20: Only server can send, only in 1-RTT (app level)
-process_frame(app, handshake_done, #state{role = client} = State) ->
+process_frame(app, handshake_done, #state{role = client} = State0) ->
+    %% Handshake confirmed: the retained Finished flight is done.
+    State = State0#state{client_hs_flight = undefined},
     %% Server confirmed handshake complete (client receiving from server)
     State;
 process_frame(app, handshake_done, #state{role = server} = State) ->
@@ -5219,11 +5225,29 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                 ?QUIC_CRYPTO_BUFFER_EXCEEDED, <<"crypto buffer exceeded">>, State
             );
         false ->
+            %% A handshake-level CRYPTO duplicate from offset 0 at a
+            %% client that has sent its Finished means the server's
+            %% retransmission timer fired: the Finished was lost, and
+            %% nothing else retransmits it once the statem has left
+            %% `handshaking'. Resend it (CRYPTO offsets are idempotent).
+            Expected = maps:get(LevelAtom, State#state.crypto_offset, 0),
+            State0 =
+                case
+                    LevelAtom =:= handshake andalso
+                        State#state.role =:= client andalso
+                        State#state.client_hs_flight =/= undefined andalso
+                        Offset =:= 0 andalso Expected > 0
+                of
+                    true ->
+                        send_handshake_crypto(State#state.client_hs_flight, State);
+                    false ->
+                        State
+                end,
             %% Add data to buffer
             NewBuffer = maps:put(Offset, Data, Buffer),
-            NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State#state.crypto_buffer),
+            NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State0#state.crypto_buffer),
 
-            State1 = State#state{crypto_buffer = NewCryptoBuffer},
+            State1 = State0#state{crypto_buffer = NewCryptoBuffer},
 
             %% Try to process contiguous data
             process_crypto_buffer(LevelAtom, State1)
@@ -5684,6 +5708,7 @@ process_tls_message(
 
                     State1 = State#state{
                         tls_state = ?TLS_HANDSHAKE_COMPLETE,
+                        client_hs_flight = HandshakePayload,
                         tls_transcript = <<Transcript2/binary, ClientFinishedMsg/binary>>,
                         master_secret = MasterSecret,
                         app_keys = {ClientAppKeys, ServerAppKeys},
@@ -9482,8 +9507,23 @@ handle_pto_timeout(#state{loss_state = LossState} = State) ->
     NewLossState = quic_loss:on_pto_expired(LossState),
     State1 = State#state{loss_state = NewLossState},
 
+    %% RFC 9002 §6.2.1: until the handshake is confirmed the PTO probes
+    %% the handshake space too. The retained Finished flight is exactly
+    %% that: a client whose Finished was lost against a server that has
+    %% stopped retransmitting its own flight would otherwise probe only
+    %% 1-RTT data the server cannot act on before handshake completion.
+    State1a =
+        case State1 of
+            #state{role = client, client_hs_flight = Flight, handshake_keys = HsKeys} when
+                Flight =/= undefined, HsKeys =/= undefined
+            ->
+                send_handshake_crypto(Flight, State1);
+            _ ->
+                State1
+        end,
+
     %% Send probe packet (retransmit oldest unacked or send PING)
-    State2 = send_probe_packet(State1),
+    State2 = send_probe_packet(State1a),
 
     %% Probes use the control allowance, so retry any CC-deferred control
     %% retransmits here too (they are not in sent_q for the probe to pick up).

--- a/test/quic_async_send_loss_tests.erl
+++ b/test/quic_async_send_loss_tests.erl
@@ -1,0 +1,39 @@
+%%% A send that the peer's flow-control window has no room for must be
+%%% queued, not turned into an error.
+%%%
+%%% send_data_async is fire-and-forget, so an error return is silently
+%%% lost, and the loss is invisible to both ends: the bytes never reach
+%%% the wire, so the peer cannot detect a gap, and the next send on the
+%%% stream continues from a later offset. The application stream is then
+%%% missing a chunk with nothing reported anywhere.
+-module(quic_async_send_loss_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+queue(StreamId, Offset, Data, Fin, SendOffset) ->
+    quic_connection:test_queue_blocked_send(StreamId, Offset, Data, Fin, SendOffset).
+
+%% The regression: this used to return {error, {flow_control_blocked, _}}
+%% and drop the payload.
+blocked_send_is_queued_test() ->
+    ?assertMatch({ok, _, 1}, queue(4, 0, <<"payload">>, false, 0)).
+
+%% The offset has to advance at queue time, so a later send on the same
+%% stream orders behind this entry rather than overwriting its range.
+blocked_send_advances_offset_test() ->
+    {ok, NewOffset, _} = queue(4, 100, binary:copy(<<$x>>, 250), false, 100),
+    ?assertEqual(350, NewOffset).
+
+fin_is_preserved_test() ->
+    ?assertMatch({ok, _, 1}, queue(8, 0, <<"last">>, true, 0)).
+
+%% An empty payload still has to queue rather than error: a FIN-only send
+%% carries stream-closing intent.
+empty_payload_is_queued_test() ->
+    {ok, NewOffset, Count} = queue(4, 40, <<>>, true, 40),
+    ?assertEqual(40, NewOffset),
+    ?assertEqual(1, Count).
+
+iodata_is_accepted_test() ->
+    {ok, NewOffset, _} = queue(4, 0, [<<"ab">>, [<<"cd">>, <<"ef">>]], false, 0),
+    ?assertEqual(6, NewOffset).

--- a/test/quic_lost_finished_SUITE.erl
+++ b/test/quic_lost_finished_SUITE.erl
@@ -1,0 +1,201 @@
+%%% -*- erlang -*-
+%%%
+%%% A lost client Finished must still get through.
+%%%
+%%% The client's Certificate(+CertificateVerify)+Finished flight goes out
+%%% at the Handshake encryption level. Once the client state machine
+%%% leaves `handshaking' nothing retransmits it: handshake-space packets
+%%% are not in the 1-RTT loss tracker, and the handshake retransmit timer
+%%% only runs in that state.
+%%%
+%%% So a client whose Finished is dropped considers itself connected and
+%%% starts sending 1-RTT data the server cannot act on before the
+%%% handshake completes, while the server keeps replaying its own flight
+%%% against ACK-only answers. Nothing breaks the tie and the connection
+%%% dies on the idle timer with the Finished never acknowledged.
+%%%
+%%% One dropped datagram is enough, which makes this reachable on any
+%%% lossy path rather than an exotic case.
+%%%
+%%% The bridge here drops the client's first Handshake-level datagrams
+%%% and then lets everything through, so recovery depends entirely on the
+%%% client resending the flight on its own.
+
+-module(quic_lost_finished_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    control_no_loss/1,
+    survives_one_lost_finished/1,
+    survives_two_lost_finished/1
+]).
+
+-define(ECHO, <<"finished came back">>).
+-define(CONNECT_MS, 15000).
+-define(ECHO_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [control_no_loss, survives_one_lost_finished, survives_two_lost_finished].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: the same path with nothing dropped. Separates a real stall
+%% from a broken harness.
+control_no_loss(_Config) ->
+    ?assertEqual(?ECHO, run(0)).
+
+survives_one_lost_finished(_Config) ->
+    ?assertEqual(?ECHO, run(1)).
+
+survives_two_lost_finished(_Config) ->
+    %% Two consecutive losses, so recovery cannot depend on a single
+    %% retransmission happening to land.
+    ?assertEqual(?ECHO, run(2)).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Connect with the first Drop client Handshake-level datagrams
+%% discarded, then echo a payload. Returns what came back.
+run(Drop) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        Port = maps:get(port, Server),
+        SocketRef = make_ref(),
+        Self = self(),
+        Bridge = spawn_link(fun() -> bridge_init({127, 0, 0, 1}, Port, SocketRef, Drop, Self) end),
+        Adapter = #{
+            send_fun => fun(IP, P, Pkt) ->
+                Bridge ! {send, IP, P, Pkt},
+                ok
+            end,
+            close_fun => fun() ->
+                Bridge ! stop,
+                ok
+            end,
+            local => {{127, 0, 0, 1}, 0},
+            socket_ref => SocketRef
+        },
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            socket_backend => adapter,
+            socket_adapter => Adapter
+        },
+        {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+        Bridge ! {set_conn, Conn},
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after ?CONNECT_MS -> ct:fail("connect timeout with ~p dropped", [Drop])
+        end,
+        Bridge ! {report, self()},
+        receive
+            {dropped, N} -> ct:pal("dropped ~p client Handshake datagram(s)", [N])
+        after 2000 -> ok
+        end,
+        {ok, StreamId} = quic:open_stream(Conn),
+        ok = quic:send_data(Conn, StreamId, ?ECHO, true),
+        Got = await_echo(Conn, StreamId),
+        _ = quic:safe_close(Conn, normal),
+        Got
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+await_echo(Conn, StreamId) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, _Fin}} -> Data;
+        {quic, Conn, _Other} -> await_echo(Conn, StreamId)
+    after ?ECHO_MS -> timeout
+    end.
+
+%%====================================================================
+%% Bridge
+%%====================================================================
+
+%% Relays between the client's socket adapter and a real UDP socket,
+%% discarding the first Drop datagrams the client sends at the Handshake
+%% encryption level. The long-header form and type bits sit outside the
+%% header-protection mask, so the level is readable without keys.
+bridge_init(ServerIP, ServerPort, SocketRef, Drop, Reporter) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        to_drop => Drop,
+        dropped => 0,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef,
+        reporter => Reporter
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {report, To} ->
+            To ! {dropped, maps:get(dropped, Bridge)},
+            bridge_loop(Bridge);
+        {send, _IP, _Port, Pkt} ->
+            Left = maps:get(to_drop, Bridge),
+            case Left > 0 andalso header_level(Pkt) =:= handshake of
+                true ->
+                    bridge_loop(Bridge#{
+                        to_drop := Left - 1,
+                        dropped := maps:get(dropped, Bridge) + 1
+                    });
+                false ->
+                    ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+                    bridge_loop(Bridge)
+            end;
+        {udp, Sock, _IP, _Port, Data} ->
+            case maps:get(conn, Bridge) of
+                undefined ->
+                    bridge_loop(Bridge#{pending := [Data | maps:get(pending, Bridge)]});
+                Conn ->
+                    deliver(Bridge, Conn, Data),
+                    bridge_loop(Bridge)
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.
+
+%% QUIC v1 long-header packet types live in bits 4-5 of the first byte:
+%% Initial 0x00, 0-RTT 0x10, Handshake 0x20, Retry 0x30.
+header_level(Pkt) ->
+    <<First:8, _/binary>> = iolist_to_binary(Pkt),
+    case First band 16#80 of
+        0 ->
+            short;
+        _ ->
+            case First band 16#30 of
+                16#00 -> initial;
+                16#10 -> zero_rtt;
+                16#20 -> handshake;
+                _ -> retry
+            end
+    end.


### PR DESCRIPTION
Carries @jbevemyr's commits from #252 and #230 with the tests they were missing. Supersedes #252, #230 and #225 (#225 is contained in #230).

These two land together because **neither fixes the bug alone**. That is the substantive finding here.

## The bug

The client's Certificate(+CertificateVerify)+Finished flight goes out at the Handshake level. Once the client state machine leaves `handshaking` nothing retransmits it: handshake-space packets are not in the 1-RTT loss tracker, and the handshake retransmit timer only runs in that state.

So a client whose Finished is dropped reports itself connected and starts sending 1-RTT data the server cannot act on before the handshake completes, while the server replays its own flight against ACK-only answers. Nothing breaks the tie and the connection dies on the idle timer.

## Why both

`quic_lost_finished_SUITE` drops the client's first N Handshake-level datagrams at a bridge, then lets everything through, so recovery depends entirely on the client resending the flight.

One dropped datagram already recovers on main. **Two does not**: the client still reports connected and then no data ever flows. Measured over three runs each:

| | two dropped |
|---|---|
| main | fails |
| #252 alone | fails |
| #230 alone | fails |
| **#252 + #230** | **passes** |

#252 gets the flight resent; #230 is what lets the recovered connection actually drain its queue, by sending the part of a write that fits under the peer's flow-control limit rather than nothing. Landing either one on its own leaves the bug live, which is not visible from either PR in isolation.

The no-loss control case separates a real stall from a broken harness.

## Checks

`eunit` 2267/0, `dialyzer`, `xref`, `lint`, `fmt --check` clean. `ct` shows no new failures against main's baseline.