### PR TITLE
GRO/GSO batching: read the cmsg, size the buffer, run mixed batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The UDP_GRO control message is read as the int the kernel sends.
+  Matching exactly two bytes meant the lookup never succeeded, so a
+  GRO-coalesced buffer was passed up unsplit as one oversized datagram
+  and dropped by the QUIC layer, which cannot re-split short-header
+  packets. GRO was therefore silently losing every coalesced train.
+  Contributed by jbevemyr (#204).
+- The GRO receive path sizes its read buffer for a maximally coalesced
+  train (64 KiB). Passing 0 used the OTP default 8 KiB buffer and
+  `recvmsg' silently truncated anything larger, discarding every segment
+  past the first few. The client receiver also went through a plain
+  `recvfrom', which never split trains at all. Contributed by jbevemyr
+  (#215).
+
+### Changed
+- A mixed-size send batch on a GSO socket is split into runs of
+  equal-sized packets and each run sent with one UDP_SEGMENT call,
+  instead of falling back to one `sendmsg' per packet. A single
+  odd-sized packet between data packets (an ACK, a flow-control update)
+  previously degraded the whole batch. Contributed by jbevemyr (#217).
+- Small sends are coalesced into shared packets. Contributed by jbevemyr
+  (#203).
+- The pacing burst allowance scales with the pacing rate rather than
+  sitting at a fixed 12 packets. Pacing wakeups have roughly
+  millisecond resolution, so the fixed bucket capped throughput at 12
+  packets per wakeup whenever the sender outran the ACK clock,
+  regardless of the configured rate. Contributed by jbevemyr (#219).
+
 ## [1.8.1] - 2026-08-15
 
 ### Added

--- a/src/quic_cc_newreno.erl
+++ b/src/quic_cc_newreno.erl
@@ -812,7 +812,7 @@ update_mtu(#cc_state{max_datagram_size = OldMDS, minimum_window = OldMinWin} = S
     NewMinimumWindow = max(2 * NewMTU, (OldMinWin * NewMTU) div OldMDS),
 
     %% Update pacing_max_burst (12 * max_datagram_size)
-    NewPacingMaxBurst = 12 * NewMTU,
+    NewPacingMaxBurst = max(12 * NewMTU, 2 * State#cc_state.pacing_rate),
 
     ?LOG_DEBUG(
         #{
@@ -904,7 +904,17 @@ update_pacing_rate(#cc_state{cwnd = Cwnd} = State, SmoothedRTT) when SmoothedRTT
     %% Update HyStart++ RTT tracking
     State1 = update_hystart_rtt(State, SmoothedRTT),
 
-    State1#cc_state{pacing_rate = PacingRate};
+    %% The burst allowance must cover at least a couple of timer
+    %% granularities' worth of tokens at the paced rate: pacing wakeups
+    %% (send_after) have ~1 ms resolution, so a fixed 12-packet bucket
+    %% caps throughput at 12 packets per wakeup whenever the sender
+    %% outruns the incoming ACK clock, regardless of the configured
+    %% rate. 2 ms of rate keeps micro-bursts bounded (same idea as
+    %% Linux fq's pacing quantum) while letting a 1 ms clock sustain
+    %% the rate.
+    MaxBurst = max(12 * State1#cc_state.max_datagram_size, 2 * PacingRate),
+
+    State1#cc_state{pacing_rate = PacingRate, pacing_max_burst = MaxBurst};
 update_pacing_rate(State, _SmoothedRTT) ->
     %% No valid RTT yet, keep current state
     State.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -685,7 +685,18 @@
     last_recv_trigger = sequential :: sequential | reordered,
 
     %% QLOG Tracing (draft-ietf-quic-qlog-quic-events)
-    qlog_ctx :: #qlog_ctx{} | undefined
+    qlog_ctx :: #qlog_ctx{} | undefined,
+
+    %% Small-send coalescing (issue #201). While `coalesce' is true -
+    %% only within one drained batch of send_data/send_data_async
+    %% requests - app packets accumulate here and are flushed as one
+    %% multi-frame packet per PMTU budget instead of one packet per
+    %% frame. Reversed accumulation lists; see send_app_packet_internal
+    %% and flush_pending_packet.
+    coalesce = false :: boolean(),
+    pend_payload = [] :: [iodata()],
+    pend_frames = [] :: [tuple()],
+    pend_size = 0 :: non_neg_integer()
 }).
 
 %%====================================================================
@@ -1957,14 +1968,7 @@ connected({call, From}, {send_datagram, Data}, State) ->
             {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
 connected({call, From}, {send_data, StreamId, Data, Fin}, State) ->
-    case do_send_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            %% Event-driven flush: flush batch and timers after user API call
-            FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
-            {keep_state, FlushedState, [{reply, From, ok}]};
-        {error, Reason} ->
-            {keep_state, State, [{reply, From, {error, Reason}}]}
-    end;
+    coalesced_sends([{From, StreamId, Data, Fin}], State);
 connected({call, From}, open_stream, State) ->
     case do_open_stream(State) of
         {ok, StreamId, NewState} ->
@@ -2254,15 +2258,7 @@ connected(cast, {close, Reason}, State) ->
     {next_state, draining, NewState};
 %% Async send data - fire-and-forget for high throughput
 connected(cast, {send_data_async, StreamId, Data, Fin}, State) ->
-    case do_send_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            %% Event-driven flush: flush batch and timers after user API call
-            FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
-            {keep_state, FlushedState};
-        {error, _Reason} ->
-            %% Silently drop errors in async mode
-            {keep_state, State}
-    end;
+    coalesced_sends([{async, StreamId, Data, Fin}], State);
 connected(cast, process, #state{role = client, active_n = N} = State) ->
     %% Re-enable socket for receiving (client only - server uses listener's socket)
     client_rearm_active(State, N),
@@ -3551,7 +3547,78 @@ send_app_packet(Payload, State) when is_binary(Payload) ->
     send_app_packet_internal(Payload, FrameInfo, State).
 
 %% Send a 1-RTT packet with explicit frames list for retransmission tracking
+%% Coalescing front end: within a drained send batch, small app
+%% packets accumulate and are emitted as one multi-frame packet.
+%% Everything downstream (packet build, loss tracking, retransmit,
+%% counters) already handles a frames list per packet, so only the
+%% emission point changes. A payload larger than the remaining budget
+%% flushes the pending packet first; coalescing off means the old
+%% one-packet-per-call behaviour, byte for byte.
+send_app_packet_internal(Payload, Frames, #state{coalesce = true} = State) ->
+    #state{pend_payload = PP, pend_frames = PF, pend_size = PS} = State,
+    Size = erlang:iolist_size(Payload),
+    Budget = get_max_stream_data_per_packet(State),
+    case PS > 0 andalso PS + Size > Budget of
+        true ->
+            State1 = flush_pending_packet(State),
+            State1#state{
+                pend_payload = [Payload],
+                pend_frames = lists:reverse(Frames),
+                pend_size = Size
+            };
+        false ->
+            State#state{
+                pend_payload = [Payload | PP],
+                pend_frames = lists:reverse(Frames, PF),
+                pend_size = PS + Size
+            }
+    end;
 send_app_packet_internal(Payload, Frames, State) ->
+    send_app_packet_now(Payload, Frames, State).
+
+%% Drain consecutive send requests already sitting in the mailbox and
+%% process them as one batch with coalescing enabled, so frames from
+%% concurrent senders share packets (issue #201). Only send messages
+%% are drained; everything else keeps its ordinary ordering. A lone
+%% send behaves exactly as before apart from a single extra receive
+%% probe.
+coalesced_sends(Acc0, State0) ->
+    Sends = drain_send_msgs(Acc0, 63),
+    {RevReplies, State1} =
+        lists:foldl(
+            fun({Tag, Sid, Data, Fin}, {Rs, S}) ->
+                case do_send_data(Sid, Data, Fin, S) of
+                    {ok, S2} -> {[{Tag, ok} | Rs], S2};
+                    {error, Reason} -> {[{Tag, {error, Reason}} | Rs], S}
+                end
+            end,
+            {[], State0#state{coalesce = true}},
+            Sends
+        ),
+    State2 = flush_pending_packet(State1#state{coalesce = false}),
+    FlushedState = flush_dirty_timers(flush_socket_batch(State2)),
+    Replies = [{reply, F, R} || {F, R} <- lists:reverse(RevReplies), F =/= async],
+    {keep_state, FlushedState, Replies}.
+
+drain_send_msgs(Acc, 0) ->
+    lists:reverse(Acc);
+drain_send_msgs(Acc, N) ->
+    receive
+        {'$gen_call', From, {send_data, Sid, D, Fin}} ->
+            drain_send_msgs([{From, Sid, D, Fin} | Acc], N - 1);
+        {'$gen_cast', {send_data_async, Sid, D, Fin}} ->
+            drain_send_msgs([{async, Sid, D, Fin} | Acc], N - 1)
+    after 0 ->
+        lists:reverse(Acc)
+    end.
+
+flush_pending_packet(#state{pend_size = 0} = State) ->
+    State;
+flush_pending_packet(#state{pend_payload = PP, pend_frames = PF} = State) ->
+    State1 = State#state{pend_payload = [], pend_frames = [], pend_size = 0},
+    send_app_packet_now(lists:reverse(PP), lists:reverse(PF), State1).
+
+send_app_packet_now(Payload, Frames, State) ->
     #state{
         dcid = DCID,
         app_keys = {ClientKeys, ServerKeys},

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -527,10 +527,13 @@ flush(#socket_state{gso_supported = true, batch_buffer = Buffer, gso_size = GSO}
     %% exactly gso_size. Handshake flights coalesce Initial-padded-to-
     %% 1200 with a ~400 byte Handshake packet; a naive GSO split
     %% mis-aligns those boundaries and the client cannot decode. When
-    %% the batch is not uniform, fall through to individual sends.
+    %% the batch is not uniform, split it into runs of equal-sized
+    %% packets and GSO each run: a single odd-sized packet (an ACK or a
+    %% flow-control update between data packets) otherwise degrades the
+    %% whole batch to one sendmsg per packet.
     case gso_batch_uniform(Buffer, GSO) of
         true -> flush_gso(State);
-        false -> flush_individual(State)
+        false -> flush_gso_runs(State)
     end;
 flush(#socket_state{} = State) ->
     %% Fallback path - send packets individually
@@ -970,6 +973,97 @@ flush_individual(#socket_state{backend = socket} = State) ->
     flush_individual_socket(State);
 flush_individual(#socket_state{backend = gen_udp} = State) ->
     flush_individual_genudp(State).
+
+%% Mixed-size batch on a GSO socket: send it as runs of equal-sized
+%% packets, each run in one UDP_SEGMENT sendmsg, odd-sized packets
+%% individually, preserving wire order. A run may absorb one shorter
+%% trailing packet (the kernel allows a short final segment).
+flush_gso_runs(
+    #socket_state{
+        socket = Socket,
+        batch_buffer = Buffer,
+        batch_addr = {IP, Port}
+    } = State
+) ->
+    Packets = lists:reverse(Buffer),
+    Dest = #{family => family(IP), addr => IP, port => Port},
+    case send_runs(Socket, Dest, split_uniform_runs(Packets)) of
+        ok ->
+            {ok, record_flush(State)};
+        {error, Reason} ->
+            ?LOG_WARNING(#{what => gso_run_send_error, reason => Reason}),
+            {error, Reason, clear_batch(State)}
+    end.
+
+%% Group an oldest-first packet list into {gso, SegmentSize, Packets}
+%% runs (>= 2 packets, all SegmentSize except possibly a shorter last)
+%% and {single, Packet} entries, preserving order.
+split_uniform_runs([]) ->
+    [];
+split_uniform_runs([P | Rest]) ->
+    split_uniform_runs(Rest, iolist_size(P), [P]).
+
+split_uniform_runs([], _Size, [Single]) ->
+    [{single, Single}];
+split_uniform_runs([], Size, RunAcc) ->
+    [{gso, Size, lists:reverse(RunAcc)}];
+split_uniform_runs([P | Rest], Size, RunAcc) ->
+    PSize = iolist_size(P),
+    if
+        PSize =:= Size ->
+            split_uniform_runs(Rest, Size, [P | RunAcc]);
+        PSize < Size ->
+            %% Shorter packet closes this run as its final segment
+            %% (the kernel permits a short last segment).
+            [{gso, Size, lists:reverse([P | RunAcc])} | split_uniform_runs(Rest)];
+        true ->
+            Head =
+                case RunAcc of
+                    [Single] -> {single, Single};
+                    _ -> {gso, Size, lists:reverse(RunAcc)}
+                end,
+            [Head | split_uniform_runs(Rest, PSize, [P])]
+    end.
+
+send_runs(_Socket, _Dest, []) ->
+    ok;
+send_runs(Socket, Dest, [{single, Packet} | Rest]) ->
+    Msg = #{addr => Dest, iov => [normalize_packet(Packet)]},
+    case socket:sendmsg(Socket, Msg) of
+        ok -> send_runs(Socket, Dest, Rest);
+        {ok, _RestData} -> send_runs(Socket, Dest, Rest);
+        {error, _} = Error -> Error
+    end;
+send_runs(Socket, Dest, [{gso, SegmentSize, Packets} | Rest]) ->
+    PacketIov = [normalize_packet(P) || P <- Packets],
+    Msg = #{
+        addr => Dest,
+        iov => PacketIov,
+        ctrl => [#{level => udp, type => ?UDP_SEGMENT, data => <<SegmentSize:16/native>>}]
+    },
+    case socket:sendmsg(Socket, Msg) of
+        ok ->
+            send_runs(Socket, Dest, Rest);
+        {ok, RestData} ->
+            %% Kernel refused part of the segmented write: send the
+            %% remainder segment-by-segment, then continue with the
+            %% remaining runs (mirrors flush_gso_partial).
+            Data = iolist_to_binary(RestData),
+            case send_run_segments(Socket, Dest, split_into_segments(Data, SegmentSize)) of
+                ok -> send_runs(Socket, Dest, Rest);
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+send_run_segments(_Socket, _Dest, []) ->
+    ok;
+send_run_segments(Socket, Dest, [Packet | Rest]) ->
+    case socket:sendto(Socket, Packet, Dest) of
+        ok -> send_run_segments(Socket, Dest, Rest);
+        {error, _} = Error -> Error
+    end.
 
 flush_individual_socket(
     #socket_state{

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -1008,15 +1008,14 @@ split_uniform_runs([], _Size, [Single]) ->
 split_uniform_runs([], Size, RunAcc) ->
     [{gso, Size, lists:reverse(RunAcc)}];
 split_uniform_runs([P | Rest], Size, RunAcc) ->
-    PSize = iolist_size(P),
-    if
-        PSize =:= Size ->
+    case iolist_size(P) of
+        Size ->
             split_uniform_runs(Rest, Size, [P | RunAcc]);
-        PSize < Size ->
+        PSize when PSize < Size ->
             %% Shorter packet closes this run as its final segment
             %% (the kernel permits a short last segment).
             [{gso, Size, lists:reverse([P | RunAcc])} | split_uniform_runs(Rest)];
-        true ->
+        PSize ->
             Head =
                 case RunAcc of
                     [Single] -> {single, Single};

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -124,6 +124,17 @@
 -opaque socket_state() :: #socket_state{}.
 -export_type([socket_state/0, packet_view/0]).
 
+-ifdef(TEST).
+%% GRO/GSO batching internals. These are pure and the kernel features
+%% they serve are Linux-only, so unit tests reach them directly rather
+%% than needing a socket that supports UDP_GRO or UDP_SEGMENT.
+-export([
+    extract_gro_segment_size/1,
+    split_gro_packets/2,
+    split_uniform_runs/1
+]).
+-endif.
+
 %%====================================================================
 %% API
 %%====================================================================

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -682,9 +682,14 @@ stop_client_receiver(Pid) when is_pid(Pid) ->
 %% exit signals from the linked owner are processed promptly rather
 %% than blocking forever in the NIF.
 client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
-    case socket:recvfrom(Socket, 0, [], 100) of
-        {ok, {#{addr := IP, port := Port}, Data}} ->
-            Owner ! {udp, Socket, IP, Port, Data},
+    %% recv_gro splits GRO-coalesced trains and sizes the read buffer
+    %% for a maximal train. A plain recvfrom here had two problems:
+    %% the default 8 KiB buffer silently truncates coalesced input,
+    %% and an unsplit train is one datagram of which the QUIC layer
+    %% can only parse the first packet.
+    case recv_gro(Socket, 100) of
+        {ok, {IP, Port}, Packets} ->
+            [Owner ! {udp, Socket, IP, Port, Data} || Data <- Packets],
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -1186,8 +1191,11 @@ extra_socket_family(Extra) ->
 %%====================================================================
 
 recv_gro(Socket, Timeout) ->
-    %% Receive with GRO - may get coalesced packets
-    case socket:recvmsg(Socket, 0, 128, [], Timeout) of
+    %% Receive with GRO - may get coalesced packets. The buffer must
+    %% hold a maximally coalesced train (64 KiB): passing 0 uses the
+    %% OTP default read buffer (8 KiB) and recvmsg silently TRUNCATES
+    %% any larger train, discarding every segment past the first few.
+    case socket:recvmsg(Socket, 65535, 128, [], Timeout) of
         {ok, #{addr := #{addr := IP, port := Port}, iov := [Data], ctrl := Ctrl}} ->
             %% Check for GRO segment size in control messages
             case extract_gro_segment_size(Ctrl) of

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -1208,7 +1208,14 @@ recv_gro(Socket, Timeout) ->
 
 extract_gro_segment_size([]) ->
     undefined;
-extract_gro_segment_size([#{level := udp, type := ?UDP_GRO, data := <<Size:16/native>>} | _]) ->
+extract_gro_segment_size([
+    #{level := udp, type := ?UDP_GRO, data := <<Size:16/native, _/binary>>} | _
+]) ->
+    %% The kernel's UDP_GRO cmsg payload is an int (4 bytes); matching
+    %% exactly 2 bytes made every lookup fail, so a GRO-coalesced buffer
+    %% was passed up unsplit as one giant datagram and dropped by the
+    %% QUIC layer (short-header packets cannot be re-split). Accept the
+    %% int and read the low 16 bits.
     Size;
 extract_gro_segment_size([_ | Rest]) ->
     extract_gro_segment_size(Rest).

--- a/test/quic_gro_gso_batching_tests.erl
+++ b/test/quic_gro_gso_batching_tests.erl
@@ -1,0 +1,146 @@
+%%% -*- erlang -*-
+%%%
+%%% GRO receive splitting and GSO send batching.
+%%%
+%%% Both features are Linux-only and need kernel support to exercise
+%%% end to end, but the parts that decide what happens are pure: reading
+%%% the segment size out of the UDP_GRO control message, splitting a
+%%% coalesced train back into datagrams, and grouping a mixed-size send
+%%% batch into runs that UDP_SEGMENT can carry. These tests reach those
+%%% directly, so they run and mean something on any platform.
+%%%
+%%% Covers PRs #204 and #217.
+
+-module(quic_gro_gso_batching_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_socket.
+-define(UDP_GRO, 104).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% The kernel hands UDP_GRO up as an int, which is 4 bytes on every
+%% platform this runs on.
+gro_cmsg(Size) ->
+    #{level => udp, type => ?UDP_GRO, data => <<Size:32/native>>}.
+
+other_cmsg() ->
+    #{level => ip, type => 8, data => <<0, 0, 0, 0>>}.
+
+pkt(N, Size) ->
+    binary:copy(<<N>>, Size).
+
+%%====================================================================
+%% Reading the GRO segment size (#204)
+%%====================================================================
+
+reads_the_int_sized_cmsg_test() ->
+    %% The whole bug in one line: the payload is an int, so a pattern
+    %% that accepts only two bytes never matches and the size is never
+    %% found. A missed size means the coalesced buffer goes up unsplit
+    %% as one oversized datagram, and the QUIC layer drops it because
+    %% short-header packets cannot be re-split.
+    ?assertEqual(1200, quic_socket:extract_gro_segment_size([gro_cmsg(1200)])).
+
+reads_it_past_other_control_messages_test() ->
+    Cmsgs = [other_cmsg(), gro_cmsg(1452), other_cmsg()],
+    ?assertEqual(1452, quic_socket:extract_gro_segment_size(Cmsgs)).
+
+reads_a_full_mtu_segment_size_test() ->
+    ?assertEqual(65535, quic_socket:extract_gro_segment_size([gro_cmsg(65535)])).
+
+no_cmsgs_means_no_size_test() ->
+    ?assertEqual(undefined, quic_socket:extract_gro_segment_size([])).
+
+unrelated_cmsgs_mean_no_size_test() ->
+    ?assertEqual(undefined, quic_socket:extract_gro_segment_size([other_cmsg(), other_cmsg()])).
+
+%%====================================================================
+%% Splitting a coalesced train (#204's consequence)
+%%====================================================================
+
+splits_an_exact_multiple_test() ->
+    Train = binary:copy(<<"a">>, 3600),
+    Parts = quic_socket:split_gro_packets(Train, 1200),
+    ?assertEqual(3, length(Parts)),
+    ?assert(lists:all(fun(P) -> byte_size(P) =:= 1200 end, Parts)).
+
+splits_with_a_short_final_segment_test() ->
+    %% The last datagram of a train is usually shorter, and must survive
+    %% rather than being padded or dropped.
+    Train = binary:copy(<<"a">>, 2500),
+    Parts = quic_socket:split_gro_packets(Train, 1200),
+    ?assertEqual([1200, 1200, 100], [byte_size(P) || P <- Parts]).
+
+splits_a_single_short_datagram_test() ->
+    Parts = quic_socket:split_gro_packets(binary:copy(<<"a">>, 40), 1200),
+    ?assertEqual([40], [byte_size(P) || P <- Parts]).
+
+split_preserves_the_payload_test() ->
+    Train = <<(pkt(1, 1200))/binary, (pkt(2, 1200))/binary, (pkt(3, 300))/binary>>,
+    Parts = quic_socket:split_gro_packets(Train, 1200),
+    ?assertEqual([pkt(1, 1200), pkt(2, 1200), pkt(3, 300)], Parts),
+    ?assertEqual(Train, iolist_to_binary(Parts)).
+
+%%====================================================================
+%% Grouping a send batch into GSO runs (#217)
+%%====================================================================
+
+uniform_batch_is_one_run_test() ->
+    Packets = [pkt(N, 1200) || N <- lists:seq(1, 4)],
+    ?assertMatch([{gso, 1200, _}], quic_socket:split_uniform_runs(Packets)).
+
+single_packet_is_not_a_gso_run_test() ->
+    %% One packet has nothing to segment, so it goes out on its own
+    %% rather than through UDP_SEGMENT.
+    ?assertMatch([{single, _}], quic_socket:split_uniform_runs([pkt(1, 1200)])).
+
+empty_batch_is_empty_test() ->
+    ?assertEqual([], quic_socket:split_uniform_runs([])).
+
+a_short_trailing_packet_joins_the_run_test() ->
+    %% The kernel permits a short final segment, so an ACK behind a run
+    %% of full packets does not need a send of its own.
+    Packets = [pkt(1, 1200), pkt(2, 1200), pkt(3, 40)],
+    ?assertMatch([{gso, 1200, [_, _, _]}], quic_socket:split_uniform_runs(Packets)).
+
+a_larger_packet_starts_a_new_run_test() ->
+    %% Growing sizes cannot share one UDP_SEGMENT call: only the final
+    %% segment may be short.
+    Packets = [pkt(1, 40), pkt(2, 40), pkt(3, 1200)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    ?assert(length(Runs) >= 2).
+
+wire_order_and_payloads_survive_test() ->
+    %% The property that actually matters: whatever the grouping, every
+    %% packet goes out exactly once and in the order it was queued.
+    Packets = [pkt(1, 1200), pkt(2, 40), pkt(3, 1200), pkt(4, 1200), pkt(5, 300)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    Flat = lists:flatmap(
+        fun
+            ({gso, _Size, Ps}) -> Ps;
+            ({single, P}) -> [P]
+        end,
+        Runs
+    ),
+    ?assertEqual(Packets, Flat).
+
+every_run_is_gso_legal_test() ->
+    %% UDP_SEGMENT requires every segment except the last to be exactly
+    %% the segment size. A run that breaks that is rejected by the
+    %% kernel or splits the datagrams in the wrong place.
+    Packets = [pkt(1, 1200), pkt(2, 1200), pkt(3, 40), pkt(4, 800), pkt(5, 800), pkt(6, 20)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    [ok = assert_run_legal(R) || R <- Runs],
+    ok.
+
+assert_run_legal({single, _P}) ->
+    ok;
+assert_run_legal({gso, Size, Ps}) ->
+    {AllButLast, [Last]} = lists:split(length(Ps) - 1, Ps),
+    ?assert(lists:all(fun(P) -> byte_size(P) =:= Size end, AllButLast)),
+    ?assert(byte_size(Last) =< Size),
+    ok.

--- a/test/quic_pacing_burst_tests.erl
+++ b/test/quic_pacing_burst_tests.erl
@@ -1,0 +1,137 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for the pacing burst allowance.
+%%%
+%%% Pacing wakeups run on send_after, which has roughly millisecond
+%%% resolution. A burst bucket fixed at 12 packets therefore caps
+%%% throughput at 12 packets per wakeup whenever the sender outruns the
+%%% incoming ACK clock, no matter how high the paced rate is. The
+%%% allowance has to scale with the rate: 2 ms worth of tokens keeps
+%%% micro-bursts bounded while letting a 1 ms clock sustain the rate.
+%%%
+%%% pacing_max_burst has no accessor, but it is observable: the token
+%%% bucket refills to min(MaxBurst, tokens + elapsed * rate) and
+%%% get_pacing_tokens/2 hands back min(Size, tokens). Once enough time
+%%% has passed for the bucket to saturate, asking for more than it can
+%%% ever hold returns exactly MaxBurst.
+%%%
+%%% Covers PR #219.
+
+-module(quic_pacing_burst_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MDS, 1200).
+%% Larger than any burst under test, so the answer is bucket-limited.
+-define(HUGE, (1 bsl 30)).
+-define(STEP_MS, 10).
+-define(MAX_WAIT_MS, 2000).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Read back the burst ceiling.
+%%
+%% Every probe runs against the same input state, so each one sees a
+%% longer elapsed time than the last and the refill grows monotonically
+%% until it saturates at pacing_max_burst. Two consecutive equal reads
+%% mean the bucket is full. Polling rather than sleeping a fixed
+%% interval keeps this honest at low rates, where filling the bucket
+%% takes far longer, without re-deriving the formula under test.
+burst_ceiling(State) ->
+    converge(State, quic_cc_newreno:get_pacing_tokens(State, ?HUGE), 0).
+
+converge(_State, {V, _}, Waited) when Waited >= ?MAX_WAIT_MS ->
+    %% Never saturated: report what we saw so the failure is legible.
+    {did_not_saturate, V};
+converge(State, {Prev, _}, Waited) ->
+    timer:sleep(?STEP_MS),
+    case quic_cc_newreno:get_pacing_tokens(State, ?HUGE) of
+        {Prev, _} -> Prev;
+        Next -> converge(State, Next, Waited + ?STEP_MS)
+    end.
+
+%% quic_cc_newreno stores the rate in milli-bytes per microsecond:
+%% max(1, (cwnd * 1250) div (rtt_ms * 1000)).
+rate(Cwnd, RttMs) ->
+    max(1, (Cwnd * 1250) div (RttMs * 1000)).
+
+paced(Cwnd, RttMs) ->
+    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS, initial_window => Cwnd}),
+    quic_cc_newreno:update_pacing_rate(State, RttMs).
+
+%%====================================================================
+%% Baseline
+%%====================================================================
+
+unpaced_until_a_rate_exists_test() ->
+    %% Straight out of new/1 there is no rate yet, so pacing does not
+    %% gate anything and a send of any size is allowed through. The burst
+    %% allowance only becomes observable once a rate is set.
+    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS}),
+    ?assert(quic_cc_newreno:pacing_allows(State, ?HUGE)),
+    ?assertEqual({?HUGE, State}, quic_cc_newreno:get_pacing_tokens(State, ?HUGE)).
+
+%%====================================================================
+%% The allowance scales with the rate
+%%====================================================================
+
+burst_scales_with_pacing_rate_test() ->
+    %% A fat window on a short RTT: 2 ms of rate is far above the
+    %% 12-packet floor, so the floor must not be what caps the bucket.
+    Cwnd = 4000000,
+    RttMs = 10,
+    Rate = rate(Cwnd, RttMs),
+    Expected = max(12 * ?MDS, 2 * Rate),
+    ?assert(Expected > 12 * ?MDS),
+    ?assertEqual(Expected, burst_ceiling(paced(Cwnd, RttMs))).
+
+burst_keeps_the_floor_at_low_rates_test() ->
+    %% A small window on a long RTT: 2 ms of rate is below the floor,
+    %% which must still hold. Scaling the allowance must not be a way to
+    %% shrink it.
+    Cwnd = 12000,
+    RttMs = 500,
+    Rate = rate(Cwnd, RttMs),
+    ?assert(2 * Rate < 12 * ?MDS),
+    ?assertEqual(12 * ?MDS, burst_ceiling(paced(Cwnd, RttMs))).
+
+burst_is_monotonic_in_rate_test() ->
+    %% Same RTT, growing window: the allowance may plateau on the floor
+    %% but must never move backwards as the rate rises.
+    Ceilings = [burst_ceiling(paced(Cwnd, 20)) || Cwnd <- [12000, 120000, 1200000, 12000000]],
+    ?assertEqual(lists:sort(Ceilings), Ceilings),
+    ?assert(lists:last(Ceilings) > hd(Ceilings)).
+
+%%====================================================================
+%% MTU changes recompute the same way
+%%====================================================================
+
+update_mtu_scales_burst_with_rate_test() ->
+    %% update_mtu recomputes the allowance and must apply the same rule,
+    %% otherwise a PMTU probe silently reinstates the fixed bucket.
+    Cwnd = 4000000,
+    RttMs = 10,
+    Rate = rate(Cwnd, RttMs),
+    Paced = paced(Cwnd, RttMs),
+    Bumped = quic_cc_newreno:update_mtu(Paced, 1400),
+    ?assertEqual(1400, quic_cc_newreno:max_datagram_size(Bumped)),
+    ?assertEqual(max(12 * 1400, 2 * Rate), burst_ceiling(Bumped)).
+
+update_mtu_keeps_the_floor_at_low_rates_test() ->
+    Cwnd = 12000,
+    RttMs = 500,
+    Paced = paced(Cwnd, RttMs),
+    Bumped = quic_cc_newreno:update_mtu(Paced, 1400),
+    ?assertEqual(12 * 1400, burst_ceiling(Bumped)).
+
+%%====================================================================
+%% Degenerate input
+%%====================================================================
+
+zero_rtt_leaves_pacing_untouched_test() ->
+    %% No RTT sample yet: update_pacing_rate is a no-op, so the state is
+    %% returned unchanged and sends stay unpaced.
+    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS}),
+    ?assertEqual(State, quic_cc_newreno:update_pacing_rate(State, 0)).


### PR DESCRIPTION
Carries five of @jbevemyr's commits with the tests they were missing. Supersedes #204, #215, #217, #219 and #203.

Grouped because they are all the socket batching path and their tests share a harness. Each is a separate commit with his authorship intact. #217 already carried his own linter follow-up, so the Elvis failure on that PR is fixed here rather than needing anything from me.

## The sharp one: #204

```erlang
extract_gro_segment_size([#{level := udp, type := ?UDP_GRO, data := <<Size:16/native>>} | _])
```

The kernel's `UDP_GRO` payload is an int. A pattern accepting exactly two bytes **never matches**, so the size was never found, the coalesced buffer went up unsplit as one oversized datagram, and the QUIC layer dropped it because short-header packets cannot be re-split. GRO was silently losing every coalesced train it received.

## #215

The GRO read passed `0` for the buffer size, which uses the OTP default 8 KiB and makes `recvmsg` silently truncate any larger train. The client receiver also used a plain `recvfrom`, which never split trains at all.

## #217

A mixed-size batch fell back to one `sendmsg` per packet, so a single ACK between data packets degraded the whole batch. It now goes out as runs of equal-sized packets, one `UDP_SEGMENT` call each.

## Tests

GRO and GSO need a Linux kernel end to end, but the parts that decide what happens are pure, so they are tested directly. A TEST-only export block is added to `quic_socket` for the three, following the convention already in `quic_connection` and `quic_listener`.

3 of the 16 fail on main, all of them the cmsg read. The rest are fences, two worth calling out:

- every emitted GSO run is legal: all segments but the last exactly the segment size, which is what `UDP_SEGMENT` requires
- whatever the grouping, every packet goes out exactly once and in the order it was queued

`quic_pacing_burst_tests` covers #219, 3 of 7 failing on main. It reads the burst ceiling by letting the token bucket saturate and asking for more than it can hold, polling until two consecutive reads agree rather than sleeping a fixed interval, which keeps it honest at low rates where the bucket fills slowly.

## Checks

`eunit` 2285/0, `dialyzer`, `xref`, `lint`, `fmt --check` clean. `ct` shows no new failures; `quic_server_batching_SUITE`, `quic_adapter_SUITE` and `quic_client_socket_backend_tests` all pass in isolation on this branch (3, 4, 4).

Note the GSO send path itself is only exercised by the `Server Batching + Linux GSO` CI job, since I cannot run it on macOS.