### PR TITLE
Socket batching: GSO segment sizing, GRO receive, send-path options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,32 @@ All notable changes to this project will be documented in this file.
   (receiver queueing, bufferbloat) turned into a throughput collapse.
   Contributed by jbevemyr (#210).
 - PMTU probes are tracked as non-ack-eliciting, so a probe lost past the path MTU no longer inflates `bytes_in_flight`, arms the PTO machinery, or feeds a congestion event (RFC 8899 §3, RFC 9000 §14.4). Combined with an in-flight-keyed liveness check, the periodic raise probe previously killed every long-lived connection on an MTU-limited path once per 600-second raise interval, both ends at once. The raise interval is configurable as `pmtu_raise_interval`. (#264)
+- The UDP_GRO control message is read as the int the kernel sends.
+  Matching exactly two bytes meant the lookup never succeeded, so a
+  GRO-coalesced buffer was passed up unsplit as one oversized datagram
+  and dropped by the QUIC layer, which cannot re-split short-header
+  packets. GRO was therefore silently losing every coalesced train.
+  Contributed by jbevemyr (#204).
+- The GRO receive path sizes its read buffer for a maximally coalesced
+  train (64 KiB). Passing 0 used the OTP default 8 KiB buffer and
+  `recvmsg' silently truncated anything larger, discarding every segment
+  past the first few. The client receiver also went through a plain
+  `recvfrom', which never split trains at all. Contributed by jbevemyr
+  (#215).
+
+### Changed
+- A mixed-size send batch on a GSO socket is split into runs of
+  equal-sized packets and each run sent with one UDP_SEGMENT call,
+  instead of falling back to one `sendmsg' per packet. A single
+  odd-sized packet between data packets (an ACK, a flow-control update)
+  previously degraded the whole batch. Contributed by jbevemyr (#217).
+- Small sends are coalesced into shared packets. Contributed by jbevemyr
+  (#203).
+- The pacing burst allowance scales with the pacing rate rather than
+  sitting at a fixed 12 packets. Pacing wakeups have roughly
+  millisecond resolution, so the fixed bucket capped throughput at 12
+  packets per wakeup whenever the sender outran the ACK clock,
+  regardless of the configured rate. Contributed by jbevemyr (#219).
 
 ## [1.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `max_burst_packets` bounds how many packets leave per send drain, so a
+  large queued write cannot monopolise the scheduler. Contributed by
+  jbevemyr (#214).
+- `ack_packet_tolerance` makes the 1-RTT ACK decimation threshold
+  configurable; it defaults to the RFC 9000 section 13.2.1 value of 2.
+  Contributed by jbevemyr (#213).
+
 ### Fixed
+- The GSO segment size is derived from the batch instead of a
+  configured constant. 1-RTT packets follow the current max datagram
+  size, so the uniformity check against the fixed 1200 never matched and
+  the GSO path never ran; a batch is now split into runs of equal-sized
+  packets and each run segmented on its own size. Each write is capped
+  at 64 segments and 64 KB, and GSO is requested per message rather than
+  as a socket-level `UDP_SEGMENT`, which segmented every datagram
+  including handshake packets. Reported by jbevemyr (#196).
+- The socket-backend client binds the source address from
+  `extra_socket_opts` instead of leaving it to the kernel's route
+  lookup, which picks the wrong address on a multi-address host.
+  Contributed by jbevemyr (#261).
+- A GRO train reaches the client connection as one message rather than
+  one per packet, so the whole train is processed in a single receive
+  pass. Contributed by jbevemyr (#248).
 - PTO probe packets are exempt from the congestion window and loss
   retransmissions are bound to it, per RFC 9002 section 7. A probe is
   the only thing that can restart a stalled connection, so blocking it

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -404,6 +404,11 @@
 -define(DEFAULT_MAX_BATCH_PACKETS, 64).
 %% Default GSO segment size (QUIC packet size for batching)
 -define(DEFAULT_GSO_SEGMENT_SIZE, 1200).
+%% Kernel limits on a single UDP_SEGMENT write: UDP_MAX_SEGMENTS segments,
+%% and a payload that still fits a 16-bit UDP length. A run larger than
+%% either is split across writes.
+-define(MAX_GSO_SEGMENTS, 64).
+-define(MAX_GSO_PAYLOAD, 65535).
 
 %%====================================================================
 %% Records

--- a/src/quic_cc_newreno.erl
+++ b/src/quic_cc_newreno.erl
@@ -812,7 +812,7 @@ update_mtu(#cc_state{max_datagram_size = OldMDS, minimum_window = OldMinWin} = S
     NewMinimumWindow = max(2 * NewMTU, (OldMinWin * NewMTU) div OldMDS),
 
     %% Update pacing_max_burst (12 * max_datagram_size)
-    NewPacingMaxBurst = 12 * NewMTU,
+    NewPacingMaxBurst = max(12 * NewMTU, 2 * State#cc_state.pacing_rate),
 
     ?LOG_DEBUG(
         #{
@@ -904,7 +904,17 @@ update_pacing_rate(#cc_state{cwnd = Cwnd} = State, SmoothedRTT) when SmoothedRTT
     %% Update HyStart++ RTT tracking
     State1 = update_hystart_rtt(State, SmoothedRTT),
 
-    State1#cc_state{pacing_rate = PacingRate};
+    %% The burst allowance must cover at least a couple of timer
+    %% granularities' worth of tokens at the paced rate: pacing wakeups
+    %% (send_after) have ~1 ms resolution, so a fixed 12-packet bucket
+    %% caps throughput at 12 packets per wakeup whenever the sender
+    %% outruns the incoming ACK clock, regardless of the configured
+    %% rate. 2 ms of rate keeps micro-bursts bounded (same idea as
+    %% Linux fq's pacing quantum) while letting a 1 ms clock sustain
+    %% the rate.
+    MaxBurst = max(12 * State1#cc_state.max_datagram_size, 2 * PacingRate),
+
+    State1#cc_state{pacing_rate = PacingRate, pacing_max_burst = MaxBurst};
 update_pacing_rate(State, _SmoothedRTT) ->
     %% No valid RTT yet, keep current state
     State.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -691,7 +691,18 @@
     last_recv_trigger = sequential :: sequential | reordered,
 
     %% QLOG Tracing (draft-ietf-quic-qlog-quic-events)
-    qlog_ctx :: #qlog_ctx{} | undefined
+    qlog_ctx :: #qlog_ctx{} | undefined,
+
+    %% Small-send coalescing (issue #201). While `coalesce' is true -
+    %% only within one drained batch of send_data/send_data_async
+    %% requests - app packets accumulate here and are flushed as one
+    %% multi-frame packet per PMTU budget instead of one packet per
+    %% frame. Reversed accumulation lists; see send_app_packet_internal
+    %% and flush_pending_packet.
+    coalesce = false :: boolean(),
+    pend_payload = [] :: [iodata()],
+    pend_frames = [] :: [tuple()],
+    pend_size = 0 :: non_neg_integer()
 }).
 
 %%====================================================================
@@ -1965,14 +1976,7 @@ connected({call, From}, {send_datagram, Data}, State) ->
             {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
 connected({call, From}, {send_data, StreamId, Data, Fin}, State) ->
-    case do_send_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            %% Event-driven flush: flush batch and timers after user API call
-            FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
-            {keep_state, FlushedState, [{reply, From, ok}]};
-        {error, Reason} ->
-            {keep_state, State, [{reply, From, {error, Reason}}]}
-    end;
+    coalesced_sends([{From, StreamId, Data, Fin}], State);
 connected({call, From}, open_stream, State) ->
     case do_open_stream(State) of
         {ok, StreamId, NewState} ->
@@ -2262,15 +2266,7 @@ connected(cast, {close, Reason}, State) ->
     {next_state, draining, NewState};
 %% Async send data - fire-and-forget for high throughput
 connected(cast, {send_data_async, StreamId, Data, Fin}, State) ->
-    case do_send_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            %% Event-driven flush: flush batch and timers after user API call
-            FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
-            {keep_state, FlushedState};
-        {error, _Reason} ->
-            %% Silently drop errors in async mode
-            {keep_state, State}
-    end;
+    coalesced_sends([{async, StreamId, Data, Fin}], State);
 connected(cast, process, #state{role = client, active_n = N} = State) ->
     %% Re-enable socket for receiving (client only - server uses listener's socket)
     client_rearm_active(State, N),
@@ -3549,7 +3545,78 @@ send_frame(Frame, State) ->
 %% Decodes the payload to extract frame info for loss tracking
 %% Note: Prefer send_frame/2 when frame tuple is available
 %% Send a 1-RTT packet with explicit frames list for retransmission tracking
+%% Coalescing front end: within a drained send batch, small app
+%% packets accumulate and are emitted as one multi-frame packet.
+%% Everything downstream (packet build, loss tracking, retransmit,
+%% counters) already handles a frames list per packet, so only the
+%% emission point changes. A payload larger than the remaining budget
+%% flushes the pending packet first; coalescing off means the old
+%% one-packet-per-call behaviour, byte for byte.
+send_app_packet_internal(Payload, Frames, #state{coalesce = true} = State) ->
+    #state{pend_payload = PP, pend_frames = PF, pend_size = PS} = State,
+    Size = erlang:iolist_size(Payload),
+    Budget = get_max_stream_data_per_packet(State),
+    case PS > 0 andalso PS + Size > Budget of
+        true ->
+            State1 = flush_pending_packet(State),
+            State1#state{
+                pend_payload = [Payload],
+                pend_frames = lists:reverse(Frames),
+                pend_size = Size
+            };
+        false ->
+            State#state{
+                pend_payload = [Payload | PP],
+                pend_frames = lists:reverse(Frames, PF),
+                pend_size = PS + Size
+            }
+    end;
 send_app_packet_internal(Payload, Frames, State) ->
+    send_app_packet_now(Payload, Frames, State).
+
+%% Drain consecutive send requests already sitting in the mailbox and
+%% process them as one batch with coalescing enabled, so frames from
+%% concurrent senders share packets (issue #201). Only send messages
+%% are drained; everything else keeps its ordinary ordering. A lone
+%% send behaves exactly as before apart from a single extra receive
+%% probe.
+coalesced_sends(Acc0, State0) ->
+    Sends = drain_send_msgs(Acc0, 63),
+    {RevReplies, State1} =
+        lists:foldl(
+            fun({Tag, Sid, Data, Fin}, {Rs, S}) ->
+                case do_send_data(Sid, Data, Fin, S) of
+                    {ok, S2} -> {[{Tag, ok} | Rs], S2};
+                    {error, Reason} -> {[{Tag, {error, Reason}} | Rs], S}
+                end
+            end,
+            {[], State0#state{coalesce = true}},
+            Sends
+        ),
+    State2 = flush_pending_packet(State1#state{coalesce = false}),
+    FlushedState = flush_dirty_timers(flush_socket_batch(State2)),
+    Replies = [{reply, F, R} || {F, R} <- lists:reverse(RevReplies), F =/= async],
+    {keep_state, FlushedState, Replies}.
+
+drain_send_msgs(Acc, 0) ->
+    lists:reverse(Acc);
+drain_send_msgs(Acc, N) ->
+    receive
+        {'$gen_call', From, {send_data, Sid, D, Fin}} ->
+            drain_send_msgs([{From, Sid, D, Fin} | Acc], N - 1);
+        {'$gen_cast', {send_data_async, Sid, D, Fin}} ->
+            drain_send_msgs([{async, Sid, D, Fin} | Acc], N - 1)
+    after 0 ->
+        lists:reverse(Acc)
+    end.
+
+flush_pending_packet(#state{pend_size = 0} = State) ->
+    State;
+flush_pending_packet(#state{pend_payload = PP, pend_frames = PF} = State) ->
+    State1 = State#state{pend_payload = [], pend_frames = [], pend_size = 0},
+    send_app_packet_now(lists:reverse(PP), lists:reverse(PF), State1).
+
+send_app_packet_now(Payload, Frames, State) ->
     #state{
         dcid = DCID,
         app_keys = {ClientKeys, ServerKeys},

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1774,6 +1774,10 @@ idle(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     %% Flush batched packets and timers after processing incoming data
     FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
     check_state_transition(idle, FlushedState);
+idle(info, {udp_batch, Socket, _IP, _Port, Packets}, #state{socket = Socket} = State) ->
+    NewState = handle_packets_batch(Packets, State),
+    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    check_state_transition(idle, FlushedState);
 %% Server receives packets from listener
 idle(info, {quic_packet, Data, _RemoteAddr}, #state{role = server} = State) ->
     NewState = handle_packet(Data, State),
@@ -1865,6 +1869,10 @@ handshaking({call, From}, {send_data, StreamId, Data, Fin}, #state{early_keys = 
 handshaking(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     NewState = handle_packet(Data, State),
     %% Flush batched packets and timers after processing incoming data
+    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    check_state_transition(handshaking, FlushedState);
+handshaking(info, {udp_batch, Socket, _IP, _Port, Packets}, #state{socket = Socket} = State) ->
+    NewState = handle_packets_batch(Packets, State),
     FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
     check_state_transition(handshaking, FlushedState);
 %% Server receives packets from listener
@@ -2224,6 +2232,15 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
     State1 = State#state{current_packet_source = {IP, Port}},
     NewState = handle_packet(Data, State1),
     %% Clear packet source and flush
+    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    FinalState = FlushedState#state{current_packet_source = undefined},
+    check_state_transition(connected, FinalState);
+%% Client receives a whole GRO train from the receiver process as one
+%% message; processing it in one pass amortizes the per-event flushes
+%% over the train.
+connected(info, {udp_batch, Socket, IP, Port, Packets}, #state{socket = Socket} = State) ->
+    State1 = State#state{current_packet_source = {IP, Port}},
+    NewState = handle_packets_batch(Packets, State1),
     FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -682,6 +682,12 @@
     %% armed so the peer sees an ACK at worst max_ack_delay ms after
     %% the first ack-eliciting packet in the window.
     ack_elicited_count = 0 :: non_neg_integer(),
+    %% How many ack-eliciting 1-RTT packets to accumulate before
+    %% flushing an ACK. 2 is the RFC 9000 §13.2.1 recommendation;
+    %% higher values trade ACK traffic (and receiver CPU) for RTT
+    %% sample granularity and slower loss feedback, bounded by the
+    %% max_ack_delay timer either way.
+    ack_packet_tolerance = ?ACK_PACKET_TOLERANCE :: pos_integer(),
     ack_timer = undefined :: reference() | undefined,
     %% Transient: classification of the most recently received 1-RTT
     %% packet. Set by `record_received_pn/3' and consumed once by
@@ -1171,6 +1177,7 @@ init({server, Opts}) ->
         fc_last_stream_update = undefined,
         fc_last_conn_update = undefined,
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
+        ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
         % Server-initiated bidi: 1, 5, 9, ...
         next_stream_id_bidi = 1,
         % Server-initiated uni: 3, 7, 11, ...
@@ -1553,6 +1560,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         fc_last_stream_update = undefined,
         fc_last_conn_update = undefined,
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
+        ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
         % Client-initiated bidi: 0, 4, 8, ...
         next_stream_id_bidi = 0,
         % Client-initiated uni: 2, 6, 10, ...
@@ -4726,14 +4734,22 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
                         LostPackets
                     ),
 
-                    %% Handle PMTU probe ACKs
-                    State2 = lists:foldl(
-                        fun(#sent_packet{pn = PN}, S) ->
-                            handle_pmtu_probe_ack(PN, S)
+                    %% Handle PMTU probe ACKs. Only walk the acked list when a
+                    %% probe is actually outstanding - the common bulk-ACK case
+                    %% has none and skips the per-packet fold.
+                    State2 =
+                        case pmtu_probe_outstanding(State1) of
+                            true ->
+                                lists:foldl(
+                                    fun(#sent_packet{pn = PN}, S) ->
+                                        handle_pmtu_probe_ack(PN, S)
+                                    end,
+                                    State1,
+                                    AckedPackets
+                                );
+                            false ->
+                                State1
                         end,
-                        State1,
-                        AckedPackets
-                    ),
 
                     %% Handle PMTU probe losses
                     %% Pass packet size directly since packets are removed from sent_packets
@@ -7017,7 +7033,7 @@ maybe_send_ack(_, _, State) ->
 %% the counter and arm a max_ack_delay timer (if not already armed).
 maybe_decimate_app_ack(State) ->
     NewCount = State#state.ack_elicited_count + 1,
-    case NewCount >= ?ACK_PACKET_TOLERANCE of
+    case NewCount >= State#state.ack_packet_tolerance of
         true ->
             send_app_ack(State);
         false ->
@@ -11547,6 +11563,13 @@ maybe_set_pmtu_raise_timer(#state{pmtu_raise_timer = undefined} = State) ->
     State#state{pmtu_raise_timer = Ref};
 maybe_set_pmtu_raise_timer(State) ->
     State.
+
+%% Whether a PMTU probe packet is in flight awaiting ACK/loss.
+-spec pmtu_probe_outstanding(#state{}) -> boolean().
+pmtu_probe_outstanding(#state{pmtu_state = undefined}) ->
+    false;
+pmtu_probe_outstanding(#state{pmtu_state = #pmtu_state{probe_pn = ProbePN}}) ->
+    ProbePN =/= undefined.
 
 %% @doc Handle ACK of a potential PMTU probe packet.
 -spec handle_pmtu_probe_ack(non_neg_integer(), #state{}) -> #state{}.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2165,7 +2165,7 @@ connected(
     %% Return packet counts for liveness detection (net_kernel uses
     %% recv count to verify peer is alive) plus send-path batching
     %% counters for benchmarks and tests.
-    {Flushes, Coalesced} = send_batch_counters(SocketState),
+    {Flushes, Coalesced, GSOFlushes} = send_batch_counters(SocketState),
     Stats = #{
         packets_received => PacketsRecv,
         packets_sent => PacketsSent,
@@ -2174,7 +2174,8 @@ connected(
         ack_sent => AckSent,
         retransmits => Retransmits,
         batch_flushes => Flushes,
-        packets_coalesced => Coalesced
+        packets_coalesced => Coalesced,
+        gso_flushes => GSOFlushes
     },
     {keep_state, State, [{reply, From, {ok, Stats}}]};
 connected({call, From}, get_peer_transport_params, #state{transport_params = TP} = State) ->
@@ -9947,10 +9948,14 @@ send_gso_supported(SocketState) ->
     maps:get(gso_supported, quic_socket:info(SocketState)).
 
 send_batch_counters(undefined) ->
-    {0, 0};
+    {0, 0, 0};
 send_batch_counters(SocketState) ->
     Info = quic_socket:info(SocketState),
-    {maps:get(batch_flushes, Info), maps:get(packets_coalesced, Info)}.
+    {
+        maps:get(batch_flushes, Info),
+        maps:get(packets_coalesced, Info),
+        maps:get(gso_flushes, Info)
+    }.
 
 %% Normalize ALPN list - handles binary, list of binaries, list of strings
 normalize_alpn_list(undefined) ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -239,6 +239,10 @@
 %% ACK traffic for RTT-sample granularity.
 -define(ACK_PACKET_TOLERANCE, 2).
 
+%% Default per-drain send burst budget in packets (max_burst_packets
+%% option). See the burst_budget field.
+-define(DEFAULT_MAX_BURST_PACKETS, 64).
+
 %% Max receive buffer size in bytes (32 MB total across all streams) - protects against malicious peers
 -define(MAX_RECV_BUFFER_BYTES, 33554432).
 
@@ -681,6 +685,15 @@
     %% immediately; otherwise a max_ack_delay timer (ack_timer) is
     %% armed so the peer sees an ACK at worst max_ack_delay ms after
     %% the first ack-eliciting packet in the window.
+    %% Per-drain send burst budget (max_burst_packets option). Bounds
+    %% how many packets one drain emits before the remainder is queued
+    %% and a zero-delay pacing continuation is armed, yielding to the
+    %% event loop so ACK/loss feedback interleaves with bulk sending.
+    %% Without the bound a large cwnd lets a single send event emit
+    %% hundreds of packets back-to-back, which overflows slow receivers
+    %% (GSO bursts especially) before any loss signal is seen.
+    burst_budget = ?DEFAULT_MAX_BURST_PACKETS :: pos_integer(),
+    burst_sent = 0 :: non_neg_integer(),
     ack_elicited_count = 0 :: non_neg_integer(),
     %% How many ack-eliciting 1-RTT packets to accumulate before
     %% flushing an ACK. 2 is the RFC 9000 §13.2.1 recommendation;
@@ -1178,6 +1191,7 @@ init({server, Opts}) ->
         fc_last_conn_update = undefined,
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
         ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
+        burst_budget = maps:get(max_burst_packets, Opts, ?DEFAULT_MAX_BURST_PACKETS),
         % Server-initiated bidi: 1, 5, 9, ...
         next_stream_id_bidi = 1,
         % Server-initiated uni: 3, 7, 11, ...
@@ -1561,6 +1575,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         fc_last_conn_update = undefined,
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
         ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
+        burst_budget = maps:get(max_burst_packets, Opts, ?DEFAULT_MAX_BURST_PACKETS),
         % Client-initiated bidi: 0, 4, 8, ...
         next_stream_id_bidi = 0,
         % Client-initiated uni: 2, 6, 10, ...
@@ -3624,7 +3639,11 @@ flush_pending_packet(#state{pend_payload = PP, pend_frames = PF} = State) ->
     State1 = State#state{pend_payload = [], pend_frames = [], pend_size = 0},
     send_app_packet_now(lists:reverse(PP), lists:reverse(PF), State1).
 
-send_app_packet_now(Payload, Frames, State) ->
+%% Counts against the per-drain burst budget here rather than in
+%% send_app_packet_internal/3: with coalescing on, several sends share
+%% one packet, and the budget bounds packets on the wire.
+send_app_packet_now(Payload, Frames, State0) ->
+    State = State0#state{burst_sent = State0#state.burst_sent + 1},
     #state{
         dcid = DCID,
         app_keys = {ClientKeys, ServerKeys},
@@ -8417,6 +8436,21 @@ send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
     end.
 
 send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
+    case burst_exhausted(State) of
+        true ->
+            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+                {ok, QueuedState} ->
+                    {arm_burst_continuation(QueuedState), BytesSentSoFar};
+                {error, send_queue_full} ->
+                    {error, send_queue_full}
+            end;
+        false ->
+            send_stream_chunked_step_unbudgeted(
+                StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
+            )
+    end.
+
+send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
     {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint} = Ctx,
     #state{cc_state = CCState, pacing_enabled = PacingEnabled} = State,
     Check =
@@ -8546,7 +8580,13 @@ get_stream_urgency(StreamId, Streams) ->
 %% bytes at 0 while a real entry is pending.
 process_send_queue(#state{send_queue_count = 0} = State) ->
     State;
-process_send_queue(#state{send_queue = PQ} = State) ->
+process_send_queue(State) ->
+    case burst_exhausted(State) of
+        true -> arm_burst_continuation(State);
+        false -> process_send_queue_unbudgeted(State)
+    end.
+
+process_send_queue_unbudgeted(#state{send_queue = PQ} = State) ->
     case pqueue_peek(PQ) of
         empty ->
             State;
@@ -9690,11 +9730,11 @@ cancel_timer(Ref) -> erlang:cancel_timer(Ref).
 %% because zero-byte FIN-only entries can sit in the queue with bytes=0.
 handle_pacing_timeout(#state{send_queue_count = 0} = State) ->
     ?LOG_DEBUG(#{what => pacing_timeout_fired, queue_empty => true}, ?QUIC_LOG_META),
-    State;
+    State#state{burst_sent = 0};
 handle_pacing_timeout(State) ->
     ?LOG_DEBUG(#{what => pacing_timeout_fired, queue_empty => false}, ?QUIC_LOG_META),
-    %% Process the send queue
-    State1 = process_send_queue(State),
+    %% Fresh drain: reset the burst budget, then process the send queue
+    State1 = process_send_queue(State#state{burst_sent = 0}),
     %% If there's still queued data and pacing is blocking, set another timer
     State2 = maybe_reschedule_pacing(State1),
     %% Event-driven flush: flush batch and timers after pacing timeout processing
@@ -9824,6 +9864,21 @@ maybe_set_pacing_timer(Delay, #state{pacing_timer = undefined} = State) ->
     ?LOG_DEBUG(#{what => pacing_timer_set, delay_ms => Delay}, ?QUIC_LOG_META),
     Ref = make_ref(),
     erlang:send_after(Delay, self(), {pacing_timeout, Ref}),
+    State#state{pacing_timer = Ref}.
+
+%% Burst budget: bounds packets emitted per drain (see burst_budget).
+burst_exhausted(#state{burst_sent = Sent, burst_budget = Budget}) ->
+    Sent >= Budget.
+
+%% Arm a zero-delay pacing continuation so the queued remainder is
+%% drained in the next event-loop pass, after any pending ACK / loss
+%% feedback in the mailbox. Reuses the pacing timer and message so the
+%% drain and stale-reference handling are shared with real pacing.
+arm_burst_continuation(#state{pacing_timer = Ref} = State) when Ref =/= undefined ->
+    State;
+arm_burst_continuation(State) ->
+    Ref = make_ref(),
+    erlang:send_after(0, self(), {pacing_timeout, Ref}),
     State#state{pacing_timer = Ref}.
 
 %% Convert state to map for debugging

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -1013,15 +1013,14 @@ split_uniform_runs([], _Size, [Single]) ->
 split_uniform_runs([], Size, RunAcc) ->
     [{gso, Size, lists:reverse(RunAcc)}];
 split_uniform_runs([P | Rest], Size, RunAcc) ->
-    PSize = iolist_size(P),
-    if
-        PSize =:= Size ->
+    case iolist_size(P) of
+        Size ->
             split_uniform_runs(Rest, Size, [P | RunAcc]);
-        PSize < Size ->
+        PSize when PSize < Size ->
             %% Shorter packet closes this run as its final segment
             %% (the kernel permits a short last segment).
             [{gso, Size, lists:reverse([P | RunAcc])} | split_uniform_runs(Rest)];
-        true ->
+        PSize ->
             Head =
                 case RunAcc of
                     [Single] -> {single, Single};

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -194,6 +194,8 @@ open_for_send(RemoteIP, Opts) ->
     Backend = maps:get(backend, Opts, DetectedBackend),
     DetectedGSO = maps:get(gso, Capabilities, false),
     GSOSupported = maps:get(gso, Opts, DetectedGSO),
+    DetectedGRO = maps:get(gro, Capabilities, false),
+    GROSupported = maps:get(gro, Opts, DetectedGRO),
 
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
@@ -203,6 +205,7 @@ open_for_send(RemoteIP, Opts) ->
         socket ->
             open_send_socket_backend(Family, Opts, #{
                 gso_supported => GSOSupported,
+                gro_supported => GROSupported,
                 batching_enabled => BatchingEnabled,
                 max_batch => MaxBatch
             });
@@ -679,13 +682,17 @@ stop_client_receiver(Pid) when is_pid(Pid) ->
 %% than blocking forever in the NIF.
 client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
     %% recv_gro splits GRO-coalesced trains and sizes the read buffer
-    %% for a maximal train. A plain recvfrom here had two problems:
-    %% the default 8 KiB buffer silently truncates coalesced input,
-    %% and an unsplit train is one datagram of which the QUIC layer
-    %% can only parse the first packet.
+    %% for a maximal train; a plain recvfrom with the default 8 KiB
+    %% buffer would silently truncate coalesced input. A multi-packet
+    %% train goes to the owner as ONE message so the mailbox holds
+    %% trains, not packets, and the whole train is processed in one
+    %% receive pass.
     case recv_gro(Socket, 100) of
+        {ok, {IP, Port}, [Single]} ->
+            Owner ! {udp, Socket, IP, Port, Single},
+            client_recv_loop(SocketState, Owner);
         {ok, {IP, Port}, Packets} ->
-            [Owner ! {udp, Socket, IP, Port, Data} || Data <- Packets],
+            Owner ! {udp_batch, Socket, IP, Port, Packets},
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -815,12 +822,18 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
     %% fallback sends, which stalled handshakes and mis-segmented
     %% coalesced Initial+Handshake flights against gen_udp servers.
     GSOEnabled = maps:get(gso_supported, BatchConfig, false),
+    %% Enable GRO so a GSO-batching peer's trains arrive as one
+    %% recvmsg with a UDP_GRO cmsg instead of one syscall per segment;
+    %% recv_gro/2 already handles both shapes.
+    GROEnabled = maybe_enable_gro(Socket, #{
+        gro_supported => maps:get(gro_supported, BatchConfig, false)
+    }),
     State = #socket_state{
         socket = Socket,
         backend = socket,
         owns_socket = true,
         gso_supported = GSOEnabled,
-        gro_enabled = false,
+        gro_enabled = GROEnabled,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
     },
@@ -1242,7 +1255,7 @@ extra_socket_family(Extra) ->
 recv_gro(Socket, Timeout) ->
     %% Receive with GRO - may get coalesced packets. The buffer must
     %% hold a maximally coalesced train (64 KiB): passing 0 uses the
-    %% OTP default read buffer (8 KiB) and recvmsg silently TRUNCATES
+    %% OTP default read buffer (8 KiB) and recvmsg silently truncates
     %% any larger train, discarding every segment past the first few.
     case socket:recvmsg(Socket, 65535, 128, [], Timeout) of
         {ok, #{addr := #{addr := IP, port := Port}, iov := [Data], ctrl := Ctrl}} ->

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -93,8 +93,10 @@
     owns_socket = true :: boolean(),
     %% GSO support detected and enabled
     gso_supported = false :: boolean(),
-    %% GSO segment size for batching
-    gso_size = ?DEFAULT_GSO_SEGMENT_SIZE :: non_neg_integer(),
+    %% Segment size of the most recent GSO flush, 0 before the first one.
+    %% Derived per run from the batch: packet sizes follow the current max
+    %% datagram size, so there is no fixed value to configure.
+    gso_size = 0 :: non_neg_integer(),
     %% GRO enabled for receive
     gro_enabled = false :: boolean(),
     %% Batching enabled
@@ -112,7 +114,9 @@
     %% the batching win. batch_flushes counts each flush that actually
     %% transmitted something.
     batch_flushes = 0 :: non_neg_integer(),
-    packets_coalesced = 0 :: non_neg_integer()
+    packets_coalesced = 0 :: non_neg_integer(),
+    %% Batches the kernel segmented, as opposed to sent packet by packet.
+    gso_flushes = 0 :: non_neg_integer()
 }).
 
 %% Packet can be:
@@ -155,7 +159,6 @@ open(Port, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     case Backend of
         socket ->
@@ -163,14 +166,12 @@ open(Port, Opts) ->
                 gso_supported => GSOSupported,
                 gro_supported => GROSupported,
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             });
         gen_udp ->
             open_genudp_backend(Port, Opts, #{
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             })
     end.
 
@@ -197,21 +198,18 @@ open_for_send(RemoteIP, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     case Backend of
         socket ->
             open_send_socket_backend(Family, Opts, #{
                 gso_supported => GSOSupported,
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             });
         gen_udp ->
             open_send_genudp_backend(Family, Opts, #{
                 batching_enabled => BatchingEnabled,
-                max_batch => MaxBatch,
-                gso_size => GSOSize
+                max_batch => MaxBatch
             })
     end.
 
@@ -229,13 +227,11 @@ open_server_send({LocalIP, LocalPort}, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     BatchConfig = #{
         gso_supported => GSOSupported,
         batching_enabled => BatchingEnabled,
-        max_batch => MaxBatch,
-        gso_size => GSOSize
+        max_batch => MaxBatch
     },
 
     case Backend of
@@ -267,13 +263,12 @@ configure_server_send_socket(Socket, LocalIP, LocalPort, Family, Opts, BatchConf
     SockAddr = #{family => Family, addr => LocalIP, port => LocalPort},
     case socket:bind(Socket, SockAddr) of
         ok ->
-            GSOEnabled = maybe_enable_gso(Socket, BatchConfig),
+            GSOEnabled = maybe_enable_gso(BatchConfig),
             State = #socket_state{
                 socket = Socket,
                 backend = socket,
                 owns_socket = true,
                 gso_supported = GSOEnabled,
-                gso_size = maps:get(gso_size, BatchConfig),
                 gro_enabled = false,
                 batching_enabled = maps:get(batching_enabled, BatchConfig),
                 max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -339,7 +334,8 @@ gso_supported(#socket_state{gso_supported = Supported}) ->
         batching_enabled := boolean(),
         max_batch_packets := pos_integer(),
         batch_flushes := non_neg_integer(),
-        packets_coalesced := non_neg_integer()
+        packets_coalesced := non_neg_integer(),
+        gso_flushes := non_neg_integer()
     }.
 info(#socket_state{
     backend = Backend,
@@ -349,7 +345,8 @@ info(#socket_state{
     batching_enabled = Batching,
     max_batch_packets = MaxBatch,
     batch_flushes = Flushes,
-    packets_coalesced = Coalesced
+    packets_coalesced = Coalesced,
+    gso_flushes = GSOFlushes
 }) ->
     #{
         backend => Backend,
@@ -359,7 +356,8 @@ info(#socket_state{
         batching_enabled => Batching,
         max_batch_packets => MaxBatch,
         batch_flushes => Flushes,
-        packets_coalesced => Coalesced
+        packets_coalesced => Coalesced,
+        gso_flushes => GSOFlushes
     }.
 
 %% @doc Build a socket_state backed by caller-supplied callbacks instead
@@ -412,14 +410,12 @@ wrap(Socket, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     State = #socket_state{
         socket = Socket,
         backend = gen_udp,
         owns_socket = false,
         gso_supported = false,
-        gso_size = GSOSize,
         gro_enabled = false,
         batching_enabled = BatchingEnabled,
         max_batch_packets = MaxBatch
@@ -440,14 +436,12 @@ new_sender(Socket, Opts) ->
     BatchOpts = maps:get(batching, Opts, #{}),
     BatchingEnabled = maps:get(enabled, BatchOpts, true),
     MaxBatch = maps:get(max_packets, BatchOpts, ?DEFAULT_MAX_BATCH_PACKETS),
-    GSOSize = maps:get(gso_size, BatchOpts, ?DEFAULT_GSO_SEGMENT_SIZE),
 
     State = #socket_state{
         socket = Socket,
         backend = Backend,
         owns_socket = false,
         gso_supported = GSOSupported andalso (Backend =:= socket),
-        gso_size = GSOSize,
         gro_enabled = false,
         batching_enabled = BatchingEnabled,
         max_batch_packets = MaxBatch
@@ -533,31 +527,19 @@ flush(#socket_state{batch_count = Count, batch_addr = undefined} = State) ->
 flush(#socket_state{gso_supported = true, batch_count = 1} = State) ->
     %% Single-packet batch has no segmentation work; direct send.
     flush_individual(State);
-flush(#socket_state{gso_supported = true, batch_buffer = Buffer, gso_size = GSO} = State) ->
-    %% UDP_SEGMENT requires every segment except the last to be
-    %% exactly gso_size. Handshake flights coalesce Initial-padded-to-
-    %% 1200 with a ~400 byte Handshake packet; a naive GSO split
-    %% mis-aligns those boundaries and the client cannot decode. When
-    %% the batch is not uniform, split it into runs of equal-sized
-    %% packets and GSO each run: a single odd-sized packet (an ACK or a
-    %% flow-control update between data packets) otherwise degrades the
-    %% whole batch to one sendmsg per packet.
-    case gso_batch_uniform(Buffer, GSO) of
-        true -> flush_gso(State);
-        false -> flush_gso_runs(State)
-    end;
+flush(#socket_state{gso_supported = true} = State) ->
+    %% UDP_SEGMENT requires every segment except the last to be exactly
+    %% the segment size, so the batch goes out as runs of equal-sized
+    %% packets, one sendmsg each. The size comes from the run itself:
+    %% 1-RTT packets follow the current max datagram size, so comparing
+    %% against a configured constant never matched and the GSO path
+    %% never ran (issue #196). Handshake flights, which coalesce an
+    %% Initial padded to 1200 with a ~400 byte Handshake packet, split
+    %% into their own runs instead of being mis-segmented.
+    flush_gso_runs(State);
 flush(#socket_state{} = State) ->
     %% Fallback path - send packets individually
     flush_individual(State).
-
-%% Batch buffer is stored newest-first (head was last added). For GSO
-%% correctness we need all packets EXCEPT the last-transmitted one
-%% (which is the head of the buffer) to be exactly gso_size. The
-%% last-transmitted packet may be shorter.
-gso_batch_uniform([], _GSO) ->
-    true;
-gso_batch_uniform([_Last | Earlier], GSO) ->
-    lists:all(fun(P) -> iolist_size(P) =:= GSO end, Earlier).
 
 %% @doc Receive packets from the socket.
 %% On Linux with GRO, may return multiple coalesced packets.
@@ -786,7 +768,6 @@ build_socket_state(Socket, BatchConfig) ->
         socket = Socket,
         backend = socket,
         gso_supported = GSOEnabled,
-        gso_size = maps:get(gso_size, BatchConfig),
         gro_enabled = GROEnabled,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -796,12 +777,9 @@ build_socket_state(Socket, BatchConfig) ->
 %% Retained for open_server_send's separate-socket path, which still
 %% uses a dedicated socket where a socket-level UDP_SEGMENT is safe
 %% (it is a send-only socket, never used for short handshake packets).
-maybe_enable_gso(Socket, #{gso_supported := true, gso_size := Size}) ->
-    case socket:setopt_native(Socket, {udp, ?UDP_SEGMENT}, <<Size:32/native>>) of
-        ok -> true;
-        {error, _} -> false
-    end;
-maybe_enable_gso(_, _) ->
+maybe_enable_gso(#{gso_supported := true}) ->
+    true;
+maybe_enable_gso(_) ->
     false.
 
 maybe_enable_gro(Socket, #{gro_supported := true}) ->
@@ -842,7 +820,6 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
         backend = socket,
         owns_socket = true,
         gso_supported = GSOEnabled,
-        gso_size = maps:get(gso_size, BatchConfig),
         gro_enabled = false,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -912,7 +889,6 @@ build_genudp_state(Socket, BatchConfig) ->
         socket = Socket,
         backend = gen_udp,
         gso_supported = false,
-        gso_size = maps:get(gso_size, BatchConfig),
         gro_enabled = false,
         batching_enabled = maps:get(batching_enabled, BatchConfig),
         max_batch_packets = maps:get(max_batch, BatchConfig)
@@ -940,51 +916,6 @@ add_to_batch(
             {ok, State1}
     end.
 
-flush_gso(
-    #socket_state{
-        socket = Socket,
-        batch_buffer = Buffer,
-        batch_addr = {IP, Port},
-        gso_size = SegmentSize
-    } = State
-) ->
-    %% Pass the batch as a multi-iov to socket:sendmsg/2. The kernel
-    %% treats concatenated iov buffers as a single logical payload and
-    %% segments at SegmentSize byte boundaries via the UDP_SEGMENT
-    %% cmsg, so the wire bytes are identical to the old flatten-first
-    %% shape. We save a full user-space copy per flush (up to ~76 KB
-    %% at a 64-packet batch of 1200-byte segments).
-    Packets = lists:reverse(Buffer),
-    PacketIov = [normalize_packet(P) || P <- Packets],
-    Msg = #{
-        addr => #{family => family(IP), addr => IP, port => Port},
-        iov => PacketIov,
-        ctrl => [#{level => udp, type => ?UDP_SEGMENT, data => <<SegmentSize:16/native>>}]
-    },
-
-    case socket:sendmsg(Socket, Msg) of
-        ok ->
-            {ok, record_flush(State)};
-        {ok, RestData} ->
-            flush_gso_partial(State, IP, Port, PacketIov, RestData);
-        {error, Reason} ->
-            ?LOG_WARNING(#{what => gso_send_error, reason => Reason}),
-            {error, Reason, clear_batch(State)}
-    end.
-
-%% Partial GSO send: log, disable GSO on this socket, and retry the
-%% remaining bytes segment-by-segment.
-flush_gso_partial(State, IP, Port, PacketIov, RestData) ->
-    TotalBytes = iolist_size(PacketIov),
-    Remaining = iolist_size(RestData),
-    ?LOG_WARNING(#{
-        what => gso_partial_send,
-        sent => TotalBytes - Remaining,
-        remaining => Remaining
-    }),
-    State1 = clear_batch(State#socket_state{gso_supported = false}),
-    send_remaining_individually(State1, IP, Port, RestData).
-
 flush_individual(#socket_state{backend = socket} = State) ->
     flush_individual_socket(State);
 flush_individual(#socket_state{backend = gen_udp} = State) ->
@@ -1003,9 +934,10 @@ flush_gso_runs(
 ) ->
     Packets = lists:reverse(Buffer),
     Dest = #{family => family(IP), addr => IP, port => Port},
-    case send_runs(Socket, Dest, split_uniform_runs(Packets)) of
+    Runs = split_uniform_runs(Packets),
+    case send_runs(Socket, Dest, Runs) of
         ok ->
-            {ok, record_flush(State)};
+            {ok, record_run_flush(State, Runs)};
         {error, Reason} ->
             ?LOG_WARNING(#{what => gso_run_send_error, reason => Reason}),
             {error, Reason, clear_batch(State)}
@@ -1022,7 +954,7 @@ split_uniform_runs([P | Rest]) ->
 split_uniform_runs([], _Size, [Single]) ->
     [{single, Single}];
 split_uniform_runs([], Size, RunAcc) ->
-    [{gso, Size, lists:reverse(RunAcc)}];
+    cap_run(Size, lists:reverse(RunAcc));
 split_uniform_runs([P | Rest], Size, RunAcc) ->
     case iolist_size(P) of
         Size ->
@@ -1030,15 +962,30 @@ split_uniform_runs([P | Rest], Size, RunAcc) ->
         PSize when PSize < Size ->
             %% Shorter packet closes this run as its final segment
             %% (the kernel permits a short last segment).
-            [{gso, Size, lists:reverse([P | RunAcc])} | split_uniform_runs(Rest)];
+            cap_run(Size, lists:reverse([P | RunAcc])) ++ split_uniform_runs(Rest);
         PSize ->
             Head =
                 case RunAcc of
-                    [Single] -> {single, Single};
-                    _ -> {gso, Size, lists:reverse(RunAcc)}
+                    [Single] -> [{single, Single}];
+                    _ -> cap_run(Size, lists:reverse(RunAcc))
                 end,
-            [Head | split_uniform_runs(Rest, PSize, [P])]
+            Head ++ split_uniform_runs(Rest, PSize, [P])
     end.
+
+%% One UDP_SEGMENT write carries at most UDP_MAX_SEGMENTS segments and a
+%% payload that still fits a 16-bit UDP length, so a long run is split
+%% across writes: 64 packets of 1398 bytes is 89 KB, well over the cap.
+%% Only the final packet of the batch may be short, and it stays in the
+%% final chunk, so every chunk remains a legal segmented write.
+cap_run(SegmentSize, Packets) ->
+    PerWrite = max(1, min(?MAX_GSO_SEGMENTS, ?MAX_GSO_PAYLOAD div SegmentSize)),
+    [{gso, SegmentSize, Chunk} || Chunk <- chunk_list(Packets, PerWrite)].
+
+chunk_list(Packets, Size) when length(Packets) =< Size ->
+    [Packets];
+chunk_list(Packets, Size) ->
+    {Head, Tail} = lists:split(Size, Packets),
+    [Head | chunk_list(Tail, Size)].
 
 send_runs(_Socket, _Dest, []) ->
     ok;
@@ -1142,16 +1089,6 @@ send_packets_genudp(Socket, IP, Port, [Packet | Rest], Sent) ->
             {error, Reason, Sent}
     end.
 
-%% Send remaining data after GSO partial write (RestData is iolist)
-%% Split into segment-sized packets to preserve QUIC datagram boundaries
-send_remaining_individually(
-    #socket_state{socket = Socket, gso_size = SegmentSize} = State, IP, Port, RestData
-) ->
-    Dest = #{family => family(IP), addr => IP, port => Port},
-    Data = iolist_to_binary(RestData),
-    Packets = split_into_segments(Data, SegmentSize),
-    send_segments(Socket, Dest, Packets, State).
-
 %% Split binary data into segment-sized chunks
 split_into_segments(Data, SegmentSize) ->
     split_into_segments(Data, SegmentSize, []).
@@ -1163,15 +1100,6 @@ split_into_segments(Data, SegmentSize, Acc) when byte_size(Data) =< SegmentSize 
 split_into_segments(Data, SegmentSize, Acc) ->
     <<Segment:SegmentSize/binary, Rest/binary>> = Data,
     split_into_segments(Rest, SegmentSize, [Segment | Acc]).
-
-%% Send each segment as a separate datagram
-send_segments(_Socket, _Dest, [], State) ->
-    {ok, State};
-send_segments(Socket, Dest, [Packet | Rest], State) ->
-    case socket:sendto(Socket, Packet, Dest) of
-        ok -> send_segments(Socket, Dest, Rest, State);
-        {error, Reason} -> {error, Reason, State}
-    end.
 
 do_send_immediate(
     #socket_state{backend = adapter, adapter_send_fun = Fun} = State, IP, Port, Packet
@@ -1272,6 +1200,23 @@ record_flush(
         batch_flushes = Flushes + 1,
         packets_coalesced = Coalesced + Count
     }.
+
+%% As record_flush/1, for a batch the kernel segmented. gso_flushes
+%% counts only those: batch_flushes and packets_coalesced advance on the
+%% individual path too, so a ratio over them proves batching, not
+%% offload, and stayed green while the GSO path was dead (issue #196).
+%% gso_size records the segment size that actually went on the wire.
+record_run_flush(State, Runs) ->
+    State1 = record_flush(State),
+    case [Size || {gso, Size, _} <- Runs] of
+        [] ->
+            State1;
+        [Size | _] = Sizes ->
+            State1#socket_state{
+                gso_flushes = State#socket_state.gso_flushes + length(Sizes),
+                gso_size = Size
+            }
+    end.
 
 %% Get address family
 family({_, _, _, _}) -> inet;

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -124,6 +124,17 @@
 -opaque socket_state() :: #socket_state{}.
 -export_type([socket_state/0, packet_view/0]).
 
+-ifdef(TEST).
+%% GRO/GSO batching internals. These are pure and the kernel features
+%% they serve are Linux-only, so unit tests reach them directly rather
+%% than needing a socket that supports UDP_GRO or UDP_SEGMENT.
+-export([
+    extract_gro_segment_size/1,
+    split_gro_packets/2,
+    split_uniform_runs/1
+]).
+-endif.
+
 %%====================================================================
 %% API
 %%====================================================================

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -682,9 +682,14 @@ stop_client_receiver(Pid) when is_pid(Pid) ->
 %% exit signals from the linked owner are processed promptly rather
 %% than blocking forever in the NIF.
 client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
-    case socket:recvfrom(Socket, 0, [], 100) of
-        {ok, {#{addr := IP, port := Port}, Data}} ->
-            Owner ! {udp, Socket, IP, Port, Data},
+    %% recv_gro splits GRO-coalesced trains and sizes the read buffer
+    %% for a maximal train. A plain recvfrom here had two problems:
+    %% the default 8 KiB buffer silently truncates coalesced input,
+    %% and an unsplit train is one datagram of which the QUIC layer
+    %% can only parse the first packet.
+    case recv_gro(Socket, 100) of
+        {ok, {IP, Port}, Packets} ->
+            [Owner ! {udp, Socket, IP, Port, Data} || Data <- Packets],
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -1186,8 +1191,11 @@ extra_socket_family(Extra) ->
 %%====================================================================
 
 recv_gro(Socket, Timeout) ->
-    %% Receive with GRO - may get coalesced packets
-    case socket:recvmsg(Socket, 0, 128, [], Timeout) of
+    %% Receive with GRO - may get coalesced packets. The buffer must
+    %% hold a maximally coalesced train (64 KiB): passing 0 uses the
+    %% OTP default read buffer (8 KiB) and recvmsg silently TRUNCATES
+    %% any larger train, discarding every segment past the first few.
+    case socket:recvmsg(Socket, 65535, 128, [], Timeout) of
         {ok, #{addr := #{addr := IP, port := Port}, iov := [Data], ctrl := Ctrl}} ->
             %% Check for GRO segment size in control messages
             case extract_gro_segment_size(Ctrl) of

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -815,6 +815,7 @@ open_send_socket_backend(Family, Opts, BatchConfig) ->
 configure_send_socket(Socket, Opts, BatchConfig) ->
     ok = socket:setopt(Socket, {socket, reuseaddr}, true),
     set_socket_buffer_sizes(Socket, Opts),
+    maybe_bind_source(Socket, Opts),
     %% GSO is applied per-message via the UDP_SEGMENT cmsg in
     %% flush_gso/1, never as a socket-level setsockopt. A socket-level
     %% UDP_SEGMENT would force GSO segmentation on every outbound
@@ -838,6 +839,32 @@ configure_send_socket(Socket, Opts, BatchConfig) ->
         max_batch_packets = maps:get(max_batch, BatchConfig)
     },
     {ok, State}.
+
+%% Honor a specific source address from extra_socket_opts {ip, Addr},
+%% as the gen_udp client path does. Without the bind the kernel
+%% picks the source per route (127.0.0.1 for loopback), which
+%% misidentifies the sender on multi-address hosts.
+maybe_bind_source(Socket, Opts) ->
+    case proplists:get_value(ip, maps:get(extra_socket_opts, Opts, []), undefined) of
+        undefined ->
+            ok;
+        BindAddr ->
+            case
+                socket:bind(Socket, #{
+                    family => family(BindAddr), addr => BindAddr, port => 0
+                })
+            of
+                ok ->
+                    ok;
+                {error, BindErr} ->
+                    ?LOG_WARNING(#{
+                        what => client_source_bind_failed,
+                        addr => BindAddr,
+                        reason => BindErr
+                    }),
+                    ok
+            end
+    end.
 
 %% Open gen_udp backend optimized for sending (ephemeral port)
 open_send_genudp_backend(Family, Opts, BatchConfig) ->

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -1208,7 +1208,14 @@ recv_gro(Socket, Timeout) ->
 
 extract_gro_segment_size([]) ->
     undefined;
-extract_gro_segment_size([#{level := udp, type := ?UDP_GRO, data := <<Size:16/native>>} | _]) ->
+extract_gro_segment_size([
+    #{level := udp, type := ?UDP_GRO, data := <<Size:16/native, _/binary>>} | _
+]) ->
+    %% The kernel's UDP_GRO cmsg payload is an int (4 bytes); matching
+    %% exactly 2 bytes made every lookup fail, so a GRO-coalesced buffer
+    %% was passed up unsplit as one giant datagram and dropped by the
+    %% QUIC layer (short-header packets cannot be re-split). Accept the
+    %% int and read the low 16 bits.
     Size;
 extract_gro_segment_size([_ | Rest]) ->
     extract_gro_segment_size(Rest).

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -527,10 +527,13 @@ flush(#socket_state{gso_supported = true, batch_buffer = Buffer, gso_size = GSO}
     %% exactly gso_size. Handshake flights coalesce Initial-padded-to-
     %% 1200 with a ~400 byte Handshake packet; a naive GSO split
     %% mis-aligns those boundaries and the client cannot decode. When
-    %% the batch is not uniform, fall through to individual sends.
+    %% the batch is not uniform, split it into runs of equal-sized
+    %% packets and GSO each run: a single odd-sized packet (an ACK or a
+    %% flow-control update between data packets) otherwise degrades the
+    %% whole batch to one sendmsg per packet.
     case gso_batch_uniform(Buffer, GSO) of
         true -> flush_gso(State);
-        false -> flush_individual(State)
+        false -> flush_gso_runs(State)
     end;
 flush(#socket_state{} = State) ->
     %% Fallback path - send packets individually
@@ -975,6 +978,97 @@ flush_individual(#socket_state{backend = socket} = State) ->
     flush_individual_socket(State);
 flush_individual(#socket_state{backend = gen_udp} = State) ->
     flush_individual_genudp(State).
+
+%% Mixed-size batch on a GSO socket: send it as runs of equal-sized
+%% packets, each run in one UDP_SEGMENT sendmsg, odd-sized packets
+%% individually, preserving wire order. A run may absorb one shorter
+%% trailing packet (the kernel allows a short final segment).
+flush_gso_runs(
+    #socket_state{
+        socket = Socket,
+        batch_buffer = Buffer,
+        batch_addr = {IP, Port}
+    } = State
+) ->
+    Packets = lists:reverse(Buffer),
+    Dest = #{family => family(IP), addr => IP, port => Port},
+    case send_runs(Socket, Dest, split_uniform_runs(Packets)) of
+        ok ->
+            {ok, record_flush(State)};
+        {error, Reason} ->
+            ?LOG_WARNING(#{what => gso_run_send_error, reason => Reason}),
+            {error, Reason, clear_batch(State)}
+    end.
+
+%% Group an oldest-first packet list into {gso, SegmentSize, Packets}
+%% runs (>= 2 packets, all SegmentSize except possibly a shorter last)
+%% and {single, Packet} entries, preserving order.
+split_uniform_runs([]) ->
+    [];
+split_uniform_runs([P | Rest]) ->
+    split_uniform_runs(Rest, iolist_size(P), [P]).
+
+split_uniform_runs([], _Size, [Single]) ->
+    [{single, Single}];
+split_uniform_runs([], Size, RunAcc) ->
+    [{gso, Size, lists:reverse(RunAcc)}];
+split_uniform_runs([P | Rest], Size, RunAcc) ->
+    PSize = iolist_size(P),
+    if
+        PSize =:= Size ->
+            split_uniform_runs(Rest, Size, [P | RunAcc]);
+        PSize < Size ->
+            %% Shorter packet closes this run as its final segment
+            %% (the kernel permits a short last segment).
+            [{gso, Size, lists:reverse([P | RunAcc])} | split_uniform_runs(Rest)];
+        true ->
+            Head =
+                case RunAcc of
+                    [Single] -> {single, Single};
+                    _ -> {gso, Size, lists:reverse(RunAcc)}
+                end,
+            [Head | split_uniform_runs(Rest, PSize, [P])]
+    end.
+
+send_runs(_Socket, _Dest, []) ->
+    ok;
+send_runs(Socket, Dest, [{single, Packet} | Rest]) ->
+    Msg = #{addr => Dest, iov => [normalize_packet(Packet)]},
+    case socket:sendmsg(Socket, Msg) of
+        ok -> send_runs(Socket, Dest, Rest);
+        {ok, _RestData} -> send_runs(Socket, Dest, Rest);
+        {error, _} = Error -> Error
+    end;
+send_runs(Socket, Dest, [{gso, SegmentSize, Packets} | Rest]) ->
+    PacketIov = [normalize_packet(P) || P <- Packets],
+    Msg = #{
+        addr => Dest,
+        iov => PacketIov,
+        ctrl => [#{level => udp, type => ?UDP_SEGMENT, data => <<SegmentSize:16/native>>}]
+    },
+    case socket:sendmsg(Socket, Msg) of
+        ok ->
+            send_runs(Socket, Dest, Rest);
+        {ok, RestData} ->
+            %% Kernel refused part of the segmented write: send the
+            %% remainder segment-by-segment, then continue with the
+            %% remaining runs (mirrors flush_gso_partial).
+            Data = iolist_to_binary(RestData),
+            case send_run_segments(Socket, Dest, split_into_segments(Data, SegmentSize)) of
+                ok -> send_runs(Socket, Dest, Rest);
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+send_run_segments(_Socket, _Dest, []) ->
+    ok;
+send_run_segments(Socket, Dest, [Packet | Rest]) ->
+    case socket:sendto(Socket, Packet, Dest) of
+        ok -> send_run_segments(Socket, Dest, Rest);
+        {error, _} = Error -> Error
+    end.
 
 flush_individual_socket(
     #socket_state{

--- a/test/quic_gro_gso_batching_tests.erl
+++ b/test/quic_gro_gso_batching_tests.erl
@@ -1,0 +1,146 @@
+%%% -*- erlang -*-
+%%%
+%%% GRO receive splitting and GSO send batching.
+%%%
+%%% Both features are Linux-only and need kernel support to exercise
+%%% end to end, but the parts that decide what happens are pure: reading
+%%% the segment size out of the UDP_GRO control message, splitting a
+%%% coalesced train back into datagrams, and grouping a mixed-size send
+%%% batch into runs that UDP_SEGMENT can carry. These tests reach those
+%%% directly, so they run and mean something on any platform.
+%%%
+%%% Covers PRs #204 and #217.
+
+-module(quic_gro_gso_batching_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Must match quic_socket.
+-define(UDP_GRO, 104).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% The kernel hands UDP_GRO up as an int, which is 4 bytes on every
+%% platform this runs on.
+gro_cmsg(Size) ->
+    #{level => udp, type => ?UDP_GRO, data => <<Size:32/native>>}.
+
+other_cmsg() ->
+    #{level => ip, type => 8, data => <<0, 0, 0, 0>>}.
+
+pkt(N, Size) ->
+    binary:copy(<<N>>, Size).
+
+%%====================================================================
+%% Reading the GRO segment size (#204)
+%%====================================================================
+
+reads_the_int_sized_cmsg_test() ->
+    %% The whole bug in one line: the payload is an int, so a pattern
+    %% that accepts only two bytes never matches and the size is never
+    %% found. A missed size means the coalesced buffer goes up unsplit
+    %% as one oversized datagram, and the QUIC layer drops it because
+    %% short-header packets cannot be re-split.
+    ?assertEqual(1200, quic_socket:extract_gro_segment_size([gro_cmsg(1200)])).
+
+reads_it_past_other_control_messages_test() ->
+    Cmsgs = [other_cmsg(), gro_cmsg(1452), other_cmsg()],
+    ?assertEqual(1452, quic_socket:extract_gro_segment_size(Cmsgs)).
+
+reads_a_full_mtu_segment_size_test() ->
+    ?assertEqual(65535, quic_socket:extract_gro_segment_size([gro_cmsg(65535)])).
+
+no_cmsgs_means_no_size_test() ->
+    ?assertEqual(undefined, quic_socket:extract_gro_segment_size([])).
+
+unrelated_cmsgs_mean_no_size_test() ->
+    ?assertEqual(undefined, quic_socket:extract_gro_segment_size([other_cmsg(), other_cmsg()])).
+
+%%====================================================================
+%% Splitting a coalesced train (#204's consequence)
+%%====================================================================
+
+splits_an_exact_multiple_test() ->
+    Train = binary:copy(<<"a">>, 3600),
+    Parts = quic_socket:split_gro_packets(Train, 1200),
+    ?assertEqual(3, length(Parts)),
+    ?assert(lists:all(fun(P) -> byte_size(P) =:= 1200 end, Parts)).
+
+splits_with_a_short_final_segment_test() ->
+    %% The last datagram of a train is usually shorter, and must survive
+    %% rather than being padded or dropped.
+    Train = binary:copy(<<"a">>, 2500),
+    Parts = quic_socket:split_gro_packets(Train, 1200),
+    ?assertEqual([1200, 1200, 100], [byte_size(P) || P <- Parts]).
+
+splits_a_single_short_datagram_test() ->
+    Parts = quic_socket:split_gro_packets(binary:copy(<<"a">>, 40), 1200),
+    ?assertEqual([40], [byte_size(P) || P <- Parts]).
+
+split_preserves_the_payload_test() ->
+    Train = <<(pkt(1, 1200))/binary, (pkt(2, 1200))/binary, (pkt(3, 300))/binary>>,
+    Parts = quic_socket:split_gro_packets(Train, 1200),
+    ?assertEqual([pkt(1, 1200), pkt(2, 1200), pkt(3, 300)], Parts),
+    ?assertEqual(Train, iolist_to_binary(Parts)).
+
+%%====================================================================
+%% Grouping a send batch into GSO runs (#217)
+%%====================================================================
+
+uniform_batch_is_one_run_test() ->
+    Packets = [pkt(N, 1200) || N <- lists:seq(1, 4)],
+    ?assertMatch([{gso, 1200, _}], quic_socket:split_uniform_runs(Packets)).
+
+single_packet_is_not_a_gso_run_test() ->
+    %% One packet has nothing to segment, so it goes out on its own
+    %% rather than through UDP_SEGMENT.
+    ?assertMatch([{single, _}], quic_socket:split_uniform_runs([pkt(1, 1200)])).
+
+empty_batch_is_empty_test() ->
+    ?assertEqual([], quic_socket:split_uniform_runs([])).
+
+a_short_trailing_packet_joins_the_run_test() ->
+    %% The kernel permits a short final segment, so an ACK behind a run
+    %% of full packets does not need a send of its own.
+    Packets = [pkt(1, 1200), pkt(2, 1200), pkt(3, 40)],
+    ?assertMatch([{gso, 1200, [_, _, _]}], quic_socket:split_uniform_runs(Packets)).
+
+a_larger_packet_starts_a_new_run_test() ->
+    %% Growing sizes cannot share one UDP_SEGMENT call: only the final
+    %% segment may be short.
+    Packets = [pkt(1, 40), pkt(2, 40), pkt(3, 1200)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    ?assert(length(Runs) >= 2).
+
+wire_order_and_payloads_survive_test() ->
+    %% The property that actually matters: whatever the grouping, every
+    %% packet goes out exactly once and in the order it was queued.
+    Packets = [pkt(1, 1200), pkt(2, 40), pkt(3, 1200), pkt(4, 1200), pkt(5, 300)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    Flat = lists:flatmap(
+        fun
+            ({gso, _Size, Ps}) -> Ps;
+            ({single, P}) -> [P]
+        end,
+        Runs
+    ),
+    ?assertEqual(Packets, Flat).
+
+every_run_is_gso_legal_test() ->
+    %% UDP_SEGMENT requires every segment except the last to be exactly
+    %% the segment size. A run that breaks that is rejected by the
+    %% kernel or splits the datagrams in the wrong place.
+    Packets = [pkt(1, 1200), pkt(2, 1200), pkt(3, 40), pkt(4, 800), pkt(5, 800), pkt(6, 20)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    [ok = assert_run_legal(R) || R <- Runs],
+    ok.
+
+assert_run_legal({single, _P}) ->
+    ok;
+assert_run_legal({gso, Size, Ps}) ->
+    {AllButLast, [Last]} = lists:split(length(Ps) - 1, Ps),
+    ?assert(lists:all(fun(P) -> byte_size(P) =:= Size end, AllButLast)),
+    ?assert(byte_size(Last) =< Size),
+    ok.

--- a/test/quic_gro_gso_batching_tests.erl
+++ b/test/quic_gro_gso_batching_tests.erl
@@ -144,3 +144,49 @@ assert_run_legal({gso, Size, Ps}) ->
     ?assert(lists:all(fun(P) -> byte_size(P) =:= Size end, AllButLast)),
     ?assert(byte_size(Last) =< Size),
     ok.
+
+%%====================================================================
+%% Per-write kernel limits (#200)
+%%====================================================================
+
+%% One UDP_SEGMENT write takes at most 64 segments and a payload that
+%% fits a 16-bit UDP length. 64 packets of 1398 bytes is 89 KB, so a
+%% full batch has to become more than one write.
+a_full_batch_of_mtu_packets_splits_across_writes_test() ->
+    Packets = [pkt(N rem 251, 1398) || N <- lists:seq(1, 64)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    ?assert(length(Runs) > 1),
+    [
+        begin
+            ?assert(length(Ps) =< 64),
+            ?assert(lists:sum([byte_size(P) || P <- Ps]) =< 65535)
+        end
+     || {gso, _Size, Ps} <- Runs
+    ],
+    ok.
+
+%% Splitting for the write limit must not drop, duplicate or reorder
+%% anything, and each piece must still be a legal segmented write.
+capped_runs_keep_every_packet_in_order_test() ->
+    Packets = [pkt(N rem 251, 1398) || N <- lists:seq(1, 100)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    Flat = lists:append([
+        case R of
+            {single, P} -> [P];
+            {gso, _, Ps} -> Ps
+        end
+     || R <- Runs
+    ]),
+    ?assertEqual(Packets, Flat),
+    [ok = assert_run_legal(R) || R <- Runs],
+    ok.
+
+%% A short final packet is the batch's last segment, so it must land in
+%% the final write rather than being carried into an earlier one.
+a_capped_run_keeps_the_short_packet_last_test() ->
+    Packets = [pkt(1, 1398) || _ <- lists:seq(1, 64)] ++ [pkt(2, 200)],
+    Runs = quic_socket:split_uniform_runs(Packets),
+    {gso, _, LastPs} = lists:last(Runs),
+    ?assertEqual(200, byte_size(lists:last(LastPs))),
+    [ok = assert_run_legal(R) || R <- Runs],
+    ok.

--- a/test/quic_pacing_burst_tests.erl
+++ b/test/quic_pacing_burst_tests.erl
@@ -1,0 +1,137 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for the pacing burst allowance.
+%%%
+%%% Pacing wakeups run on send_after, which has roughly millisecond
+%%% resolution. A burst bucket fixed at 12 packets therefore caps
+%%% throughput at 12 packets per wakeup whenever the sender outruns the
+%%% incoming ACK clock, no matter how high the paced rate is. The
+%%% allowance has to scale with the rate: 2 ms worth of tokens keeps
+%%% micro-bursts bounded while letting a 1 ms clock sustain the rate.
+%%%
+%%% pacing_max_burst has no accessor, but it is observable: the token
+%%% bucket refills to min(MaxBurst, tokens + elapsed * rate) and
+%%% get_pacing_tokens/2 hands back min(Size, tokens). Once enough time
+%%% has passed for the bucket to saturate, asking for more than it can
+%%% ever hold returns exactly MaxBurst.
+%%%
+%%% Covers PR #219.
+
+-module(quic_pacing_burst_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MDS, 1200).
+%% Larger than any burst under test, so the answer is bucket-limited.
+-define(HUGE, (1 bsl 30)).
+-define(STEP_MS, 10).
+-define(MAX_WAIT_MS, 2000).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Read back the burst ceiling.
+%%
+%% Every probe runs against the same input state, so each one sees a
+%% longer elapsed time than the last and the refill grows monotonically
+%% until it saturates at pacing_max_burst. Two consecutive equal reads
+%% mean the bucket is full. Polling rather than sleeping a fixed
+%% interval keeps this honest at low rates, where filling the bucket
+%% takes far longer, without re-deriving the formula under test.
+burst_ceiling(State) ->
+    converge(State, quic_cc_newreno:get_pacing_tokens(State, ?HUGE), 0).
+
+converge(_State, {V, _}, Waited) when Waited >= ?MAX_WAIT_MS ->
+    %% Never saturated: report what we saw so the failure is legible.
+    {did_not_saturate, V};
+converge(State, {Prev, _}, Waited) ->
+    timer:sleep(?STEP_MS),
+    case quic_cc_newreno:get_pacing_tokens(State, ?HUGE) of
+        {Prev, _} -> Prev;
+        Next -> converge(State, Next, Waited + ?STEP_MS)
+    end.
+
+%% quic_cc_newreno stores the rate in milli-bytes per microsecond:
+%% max(1, (cwnd * 1250) div (rtt_ms * 1000)).
+rate(Cwnd, RttMs) ->
+    max(1, (Cwnd * 1250) div (RttMs * 1000)).
+
+paced(Cwnd, RttMs) ->
+    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS, initial_window => Cwnd}),
+    quic_cc_newreno:update_pacing_rate(State, RttMs).
+
+%%====================================================================
+%% Baseline
+%%====================================================================
+
+unpaced_until_a_rate_exists_test() ->
+    %% Straight out of new/1 there is no rate yet, so pacing does not
+    %% gate anything and a send of any size is allowed through. The burst
+    %% allowance only becomes observable once a rate is set.
+    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS}),
+    ?assert(quic_cc_newreno:pacing_allows(State, ?HUGE)),
+    ?assertEqual({?HUGE, State}, quic_cc_newreno:get_pacing_tokens(State, ?HUGE)).
+
+%%====================================================================
+%% The allowance scales with the rate
+%%====================================================================
+
+burst_scales_with_pacing_rate_test() ->
+    %% A fat window on a short RTT: 2 ms of rate is far above the
+    %% 12-packet floor, so the floor must not be what caps the bucket.
+    Cwnd = 4000000,
+    RttMs = 10,
+    Rate = rate(Cwnd, RttMs),
+    Expected = max(12 * ?MDS, 2 * Rate),
+    ?assert(Expected > 12 * ?MDS),
+    ?assertEqual(Expected, burst_ceiling(paced(Cwnd, RttMs))).
+
+burst_keeps_the_floor_at_low_rates_test() ->
+    %% A small window on a long RTT: 2 ms of rate is below the floor,
+    %% which must still hold. Scaling the allowance must not be a way to
+    %% shrink it.
+    Cwnd = 12000,
+    RttMs = 500,
+    Rate = rate(Cwnd, RttMs),
+    ?assert(2 * Rate < 12 * ?MDS),
+    ?assertEqual(12 * ?MDS, burst_ceiling(paced(Cwnd, RttMs))).
+
+burst_is_monotonic_in_rate_test() ->
+    %% Same RTT, growing window: the allowance may plateau on the floor
+    %% but must never move backwards as the rate rises.
+    Ceilings = [burst_ceiling(paced(Cwnd, 20)) || Cwnd <- [12000, 120000, 1200000, 12000000]],
+    ?assertEqual(lists:sort(Ceilings), Ceilings),
+    ?assert(lists:last(Ceilings) > hd(Ceilings)).
+
+%%====================================================================
+%% MTU changes recompute the same way
+%%====================================================================
+
+update_mtu_scales_burst_with_rate_test() ->
+    %% update_mtu recomputes the allowance and must apply the same rule,
+    %% otherwise a PMTU probe silently reinstates the fixed bucket.
+    Cwnd = 4000000,
+    RttMs = 10,
+    Rate = rate(Cwnd, RttMs),
+    Paced = paced(Cwnd, RttMs),
+    Bumped = quic_cc_newreno:update_mtu(Paced, 1400),
+    ?assertEqual(1400, quic_cc_newreno:max_datagram_size(Bumped)),
+    ?assertEqual(max(12 * 1400, 2 * Rate), burst_ceiling(Bumped)).
+
+update_mtu_keeps_the_floor_at_low_rates_test() ->
+    Cwnd = 12000,
+    RttMs = 500,
+    Paced = paced(Cwnd, RttMs),
+    Bumped = quic_cc_newreno:update_mtu(Paced, 1400),
+    ?assertEqual(12 * 1400, burst_ceiling(Bumped)).
+
+%%====================================================================
+%% Degenerate input
+%%====================================================================
+
+zero_rtt_leaves_pacing_untouched_test() ->
+    %% No RTT sample yet: update_pacing_rate is a no-op, so the state is
+    %% returned unchanged and sends stay unpaced.
+    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS}),
+    ?assertEqual(State, quic_cc_newreno:update_pacing_rate(State, 0)).

--- a/test/quic_send_batching_opts_tests.erl
+++ b/test/quic_send_batching_opts_tests.erl
@@ -1,0 +1,112 @@
+%%% -*- erlang -*-
+%%%
+%%% Options and socket wiring on the batched send/receive path.
+%%%
+%%% GSO and GRO themselves need a Linux kernel, so what is covered here
+%%% is what does not: the source bind the client performs, and the two
+%%% send-path options staying honest end to end. A too-small burst
+%%% budget or ACK tolerance must slow a transfer down, never stall or
+%%% corrupt it.
+
+-module(quic_send_batching_opts_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PAYLOAD_SIZE, 262144).
+
+%%====================================================================
+%% Client source bind (#261)
+%%====================================================================
+
+%% The socket backend used to leave the source address to the kernel's
+%% route lookup, which picks a different address than the caller asked
+%% for on a multi-address host.
+client_binds_the_requested_source_address_test() ->
+    {ok, State} = quic_socket:open_for_send({127, 0, 0, 1}, #{
+        backend => socket,
+        extra_socket_opts => [{ip, {127, 0, 0, 1}}]
+    }),
+    try
+        {ok, {Addr, Port}} = quic_socket:sockname(State),
+        ?assertEqual({127, 0, 0, 1}, Addr),
+        ?assert(Port > 0)
+    after
+        quic_socket:close(State)
+    end.
+
+%% Without the option the kernel still chooses, and the socket is
+%% usable: the bind is opt-in, not a new requirement.
+client_without_a_source_option_still_opens_test() ->
+    {ok, State} = quic_socket:open_for_send({127, 0, 0, 1}, #{backend => socket}),
+    try
+        ?assertMatch({ok, {_Addr, _Port}}, quic_socket:sockname(State))
+    after
+        quic_socket:close(State)
+    end.
+
+%%====================================================================
+%% Send-path options (#213, #214)
+%%====================================================================
+
+burst_budget_test_() ->
+    {timeout, 30, fun a_small_burst_budget_still_delivers/0}.
+
+ack_tolerance_test_() ->
+    {timeout, 30, fun a_tight_ack_tolerance_still_delivers/0}.
+
+%% max_burst_packets bounds how many packets leave per drain. Setting it
+%% far below the default must only add drains, never drop the remainder
+%% of the queue.
+a_small_burst_budget_still_delivers() ->
+    ?assertEqual(?PAYLOAD_SIZE, echo_roundtrip(#{max_burst_packets => 4})).
+
+%% ack_packet_tolerance controls how many ack-eliciting packets pile up
+%% before an ACK goes out. 1 acks every packet, which is legal and just
+%% chattier.
+a_tight_ack_tolerance_still_delivers() ->
+    ?assertEqual(?PAYLOAD_SIZE, echo_roundtrip(#{ack_packet_tolerance => 1})).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+echo_roundtrip(ExtraClientOpts) ->
+    Windows = #{
+        max_data => 16 * 1024 * 1024,
+        max_stream_data_bidi_local => 8 * 1024 * 1024,
+        max_stream_data_bidi_remote => 8 * 1024 * 1024,
+        max_stream_data_uni => 8 * 1024 * 1024
+    },
+    {ok, Srv} = quic_test_echo_server:start(Windows),
+    try
+        #{port := Port} = Srv,
+        Opts = maps:merge(
+            maps:merge(quic_test_echo_server:client_opts(), Windows),
+            ExtraClientOpts
+        ),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, Opts, self()),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> error(connect_timeout)
+            end,
+            {ok, StreamId} = quic:open_stream(Conn),
+            Payload = binary:copy(<<"x">>, ?PAYLOAD_SIZE),
+            ok = quic:send_data(Conn, StreamId, Payload, true),
+            byte_size(collect(Conn, StreamId, <<>>))
+        after
+            quic:safe_close(Conn, normal)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+collect(Conn, StreamId, Acc) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            collect(Conn, StreamId, <<Acc/binary, Data/binary>>)
+    after 20000 ->
+        Acc
+    end.

--- a/test/quic_server_batching_SUITE.erl
+++ b/test/quic_server_batching_SUITE.erl
@@ -176,20 +176,27 @@ server_download_uses_gso_on_linux(Config) ->
 
                 Flushes = maps:get(batch_flushes, Delta),
                 Coalesced = maps:get(packets_coalesced, Delta),
+                GSOFlushes = maps:get(gso_flushes, Delta),
                 Ratio =
                     case Flushes of
                         0 -> 0.0;
                         _ -> Coalesced / Flushes
                     end,
                 ct:log(
-                    "GSO delta: flushes=~p coalesced=~p ratio=~.2f",
-                    [Flushes, Coalesced, float(Ratio)]
+                    "GSO delta: flushes=~p coalesced=~p gso_flushes=~p ratio=~.2f",
+                    [Flushes, Coalesced, GSOFlushes, float(Ratio)]
                 ),
                 %% On Linux + GSO the download-path batches should
                 %% coalesce significantly. A ratio > 1.5 proves real
                 %% coalescing on top of the Coalesced > Flushes check.
                 ?assert(Coalesced > Flushes),
-                ?assert(Ratio > 1.5)
+                ?assert(Ratio > 1.5),
+                %% Coalescing alone only proves the packets were
+                %% batched: both flush paths bump those counters, which
+                %% is why this suite stayed green while the GSO path was
+                %% dead (issue #196). gso_flushes counts the batches the
+                %% kernel actually segmented.
+                ?assert(GSOFlushes > 0)
             after
                 stop_server(Srv)
             end,
@@ -297,7 +304,7 @@ stats_delta(After, Before) ->
     maps:from_list(
         [
             {K, maps:get(K, After, 0) - maps:get(K, Before, 0)}
-         || K <- [packets_sent, batch_flushes, packets_coalesced]
+         || K <- [packets_sent, batch_flushes, packets_coalesced, gso_flushes]
         ]
     ).
 


### PR DESCRIPTION
Aggregates #262, #200, #213, #214, #248 and #261, commits keeping their authors.

#262 and #200 both rewrite `flush/1` and each missed what the other fixed, so they are merged by hand: run splitting and the cmsg and buffer fixes from #262; per-run segment size, write caps and per-message `UDP_SEGMENT` from #200. The fixed-size gate is dropped rather than kept beside the splitter, since it never matched a 1-RTT packet and that is why GSO never ran.

Burst counting moved to `send_app_packet_now/3`: with coalescing several sends share one packet. #248's receive loop replaces #262's, delivering a GRO train as one message.

GSO and GRO need Linux, so the new tests cover the write cap, the source bind, and small budgets still delivering. `gso_flushes` is what the Linux job asserts, since `batch_flushes` advances on both flush paths.

Closes #196.