### PR TITLE
Bind the socket-backend client to the requested source address

### DIFF
--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -811,6 +811,7 @@ open_send_socket_backend(Family, Opts, BatchConfig) ->
 configure_send_socket(Socket, Opts, BatchConfig) ->
     ok = socket:setopt(Socket, {socket, reuseaddr}, true),
     set_socket_buffer_sizes(Socket, Opts),
+    maybe_bind_source(Socket, Opts),
     %% GSO is applied per-message via the UDP_SEGMENT cmsg in
     %% flush_gso/1, never as a socket-level setsockopt. A socket-level
     %% UDP_SEGMENT would force GSO segmentation on every outbound
@@ -829,6 +830,32 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
         max_batch_packets = maps:get(max_batch, BatchConfig)
     },
     {ok, State}.
+
+%% Honor a specific source address from extra_socket_opts {ip, Addr},
+%% as the gen_udp client path does. Without the bind the kernel
+%% picks the source per route (127.0.0.1 for loopback), which
+%% misidentifies the sender on multi-address hosts.
+maybe_bind_source(Socket, Opts) ->
+    case proplists:get_value(ip, maps:get(extra_socket_opts, Opts, []), undefined) of
+        undefined ->
+            ok;
+        BindAddr ->
+            case
+                socket:bind(Socket, #{
+                    family => family(BindAddr), addr => BindAddr, port => 0
+                })
+            of
+                ok ->
+                    ok;
+                {error, BindErr} ->
+                    ?LOG_WARNING(#{
+                        what => client_source_bind_failed,
+                        addr => BindAddr,
+                        reason => BindErr
+                    }),
+                    ok
+            end
+    end.
 
 %% Open gen_udp backend optimized for sending (ephemeral port)
 open_send_genudp_backend(Family, Opts, BatchConfig) ->


### PR DESCRIPTION
## The bug

The gen_udp client path passes `extra_socket_opts` (including `{ip, Addr}`) through to `gen_udp:open`, so a caller on a multi-address host can pick which address its connections originate from. The socket backend dropped those options entirely: the socket was never bound, the kernel picked the source address per route (127.0.0.1 for any loopback destination), and the peer attributed the connection to the wrong host.

We hit this in a test rig where several simulated hosts share one machine and are told apart by loopback source address; every socket-backend client appeared as 127.0.0.1.

## The fix

`configure_send_socket/3` now honors `{ip, Addr}` from `extra_socket_opts` with an explicit `socket:bind` (port 0, family derived from the address), matching the gen_udp path. A failed bind logs a warning and falls back to the previous unbound behaviour rather than failing the connect, since the address may be legitimately absent on the host (e.g. DHCP renumbering between config and connect).
