### PR TITLE
Loss detection and recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- PTO probe packets are exempt from the congestion window and loss
+  retransmissions are bound to it, per RFC 9002 section 7. A probe is
+  the only thing that can restart a stalled connection, so blocking it
+  on a window the peer's silence keeps closed deadlocks the transfer;
+  ordinary loss retransmissions, which were previously sent regardless,
+  now respect the window like any other send. Contributed by jbevemyr
+  (#249).
 - ACKs arriving at the Initial or Handshake encryption level no longer
   reach the 1-RTT loss tracker. Packet numbers restart per space
   (RFC 9000 §12.3), so a Handshake-space ACK of packet numbers 0..N was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- ACKs arriving at the Initial or Handshake encryption level no longer
+  reach the 1-RTT loss tracker. Packet numbers restart per space
+  (RFC 9000 §12.3), so a Handshake-space ACK of packet numbers 0..N was
+  retiring the first N 1-RTT packets from the sent queue without the peer
+  having received them: nothing retransmitted them and the peer kept a
+  permanent hole in the stream. A path that drops a full window and then
+  returns (WiFi-to-cellular handover, VPN reconnect, NAT rebind) left the
+  transfer stalled for good. Contributed by jbevemyr (#250).
+
 ## [1.8.1] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
   and collapses the congestion window, so a single latency excursion
   (receiver queueing, bufferbloat) turned into a throughput collapse.
   Contributed by jbevemyr (#210).
+- PMTU probes are tracked as non-ack-eliciting, so a probe lost past the path MTU no longer inflates `bytes_in_flight`, arms the PTO machinery, or feeds a congestion event (RFC 8899 §3, RFC 9000 §14.4). Combined with an in-flight-keyed liveness check, the periodic raise probe previously killed every long-lived connection on an MTU-limited path once per 600-second raise interval, both ends at once. The raise interval is configurable as `pmtu_raise_interval`. (#264)
 
 ## [1.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ All notable changes to this project will be documented in this file.
   permanent hole in the stream. A path that drops a full window and then
   returns (WiFi-to-cellular handover, VPN reconnect, NAT rebind) left the
   transfer stalled for good. Contributed by jbevemyr (#250).
+- The sent-packet tracker now survives an active path migration. It was
+  replaced wholesale, which orphaned every packet already in flight: no
+  ACK matched them, loss detection never ran, and `bytes_in_flight` read
+  zero so no PTO fired either. Their data was never retransmitted and
+  the peer kept a permanent hole in the stream. The path-derived
+  estimates (RTT, PTO count) still reset, since those belong to the old
+  path. Contributed by jbevemyr (#251).
+- The PTO backoff is capped at 5 seconds. RFC 9002 section 6.2.1 doubles
+  the PTO on each consecutive expiration and the doubling had no
+  ceiling, so on a 50 ms path it reached roughly 90 seconds after nine
+  expirations and about twelve minutes after twelve. A probe scheduled
+  that far out never happens: the idle timer and any request deadline
+  above it have long since fired. Contributed by jbevemyr (#254).
 
 ## [1.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ All notable changes to this project will be documented in this file.
   expirations and about twelve minutes after twelve. A probe scheduled
   that far out never happens: the idle timer and any request deadline
   above it have long since fired. Contributed by jbevemyr (#254).
+- The loss time threshold is `max(smoothed_rtt, latest_rtt)`
+  (RFC 9002 section 6.1.2) rather than the smoothed estimate alone. When
+  an RTT spike outruns the EWMA the two diverge, and the smaller
+  threshold declares in-flight packets lost while their ACKs are merely
+  late. Each spurious loss both retransmits data the peer already has
+  and collapses the congestion window, so a single latency excursion
+  (receiver queueing, bufferbloat) turned into a throughput collapse.
+  Contributed by jbevemyr (#210).
 
 ## [1.8.1] - 2026-08-15
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -186,7 +186,10 @@
     test_decimate_step/1,
     test_decimate_on_timer_fire/1,
     test_maybe_send_ack_app/2,
-    test_classify_recv_trigger/2
+    test_classify_recv_trigger/2,
+    %% Per-space ACK isolation (RFC 9000 Section 12.3)
+    test_state_with_loss/1,
+    test_loss_state/1
 ]).
 -endif.
 
@@ -11658,6 +11661,21 @@ test_state_for_server(RemoteAddr, Secret, ODCID) ->
 
 -spec test_close_reason(#state{}) -> term().
 test_close_reason(#state{close_reason = R}) -> R.
+
+%% Minimal #state{} carrying a caller-supplied loss tracker, for tests
+%% that need to observe what an incoming frame does to it.
+-spec test_state_with_loss(quic_loss:loss_state()) -> #state{}.
+test_state_with_loss(LossState) ->
+    #state{
+        role = client,
+        app_keys = undefined,
+        loss_state = LossState,
+        cc_state = quic_cc:new(#{})
+    }.
+
+%% Read the loss tracker back out without exposing the record.
+-spec test_loss_state(#state{}) -> quic_loss:loss_state().
+test_loss_state(#state{loss_state = L}) -> L.
 
 %% Test helper for check_send_queue_flow_control/3.
 %% Wraps the internal function to avoid exposing #state{} record.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -166,6 +166,8 @@
     maybe_store_initial_reset_token/2,
     check_stateless_reset/2,
     test_state_for_reset/3,
+    %% Retransmission congestion policy (RFC 9002 §7)
+    retransmit_cc_allowed/3,
     %% NEW_TOKEN frame dispatch (RFC 9000 §8.1.3)
     process_frame/3,
     test_state_for_role/1,
@@ -9388,12 +9390,7 @@ send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = 
     Payload = iolist_to_binary([quic_frame:encode(F) || F <- Frames]),
     PacketSize = byte_size(Payload) + 50,
 
-    Allowed =
-        case Mode of
-            probe -> true;
-            normal -> quic_cc:can_send_control(CCState, PacketSize)
-        end,
-    case Allowed of
+    case retransmit_cc_allowed(Mode, CCState, PacketSize) of
         true ->
             send_app_packet_internal(Payload, Frames, State#state{retransmits = R + 1});
         false ->
@@ -9414,6 +9411,16 @@ send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = 
             ),
             defer_retransmit_frames(Frames, State)
     end.
+
+%% RFC 9002 §7: an endpoint MUST NOT exceed cwnd "unless the packet is
+%% sent on a PTO timer expiration or when entering a recovery period".
+%% A PTO probe is exempt outright; an ordinary loss retransmission
+%% stays bound by the congestion window proper, not by the more
+%% lenient control allowance.
+retransmit_cc_allowed(probe, _CCState, _PacketSize) ->
+    true;
+retransmit_cc_allowed(normal, CCState, PacketSize) ->
+    quic_cc:can_send(CCState, PacketSize).
 
 %% Split CC-deferred lost frames: stream data into FC-exempt retransmit_stream
 %% queue entries (retried by process_send_queue/1), control frames into

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4556,6 +4556,15 @@ process_frame(_Level, ping, State) ->
     State;
 process_frame(Level, {crypto, Offset, Data}, State) ->
     buffer_crypto_data(Level, Offset, Data, State);
+process_frame(Level, {ack, _Ranges, _AckDelay, _ECN}, State) when Level =/= app ->
+    %% Initial/Handshake ACKs must never touch the loss tracker: only
+    %% 1-RTT packets are registered there, and packet numbers restart
+    %% per space, so a Handshake-space ACK of PN 0..N silently "acks"
+    %% the first N 1-RTT packets out of sent_q. If those carried data
+    %% the peer never received, nothing retransmits them and the peer
+    %% stalls on a permanent stream hole. Handshake flights have their
+    %% own retransmission machinery.
+    State;
 process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
     %% Process ACK - update loss detection and congestion control
     #state{loss_state = LossState, cc_state = CCState} = State,

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -9374,14 +9374,26 @@ filter_reset_stream_at_data(Frames, #state{streams = Streams}) ->
 %% Send frames for retransmission with congestion control check
 send_retransmit_frames_cc([], State) ->
     State;
-send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = State) ->
+send_retransmit_frames_cc(Frames, State) ->
+    send_retransmit_frames_cc(Frames, State, normal).
+
+%% Mode `probe' (PTO) is exempt from congestion control per RFC 9002
+%% §7.5. Gating probes on the control allowance deadlocks a full
+%% window: bytes_in_flight sits at or just above cwnd, every PTO probe
+%% is denied, no probe means no ACK, no ACK means loss detection never
+%% runs, and the connection stalls until idle timeout with a full
+%% sent_q. Mode `normal' (loss retransmission) stays subject to cwnd.
+send_retransmit_frames_cc(Frames, #state{cc_state = CCState, retransmits = R} = State, Mode) ->
     %% Encode all frames and check size
     Payload = iolist_to_binary([quic_frame:encode(F) || F <- Frames]),
     PacketSize = byte_size(Payload) + 50,
 
-    %% Check if CC allows sending this retransmission
-    %% Use can_send_control to allow small overage for retransmissions
-    case quic_cc:can_send_control(CCState, PacketSize) of
+    Allowed =
+        case Mode of
+            probe -> true;
+            normal -> quic_cc:can_send_control(CCState, PacketSize)
+        end,
+    case Allowed of
         true ->
             send_app_packet_internal(Payload, Frames, State#state{retransmits = R + 1});
         false ->
@@ -9501,8 +9513,8 @@ handle_pto_timeout(#state{loss_state = LossState} = State) ->
 send_probe_packet(State) ->
     case get_oldest_unacked_frames(State) of
         {ok, Frames} ->
-            %% Retransmit oldest data as probe with CC check
-            send_retransmit_frames_cc(Frames, State);
+            %% Retransmit oldest data as the probe, cwnd-exempt
+            send_retransmit_frames_cc(Frames, State, probe);
         none ->
             %% No data to retransmit, send PING (always allowed as control)
             Payload = quic_frame:encode(ping),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -668,6 +668,7 @@
     pmtu_state :: #pmtu_state{} | undefined,
     pmtu_probe_timer :: reference() | undefined,
     pmtu_raise_timer :: reference() | undefined,
+    pmtu_raise_interval = ?PMTU_DEFAULT_RAISE_INTERVAL :: pos_integer(),
 
     %% Deferred PTO timer reset, flushed at batch boundaries via
     %% flush_dirty_timers/1. (Idle and keep-alive timers are lazy and
@@ -1191,6 +1192,7 @@ init({server, Opts}) ->
         congestion_threshold = maps:get(congestion_threshold, Opts, 2),
         pacing_enabled = maps:get(pacing_enabled, Opts, true),
         pmtu_state = init_pmtu_state(Opts),
+        pmtu_raise_interval = maps:get(pmtu_raise_interval, Opts, ?PMTU_DEFAULT_RAISE_INTERVAL),
         qlog_ctx = quic_qlog:new(Opts, InitialDCID, server)
     },
 
@@ -1573,6 +1575,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         pacing_enabled = maps:get(pacing_enabled, Opts, true),
         active_n = maps:get(active_n, Opts, 100),
         pmtu_state = init_pmtu_state(Opts),
+        pmtu_raise_interval = maps:get(pmtu_raise_interval, Opts, ?PMTU_DEFAULT_RAISE_INTERVAL),
         qlog_ctx = quic_qlog:new(Opts, DCID, client)
     },
 
@@ -3545,16 +3548,6 @@ send_frame(Frame, State) ->
 %% Send a 1-RTT (application) packet with pre-encoded binary payload
 %% Decodes the payload to extract frame info for loss tracking
 %% Note: Prefer send_frame/2 when frame tuple is available
-send_app_packet(Payload, State) when is_binary(Payload) ->
-    %% Try to decode the frame for proper loss tracking
-    FrameInfo =
-        case quic_frame:decode(Payload) of
-            {Frame, _Rest} when is_tuple(Frame); is_atom(Frame) -> [Frame];
-            % Fall back to empty if decode fails
-            _ -> []
-        end,
-    send_app_packet_internal(Payload, FrameInfo, State).
-
 %% Send a 1-RTT packet with explicit frames list for retransmission tracking
 send_app_packet_internal(Payload, Frames, State) ->
     #state{
@@ -11428,8 +11421,19 @@ send_pmtu_probe_packet(ProbeSize, Frames, #state{dcid = DCID, pn_app = PNSpace} 
     %% Add extra padding to frame payload
     PaddedFrames = <<EncodedFrames/binary, (binary:copy(<<0>>, ExtraPadding))/binary>>,
 
-    %% Use existing send_app_packet which handles all encryption/tracking
-    send_app_packet(PaddedFrames, State).
+    %% Send with an empty frames list so the probe is tracked as
+    %% non-ack-eliciting locally: it stays in sent_q, which is what the
+    %% PMTU ack/lost hooks fold over, but adds nothing to
+    %% bytes_in_flight, arms no PTO, and is never retransmitted. Losing
+    %% a probe is the expected outcome of probing past the path MTU
+    %% (RFC 8899 §3, RFC 9000 §14.4): it must be decided by quic_pmtu's
+    %% own probe timer, never surface as connection loss. Tracking it
+    %% as in-flight data let a single lost raise-probe hold
+    %% bytes_in_flight above zero with no possible progress, and the
+    %% disconnect timeout then declared the peer dead: every long-lived
+    %% connection on an MTU-limited path died on the first periodic
+    %% re-probe, both ends at once.
+    send_app_packet_internal(PaddedFrames, [], State).
 
 %% @doc Encode PMTU probe frames (PING + PADDING).
 -spec encode_pmtu_frames([term()]) -> binary().
@@ -11472,7 +11476,7 @@ set_pmtu_probe_timer(#state{pmtu_probe_timer = OldTimer, loss_state = LossState}
 -spec maybe_set_pmtu_raise_timer(#state{}) -> #state{}.
 maybe_set_pmtu_raise_timer(#state{pmtu_raise_timer = undefined} = State) ->
     Ref = make_ref(),
-    erlang:send_after(?PMTU_DEFAULT_RAISE_INTERVAL, self(), {pmtu_raise_timeout, Ref}),
+    erlang:send_after(State#state.pmtu_raise_interval, self(), {pmtu_raise_timeout, Ref}),
     State#state{pmtu_raise_timer = Ref};
 maybe_set_pmtu_raise_timer(State) ->
     State.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -10770,9 +10770,18 @@ complete_migration(
     NewPMTUState = quic_pmtu:on_path_change(PMTUState),
 
     %% RFC 9002 Section 9.4: Reset congestion controller on path change
-    %% The new path may have different RTT and bandwidth characteristics
-    NewCCState = quic_cc:new(#{}),
-    NewLossState = quic_loss:new(),
+    %% The new path may have different RTT and bandwidth characteristics.
+    %% The loss tracker's sent_q must SURVIVE the switch: replacing it
+    %% orphans every in-flight packet (no ACK match, no loss detection,
+    %% no PTO since bytes_in_flight reads 0) and their data is never
+    %% retransmitted - the peer then stalls on a permanent stream hole.
+    NewLossState = quic_loss:reset_for_new_path(State#state.loss_state),
+    NewCCState0 = quic_cc:new(#{}),
+    NewCCState =
+        case quic_loss:bytes_in_flight(NewLossState) of
+            0 -> NewCCState0;
+            Outstanding -> quic_cc:on_packet_sent(NewCCState0, Outstanding)
+        end,
 
     State#state{
         remote_addr = NewPath#path_state.remote_addr,
@@ -10783,7 +10792,8 @@ complete_migration(
         pmtu_raise_timer = undefined,
         %% Reset CC and loss detection for new path
         cc_state = NewCCState,
-        loss_state = NewLossState
+        loss_state = NewLossState,
+        pto_dirty = true
     };
 complete_migration(_, State) ->
     %% Can only migrate to validated paths

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -408,11 +408,20 @@ detect_lost_q(
                     true -> LostBytes + Size;
                     false -> LostBytes
                 end,
+            %% Only ack-eliciting losses drive the congestion event
+            %% (largest_lost_sent_time feeds on_congestion_event). A lost
+            %% non-ack-eliciting packet, a PMTU probe in particular, is
+            %% not a congestion signal (RFC 9000 §14.4).
             NewLL =
-                case LL of
-                    undefined -> {PN, TS};
-                    {OldPN, _} when PN > OldPN -> {PN, TS};
-                    _ -> LL
+                case AE of
+                    false ->
+                        LL;
+                    true ->
+                        case LL of
+                            undefined -> {PN, TS};
+                            {OldPN, _} when PN > OldPN -> {PN, TS};
+                            _ -> LL
+                        end
                 end,
             detect_lost_q(Rest, SRTT, LargestAcked, Now, [P | LostAcc], SurvQ, NewBytes, NewLL);
         false ->

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -72,6 +72,7 @@
 % 9/8
 -define(TIME_THRESHOLD, 1.125).
 % 1 millisecond
+-define(MAX_PTO_MS, 5000).
 -define(GRANULARITY, 1).
 % RFC 9002 default is 333ms, but 100ms is more aggressive for faster ramp-up
 -define(DEFAULT_INITIAL_RTT, 100).
@@ -518,7 +519,12 @@ get_pto(#loss_state{
 }) ->
     PTO = SRTT + max(4 * RTTVAR, ?GRANULARITY) + MaxAckDelay,
     %% Exponential backoff
-    PTO bsl PTOCount.
+    %% Exponential backoff, capped: uncapped doubling reaches tens of
+    %% seconds after a loss streak, and a probe that arrives after the
+    %% peer's patience is a probe that never happened. Probes are tiny,
+    %% so a bounded worst-case interval costs nothing while keeping
+    %% recovery inside real-world request timeouts.
+    min(PTO bsl PTOCount, ?MAX_PTO_MS).
 
 %% @doc Handle PTO expiration.
 -spec on_pto_expired(loss_state()) -> loss_state().

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -260,7 +260,7 @@ on_ack_received(State, {ack, LargestAcked, AckDelay, FirstRange, AckRanges}, Now
             {LostList, SurvHeadQ, LostBytes, LargestLostSentTime} =
                 detect_lost_q(
                     KeptList,
-                    NewState1#loss_state.smoothed_rtt,
+                    max(NewState1#loss_state.smoothed_rtt, NewState1#loss_state.latest_rtt),
                     LargestAcked,
                     Now,
                     [],
@@ -350,13 +350,19 @@ maybe_update_rtt(State, LargestAcked, AckedList, AckDelay, Now) ->
 -spec detect_lost_packets(loss_state(), non_neg_integer()) ->
     {loss_state(), [#sent_packet{}]}.
 detect_lost_packets(
-    #loss_state{sent_q = Q, smoothed_rtt = SRTT} = State,
+    #loss_state{sent_q = Q, smoothed_rtt = SRTT, latest_rtt = LatestRTT} = State,
     LargestAcked
 ) ->
     Now = erlang:monotonic_time(millisecond),
     SentList = queue:to_list(Q),
+    %% RFC 9002 §6.1.2: the time threshold uses max(smoothed_rtt,
+    %% latest_rtt). With the EWMA alone, an RTT spike that outruns it
+    %% (receiver queueing, bufferbloat) mass-declares in-flight packets
+    %% lost while their ACKs are merely late; each spurious loss both
+    %% retransmits data and collapses the congestion window.
+    RTT = max(SRTT, LatestRTT),
     {LostPackets, SurvQ, LostBytes, _LargestLostSentTime} =
-        detect_lost_q(SentList, SRTT, LargestAcked, Now, [], queue:new(), 0, undefined),
+        detect_lost_q(SentList, RTT, LargestAcked, Now, [], queue:new(), 0, undefined),
     NewState = State#loss_state{
         sent_q = SurvQ,
         bytes_in_flight = max(0, State#loss_state.bytes_in_flight - LostBytes)
@@ -429,8 +435,8 @@ largest_lost_ts({_PN, TS}) -> TS.
 %% peek in the common case (head is in_flight).
 -spec get_loss_time_and_space(loss_state()) ->
     {non_neg_integer() | undefined, atom()}.
-get_loss_time_and_space(#loss_state{sent_q = Q, smoothed_rtt = SRTT}) ->
-    LossDelay = max(trunc(?TIME_THRESHOLD * SRTT), ?GRANULARITY),
+get_loss_time_and_space(#loss_state{sent_q = Q, smoothed_rtt = SRTT, latest_rtt = LatestRTT}) ->
+    LossDelay = max(trunc(?TIME_THRESHOLD * max(SRTT, LatestRTT)), ?GRANULARITY),
     case earliest_in_flight_time(queue:to_list(Q)) of
         undefined -> {undefined, initial};
         TimeSent -> {TimeSent + LossDelay, initial}

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -29,6 +29,7 @@
 -include("quic.hrl").
 
 -export([
+    reset_for_new_path/1,
     %% Loss detection state
     new/0,
     new/1,
@@ -113,6 +114,25 @@
 
 -opaque loss_state() :: #loss_state{}.
 -export_type([loss_state/0]).
+
+%% RFC 9002 §9.4 path-change reset: RTT and PTO state belong to the
+%% old path, but the sent-packet tracking must survive - dropping it
+%% orphans every in-flight packet (no ACK match, no loss declaration,
+%% no PTO since bytes_in_flight reads 0) and any lost data in that set
+%% is never retransmitted.
+-spec reset_for_new_path(loss_state() | undefined) -> loss_state().
+reset_for_new_path(undefined) ->
+    new();
+reset_for_new_path(#loss_state{} = S) ->
+    S#loss_state{
+        latest_rtt = 0,
+        smoothed_rtt = ?DEFAULT_INITIAL_RTT,
+        rtt_var = ?DEFAULT_INITIAL_RTT div 2,
+        min_rtt = infinity,
+        first_rtt_sample = false,
+        pto_count = 0,
+        loss_time = undefined
+    }.
 
 %%====================================================================
 %% Loss Detection State

--- a/test/quic_handshake_ack_isolation_tests.erl
+++ b/test/quic_handshake_ack_isolation_tests.erl
@@ -1,0 +1,132 @@
+%%% -*- erlang -*-
+%%%
+%%% ACKs are per packet-number space (RFC 9000 §12.3, RFC 9002 §A.10).
+%%%
+%%% Packet numbers restart at 0 in each space, so the same number means
+%%% a different packet in Initial, Handshake and 1-RTT. Only 1-RTT
+%%% packets are registered in the connection's loss tracker, so feeding
+%%% it a Handshake-space ACK of packet numbers 0..N acknowledges the
+%%% first N 1-RTT packets that were never acknowledged at all. They
+%%% leave the sent queue, nothing retransmits them, and the peer is left
+%%% with a permanent hole in the stream.
+%%%
+%%% These tests pin the isolation at the frame-dispatch boundary: an ACK
+%%% arriving at a non-application encryption level must leave the loss
+%%% tracker exactly as it found it, while an application-level ACK must
+%%% still be processed normally.
+%%%
+%%% The end-to-end consequence is covered by
+%%% quic_stranded_window_recovery_SUITE.
+
+-module(quic_handshake_ack_isolation_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PACKET_BYTES, 1200).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Three ack-eliciting 1-RTT packets in flight. The send times are real
+%% monotonic milliseconds because processing an application ACK arms the
+%% PTO timer, and a timestamp far in the past yields a negative delay.
+loss_with_three_inflight() ->
+    Now = erlang:monotonic_time(millisecond),
+    S0 = quic_loss:new(),
+    S1 = quic_loss:on_packet_sent(S0, 0, ?PACKET_BYTES, true, [], Now),
+    S2 = quic_loss:on_packet_sent(S1, 1, ?PACKET_BYTES, true, [], Now + 1),
+    quic_loss:on_packet_sent(S2, 2, ?PACKET_BYTES, true, [], Now + 2).
+
+state() ->
+    quic_connection:test_state_with_loss(loss_with_three_inflight()).
+
+%% An ACK frame in the shape process_frame/3 consumes. Each range is
+%% {LargestAcked, FirstRange} where FirstRange is a *count* of further
+%% packets below the largest, as on the wire (RFC 9000 §19.3), not the
+%% smallest packet number.
+ack(Ranges) ->
+    {ack, Ranges, 0, undefined}.
+
+%% Acknowledge all three packets, 0..2.
+ack_all() ->
+    ack([{2, 2}]).
+
+%% Everything about the tracker a stray ACK could disturb.
+snapshot(State) ->
+    L = quic_connection:test_loss_state(State),
+    #{
+        in_flight => quic_loss:bytes_in_flight(L),
+        sent => quic_loss:sent_packets(L),
+        oldest => quic_loss:oldest_unacked(L),
+        pto_count => quic_loss:pto_count(L)
+    }.
+
+%%====================================================================
+%% Premise
+%%====================================================================
+
+three_packets_are_in_flight_test() ->
+    #{in_flight := InFlight} = snapshot(state()),
+    %% Without this the isolation assertions below would hold vacuously.
+    ?assertEqual(3 * ?PACKET_BYTES, InFlight).
+
+%%====================================================================
+%% Non-application levels must not touch the tracker
+%%====================================================================
+
+handshake_ack_leaves_the_tracker_untouched_test() ->
+    Before = snapshot(state()),
+    After = snapshot(quic_connection:process_frame(handshake, ack_all(), state())),
+    ?assertEqual(Before, After).
+
+initial_ack_leaves_the_tracker_untouched_test() ->
+    Before = snapshot(state()),
+    After = snapshot(quic_connection:process_frame(initial, ack_all(), state())),
+    ?assertEqual(Before, After).
+
+handshake_ack_of_a_single_packet_leaves_it_in_flight_test() ->
+    %% The narrow case: one packet number that exists in both spaces.
+    After = snapshot(quic_connection:process_frame(handshake, ack([{0, 0}]), state())),
+    ?assertEqual(3 * ?PACKET_BYTES, maps:get(in_flight, After)).
+
+handshake_ack_beyond_the_tracker_is_harmless_test() ->
+    %% A Handshake space that outran the 1-RTT one must not be treated as
+    %% an invalid range against 1-RTT packets that were never sent.
+    After = snapshot(quic_connection:process_frame(handshake, ack([{99, 90}]), state())),
+    ?assertEqual(3 * ?PACKET_BYTES, maps:get(in_flight, After)).
+
+%%====================================================================
+%% Application level must still work
+%%====================================================================
+
+app_ack_is_processed_test() ->
+    %% The inverse case. If this passed too, the fix would have disabled
+    %% ACK processing altogether rather than scoping it.
+    After = snapshot(quic_connection:process_frame(app, ack_all(), state())),
+    ?assertEqual(0, maps:get(in_flight, After)),
+    ?assertEqual(none, maps:get(oldest, After)).
+
+app_ack_of_a_prefix_retires_only_that_prefix_test() ->
+    After = snapshot(quic_connection:process_frame(app, ack([{1, 1}]), state())),
+    %% Two of the three retire; the third is still outstanding.
+    ?assertEqual(?PACKET_BYTES, maps:get(in_flight, After)),
+    ?assertNotEqual(none, maps:get(oldest, After)).
+
+%%====================================================================
+%% Degenerate input (fences: these hold before and after the fix)
+%%====================================================================
+
+empty_ack_is_a_no_op_at_every_level_test() ->
+    Before = snapshot(state()),
+    [
+        ?assertEqual(Before, snapshot(quic_connection:process_frame(Level, ack([]), state())))
+     || Level <- [initial, handshake, app]
+    ].
+
+non_ack_frame_is_unaffected_test() ->
+    %% The new clause is guarded on ACK frames; a PING at handshake level
+    %% must still take its own path rather than being swallowed.
+    Before = snapshot(state()),
+    After = snapshot(quic_connection:process_frame(handshake, ping, state())),
+    ?assertEqual(Before, After).

--- a/test/quic_loss_path_migration_tests.erl
+++ b/test/quic_loss_path_migration_tests.erl
@@ -1,0 +1,110 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for loss-tracker handling across an active path migration
+%%% (RFC 9000 §9.4).
+%%%
+%%% A migration invalidates the path's RTT and congestion estimates, but
+%%% not the packets already in flight. Replacing the whole tracker with a
+%%% fresh one orphans them: no ACK matches, loss detection never runs,
+%%% and bytes_in_flight reads 0 so no PTO fires either. Their data is
+%%% never retransmitted and the peer stalls on a permanent stream hole.
+%%%
+%%% reset_for_new_path/1 draws that line: path-derived estimates reset,
+%%% the sent queue and its byte accounting survive.
+%%%
+%%% Covers PR #251.
+
+-module(quic_loss_path_migration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_loss.
+-define(DEFAULT_INITIAL_RTT, 100).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% A tracker mid-flight: three ack-eliciting packets outstanding and an
+%% established RTT sample, i.e. what a connection looks like when a
+%% migration completes under load.
+in_flight_state() ->
+    S0 = quic_loss:new(),
+    S1 = quic_loss:on_packet_sent(S0, 1, 1200, true, [], 1000),
+    S2 = quic_loss:on_packet_sent(S1, 2, 1200, true, [], 1010),
+    S3 = quic_loss:on_packet_sent(S2, 3, 1000, true, [], 1020),
+    quic_loss:update_rtt(S3, 40, 0).
+
+%%====================================================================
+%% What must survive
+%%====================================================================
+
+keeps_bytes_in_flight_test() ->
+    State = in_flight_state(),
+    Before = quic_loss:bytes_in_flight(State),
+    ?assertEqual(3400, Before),
+    After = quic_loss:reset_for_new_path(State),
+    %% The bytes are still on the wire; forgetting them makes the
+    %% congestion controller think the path is idle.
+    ?assertEqual(Before, quic_loss:bytes_in_flight(After)).
+
+keeps_sent_packets_test() ->
+    State = in_flight_state(),
+    Before = quic_loss:sent_packets(State),
+    After = quic_loss:reset_for_new_path(State),
+    ?assertEqual(Before, quic_loss:sent_packets(After)),
+    %% And they remain retransmittable rather than being dropped on the
+    %% floor by the migration.
+    ?assertNotEqual(undefined, quic_loss:oldest_unacked(After)).
+
+keeps_oldest_unacked_test() ->
+    State = in_flight_state(),
+    ?assertEqual(
+        quic_loss:oldest_unacked(State),
+        quic_loss:oldest_unacked(quic_loss:reset_for_new_path(State))
+    ).
+
+%%====================================================================
+%% What must reset
+%%====================================================================
+
+resets_rtt_estimates_test() ->
+    State = in_flight_state(),
+    ?assertEqual(40, quic_loss:latest_rtt(State)),
+    ?assertEqual(40, quic_loss:smoothed_rtt(State)),
+    After = quic_loss:reset_for_new_path(State),
+    %% The new path has its own RTT; carrying the old one over paces the
+    %% first flight against a path that no longer exists.
+    ?assertEqual(0, quic_loss:latest_rtt(After)),
+    ?assertEqual(?DEFAULT_INITIAL_RTT, quic_loss:smoothed_rtt(After)),
+    ?assertEqual(?DEFAULT_INITIAL_RTT div 2, quic_loss:rtt_var(After)),
+    ?assertEqual(infinity, quic_loss:min_rtt(After)).
+
+resets_rtt_sample_flag_test() ->
+    State = in_flight_state(),
+    ?assert(quic_loss:has_rtt_sample(State)),
+    %% The next sample on the new path must be taken as a first sample,
+    %% not blended into the old path's EWMA.
+    ?assertNot(quic_loss:has_rtt_sample(quic_loss:reset_for_new_path(State))).
+
+resets_pto_count_test() ->
+    State = quic_loss:on_pto_expired(in_flight_state()),
+    ?assert(quic_loss:pto_count(State) > 0),
+    ?assertEqual(0, quic_loss:pto_count(quic_loss:reset_for_new_path(State))).
+
+first_sample_on_new_path_is_not_blended_test() ->
+    After = quic_loss:reset_for_new_path(in_flight_state()),
+    Sampled = quic_loss:update_rtt(After, 250, 0),
+    %% A first sample sets the EWMA outright. Had the flag survived, the
+    %% 250 would have been averaged against the stale 40.
+    ?assertEqual(250, quic_loss:smoothed_rtt(Sampled)),
+    ?assertEqual(250, quic_loss:latest_rtt(Sampled)).
+
+%%====================================================================
+%% Degenerate input
+%%====================================================================
+
+undefined_state_yields_fresh_tracker_test() ->
+    State = quic_loss:reset_for_new_path(undefined),
+    ?assertEqual(0, quic_loss:bytes_in_flight(State)),
+    ?assertNot(quic_loss:has_rtt_sample(State)).

--- a/test/quic_loss_time_threshold_tests.erl
+++ b/test/quic_loss_time_threshold_tests.erl
@@ -1,0 +1,142 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for the loss time threshold (RFC 9002 §6.1.2).
+%%%
+%%% The threshold is max(smoothed_rtt, latest_rtt), not smoothed_rtt
+%%% alone. When an RTT spike outruns the EWMA the two diverge, and an
+%%% EWMA-only threshold declares in-flight packets lost while their ACKs
+%%% are merely late; each spurious loss both retransmits data and
+%%% collapses the congestion window.
+%%%
+%%% The delay is observable through get_loss_time_and_space/1, which
+%%% returns TimeSent + LossDelay for the oldest in-flight packet. Pinning
+%%% TimeSent with on_packet_sent/6 makes LossDelay readable by
+%%% subtraction, so these tests assert on the delay itself rather than
+%%% re-deriving it from the formula under test.
+%%%
+%%% Covers PR #210.
+
+-module(quic_loss_time_threshold_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_loss.
+-define(TIME_THRESHOLD, 1.125).
+-define(GRANULARITY, 1).
+
+%% Arbitrary fixed send time, in the monotonic milliseconds
+%% on_packet_sent/6 expects.
+-define(SENT_AT, 1000000).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% One in-flight packet sent at ?SENT_AT.
+with_inflight_packet(State) ->
+    quic_loss:on_packet_sent(State, 1, 1200, true, [], ?SENT_AT).
+
+%% Feed RTT samples in order.
+samples(State, Rtts) ->
+    lists:foldl(fun(Rtt, S) -> quic_loss:update_rtt(S, Rtt, 0) end, State, Rtts).
+
+%% The delay actually applied, recovered from the returned loss time.
+applied_delay(State) ->
+    {LossTime, _Space} = quic_loss:get_loss_time_and_space(State),
+    ?assertNotEqual(undefined, LossTime),
+    LossTime - ?SENT_AT.
+
+expected_delay(Rtt) ->
+    max(trunc(?TIME_THRESHOLD * Rtt), ?GRANULARITY).
+
+%%====================================================================
+%% RTT bookkeeping these tests depend on
+%%====================================================================
+
+spike_leaves_latest_above_smoothed_test() ->
+    State = samples(quic_loss:new(), [20, 400]),
+    ?assertEqual(400, quic_loss:latest_rtt(State)),
+    %% The EWMA lags the spike, otherwise the assertions below would not
+    %% distinguish the two thresholds.
+    ?assert(quic_loss:smoothed_rtt(State) < 400).
+
+decay_leaves_smoothed_above_latest_test() ->
+    State = samples(quic_loss:new(), [400, 20]),
+    ?assertEqual(20, quic_loss:latest_rtt(State)),
+    ?assert(quic_loss:smoothed_rtt(State) > 20).
+
+%%====================================================================
+%% Loss time threshold
+%%====================================================================
+
+delay_follows_latest_rtt_when_it_exceeds_smoothed_test() ->
+    State = with_inflight_packet(samples(quic_loss:new(), [20, 400])),
+    SRTT = quic_loss:smoothed_rtt(State),
+    Latest = quic_loss:latest_rtt(State),
+    ?assertEqual(expected_delay(Latest), applied_delay(State)),
+    %% Explicitly not the smoothed-only value, which is what an
+    %% EWMA-only threshold would produce.
+    ?assertNotEqual(expected_delay(SRTT), applied_delay(State)).
+
+delay_follows_smoothed_rtt_when_it_exceeds_latest_test() ->
+    State = with_inflight_packet(samples(quic_loss:new(), [400, 20])),
+    SRTT = quic_loss:smoothed_rtt(State),
+    Latest = quic_loss:latest_rtt(State),
+    ?assertEqual(expected_delay(SRTT), applied_delay(State)),
+    ?assertNotEqual(expected_delay(Latest), applied_delay(State)).
+
+delay_equals_both_when_rtt_is_stable_test() ->
+    %% With a flat RTT the two estimates coincide and the max() is a
+    %% no-op; the threshold must not drift.
+    State = with_inflight_packet(samples(quic_loss:new(), [50, 50, 50])),
+    ?assertEqual(50, quic_loss:latest_rtt(State)),
+    ?assertEqual(50, quic_loss:smoothed_rtt(State)),
+    ?assertEqual(expected_delay(50), applied_delay(State)).
+
+delay_floors_at_granularity_test() ->
+    %% A zero RTT sample must still leave a floor of one granularity
+    %% unit, otherwise loss detection fires on scheduling jitter alone.
+    State = with_inflight_packet(samples(quic_loss:new(), [0])),
+    ?assertEqual(?GRANULARITY, applied_delay(State)).
+
+no_in_flight_packet_has_no_loss_time_test() ->
+    State = samples(quic_loss:new(), [50]),
+    ?assertEqual({undefined, initial}, quic_loss:get_loss_time_and_space(State)).
+
+%%====================================================================
+%% What the threshold is for: not declaring loss on an RTT spike
+%%====================================================================
+
+%% Two ack-eliciting packets sent SpreadMs before a third, then only the
+%% third acknowledged with a sample of SampleMs.
+%%
+%% The packet-number threshold (RFC 9002 6.1.1, kPacketThreshold 3) is
+%% deliberately kept out of it: PN 3 and 4 are within 3 of the acked PN
+%% 5, so nothing declares them lost on packet number alone and the time
+%% threshold is the only thing deciding.
+%%
+%% Their age at detection is SampleMs + SpreadMs. Choosing that to sit
+%% above 1.125 * smoothed_rtt but below 1.125 * latest_rtt is what makes
+%% the two thresholds disagree.
+spike_scenario(SpreadMs, SampleMs) ->
+    Now = erlang:monotonic_time(millisecond),
+    Sent = Now - SampleMs,
+    S0 = quic_loss:update_rtt(quic_loss:new(), 20, 0),
+    S1 = quic_loss:on_packet_sent(S0, 3, 1200, true, [], Sent - SpreadMs),
+    S2 = quic_loss:on_packet_sent(S1, 4, 1200, true, [], Sent - SpreadMs),
+    S3 = quic_loss:on_packet_sent(S2, 5, 1200, true, [], Sent),
+    quic_loss:on_ack_received(S3, {ack, 5, 0, 0, []}, Now).
+
+a_spike_does_not_declare_the_earlier_flight_lost_test() ->
+    %% Settled at 20 ms, then a 400 ms sample. The earlier packets are
+    %% 420 ms old: past 1.125 * smoothed_rtt, inside 1.125 * latest_rtt.
+    %% Their ACKs are late, not missing. Declaring them lost retransmits
+    %% data that arrived and collapses the window for nothing.
+    {_State, _Acked, Lost, _Meta} = spike_scenario(20, 400),
+    ?assertEqual([], Lost).
+
+a_genuinely_old_flight_is_still_declared_lost_test() ->
+    %% The inverse, and the fence: far past even the spiked threshold,
+    %% so taking the larger RTT must not switch loss detection off.
+    {_State, _Acked, Lost, _Meta} = spike_scenario(20000, 400),
+    ?assert(length(Lost) > 0).

--- a/test/quic_pmtu_probe_loss_tests.erl
+++ b/test/quic_pmtu_probe_loss_tests.erl
@@ -1,0 +1,90 @@
+%%% -*- erlang -*-
+%%%
+%%% PMTU probes must not surface as connection loss (RFC 8899 §3,
+%%% RFC 9000 §14.4).
+%%%
+%%% A probe sent past the path MTU is lost by design: its fate belongs
+%%% to the PMTUD state machine alone. The connection sends probes
+%%% tracked as non-ack-eliciting: they stay in the sent queue, which is
+%%% what the PMTU ack/lost hooks fold over, but contribute nothing to
+%%% bytes_in_flight, acked_bytes, lost_bytes, or the congestion-event
+%%% timestamp.
+%%%
+%%% Before this held, a single lost 600-second raise probe kept
+%%% bytes_in_flight above zero with no possible progress and the
+%%% disconnect timeout declared the peer dead: every long-lived
+%%% connection on an MTU-limited path died on its first periodic
+%%% re-probe, both ends at once. The end-to-end consequence is covered
+%%% by quic_pmtu_raise_probe_SUITE.
+
+-module(quic_pmtu_probe_loss_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(PROBE_SIZE, 1467).
+-define(DATA_SIZE, 1200).
+
+%% An ACK frame in the shape on_ack_received/3 consumes:
+%% {ack, LargestAcked, AckDelay, FirstRange, AckRanges}.
+ack(Largest, FirstRange) ->
+    {ack, Largest, 0, FirstRange, []}.
+
+now_ms() ->
+    erlang:monotonic_time(millisecond).
+
+%% A probe is registered with an empty frames list, exactly as
+%% send_pmtu_probe_packet does, which makes it non-ack-eliciting.
+send_probe(State, PN, Now) ->
+    quic_loss:on_packet_sent(State, PN, ?PROBE_SIZE, false, [], Now).
+
+send_data(State, PN, Now) ->
+    quic_loss:on_packet_sent(State, PN, ?DATA_SIZE, true, [{ping}], Now).
+
+probe_adds_no_bytes_in_flight_test() ->
+    S0 = quic_loss:new(),
+    S1 = send_probe(S0, 0, now_ms()),
+    ?assertEqual(0, quic_loss:bytes_in_flight(S1)).
+
+acked_probe_is_seen_but_counts_nothing_test() ->
+    Now = now_ms(),
+    S0 = send_probe(quic_loss:new(), 0, Now),
+    {S1, Acked, Lost, Meta} = quic_loss:on_ack_received(S0, ack(0, 0), Now + 20),
+    %% The PMTU ack hook folds over the acked list, so the probe must
+    %% appear there even though it elicits nothing locally.
+    ?assertEqual([0], [P#sent_packet.pn || P <- Acked]),
+    ?assertEqual([], Lost),
+    ?assertEqual(0, maps:get(acked_bytes, Meta)),
+    ?assertNot(maps:get(has_ack_eliciting, Meta)),
+    ?assertEqual(0, quic_loss:bytes_in_flight(S1)).
+
+lost_probe_is_seen_but_is_not_a_congestion_signal_test() ->
+    Now = now_ms(),
+    %% Probe as pn 0, then three real packets; acking 1..3 pushes pn 0
+    %% past the packet threshold (RFC 9002 §6.1.1) and declares it lost.
+    S0 = send_probe(quic_loss:new(), 0, Now),
+    S1 = send_data(S0, 1, Now + 1),
+    S2 = send_data(S1, 2, Now + 2),
+    S3 = send_data(S2, 3, Now + 3),
+    {S4, Acked, Lost, Meta} = quic_loss:on_ack_received(S3, ack(3, 2), Now + 30),
+    ?assertEqual([1, 2, 3], lists:sort([P#sent_packet.pn || P <- Acked])),
+    %% The PMTU lost hook folds over the lost list, so the probe must
+    %% appear there...
+    ?assertEqual([0], [P#sent_packet.pn || P <- Lost]),
+    %% ...while contributing neither lost bytes nor the timestamp that
+    %% drives on_congestion_event.
+    ?assertEqual(0, maps:get(lost_bytes, Meta)),
+    ?assertEqual(undefined, maps:get(largest_lost_sent_time, Meta)),
+    ?assertEqual(0, quic_loss:bytes_in_flight(S4)).
+
+%% Fence: a lost ack-eliciting packet still drives the congestion event.
+lost_data_still_signals_congestion_test() ->
+    Now = now_ms(),
+    S0 = send_data(quic_loss:new(), 0, Now),
+    S1 = send_data(S0, 1, Now + 1),
+    S2 = send_data(S1, 2, Now + 2),
+    S3 = send_data(S2, 3, Now + 3),
+    {_S4, _Acked, Lost, Meta} = quic_loss:on_ack_received(S3, ack(3, 2), Now + 30),
+    ?assertEqual([0], [P#sent_packet.pn || P <- Lost]),
+    ?assertEqual(?DATA_SIZE, maps:get(lost_bytes, Meta)),
+    ?assertNotEqual(undefined, maps:get(largest_lost_sent_time, Meta)).

--- a/test/quic_pmtu_raise_probe_SUITE.erl
+++ b/test/quic_pmtu_raise_probe_SUITE.erl
@@ -1,0 +1,230 @@
+%%% -*- erlang -*-
+%%%
+%%% A connection on an MTU-limited path must survive its periodic PMTU
+%%% raise probes (RFC 8899 §3, RFC 9000 §14.4).
+%%%
+%%% After the PMTU search settles, a raise timer re-probes toward
+%%% pmtu_max_mtu to detect a path that has improved. On a path whose
+%%% MTU sits below that ceiling the raise probe is lost by design,
+%%% every time, forever. Probe loss belongs to the PMTUD state machine
+%%% alone: tracked as ordinary in-flight data it inflates
+%%% bytes_in_flight, arms the PTO machinery, and feeds spurious
+%%% congestion events, and any liveness check keyed on unacknowledged
+%%% in-flight data (a disconnect timeout) then declares a healthy peer
+%%% dead. On a downstream deployment carrying such a check, every
+%%% long-lived connection on an MTU-limited path (that is: most real
+%%% WAN paths) died and reconnected once per raise interval, both ends
+%%% at once.
+%%%
+%%% The harness caps the path at 1300 bytes with a size filter in the
+%%% bridge: handshake and echo traffic (and the search probes that
+%%% matter) fit; every raise probe above it is silently dropped. The
+%%% raise interval is shortened so several probe-and-lose cycles run
+%%% inside the observation window, and the case requires the
+%%% connection to stay quiet-alive throughout and still carry data
+%%% afterwards.
+%%%
+%%% Frame-level coverage of the same rule is in
+%%% quic_pmtu_probe_loss_tests.
+
+-module(quic_pmtu_raise_probe_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([control_unlimited_path/1, survives_raise_probes_on_limited_path/1]).
+
+%% Path MTU cap: above every handshake/echo datagram, below the
+%% 1500-byte probe ceiling, so only raise probes exceed it.
+-define(PATH_LIMIT, 1300).
+%% Raise probes fire quickly so several cycles fit in the window.
+-define(RAISE_INTERVAL_MS, 1500).
+%% A short disconnect timeout, for implementations that enforce one:
+%% an in-flight-keyed liveness check turns the mistracked probe lethal
+%% this soon after it is lost, so the case fails fast rather than
+%% flaking.
+-define(DISCONNECT_MS, 3000).
+%% Quiet observation window: covers the search phase (probe timeouts
+%% are >= 1 s each) plus several raise cycles, with margin. The window
+%% is deliberately traffic-free: the failure mode needs an idle
+%% connection, where the lost probe is the only thing in flight and
+%% nothing else advances the progress clock. The keep-alive interval
+%% sits above the disconnect timeout for the same reason, mirroring
+%% the production configuration that hit this (keep-alive 20 s,
+%% disconnect 16 s).
+-define(OBSERVE_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [control_unlimited_path, survives_raise_probes_on_limited_path].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: same harness, no size cap. Holds with and without the fix and
+%% tells a failure of the case below apart from a broken harness.
+control_unlimited_path(_Config) ->
+    run_echo_window(infinity).
+
+survives_raise_probes_on_limited_path(_Config) ->
+    run_echo_window(?PATH_LIMIT).
+
+run_echo_window(Limit) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        {Conn, _Bridge} = connect_through_bridge(maps:get(port, Server), Limit),
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 10000 -> ct:fail("connect timeout")
+        end,
+        %% The path works when we start.
+        echo_roundtrip(Conn, <<"before the raise probes">>),
+        %% Stay quiet through the search and at least two raise cycles;
+        %% only the connection's own keep-alives run. A disconnect in
+        %% this window is exactly the bug.
+        quiet_watch(Conn, erlang:monotonic_time(millisecond) + ?OBSERVE_MS),
+        %% The same connection still carries data afterwards.
+        echo_roundtrip(Conn, <<"after the raise probes">>),
+        quic:close(Conn, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+quiet_watch(Conn, Deadline) ->
+    Left = Deadline - erlang:monotonic_time(millisecond),
+    case Left =< 0 of
+        true ->
+            ok;
+        false ->
+            receive
+                {quic, Conn, {closed, Reason}} ->
+                    ct:fail({connection_died_while_idle, Reason});
+                {quic, Conn, _Other} ->
+                    quiet_watch(Conn, Deadline)
+            after Left -> ok
+            end
+    end.
+
+echo_roundtrip(Conn, Payload) ->
+    {ok, StreamId} = quic:open_stream(Conn),
+    ok = quic:send_data(Conn, StreamId, Payload, true),
+    ?assertEqual(Payload, collect_echo(Conn, StreamId, 5000, <<>>)).
+
+collect_echo(Conn, StreamId, Budget, Acc) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
+            Acc1 = <<Acc/binary, Data/binary>>,
+            case Fin of
+                true -> Acc1;
+                false -> collect_echo(Conn, StreamId, Budget - spent(Start), Acc1)
+            end;
+        {quic, Conn, {closed, Reason}} ->
+            ct:fail({connection_died_mid_echo, Reason});
+        {quic, Conn, _Other} ->
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc)
+    after max(0, Budget) -> Acc
+    end.
+
+spent(Start) ->
+    max(1, erlang:monotonic_time(millisecond) - Start).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Client behind a socket adapter; the bridge relays to the server's
+%% real UDP socket and silently drops any datagram larger than Limit,
+%% in both directions, which is exactly what a path with a smaller MTU
+%% does to an unfragmentable QUIC datagram.
+connect_through_bridge(Port, Limit) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef, Limit) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter,
+        pmtu_raise_interval => ?RAISE_INTERVAL_MS,
+        disconnect_timeout => ?DISCONNECT_MS,
+        keep_alive_interval => 5000,
+        idle_timeout => 30000
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    {Conn, Bridge}.
+
+fits(_Data, infinity) -> true;
+fits(Data, Limit) -> byte_size(Data) =< Limit.
+
+bridge_init(ServerIP, ServerPort, SocketRef, Limit) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        limit => Limit,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}, limit := Limit} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {send, _IP, _Port, Pkt} ->
+            Bin = iolist_to_binary(Pkt),
+            case fits(Bin, Limit) of
+                true -> ok = gen_udp:send(Sock, ServerIP, ServerPort, Bin);
+                false -> ok
+            end,
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case fits(Data, Limit) of
+                false ->
+                    bridge_loop(Bridge);
+                true ->
+                    case maps:get(conn, Bridge) of
+                        undefined ->
+                            bridge_loop(Bridge#{
+                                pending := [Data | maps:get(pending, Bridge)]
+                            });
+                        Conn ->
+                            deliver(Bridge, Conn, Data),
+                            bridge_loop(Bridge)
+                    end
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.

--- a/test/quic_pto_backoff_cap_tests.erl
+++ b/test/quic_pto_backoff_cap_tests.erl
@@ -1,0 +1,99 @@
+%%% -*- erlang -*-
+%%%
+%%% The PTO backoff is bounded.
+%%%
+%%% RFC 9002 §6.2.1 doubles the PTO on each consecutive expiration, and
+%%% the doubling on its own has no ceiling. On a 50 ms path that reaches
+%%% roughly 90 seconds after nine expirations and about twelve minutes
+%%% after twelve. A probe scheduled that far out is not a probe: the
+%%% peer's idle timer, and any request deadline above it, will have
+%%% fired long before. The connection is dead without being closed.
+%%%
+%%% Probes are a single small packet, so bounding the worst-case
+%%% interval costs almost nothing and keeps recovery inside the window
+%%% where anything is still listening. These tests pin the ceiling and,
+%%% just as importantly, pin that the doubling below it is untouched.
+%%%
+%%% Covers PR #254.
+
+-module(quic_pto_backoff_cap_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_loss.
+-define(MAX_PTO_MS, 5000).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% A tracker with a settled RTT, so the PTO has a definite base.
+settled(RttMs) ->
+    quic_loss:update_rtt(quic_loss:new(), RttMs, 0).
+
+%% The PTO after N consecutive expirations.
+pto_after(State, N) ->
+    Expired = lists:foldl(
+        fun(_, S) -> quic_loss:on_pto_expired(S) end,
+        State,
+        lists:seq(1, N)
+    ),
+    quic_loss:get_pto(Expired).
+
+series(State, Upto) ->
+    [pto_after(State, N) || N <- lists:seq(1, Upto)].
+
+%%====================================================================
+%% The ceiling
+%%====================================================================
+
+backoff_never_exceeds_the_cap_test() ->
+    Series = series(settled(50), 12),
+    ?assert(lists:all(fun(P) -> P =< ?MAX_PTO_MS end, Series)).
+
+backoff_is_capped_even_from_a_slow_path_test() ->
+    %% A long RTT reaches the ceiling in fewer steps, and must not step
+    %% over it on the way.
+    Series = series(settled(2000), 8),
+    ?assert(lists:all(fun(P) -> P =< ?MAX_PTO_MS end, Series)).
+
+a_long_loss_streak_stays_at_the_cap_test() ->
+    %% The case that motivates this: without a ceiling, the doubling is
+    %% into the minutes here.
+    ?assertEqual(?MAX_PTO_MS, pto_after(settled(50), 20)),
+    ?assertEqual(?MAX_PTO_MS, pto_after(settled(50), 40)).
+
+%%====================================================================
+%% Below the ceiling nothing changes (fences)
+%%====================================================================
+
+backoff_still_doubles_below_the_cap_test() ->
+    State = settled(50),
+    Base = quic_loss:get_pto(State),
+    ?assert(Base * 2 < ?MAX_PTO_MS),
+    %% Each step is exactly twice the last for as long as there is room.
+    ?assertEqual(Base * 2, pto_after(State, 1)),
+    ?assertEqual(Base * 4, pto_after(State, 2)),
+    ?assertEqual(Base * 8, pto_after(State, 3)).
+
+backoff_is_monotonic_test() ->
+    Series = series(settled(50), 12),
+    ?assertEqual(lists:sort(Series), Series).
+
+first_expiration_is_not_clamped_on_a_fast_path_test() ->
+    %% A short RTT must not be dragged up to the ceiling; the cap is an
+    %% upper bound, not a floor.
+    ?assert(pto_after(settled(5), 1) < ?MAX_PTO_MS).
+
+unexpired_pto_is_untouched_test() ->
+    State = settled(50),
+    ?assert(quic_loss:get_pto(State) < ?MAX_PTO_MS),
+    ?assertEqual(0, quic_loss:pto_count(State)).
+
+%%====================================================================
+%% Degenerate input
+%%====================================================================
+
+cap_holds_without_an_rtt_sample_test() ->
+    %% Before the first sample the PTO runs off the default initial RTT.
+    ?assert(pto_after(quic_loss:new(), 20) =< ?MAX_PTO_MS).

--- a/test/quic_retransmit_cc_policy_tests.erl
+++ b/test/quic_retransmit_cc_policy_tests.erl
@@ -1,0 +1,57 @@
+%%% -*- erlang -*-
+%%%
+%%% Congestion policy for retransmitted frames (RFC 9002 §7).
+%%%
+%%% "An endpoint MUST NOT send a packet if it would cause bytes_in_flight
+%%% to be larger than the congestion window, unless the packet is sent on
+%%% a PTO timer expiration or when entering recovery." That is two rules:
+%%% a PTO probe is exempt from the congestion window outright, and an
+%%% ordinary loss retransmission stays bound by it.
+%%%
+%%% Gating probes deadlocks a full window: bytes_in_flight sits at or
+%%% just above cwnd, every probe is denied, no probe means no ACK, and
+%%% loss detection never runs. Exempting loss retransmissions instead
+%%% would burst a full sent_q past the window during recovery.
+%%%
+%%% These tests pin the policy at the retransmit_cc_allowed/3 decision
+%%% point for both modes, over both a full and an open window.
+
+-module(quic_retransmit_cc_policy_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PACKET, 1200).
+
+%% A congestion state with no room: keep charging full packets until
+%% even one more no longer fits under cwnd.
+full_window() ->
+    fill(quic_cc:new()).
+
+fill(CC) ->
+    case quic_cc:can_send(CC, ?PACKET) of
+        true -> fill(quic_cc:on_packet_sent(CC, ?PACKET));
+        false -> CC
+    end.
+
+probe_is_exempt_above_cwnd_test() ->
+    CC = full_window(),
+    ?assertNot(quic_cc:can_send(CC, ?PACKET)),
+    ?assert(quic_connection:retransmit_cc_allowed(probe, CC, ?PACKET)).
+
+loss_retransmission_is_refused_above_cwnd_test() ->
+    CC = full_window(),
+    ?assertNot(quic_connection:retransmit_cc_allowed(normal, CC, ?PACKET)).
+
+loss_retransmission_passes_an_open_window_test() ->
+    CC = quic_cc:new(),
+    ?assert(quic_connection:retransmit_cc_allowed(normal, CC, ?PACKET)).
+
+%% The loss gate is the congestion window proper, not the more lenient
+%% control allowance: a state the control gate would wave through is
+%% still refused once cwnd is spent.
+loss_gate_is_cwnd_not_the_control_allowance_test() ->
+    CC = full_window(),
+    case quic_cc:can_send_control(CC, ?PACKET) of
+        true -> ?assertNot(quic_connection:retransmit_cc_allowed(normal, CC, ?PACKET));
+        false -> ok
+    end.

--- a/test/quic_stranded_window_recovery_SUITE.erl
+++ b/test/quic_stranded_window_recovery_SUITE.erl
@@ -1,0 +1,221 @@
+%%% -*- erlang -*-
+%%%
+%%% Recovery after the whole send window is stranded.
+%%%
+%%% ACKs are per packet-number space (RFC 9000 §12.3) and packet numbers
+%%% restart at 0 in each space. Only 1-RTT packets are registered in the
+%%% connection's loss tracker, so a Handshake-space ACK of packet numbers
+%%% 0..N applied to that tracker retires the first N 1-RTT packets
+%%% without the peer ever having received them. They leave the sent
+%%% queue, so nothing retransmits them, and the stream keeps a permanent
+%%% hole.
+%%%
+%%% It takes a real outage to expose this. On a healthy path the 1-RTT
+%%% packets are acknowledged before any late handshake-level ACK can
+%%% retire them, which is why the control case below passes either way.
+%%%
+%%% The scenario here is a path that drops everything for long enough to
+%%% strand a full window, then comes back: a WiFi-to-cellular handover, a
+%%% VPN reconnect, a NAT rebind. The transfer has to complete once the
+%%% path returns.
+%%%
+%%% Frame-level coverage of the same fix is in
+%%% quic_handshake_ack_isolation_tests.
+
+-module(quic_stranded_window_recovery_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([control_plain_echo/1, recovers_after_the_window_is_stranded/1]).
+
+%% Several times the initial congestion window, so the send queue still
+%% holds most of it when the outage starts.
+-define(PAYLOAD_BYTES, 256 * 1024).
+%% Long enough for the window to fill and for loss detection to run.
+-define(BLACKHOLE_MS, 1500).
+%% Budget for the whole transfer once the path is back. Recovery takes
+%% well under a second when it works at all; this is deliberately loose
+%% so the case fails on a stall rather than on a slow machine.
+-define(RECOVER_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [control_plain_echo, recovers_after_the_window_is_stranded].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: the same transfer over the same harness with no outage. It
+%% passes with and without the fix, and tells a failure of the case
+%% below apart from a broken harness.
+control_plain_echo(_Config) ->
+    with_echo_server(fun(Conn) ->
+        {ok, StreamId} = quic:open_stream(Conn),
+        Payload = payload(),
+        ok = quic:send_data_async(Conn, StreamId, Payload, true),
+        Echoed = collect_echo(Conn, StreamId, ?RECOVER_MS, 0),
+        ?assertEqual(byte_size(Payload), Echoed)
+    end).
+
+recovers_after_the_window_is_stranded(_Config) ->
+    with_echo_server(fun(Conn, Bridge) ->
+        %% Drop everything the client sends, so the window fills with
+        %% packets that can never be acknowledged.
+        Bridge ! blackhole,
+        {ok, StreamId} = quic:open_stream(Conn),
+        Payload = payload(),
+        ok = quic:send_data_async(Conn, StreamId, Payload, true),
+        timer:sleep(?BLACKHOLE_MS),
+
+        Stranded = path_stats(Conn),
+        ct:pal("at the end of the outage: ~p", [Stranded]),
+        %% The premise: the window really is full. Without it the
+        %% assertion below would pass on a connection that simply had
+        %% nothing outstanding.
+        ?assert(maps:get(bytes_in_flight, Stranded) >= maps:get(cwnd, Stranded)),
+
+        Restored = erlang:monotonic_time(millisecond),
+        Bridge ! heal,
+        Echoed = collect_echo(Conn, StreamId, ?RECOVER_MS, 0),
+        Elapsed = erlang:monotonic_time(millisecond) - Restored,
+        ct:pal(
+            "echoed ~p of ~p bytes, ~p ms after the path returned~nfinal: ~p",
+            [Echoed, byte_size(Payload), Elapsed, path_stats(Conn)]
+        ),
+        ?assertEqual(byte_size(Payload), Echoed)
+    end).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+payload() ->
+    binary:copy(<<"x">>, ?PAYLOAD_BYTES).
+
+path_stats(Conn) ->
+    {ok, Stats} = quic:get_path_stats(Conn),
+    Stats.
+
+with_echo_server(Fun) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        {Conn, Bridge} = connect_through_bridge(maps:get(port, Server)),
+        case erlang:fun_info(Fun, arity) of
+            {arity, 1} -> Fun(Conn);
+            {arity, 2} -> Fun(Conn, Bridge)
+        end,
+        _ = quic:safe_close(Conn, normal),
+        ok
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%% Accumulate echoed bytes until the payload is back or the budget runs
+%% out. The budget covers the transfer as a whole, so a trickle that
+%% never finishes still fails.
+collect_echo(_Conn, _StreamId, Budget, Acc) when Budget =< 0 ->
+    Acc;
+collect_echo(_Conn, _StreamId, _Budget, Acc) when Acc >= ?PAYLOAD_BYTES ->
+    Acc;
+collect_echo(Conn, StreamId, Budget, Acc) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc + byte_size(Data));
+        {quic, Conn, _Other} ->
+            %% Session tickets and the like arrive on the same mailbox.
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc)
+    after Budget -> Acc
+    end.
+
+spent(Start) ->
+    max(1, erlang:monotonic_time(millisecond) - Start).
+
+connect_through_bridge(Port) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    receive
+        {quic, Conn, {connected, _}} -> {Conn, Bridge}
+    after 10000 -> ct:fail("connect timeout")
+    end.
+
+%% Relays between the client's socket adapter and a real UDP socket to
+%% the server. In blackhole mode client packets are dropped rather than
+%% forwarded; `heal' puts the path back. The server direction is never
+%% touched, so nothing else about the connection changes.
+bridge_init(ServerIP, ServerPort, SocketRef) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        blackhole => false,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        blackhole ->
+            bridge_loop(Bridge#{blackhole := true});
+        heal ->
+            bridge_loop(Bridge#{blackhole := false});
+        {send, _IP, _Port, Pkt} ->
+            case maps:get(blackhole, Bridge) of
+                true -> ok;
+                false -> ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt)
+            end,
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case maps:get(conn, Bridge) of
+                undefined ->
+                    bridge_loop(Bridge#{pending := [Data | maps:get(pending, Bridge)]});
+                Conn ->
+                    deliver(Bridge, Conn, Data),
+                    bridge_loop(Bridge)
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.


### PR DESCRIPTION
Aggregates #249, #256, #258, #260 and #264, each commit kept separate with its original authorship so the batch stays bisectable. First of nine topic batches; the ordering and the rest of the plan are in the backlog triage.

These five belong together because they are one subsystem: the loss tracker and the timers driven from it. Landing them apart would mean rebasing each of the others through `quic_loss.erl` four times over.

The merge commit in #258 (`m251`) is dropped — its content comes from its two parents, both included here. The only new commit is a CHANGELOG entry for #249, which carried tests but no entry.