### PR TITLE
The terminate-path CONNECTION_CLOSE never reached the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
   (receiver queueing, bufferbloat) turned into a throughput collapse.
   Contributed by jbevemyr (#210).
 - PMTU probes are tracked as non-ack-eliciting, so a probe lost past the path MTU no longer inflates `bytes_in_flight`, arms the PTO machinery, or feeds a congestion event (RFC 8899 §3, RFC 9000 §14.4). Combined with an in-flight-keyed liveness check, the periodic raise probe previously killed every long-lived connection on an MTU-limited path once per 600-second raise interval, both ends at once. The raise interval is configurable as `pmtu_raise_interval`. (#264)
+- The CONNECTION_CLOSE sent from terminate/3 (owner death, exit signals) reaches the wire: it was batched into an updated socket state that terminate discarded, flushing the stale one instead, so the peer never learned of the close and held a phantom connection until its idle timeout. Peers now see an owner-death close within milliseconds. (#265)
 
 ## [1.8.1] - 2026-08-15
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1602,35 +1602,42 @@ terminate(
         qlog_ctx = QlogCtx
     } = State
 ) ->
-    %% If we're not already draining/closed, try to send CONNECTION_CLOSE
-    %% No owner notification here - either already notified (draining) or owner is dead
-    case StateName of
-        draining ->
-            ok;
-        closed ->
-            ok;
-        _ ->
-            try
-                %% Use close_reason from state if set, otherwise use terminate reason
-                CloseReason =
-                    case State#state.close_reason of
-                        undefined -> Reason;
-                        R -> R
-                    end,
-                send_connection_close(CloseReason, State)
-            catch
-                _:_ -> ok
-            end
-    end,
+    %% If we're not already draining/closed, try to send CONNECTION_CLOSE.
+    %% No owner notification here - either already notified (draining) or
+    %% owner is dead. The send batches the close packet into an updated
+    %% socket_state; that updated state must be the one flushed below, or
+    %% the close never reaches the wire and the peer holds a phantom
+    %% connection until its idle timeout (an owner death then looks like a
+    %% host that stays connected for up to a minute).
+    FlushSocketState =
+        case StateName of
+            draining ->
+                SocketState;
+            closed ->
+                SocketState;
+            _ ->
+                try
+                    %% Use close_reason from state if set, otherwise use terminate reason
+                    CloseReason =
+                        case State#state.close_reason of
+                            undefined -> Reason;
+                            R -> R
+                        end,
+                    CloseState = send_connection_close(CloseReason, State),
+                    CloseState#state.socket_state
+                catch
+                    _:_ -> SocketState
+                end
+        end,
     %% Flush any batched packets before closing and close owned sockets
-    case SocketState of
+    case FlushSocketState of
         undefined ->
             ok;
         _ ->
             try
-                _ = quic_socket:flush(SocketState),
+                _ = quic_socket:flush(FlushSocketState),
                 %% Close socket_state (respects owns_socket flag)
-                _ = quic_socket:close(SocketState)
+                _ = quic_socket:close(FlushSocketState)
             catch
                 _:_ -> ok
             end
@@ -9192,9 +9199,9 @@ emit_close_at_level(none, _CloseFrame, State) ->
 
 %% Send CONNECTION_CLOSE frame during terminate (best effort)
 %% This is called when the process is terminating unexpectedly
-send_connection_close(_Reason, #state{app_keys = undefined}) ->
+send_connection_close(_Reason, #state{app_keys = undefined} = State) ->
     %% No app keys yet, can't send encrypted close frame
-    ok;
+    State;
 send_connection_close(Reason, State) ->
     {ErrorCode, ReasonPhrase} =
         case Reason of
@@ -9210,13 +9217,15 @@ send_connection_close(Reason, State) ->
                 {?QUIC_APPLICATION_ERROR, <<>>}
         end,
     CloseFrame = {connection_close, application, ErrorCode, undefined, ReasonPhrase},
-    %% Best effort send - ignore errors since we're terminating anyway
+    %% Best effort send - ignore errors since we're terminating anyway.
+    %% Return the updated state: it carries the batched close packet, and
+    %% the caller must flush that socket_state for the frame to reach the
+    %% wire.
     try
         send_frame(CloseFrame, State)
     catch
-        _:_ -> ok
-    end,
-    ok.
+        _:_ -> State
+    end.
 
 %% Send TLS alert as QUIC crypto error and close connection.
 %% QUIC crypto errors are 0x100 + TLS alert code (RFC 9001 §4.8).

--- a/test/quic_owner_down_close_SUITE.erl
+++ b/test/quic_owner_down_close_SUITE.erl
@@ -1,0 +1,108 @@
+%%% -*- erlang -*-
+%%%
+%%% A dying connection owner must not leave the peer with a phantom
+%%% connection.
+%%%
+%%% When a connection's owner process dies, the connection terminates
+%%% with {shutdown, owner_down} and terminate/3 sends CONNECTION_CLOSE.
+%%% The peer must learn about it promptly: without the close frame the
+%%% peer holds the connection open until its idle timeout (up to a
+%%% minute of phantom liveness), which upstream applications see as a
+%%% host that is still connected long after its stack tore the
+%%% connection down.
+%%%
+%%% The client side of this is exactly how a controlling application
+%%% closes connections by killing the process that opened them, so the
+%%% window between owner death and peer awareness is production-visible
+%%% connection-state lag.
+
+-module(quic_owner_down_close_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([peer_learns_of_owner_death/1, peer_learns_of_clean_close/1]).
+
+%% How quickly the peer must see the close. Generous against slow rigs,
+%% far below any idle/disconnect timeout it would otherwise wait for.
+-define(NOTICE_MS, 2000).
+
+suite() ->
+    [{timetrap, {minutes, 1}}].
+
+all() ->
+    [peer_learns_of_clean_close, peer_learns_of_owner_death].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: a clean quic:close/2 reaches the peer within the same budget,
+%% so a failure of the case below is about owner death specifically.
+peer_learns_of_clean_close(_Config) ->
+    {SConn, _Owner, CConn} = connected_pair(),
+    ok = quic:close(CConn, normal),
+    assert_closed(SConn).
+
+peer_learns_of_owner_death(_Config) ->
+    {SConn, Owner, _CConn} = connected_pair(),
+    exit(Owner, kill),
+    assert_closed(SConn).
+
+assert_closed(SConn) ->
+    receive
+        {quic, SConn, {closed, Reason}} ->
+            ct:pal("peer saw close: ~p", [Reason])
+    after ?NOTICE_MS ->
+        ct:fail({peer_never_saw_close, within_ms, ?NOTICE_MS})
+    end.
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Server-side connections are owned by the test process, so peer-side
+%% events land in our mailbox. The client connection is owned by a
+%% disposable process we can kill.
+connected_pair() ->
+    Test = self(),
+    {ok, Server} = quic_test_echo_server:start(#{
+        connection_handler => fun(ConnPid, _ConnRef) ->
+            ok = quic:set_owner_sync(ConnPid, Test),
+            {ok, Test}
+        end
+    }),
+    Port = maps:get(port, Server),
+    Owner = spawn(fun() ->
+        {ok, C} = quic:connect(
+            <<"127.0.0.1">>, Port, #{verify => false, alpn => [<<"echo">>]}, self()
+        ),
+        receive
+            {quic, C, {connected, _}} -> Test ! {client_conn, C}
+        after 10000 -> Test ! client_connect_timeout
+        end,
+        receive
+        after infinity -> ok
+        end
+    end),
+    CConn =
+        receive
+            {client_conn, C0} -> C0;
+            client_connect_timeout -> ct:fail("client connect timeout")
+        after 12000 -> ct:fail("no client conn")
+        end,
+    SConn =
+        receive
+            {quic, SC, {connected, _}} -> SC
+        after 10000 -> ct:fail("no server-side connected event")
+        end,
+    {SConn, Owner, CConn}.


### PR DESCRIPTION
## The bug

`send_connection_close` sends the close frame through the normal packet path, which **batches** it into an updated `socket_state` — and returns that updated state to nobody. `terminate/3` called it for its side effect, then flushed the **stale** `socket_state` still in the state record. The close frame lived only in the discarded batch and never reached the wire.

Every teardown that goes through `terminate/3` — the connection's owner process dying, an exit signal from a supervisor or a controlling application — therefore closed our side **silently**. The peer kept a phantom connection until its idle timeout: up to a minute of a "connected" host whose stack had already torn the connection down. We found it on a rig where an application deliberately closes CT links by killing the process that owns them; the control tower kept reporting the site connected for the whole detection window. A clean `quic:close/2` was unaffected (that path keeps the updated state), which is exactly why this hid: the common path worked, the failure paths didn't.

## The fix

`send_connection_close` returns the updated state, and `terminate/3` flushes and closes **that** `socket_state`. Draining/closed states keep the old behavior (close already sent).

## Test

`quic_owner_down_close_SUITE`: server-side connections owned by the test process, client owned by a disposable process. Kill the owner → the peer must see `{closed, _}` within 2 s (far below any idle/disconnect timeout it would otherwise wait out). A clean-close fence separates owner-death failures from harness problems. Red before the fix with `{peer_never_saw_close, within_ms, 2000}`, green after.
