### PR TITLE
PMTU probes are not connection loss (RFC 8899 §3, RFC 9000 §14.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- PMTU probes are tracked as non-ack-eliciting, so a probe lost past the path MTU no longer inflates `bytes_in_flight`, arms the PTO machinery, or feeds a congestion event (RFC 8899 §3, RFC 9000 §14.4). Combined with an in-flight-keyed liveness check, the periodic raise probe previously killed every long-lived connection on an MTU-limited path once per 600-second raise interval, both ends at once. The raise interval is configurable as `pmtu_raise_interval`. (#264)
+
 ## [1.8.1] - 2026-08-15
 
 ### Added

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -663,6 +663,7 @@
     pmtu_state :: #pmtu_state{} | undefined,
     pmtu_probe_timer :: reference() | undefined,
     pmtu_raise_timer :: reference() | undefined,
+    pmtu_raise_interval = ?PMTU_DEFAULT_RAISE_INTERVAL :: pos_integer(),
 
     %% Deferred PTO timer reset, flushed at batch boundaries via
     %% flush_dirty_timers/1. (Idle and keep-alive timers are lazy and
@@ -1186,6 +1187,7 @@ init({server, Opts}) ->
         congestion_threshold = maps:get(congestion_threshold, Opts, 2),
         pacing_enabled = maps:get(pacing_enabled, Opts, true),
         pmtu_state = init_pmtu_state(Opts),
+        pmtu_raise_interval = maps:get(pmtu_raise_interval, Opts, ?PMTU_DEFAULT_RAISE_INTERVAL),
         qlog_ctx = quic_qlog:new(Opts, InitialDCID, server)
     },
 
@@ -1568,6 +1570,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         pacing_enabled = maps:get(pacing_enabled, Opts, true),
         active_n = maps:get(active_n, Opts, 100),
         pmtu_state = init_pmtu_state(Opts),
+        pmtu_raise_interval = maps:get(pmtu_raise_interval, Opts, ?PMTU_DEFAULT_RAISE_INTERVAL),
         qlog_ctx = quic_qlog:new(Opts, DCID, client)
     },
 
@@ -3540,16 +3543,6 @@ send_frame(Frame, State) ->
 %% Send a 1-RTT (application) packet with pre-encoded binary payload
 %% Decodes the payload to extract frame info for loss tracking
 %% Note: Prefer send_frame/2 when frame tuple is available
-send_app_packet(Payload, State) when is_binary(Payload) ->
-    %% Try to decode the frame for proper loss tracking
-    FrameInfo =
-        case quic_frame:decode(Payload) of
-            {Frame, _Rest} when is_tuple(Frame); is_atom(Frame) -> [Frame];
-            % Fall back to empty if decode fails
-            _ -> []
-        end,
-    send_app_packet_internal(Payload, FrameInfo, State).
-
 %% Send a 1-RTT packet with explicit frames list for retransmission tracking
 send_app_packet_internal(Payload, Frames, State) ->
     #state{
@@ -11387,8 +11380,19 @@ send_pmtu_probe_packet(ProbeSize, Frames, #state{dcid = DCID, pn_app = PNSpace} 
     %% Add extra padding to frame payload
     PaddedFrames = <<EncodedFrames/binary, (binary:copy(<<0>>, ExtraPadding))/binary>>,
 
-    %% Use existing send_app_packet which handles all encryption/tracking
-    send_app_packet(PaddedFrames, State).
+    %% Send with an empty frames list so the probe is tracked as
+    %% non-ack-eliciting locally: it stays in sent_q, which is what the
+    %% PMTU ack/lost hooks fold over, but adds nothing to
+    %% bytes_in_flight, arms no PTO, and is never retransmitted. Losing
+    %% a probe is the expected outcome of probing past the path MTU
+    %% (RFC 8899 §3, RFC 9000 §14.4): it must be decided by quic_pmtu's
+    %% own probe timer, never surface as connection loss. Tracking it
+    %% as in-flight data let a single lost raise-probe hold
+    %% bytes_in_flight above zero with no possible progress, and the
+    %% disconnect timeout then declared the peer dead: every long-lived
+    %% connection on an MTU-limited path died on the first periodic
+    %% re-probe, both ends at once.
+    send_app_packet_internal(PaddedFrames, [], State).
 
 %% @doc Encode PMTU probe frames (PING + PADDING).
 -spec encode_pmtu_frames([term()]) -> binary().
@@ -11431,7 +11435,7 @@ set_pmtu_probe_timer(#state{pmtu_probe_timer = OldTimer, loss_state = LossState}
 -spec maybe_set_pmtu_raise_timer(#state{}) -> #state{}.
 maybe_set_pmtu_raise_timer(#state{pmtu_raise_timer = undefined} = State) ->
     Ref = make_ref(),
-    erlang:send_after(?PMTU_DEFAULT_RAISE_INTERVAL, self(), {pmtu_raise_timeout, Ref}),
+    erlang:send_after(State#state.pmtu_raise_interval, self(), {pmtu_raise_timeout, Ref}),
     State#state{pmtu_raise_timer = Ref};
 maybe_set_pmtu_raise_timer(State) ->
     State.

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -381,11 +381,20 @@ detect_lost_q(
                     true -> LostBytes + Size;
                     false -> LostBytes
                 end,
+            %% Only ack-eliciting losses drive the congestion event
+            %% (largest_lost_sent_time feeds on_congestion_event). A lost
+            %% non-ack-eliciting packet, a PMTU probe in particular, is
+            %% not a congestion signal (RFC 9000 §14.4).
             NewLL =
-                case LL of
-                    undefined -> {PN, TS};
-                    {OldPN, _} when PN > OldPN -> {PN, TS};
-                    _ -> LL
+                case AE of
+                    false ->
+                        LL;
+                    true ->
+                        case LL of
+                            undefined -> {PN, TS};
+                            {OldPN, _} when PN > OldPN -> {PN, TS};
+                            _ -> LL
+                        end
                 end,
             detect_lost_q(Rest, SRTT, LargestAcked, Now, [P | LostAcc], SurvQ, NewBytes, NewLL);
         false ->

--- a/test/quic_pmtu_probe_loss_tests.erl
+++ b/test/quic_pmtu_probe_loss_tests.erl
@@ -1,0 +1,90 @@
+%%% -*- erlang -*-
+%%%
+%%% PMTU probes must not surface as connection loss (RFC 8899 §3,
+%%% RFC 9000 §14.4).
+%%%
+%%% A probe sent past the path MTU is lost by design: its fate belongs
+%%% to the PMTUD state machine alone. The connection sends probes
+%%% tracked as non-ack-eliciting: they stay in the sent queue, which is
+%%% what the PMTU ack/lost hooks fold over, but contribute nothing to
+%%% bytes_in_flight, acked_bytes, lost_bytes, or the congestion-event
+%%% timestamp.
+%%%
+%%% Before this held, a single lost 600-second raise probe kept
+%%% bytes_in_flight above zero with no possible progress and the
+%%% disconnect timeout declared the peer dead: every long-lived
+%%% connection on an MTU-limited path died on its first periodic
+%%% re-probe, both ends at once. The end-to-end consequence is covered
+%%% by quic_pmtu_raise_probe_SUITE.
+
+-module(quic_pmtu_probe_loss_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(PROBE_SIZE, 1467).
+-define(DATA_SIZE, 1200).
+
+%% An ACK frame in the shape on_ack_received/3 consumes:
+%% {ack, LargestAcked, AckDelay, FirstRange, AckRanges}.
+ack(Largest, FirstRange) ->
+    {ack, Largest, 0, FirstRange, []}.
+
+now_ms() ->
+    erlang:monotonic_time(millisecond).
+
+%% A probe is registered with an empty frames list, exactly as
+%% send_pmtu_probe_packet does, which makes it non-ack-eliciting.
+send_probe(State, PN, Now) ->
+    quic_loss:on_packet_sent(State, PN, ?PROBE_SIZE, false, [], Now).
+
+send_data(State, PN, Now) ->
+    quic_loss:on_packet_sent(State, PN, ?DATA_SIZE, true, [{ping}], Now).
+
+probe_adds_no_bytes_in_flight_test() ->
+    S0 = quic_loss:new(),
+    S1 = send_probe(S0, 0, now_ms()),
+    ?assertEqual(0, quic_loss:bytes_in_flight(S1)).
+
+acked_probe_is_seen_but_counts_nothing_test() ->
+    Now = now_ms(),
+    S0 = send_probe(quic_loss:new(), 0, Now),
+    {S1, Acked, Lost, Meta} = quic_loss:on_ack_received(S0, ack(0, 0), Now + 20),
+    %% The PMTU ack hook folds over the acked list, so the probe must
+    %% appear there even though it elicits nothing locally.
+    ?assertEqual([0], [P#sent_packet.pn || P <- Acked]),
+    ?assertEqual([], Lost),
+    ?assertEqual(0, maps:get(acked_bytes, Meta)),
+    ?assertNot(maps:get(has_ack_eliciting, Meta)),
+    ?assertEqual(0, quic_loss:bytes_in_flight(S1)).
+
+lost_probe_is_seen_but_is_not_a_congestion_signal_test() ->
+    Now = now_ms(),
+    %% Probe as pn 0, then three real packets; acking 1..3 pushes pn 0
+    %% past the packet threshold (RFC 9002 §6.1.1) and declares it lost.
+    S0 = send_probe(quic_loss:new(), 0, Now),
+    S1 = send_data(S0, 1, Now + 1),
+    S2 = send_data(S1, 2, Now + 2),
+    S3 = send_data(S2, 3, Now + 3),
+    {S4, Acked, Lost, Meta} = quic_loss:on_ack_received(S3, ack(3, 2), Now + 30),
+    ?assertEqual([1, 2, 3], lists:sort([P#sent_packet.pn || P <- Acked])),
+    %% The PMTU lost hook folds over the lost list, so the probe must
+    %% appear there...
+    ?assertEqual([0], [P#sent_packet.pn || P <- Lost]),
+    %% ...while contributing neither lost bytes nor the timestamp that
+    %% drives on_congestion_event.
+    ?assertEqual(0, maps:get(lost_bytes, Meta)),
+    ?assertEqual(undefined, maps:get(largest_lost_sent_time, Meta)),
+    ?assertEqual(0, quic_loss:bytes_in_flight(S4)).
+
+%% Fence: a lost ack-eliciting packet still drives the congestion event.
+lost_data_still_signals_congestion_test() ->
+    Now = now_ms(),
+    S0 = send_data(quic_loss:new(), 0, Now),
+    S1 = send_data(S0, 1, Now + 1),
+    S2 = send_data(S1, 2, Now + 2),
+    S3 = send_data(S2, 3, Now + 3),
+    {_S4, _Acked, Lost, Meta} = quic_loss:on_ack_received(S3, ack(3, 2), Now + 30),
+    ?assertEqual([0], [P#sent_packet.pn || P <- Lost]),
+    ?assertEqual(?DATA_SIZE, maps:get(lost_bytes, Meta)),
+    ?assertNotEqual(undefined, maps:get(largest_lost_sent_time, Meta)).

--- a/test/quic_pmtu_raise_probe_SUITE.erl
+++ b/test/quic_pmtu_raise_probe_SUITE.erl
@@ -1,0 +1,230 @@
+%%% -*- erlang -*-
+%%%
+%%% A connection on an MTU-limited path must survive its periodic PMTU
+%%% raise probes (RFC 8899 §3, RFC 9000 §14.4).
+%%%
+%%% After the PMTU search settles, a raise timer re-probes toward
+%%% pmtu_max_mtu to detect a path that has improved. On a path whose
+%%% MTU sits below that ceiling the raise probe is lost by design,
+%%% every time, forever. Probe loss belongs to the PMTUD state machine
+%%% alone: tracked as ordinary in-flight data it inflates
+%%% bytes_in_flight, arms the PTO machinery, and feeds spurious
+%%% congestion events, and any liveness check keyed on unacknowledged
+%%% in-flight data (a disconnect timeout) then declares a healthy peer
+%%% dead. On a downstream deployment carrying such a check, every
+%%% long-lived connection on an MTU-limited path (that is: most real
+%%% WAN paths) died and reconnected once per raise interval, both ends
+%%% at once.
+%%%
+%%% The harness caps the path at 1300 bytes with a size filter in the
+%%% bridge: handshake and echo traffic (and the search probes that
+%%% matter) fit; every raise probe above it is silently dropped. The
+%%% raise interval is shortened so several probe-and-lose cycles run
+%%% inside the observation window, and the case requires the
+%%% connection to stay quiet-alive throughout and still carry data
+%%% afterwards.
+%%%
+%%% Frame-level coverage of the same rule is in
+%%% quic_pmtu_probe_loss_tests.
+
+-module(quic_pmtu_raise_probe_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([control_unlimited_path/1, survives_raise_probes_on_limited_path/1]).
+
+%% Path MTU cap: above every handshake/echo datagram, below the
+%% 1500-byte probe ceiling, so only raise probes exceed it.
+-define(PATH_LIMIT, 1300).
+%% Raise probes fire quickly so several cycles fit in the window.
+-define(RAISE_INTERVAL_MS, 1500).
+%% A short disconnect timeout, for implementations that enforce one:
+%% an in-flight-keyed liveness check turns the mistracked probe lethal
+%% this soon after it is lost, so the case fails fast rather than
+%% flaking.
+-define(DISCONNECT_MS, 3000).
+%% Quiet observation window: covers the search phase (probe timeouts
+%% are >= 1 s each) plus several raise cycles, with margin. The window
+%% is deliberately traffic-free: the failure mode needs an idle
+%% connection, where the lost probe is the only thing in flight and
+%% nothing else advances the progress clock. The keep-alive interval
+%% sits above the disconnect timeout for the same reason, mirroring
+%% the production configuration that hit this (keep-alive 20 s,
+%% disconnect 16 s).
+-define(OBSERVE_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [control_unlimited_path, survives_raise_probes_on_limited_path].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: same harness, no size cap. Holds with and without the fix and
+%% tells a failure of the case below apart from a broken harness.
+control_unlimited_path(_Config) ->
+    run_echo_window(infinity).
+
+survives_raise_probes_on_limited_path(_Config) ->
+    run_echo_window(?PATH_LIMIT).
+
+run_echo_window(Limit) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        {Conn, _Bridge} = connect_through_bridge(maps:get(port, Server), Limit),
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 10000 -> ct:fail("connect timeout")
+        end,
+        %% The path works when we start.
+        echo_roundtrip(Conn, <<"before the raise probes">>),
+        %% Stay quiet through the search and at least two raise cycles;
+        %% only the connection's own keep-alives run. A disconnect in
+        %% this window is exactly the bug.
+        quiet_watch(Conn, erlang:monotonic_time(millisecond) + ?OBSERVE_MS),
+        %% The same connection still carries data afterwards.
+        echo_roundtrip(Conn, <<"after the raise probes">>),
+        quic:close(Conn, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+quiet_watch(Conn, Deadline) ->
+    Left = Deadline - erlang:monotonic_time(millisecond),
+    case Left =< 0 of
+        true ->
+            ok;
+        false ->
+            receive
+                {quic, Conn, {closed, Reason}} ->
+                    ct:fail({connection_died_while_idle, Reason});
+                {quic, Conn, _Other} ->
+                    quiet_watch(Conn, Deadline)
+            after Left -> ok
+            end
+    end.
+
+echo_roundtrip(Conn, Payload) ->
+    {ok, StreamId} = quic:open_stream(Conn),
+    ok = quic:send_data(Conn, StreamId, Payload, true),
+    ?assertEqual(Payload, collect_echo(Conn, StreamId, 5000, <<>>)).
+
+collect_echo(Conn, StreamId, Budget, Acc) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
+            Acc1 = <<Acc/binary, Data/binary>>,
+            case Fin of
+                true -> Acc1;
+                false -> collect_echo(Conn, StreamId, Budget - spent(Start), Acc1)
+            end;
+        {quic, Conn, {closed, Reason}} ->
+            ct:fail({connection_died_mid_echo, Reason});
+        {quic, Conn, _Other} ->
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc)
+    after max(0, Budget) -> Acc
+    end.
+
+spent(Start) ->
+    max(1, erlang:monotonic_time(millisecond) - Start).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Client behind a socket adapter; the bridge relays to the server's
+%% real UDP socket and silently drops any datagram larger than Limit,
+%% in both directions, which is exactly what a path with a smaller MTU
+%% does to an unfragmentable QUIC datagram.
+connect_through_bridge(Port, Limit) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef, Limit) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter,
+        pmtu_raise_interval => ?RAISE_INTERVAL_MS,
+        disconnect_timeout => ?DISCONNECT_MS,
+        keep_alive_interval => 5000,
+        idle_timeout => 30000
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    {Conn, Bridge}.
+
+fits(_Data, infinity) -> true;
+fits(Data, Limit) -> byte_size(Data) =< Limit.
+
+bridge_init(ServerIP, ServerPort, SocketRef, Limit) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        limit => Limit,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}, limit := Limit} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {send, _IP, _Port, Pkt} ->
+            Bin = iolist_to_binary(Pkt),
+            case fits(Bin, Limit) of
+                true -> ok = gen_udp:send(Sock, ServerIP, ServerPort, Bin);
+                false -> ok
+            end,
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case fits(Data, Limit) of
+                false ->
+                    bridge_loop(Bridge);
+                true ->
+                    case maps:get(conn, Bridge) of
+                        undefined ->
+                            bridge_loop(Bridge#{
+                                pending := [Data | maps:get(pending, Bridge)]
+                            });
+                        Conn ->
+                            deliver(Bridge, Conn, Data),
+                            bridge_loop(Bridge)
+                    end
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.


### PR DESCRIPTION
## The bug

RFC 8899 §3 and RFC 9000 §14.4: a PMTU probe sent past the path MTU is lost **by design**, and its fate belongs to the PMTUD state machine alone. eq sent probes through `send_app_packet`, which tracked them as ordinary ack-eliciting data. A lost probe therefore inflated `bytes_in_flight`, armed the PTO machinery, and fed a spurious congestion event when loss detection retired it.

The lethal variant appears the moment a liveness check keyed on unacknowledged in-flight data exists (our deployment carries a msquic-style 16 s disconnect timeout, and #224 brings one here): the 600-second raise timer re-probes above the settled MTU, the probe is dropped by the path, `bytes_in_flight` sits above zero with no possible progress, and 16 seconds later a perfectly healthy peer is declared dead. **Every long-lived connection on an MTU-limited path — that is, most real WAN paths — died and reconnected once per raise interval, both ends simultaneously.**

We found it on a virtualized rig with a 1463-byte path: connections lived exactly `connect + 600 s + 16 s`, in a permanent cycle, with `in_flight = 1467` (the raise probe, 1463 + the 4-byte search step) in both endpoints' death logs. It never shows on loopback test rigs: with no MTU limit the search completes at the ceiling and the raise probe never exceeds the path.

## The fix

- `send_pmtu_probe_packet` sends the probe with an **empty frames list**, so it is tracked as non-ack-eliciting: it stays in the sent queue, which is what the PMTU ack/lost hooks fold over, but contributes nothing to `bytes_in_flight`, `acked_bytes`, or `lost_bytes`, arms no PTO, and is never retransmitted (the PMTUD probe timer owns retries). The acked/lost/RTT accounting already filters on the ack-eliciting flag, so the probe becomes fully inert to the connection while remaining visible to PMTUD.
- The congestion-event timestamp in `detect_lost_q` is likewise gated on ack-eliciting packets, so a lost probe cannot trigger `on_congestion_event`.
- `pmtu_raise_interval` is now read from the connect/listen options, matching the `pmtu_opts()` type that already declared it. Tests use it to run several raise cycles in seconds; deployments on known-constrained paths can tune it.
- `send_app_packet/2` lost its only caller and is removed.

## Tests

- `quic_pmtu_probe_loss_tests` pins the rule at the loss layer: a non-ack-eliciting probe adds no in-flight bytes; acked, it appears in the acked fold (for the PMTU hook) with `acked_bytes = 0` and `has_ack_eliciting = false`; lost, it appears in the lost fold with `lost_bytes = 0` and **no congestion-event timestamp** (red before the fix); a fence case keeps real data loss signaling congestion.
- `quic_pmtu_raise_probe_SUITE` runs the scenario end to end: an echo connection through a bridge that drops any datagram above 1300 bytes, a shortened raise interval, and a 20-second traffic-free window spanning several probe-and-lose cycles. The connection must stay quiet-alive throughout and still carry data afterwards. On this branch the case guards against the non-lethal damage; once a disconnect timeout exists (#224) it is the regression net for the lethal variant.
