### PR TITLE
Fix amp-budget starvation on batched receive; retransmit the server handshake flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this project will be documented in this file.
   (receiver queueing, bufferbloat) turned into a throughput collapse.
   Contributed by jbevemyr (#210).
 - PMTU probes are tracked as non-ack-eliciting, so a probe lost past the path MTU no longer inflates `bytes_in_flight`, arms the PTO machinery, or feeds a congestion event (RFC 8899 §3, RFC 9000 §14.4). Combined with an in-flight-keyed liveness check, the periodic raise probe previously killed every long-lived connection on an MTU-limited path once per 600-second raise interval, both ends at once. The raise interval is configurable as `pmtu_raise_interval`. (#264)
+- Anti-amplification accounting (RFC 9000 §8.1) now also runs on the batched listener delivery path. A server whose ClientHello arrived in a GRO batch kept its amp budget at zero, deferred the handshake flight, and the handshake wedged until the connect timeout. (#263)
+- A server handshake flight lost on the wire is retransmitted on the client-Initial backoff schedule until the client's Finished arrives. Initial/Handshake packets are not loss-tracked, so a lost flight previously wedged the handshake permanently: the client's Initial retransmits only elicited ACKs once the server TLS state had advanced. (#263)
 
 ## [1.8.1] - 2026-08-15
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -168,6 +168,10 @@
     test_state_for_reset/3,
     %% Retransmission congestion policy (RFC 9002 §7)
     retransmit_cc_allowed/3,
+    %% Anti-amplification accounting on the batched path (RFC 9000 §8.1)
+    handle_packets_batch/2,
+    test_state_amp/2,
+    test_amp_counters/1,
     %% NEW_TOKEN frame dispatch (RFC 9000 §8.1.3)
     process_frame/3,
     test_state_for_role/1,
@@ -365,6 +369,16 @@
     %% one-shot flight; bumps after HRR so CH2 / ServerHello continue
     %% the stream (RFC 9001 §4.1.3).
     initial_tx_off = 0 :: non_neg_integer(),
+    %% Server handshake-flight retransmission: the ServerHello (with its
+    %% Initial CRYPTO offset) and the Handshake-level payload are kept
+    %% until the client's Finished arrives, and replayed on a backoff
+    %% timer. Initial/Handshake packets are not loss-tracked, so without
+    %% this a single lost flight wedges the handshake permanently: the
+    %% client's Initial retransmits only elicit ACKs once the server TLS
+    %% state has advanced.
+    server_flight = undefined :: undefined | {binary(), non_neg_integer(), binary()},
+    server_hs_rtx_timer = undefined :: undefined | reference(),
+    server_hs_rtx_attempts = 0 :: non_neg_integer(),
     %% Client-side: CH1 random + build opts, needed to rebuild CH2
     tls_ch1_random :: binary() | undefined,
     tls_ch1_opts :: map() | undefined,
@@ -2505,6 +2519,15 @@ handle_common_event(
     #state{owner_mon = Mon} = State
 ) ->
     {stop, {shutdown, owner_down}, State};
+handle_common_event(
+    info,
+    {server_hs_rtx, Ref},
+    _StateName,
+    #state{server_hs_rtx_timer = Ref, role = server} = State
+) ->
+    {keep_state, server_hs_retransmit(State#state{server_hs_rtx_timer = undefined})};
+handle_common_event(info, {server_hs_rtx, _Stale}, _StateName, State) ->
+    {keep_state, State};
 handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
@@ -2849,7 +2872,10 @@ ensure_ticket_table() ->
 %% Initial CRYPTO offset (non-zero only after a HelloRetryRequest).
 send_server_hello(ServerHelloMsg, State) ->
     Off = State#state.initial_tx_off,
-    State1 = State#state{initial_tx_off = Off + byte_size(ServerHelloMsg)},
+    State1 = State#state{
+        initial_tx_off = Off + byte_size(ServerHelloMsg),
+        server_flight = {ServerHelloMsg, Off, <<>>}
+    },
     %% Chunk across Initial packets: a hybrid ServerHello Initial is
     %% ~1225 bytes and no longer fits one datagram.
     {_Frames, NewState} = send_initial_crypto(ServerHelloMsg, Off, State1),
@@ -3100,7 +3126,15 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
 
     %% Send the flight, segmented so no datagram exceeds the peer's
     %% max_udp_payload_size (issue #134).
-    send_handshake_crypto(HandshakePayload, State1).
+    State2 = send_handshake_crypto(HandshakePayload, State1),
+    State3 =
+        case State2#state.server_flight of
+            {SH, SHOff, _} ->
+                State2#state{server_flight = {SH, SHOff, HandshakePayload}};
+            undefined ->
+                State2
+        end,
+    arm_server_hs_rtx(State3).
 
 %% @private Send a handshake CRYPTO payload as one or more packets,
 %% each sized to stay within max_udp_payload_size (RFC 9000 §14.1).
@@ -3824,6 +3858,49 @@ amp_flush_budget(#state{amp_deferred = [Packet | Rest]} = State) ->
             State
     end.
 
+%% Arm (or re-arm) the server handshake-flight retransmit timer.
+arm_server_hs_rtx(#state{role = server, server_flight = {_, _, _}} = State) ->
+    case State#state.server_hs_rtx_attempts < ?HS_RTX_MAX_ATTEMPTS of
+        true ->
+            Delay = min(
+                ?HS_RTX_BASE_MS bsl State#state.server_hs_rtx_attempts, ?HS_RTX_MAX_MS
+            ),
+            Ref = make_ref(),
+            erlang:send_after(Delay, self(), {server_hs_rtx, Ref}),
+            State#state{server_hs_rtx_timer = Ref};
+        false ->
+            State#state{server_hs_rtx_timer = undefined}
+    end;
+arm_server_hs_rtx(State) ->
+    State.
+
+%% Replay the retained server flight: ServerHello at its original
+%% Initial CRYPTO offset plus the Handshake payload (offset 0). New
+%% packet numbers, identical crypto stream bytes, so the client's
+%% reassembly is byte-exact regardless of what it already received.
+server_hs_retransmit(#state{tls_state = ?TLS_HANDSHAKE_COMPLETE} = State) ->
+    State#state{server_flight = undefined};
+server_hs_retransmit(#state{server_flight = {SH, SHOff, HsPayload}} = State) ->
+    ?LOG_WARNING(
+        #{
+            what => server_handshake_flight_retransmit,
+            attempt => State#state.server_hs_rtx_attempts + 1
+        },
+        ?QUIC_LOG_META
+    ),
+    {_Frames, State1} = send_initial_crypto(SH, SHOff, State),
+    State2 =
+        case HsPayload of
+            <<>> -> State1;
+            _ -> send_handshake_crypto(HsPayload, State1)
+        end,
+    State3 = State2#state{
+        server_hs_rtx_attempts = State2#state.server_hs_rtx_attempts + 1
+    },
+    arm_server_hs_rtx(flush_dirty_timers(flush_socket_batch(State3)));
+server_hs_retransmit(State) ->
+    State.
+
 %% State-timeout action driving client Initial retransmission while the
 %% handshake is incomplete. Empty for the server, once connected, or once
 %% the attempt budget is spent (the idle timeout then closes).
@@ -3865,13 +3942,23 @@ retransmit_initial_flight(
 retransmit_initial_flight(_StateName, State) ->
     {keep_state, State}.
 
+%% Batched variant of handle_packet/2: same anti-amplification
+%% accounting per datagram, one deferred-flight flush per batch. The
+%% batched delivery path previously skipped accounting entirely, so a
+%% server's amp budget froze at the first datagram under load and
+%% deferred flights never flushed.
+handle_packets_batch(Packets, State) ->
+    State1 = lists:foldl(fun amp_account_recv/2, State, Packets),
+    State2 = do_handle_packets_batch(Packets, State1),
+    amp_flush(State2).
+
 %% Handle batch of packets from GRO - process all without re-entering gen_statem
 %% This is more efficient than receiving multiple messages
-handle_packets_batch([], State) ->
+do_handle_packets_batch([], State) ->
     State;
-handle_packets_batch([Packet | Rest], State) ->
+do_handle_packets_batch([Packet | Rest], State) ->
     NewState = handle_packet_loop(Packet, State),
-    handle_packets_batch(Rest, NewState).
+    do_handle_packets_batch(Rest, NewState).
 
 handle_packet_loop(<<>>, #state{role = client, active_n = N} = State) ->
     %% No more data to process - re-enable socket for client connections
@@ -5740,9 +5827,11 @@ process_tls_message(
                     ),
 
                     %% Application keys are already derived when server sent its Finished
-                    %% Mark handshake as complete
+                    %% Mark handshake as complete; the retained flight is
+                    %% no longer needed for retransmission.
                     State1 = State#state{
                         tls_state = ?TLS_HANDSHAKE_COMPLETE,
+                        server_flight = undefined,
                         tls_transcript = Transcript,
                         resumption_secret = ResumptionSecret
                     },
@@ -11644,6 +11733,17 @@ test_state_for_reset(DCID, PeerCIDPool, Secret) ->
         peer_cid_pool = PeerCIDPool,
         stateless_reset_secret = Secret
     }.
+
+%% Minimal #state{} for pinning the anti-amplification accounting on the
+%% batched receive path. The datagrams fed through it are junk the parser
+%% drops, so only the accounting itself is exercised.
+-spec test_state_amp(client | server, boolean()) -> #state{}.
+test_state_amp(Role, Validated) ->
+    #state{role = Role, address_validated = Validated}.
+
+-spec test_amp_counters(#state{}) -> #{atom() => non_neg_integer()}.
+test_amp_counters(#state{amp_rx = Rx, amp_tx = Tx, amp_deferred = Deferred}) ->
+    #{amp_rx => Rx, amp_tx => Tx, deferred => length(Deferred)}.
 
 %% Minimal #state{} scoped to role for frame-dispatch tests.
 -spec test_state_for_role(client | server) -> #state{}.

--- a/test/quic_amp_batch_accounting_tests.erl
+++ b/test/quic_amp_batch_accounting_tests.erl
@@ -1,0 +1,53 @@
+%%% -*- erlang -*-
+%%%
+%%% Anti-amplification accounting on the batched receive path
+%%% (RFC 9000 §8.1).
+%%%
+%%% A server must not send more than three times the bytes it has
+%%% received from an unvalidated address. The credit side of that
+%%% budget was only maintained in the single-datagram path
+%%% (handle_packet/2); the batched path the listener uses for GRO
+%%% trains skipped it entirely. A server whose ClientHello arrived in
+%%% a batch kept amp_rx at or near zero, deferred most of its
+%%% handshake flight, and the handshake wedged.
+%%%
+%%% These tests pin the accounting at the handle_packets_batch/2
+%%% boundary, which the listener delivery path uses for servers only:
+%%% every received datagram must be credited for an unvalidated
+%%% server, and must not be for a validated one. The datagrams are
+%%% junk the packet parser drops, so the credit is isolated from
+%%% packet processing.
+%%%
+%%% The end-to-end consequence (a lost first server flight) is covered
+%%% by quic_server_flight_retransmit_SUITE.
+
+-module(quic_amp_batch_accounting_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+datagrams() ->
+    %% Sizes chosen unequal so a partial fold shows up in the sum.
+    [binary:copy(<<16#ff>>, N) || N <- [100, 321, 47]].
+
+total() ->
+    lists:sum([byte_size(D) || D <- datagrams()]).
+
+batch(Role, Validated) ->
+    State = quic_connection:test_state_amp(Role, Validated),
+    NewState = quic_connection:handle_packets_batch(datagrams(), State),
+    quic_connection:test_amp_counters(NewState).
+
+unvalidated_server_credits_every_datagram_test() ->
+    Counters = batch(server, false),
+    ?assertEqual(total(), maps:get(amp_rx, Counters)).
+
+validated_server_does_not_count_test() ->
+    Counters = batch(server, true),
+    ?assertEqual(0, maps:get(amp_rx, Counters)).
+
+%% The batch must not send anything on its own: junk datagrams are
+%% dropped, and with nothing deferred the flush is a no-op.
+batch_does_not_touch_the_spend_side_test() ->
+    Counters = batch(server, false),
+    ?assertEqual(0, maps:get(amp_tx, Counters)),
+    ?assertEqual(0, maps:get(deferred, Counters)).

--- a/test/quic_server_flight_retransmit_SUITE.erl
+++ b/test/quic_server_flight_retransmit_SUITE.erl
@@ -1,0 +1,201 @@
+%%% -*- erlang -*-
+%%%
+%%% Recovery after the server's first handshake flight is lost.
+%%%
+%%% Initial and Handshake packets are not loss-tracked, so a server
+%%% whose ServerHello-to-Finished flight is dropped never resent it:
+%%% once its TLS state has advanced, the client's Initial retransmits
+%%% only elicit ACKs, and the handshake wedges until the connect
+%%% timeout. The fix retains {ServerHello, Initial offset, Handshake
+%%% payload} until the client's Finished arrives and replays the
+%%% flight on the client Initial's backoff schedule.
+%%%
+%%% The harness drops everything the server sends for a fixed window
+%%% covering the original flight and the first retransmit attempts,
+%%% then heals the path. Without server-side retransmission there is
+%%% nothing left to deliver after the heal, so the case fails on a
+%%% connect timeout; with it the handshake completes on the first
+%%% attempt after the window.
+%%%
+%%% The credit side of the same storm-failure class is pinned in
+%%% quic_amp_batch_accounting_tests.
+%%%
+%%% The window (rather than a fixed drop count) keeps the case
+%%% deterministic against client Initial retransmits: however many
+%%% copies of the flight the client manages to elicit inside the
+%%% window, they are all dropped.
+
+-module(quic_server_flight_retransmit_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([control_plain_handshake/1, completes_after_the_first_flight_is_lost/1]).
+
+%% Covers the original flight plus the first two replay attempts, so
+%% recovery genuinely depends on the timer refiring after the heal.
+-define(DROP_MS, 700).
+%% Budget for the handshake once the path is back. Deliberately loose
+%% so the case fails on a wedge rather than on a slow machine.
+-define(CONNECT_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [control_plain_handshake, completes_after_the_first_flight_is_lost].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: the same handshake over the same harness with no drop window.
+control_plain_handshake(_Config) ->
+    with_server(fun(Port) ->
+        {Conn, _Bridge} = connect_through_bridge(Port, 0),
+        connected_within(Conn, ?CONNECT_MS),
+        echo_roundtrip(Conn),
+        quic:close(Conn, normal)
+    end).
+
+completes_after_the_first_flight_is_lost(_Config) ->
+    with_server(fun(Port) ->
+        Start = erlang:monotonic_time(millisecond),
+        {Conn, _Bridge} = connect_through_bridge(Port, ?DROP_MS),
+        connected_within(Conn, ?CONNECT_MS),
+        Elapsed = erlang:monotonic_time(millisecond) - Start,
+        ct:pal("handshake completed ~p ms after connect", [Elapsed]),
+        %% The premise: completion required surviving the window. A
+        %% handshake that finished inside it means the drop never
+        %% engaged and the case is not testing the retransmit.
+        ?assert(Elapsed >= ?DROP_MS),
+        echo_roundtrip(Conn),
+        quic:close(Conn, normal)
+    end).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+with_server(Fun) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        Fun(maps:get(port, Server))
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+connected_within(Conn, Budget) ->
+    receive
+        {quic, Conn, {connected, _}} -> ok;
+        {quic, Conn, {closed, Reason}} -> ct:fail({closed_during_handshake, Reason})
+    after Budget -> ct:fail("connect timeout")
+    end.
+
+%% One small echo over the finished connection: the retransmitted
+%% flight must yield working application keys, not just a connected
+%% event.
+echo_roundtrip(Conn) ->
+    {ok, StreamId} = quic:open_stream(Conn),
+    Payload = <<"flight check">>,
+    ok = quic:send_data(Conn, StreamId, Payload, true),
+    ?assertEqual(Payload, collect_echo(Conn, StreamId, 5000, <<>>)).
+
+collect_echo(Conn, StreamId, Budget, Acc) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
+            Acc1 = <<Acc/binary, Data/binary>>,
+            case Fin of
+                true -> Acc1;
+                false -> collect_echo(Conn, StreamId, Budget - spent(Start), Acc1)
+            end;
+        {quic, Conn, _Other} ->
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc)
+    after max(0, Budget) -> Acc
+    end.
+
+spent(Start) ->
+    max(1, erlang:monotonic_time(millisecond) - Start).
+
+%% Client behind a socket adapter; the bridge relays to the server's
+%% real UDP socket. For the first DropMs milliseconds everything the
+%% server sends back is dropped; the client direction is never touched.
+connect_through_bridge(Port, DropMs) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef, DropMs) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    {Conn, Bridge}.
+
+bridge_init(ServerIP, ServerPort, SocketRef, DropMs) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    Deadline = erlang:monotonic_time(millisecond) + DropMs,
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        drop_until => Deadline,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {send, _IP, _Port, Pkt} ->
+            ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case erlang:monotonic_time(millisecond) < maps:get(drop_until, Bridge) of
+                true ->
+                    bridge_loop(Bridge);
+                false ->
+                    case maps:get(conn, Bridge) of
+                        undefined ->
+                            bridge_loop(Bridge#{
+                                pending := [Data | maps:get(pending, Bridge)]
+                            });
+                        Conn ->
+                            deliver(Bridge, Conn, Data),
+                            bridge_loop(Bridge)
+                    end
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.


### PR DESCRIPTION
Two handshake-reliability fixes found with a handshake storm harness (waves of 50-150 concurrent connects through a lossy path): 0.1-0.5% of handshakes hung until the connect timeout, singly and in bursts.

## 1. Anti-amplification accounting skipped on the batched receive path

The amp-budget credit (RFC 9000 §8.1) only ran in `handle_packet/2`. The batched `{quic_packets, ...}` delivery the listener uses for GRO trains skipped it entirely, so a server whose ClientHello arrived in a batch kept `amp_rx` at or near zero and deferred most or all of its handshake flight. The client saw only budget-permitted fragments, its Initial retransmits often arrived batched again (still uncounted), and the handshake wedged permanently.

`handle_packets_batch/2` now runs the same per-datagram accounting before processing and flushes any deferred flight after the batch, exactly like the single-datagram path.

Pinned by `quic_amp_batch_accounting_tests`: every datagram in a batch must be credited for an unvalidated server, none for a validated one, and the batch itself must not touch the spend side.

## 2. A lost server handshake flight was never retransmitted

Initial/Handshake packets are not loss-tracked (`on_packet_sent` runs only on 1-RTT paths), so a genuinely lost ServerHello-to-Finished flight was gone for good: the server's TLS state had advanced, making the client's Initial retransmits produce only ACKs. Permanent wedge until the connect timeout.

The server now retains `{ServerHello, its Initial CRYPTO offset, Handshake payload}` until the client's Finished arrives, and replays the flight on the same backoff schedule the client uses for its Initial (RFC 9002 §6.2 behaviour without full per-space loss tracking). The replay uses new packet numbers over identical crypto-stream bytes, so client-side reassembly is byte-exact regardless of what already got through.

Pinned by `quic_server_flight_retransmit_SUITE`: the harness drops everything the server sends for a fixed 700 ms window (covering the original flight and the first two replay attempts), then heals the path. Without the fix the case fails on a connect timeout, with it the handshake completes on the first replay after the window and a small echo confirms working application keys. A control case fences the harness. The drop is by time window rather than packet count, so however many flights the client's Initial retransmits elicit inside the window, the case stays deterministic.

## Storm evidence

On the branch this was developed on: pre-fix roughly one failed round in 30-40 (single hangs plus waves of 12-50 when bursts hit the batched path); post-fix 200 rounds of 150 connects and 400 rounds of 50 connects clean, 50,000 handshakes, zero failures.
