### PR TITLE
Handshake reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ All notable changes to this project will be documented in this file.
   flow-control limit also sends the part that fits rather than nothing,
   which is what lets the recovered connection drain its queue.
   Contributed by jbevemyr (#252, #230, #225).
+- Anti-amplification accounting (RFC 9000 §8.1) now also runs on the batched listener delivery path. A server whose ClientHello arrived in a GRO batch kept its amp budget at zero, deferred the handshake flight, and the handshake wedged until the connect timeout. (#263)
+- A server handshake flight lost on the wire is retransmitted on the client-Initial backoff schedule until the client's Finished arrives. Initial/Handshake packets are not loss-tracked, so a lost flight previously wedged the handshake permanently: the client's Initial retransmits only elicited ACKs once the server TLS state had advanced. (#263)
 
 ## [1.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- The client's retained Finished flight carries its own retransmission
+  timer. Once the state machine leaves the handshake nothing is
+  guaranteed to be in flight to arm a PTO, so a Finished lost more than
+  once was never resent and the handshake stalled until the idle timeout.
 - The GSO segment size is derived from the batch instead of a
   configured constant. 1-RTT packets follow the current max datagram
   size, so the uniformity check against the fixed 1200 never matched and
@@ -77,21 +81,6 @@ All notable changes to this project will be documented in this file.
   past the first few. The client receiver also went through a plain
   `recvfrom', which never split trains at all. Contributed by jbevemyr
   (#215).
-
-### Changed
-- A mixed-size send batch on a GSO socket is split into runs of
-  equal-sized packets and each run sent with one UDP_SEGMENT call,
-  instead of falling back to one `sendmsg' per packet. A single
-  odd-sized packet between data packets (an ACK, a flow-control update)
-  previously degraded the whole batch. Contributed by jbevemyr (#217).
-- Small sends are coalesced into shared packets. Contributed by jbevemyr
-  (#203).
-- The pacing burst allowance scales with the pacing rate rather than
-  sitting at a fixed 12 packets. Pacing wakeups have roughly
-  millisecond resolution, so the fixed bucket capped throughput at 12
-  packets per wakeup whenever the sender outran the ACK clock,
-  regardless of the configured rate. Contributed by jbevemyr (#219).
-### Fixed
 - A client whose Finished is lost now recovers. The
   Certificate(+CertificateVerify)+Finished flight goes out at the
   Handshake level, and once the client state machine left `handshaking'
@@ -108,6 +97,20 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#252, #230, #225).
 - Anti-amplification accounting (RFC 9000 §8.1) now also runs on the batched listener delivery path. A server whose ClientHello arrived in a GRO batch kept its amp budget at zero, deferred the handshake flight, and the handshake wedged until the connect timeout. (#263)
 - A server handshake flight lost on the wire is retransmitted on the client-Initial backoff schedule until the client's Finished arrives. Initial/Handshake packets are not loss-tracked, so a lost flight previously wedged the handshake permanently: the client's Initial retransmits only elicited ACKs once the server TLS state had advanced. (#263)
+
+### Changed
+- A mixed-size send batch on a GSO socket is split into runs of
+  equal-sized packets and each run sent with one UDP_SEGMENT call,
+  instead of falling back to one `sendmsg' per packet. A single
+  odd-sized packet between data packets (an ACK, a flow-control update)
+  previously degraded the whole batch. Contributed by jbevemyr (#217).
+- Small sends are coalesced into shared packets. Contributed by jbevemyr
+  (#203).
+- The pacing burst allowance scales with the pacing rate rather than
+  sitting at a fixed 12 packets. Pacing wakeups have roughly
+  millisecond resolution, so the fixed bucket capped throughput at 12
+  packets per wakeup whenever the sender outran the ACK clock,
+  regardless of the configured rate. Contributed by jbevemyr (#219).
 
 ## [1.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,21 @@ All notable changes to this project will be documented in this file.
   millisecond resolution, so the fixed bucket capped throughput at 12
   packets per wakeup whenever the sender outran the ACK clock,
   regardless of the configured rate. Contributed by jbevemyr (#219).
+### Fixed
+- A client whose Finished is lost now recovers. The
+  Certificate(+CertificateVerify)+Finished flight goes out at the
+  Handshake level, and once the client state machine left `handshaking'
+  nothing retransmitted it: handshake-space packets are not in the 1-RTT
+  loss tracker and the handshake retransmit timer only runs in that
+  state. The client considered itself connected and sent 1-RTT data the
+  server could not act on before handshake completion, while the server
+  replayed its own flight against ACK-only answers, until the connection
+  died on the idle timer. The flight is now retained until
+  HANDSHAKE_DONE and resent from the PTO and on a duplicate
+  handshake-level CRYPTO at offset 0. A write that exceeds the peer's
+  flow-control limit also sends the part that fits rather than nothing,
+  which is what lets the recovered connection drain its queue.
+  Contributed by jbevemyr (#252, #230, #225).
 
 ## [1.8.1] - 2026-08-15
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -7966,7 +7966,30 @@ do_send_data(
                         ?QUIC_LOG_META
                     ),
 
+                    Allowed = min(ConnectionAllowed, StreamAllowed),
                     case {DataSize =< ConnectionAllowed, DataSize =< StreamAllowed} of
+                        Fits when Fits =/= {true, true}, Allowed > 0 ->
+                            %% Part of this write fits in the peer's window.
+                            %% Send that part and queue the rest: queuing the
+                            %% whole write instead deadlocks the transfer,
+                            %% because the peer only extends the window as it
+                            %% consumes data, so sending nothing means nothing
+                            %% ever arrives to open it.
+                            Bin = iolist_to_binary(Data),
+                            <<Head:Allowed/binary, Tail/binary>> = Bin,
+                            case do_send_data(StreamId, Head, false, State) of
+                                {ok, SentState} ->
+                                    queue_blocked_send(
+                                        StreamId,
+                                        Offset + Allowed,
+                                        Tail,
+                                        Fin,
+                                        byte_size(Tail),
+                                        SentState
+                                    );
+                                Other ->
+                                    Other
+                            end;
                         {false, _} ->
                             %% Connection-level flow control blocked
                             %% RFC 9000: Don't queue data beyond flow control limits.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -375,6 +375,10 @@
     initial_tx_off = 0 :: non_neg_integer(),
     %% Client-side: CH1 random + build opts, needed to rebuild CH2
     tls_ch1_random :: binary() | undefined,
+    %% Client-side: the Certificate(+CertificateVerify)+Finished payload,
+    %% retained until HANDSHAKE_DONE so a lost Finished can be resent -
+    %% nothing else retransmits it once the statem has left `handshaking'.
+    client_hs_flight = undefined :: undefined | binary(),
     tls_ch1_opts :: map() | undefined,
     %% Negotiated values surfaced in the connected event
     negotiated_group :: atom() | undefined,
@@ -4850,7 +4854,9 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
     end;
 %% HANDSHAKE_DONE: Server confirms handshake complete
 %% RFC 9000 Section 19.20: Only server can send, only in 1-RTT (app level)
-process_frame(app, handshake_done, #state{role = client} = State) ->
+process_frame(app, handshake_done, #state{role = client} = State0) ->
+    %% Handshake confirmed: the retained Finished flight is done.
+    State = State0#state{client_hs_flight = undefined},
     %% Server confirmed handshake complete (client receiving from server)
     State;
 process_frame(app, handshake_done, #state{role = server} = State) ->
@@ -5376,11 +5382,29 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                 ?QUIC_CRYPTO_BUFFER_EXCEEDED, <<"crypto buffer exceeded">>, State
             );
         false ->
+            %% A handshake-level CRYPTO duplicate from offset 0 at a
+            %% client that has sent its Finished means the server's
+            %% retransmission timer fired: the Finished was lost, and
+            %% nothing else retransmits it once the statem has left
+            %% `handshaking'. Resend it (CRYPTO offsets are idempotent).
+            Expected = maps:get(LevelAtom, State#state.crypto_offset, 0),
+            State0 =
+                case
+                    LevelAtom =:= handshake andalso
+                        State#state.role =:= client andalso
+                        State#state.client_hs_flight =/= undefined andalso
+                        Offset =:= 0 andalso Expected > 0
+                of
+                    true ->
+                        send_handshake_crypto(State#state.client_hs_flight, State);
+                    false ->
+                        State
+                end,
             %% Add data to buffer
             NewBuffer = maps:put(Offset, Data, Buffer),
-            NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State#state.crypto_buffer),
+            NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State0#state.crypto_buffer),
 
-            State1 = State#state{crypto_buffer = NewCryptoBuffer},
+            State1 = State0#state{crypto_buffer = NewCryptoBuffer},
 
             %% Try to process contiguous data
             process_crypto_buffer(LevelAtom, State1)
@@ -5841,6 +5865,7 @@ process_tls_message(
 
                     State1 = State#state{
                         tls_state = ?TLS_HANDSHAKE_COMPLETE,
+                        client_hs_flight = HandshakePayload,
                         tls_transcript = <<Transcript2/binary, ClientFinishedMsg/binary>>,
                         master_secret = MasterSecret,
                         app_keys = {ClientAppKeys, ServerAppKeys},
@@ -9726,8 +9751,23 @@ handle_pto_timeout(#state{loss_state = LossState} = State) ->
     NewLossState = quic_loss:on_pto_expired(LossState),
     State1 = State#state{loss_state = NewLossState},
 
+    %% RFC 9002 §6.2.1: until the handshake is confirmed the PTO probes
+    %% the handshake space too. The retained Finished flight is exactly
+    %% that: a client whose Finished was lost against a server that has
+    %% stopped retransmitting its own flight would otherwise probe only
+    %% 1-RTT data the server cannot act on before handshake completion.
+    State1a =
+        case State1 of
+            #state{role = client, client_hs_flight = Flight, handshake_keys = HsKeys} when
+                Flight =/= undefined, HsKeys =/= undefined
+            ->
+                send_handshake_crypto(Flight, State1);
+            _ ->
+                State1
+        end,
+
     %% Send probe packet (retransmit oldest unacked or send PING)
-    State2 = send_probe_packet(State1),
+    State2 = send_probe_packet(State1a),
 
     %% Probes use the control allowance, so retry any CC-deferred control
     %% retransmits here too (they are not in sent_q for the probe to pick up).

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -146,6 +146,7 @@
     convert_rest_ranges/2,
     check_send_queue_flow_control/4,
     test_check_flow_control/6,
+    test_queue_blocked_send/5,
     close_reason_to_code/1,
     %% Migration frame classification (RFC 9000 Section 9.1)
     is_probing_frame/1,
@@ -2549,6 +2550,32 @@ handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
     {keep_state, State};
+%% An async send can arrive before the state machine reaches `connected':
+%% the owner is told the connection is up a flight before the handshake
+%% concludes, so this is an ordinary race rather than misuse. Queue it the
+%% way the synchronous handshaking-state clause does, to be flushed by
+%% send_pending_data/2 on entering `connected'. Falling through to the
+%% catch-all below would discard it, and send_data_async cannot retry.
+handle_common_event(
+    cast,
+    {send_data_async, StreamId, Data, Fin},
+    StateName,
+    #state{pending_data = Pending} = State
+) ->
+    case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
+        true ->
+            ?LOG_WARNING(
+                #{
+                    what => async_send_dropped_pending_limit,
+                    state => StateName,
+                    stream_id => StreamId
+                },
+                ?QUIC_LOG_META
+            ),
+            {keep_state, State};
+        false ->
+            {keep_state, State#state{pending_data = Pending ++ [{StreamId, Data, Fin}]}}
+    end;
 %% Return error for unhandled calls to prevent timeout
 handle_common_event({call, From}, _Request, StateName, State) ->
     {keep_state, State, [{reply, From, {error, {invalid_state, StateName}}}]};
@@ -7955,13 +7982,12 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.12: DATA_BLOCKED reports the connection data limit
                             BlockedFrame = {data_blocked, MaxDataRemote},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, connection}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {_, false} ->
-                            %% Stream-level flow control blocked
-                            %% RFC 9000: Don't queue data beyond flow control limits.
-                            %% Send STREAM_DATA_BLOCKED and return error to caller.
-                            %% Caller should retry after receiving MAX_STREAM_DATA from peer.
+                            %% Stream-level flow control blocked. Send
+                            %% STREAM_DATA_BLOCKED and queue; the send queue is
+                            %% drained when MAX_STREAM_DATA arrives.
                             ?LOG_DEBUG(
                                 #{
                                     what => stream_flow_control_blocked,
@@ -7973,8 +7999,8 @@ do_send_data(
                             ),
                             %% RFC 9000 Section 19.13: STREAM_DATA_BLOCKED reports the stream data limit
                             BlockedFrame = {stream_data_blocked, StreamId, SendMaxData},
-                            _FinalState = send_frame(BlockedFrame, State),
-                            {error, {flow_control_blocked, {stream, StreamId}}};
+                            State1 = send_frame(BlockedFrame, State),
+                            queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State1);
                         {true, true} ->
                             %% Flow control allows sending
                             %% Fragment and send data - congestion control may partially
@@ -8534,6 +8560,33 @@ send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSen
                 {error, send_queue_full} ->
                     {error, send_queue_full}
             end
+    end.
+
+%% Queue a send the peer's flow-control window has no room for, rather
+%% than returning an error. process_send_queue/1 drains it when MAX_DATA
+%% or MAX_STREAM_DATA arrives. An error here is silently lost for
+%% send_data_async callers, which are fire-and-forget and have no way to
+%% retry, and the loss is invisible to both ends: the bytes never reach
+%% the wire, so the peer cannot detect a gap, and the next send on the
+%% stream simply continues from a later offset.
+%%
+%% The send offset is advanced at queue time so later sends on the stream
+%% order behind this entry. QUIC reassembly is offset-based, so the order
+%% the queued entries actually go out in does not matter.
+queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
+    case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+        {ok, QState} ->
+            case maps:find(StreamId, QState#state.streams) of
+                {ok, Stream} ->
+                    NewStream = Stream#stream_state{send_offset = Offset + DataSize},
+                    {ok, QState#state{
+                        streams = maps:put(StreamId, NewStream, QState#state.streams)
+                    }};
+                error ->
+                    {ok, QState}
+            end;
+        {error, send_queue_full} = Error ->
+            Error
     end.
 
 %% Queue stream data when congestion window is full
@@ -11878,6 +11931,21 @@ test_check_flow_control(StreamId, Offset, DataSize, MaxDataRemote, DataSent, Str
         streams = Streams
     },
     check_send_queue_flow_control(StreamId, Offset, DataSize, State).
+
+%% Test helper for queue_blocked_send/6. A send the peer's window has no
+%% room for must be queued, not dropped, and the stream offset must
+%% advance so later sends order behind it.
+%% Returns {ok, NewSendOffset, QueuedCount} | {error, Reason}.
+test_queue_blocked_send(StreamId, Offset, Data, Fin, SendOffset) ->
+    Stream = #stream_state{send_offset = SendOffset, send_max_data = 0},
+    State = #state{streams = #{StreamId => Stream}},
+    case queue_blocked_send(StreamId, Offset, Data, Fin, iolist_size(Data), State) of
+        {ok, S2} ->
+            #{StreamId := S} = S2#state.streams,
+            {ok, S#stream_state.send_offset, S2#state.send_queue_count};
+        Error ->
+            Error
+    end.
 
 %% Test helper for complete_migration/2.
 %% Tests that path_changed notification is sent to owner on active migration.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -169,6 +169,10 @@
     test_state_for_reset/3,
     %% Retransmission congestion policy (RFC 9002 §7)
     retransmit_cc_allowed/3,
+    %% Anti-amplification accounting on the batched path (RFC 9000 §8.1)
+    handle_packets_batch/2,
+    test_state_amp/2,
+    test_amp_counters/1,
     %% NEW_TOKEN frame dispatch (RFC 9000 §8.1.3)
     process_frame/3,
     test_state_for_role/1,
@@ -379,6 +383,16 @@
     %% one-shot flight; bumps after HRR so CH2 / ServerHello continue
     %% the stream (RFC 9001 §4.1.3).
     initial_tx_off = 0 :: non_neg_integer(),
+    %% Server handshake-flight retransmission: the ServerHello (with its
+    %% Initial CRYPTO offset) and the Handshake-level payload are kept
+    %% until the client's Finished arrives, and replayed on a backoff
+    %% timer. Initial/Handshake packets are not loss-tracked, so without
+    %% this a single lost flight wedges the handshake permanently: the
+    %% client's Initial retransmits only elicit ACKs once the server TLS
+    %% state has advanced.
+    server_flight = undefined :: undefined | {binary(), non_neg_integer(), binary()},
+    server_hs_rtx_timer = undefined :: undefined | reference(),
+    server_hs_rtx_attempts = 0 :: non_neg_integer(),
     %% Client-side: CH1 random + build opts, needed to rebuild CH2
     tls_ch1_random :: binary() | undefined,
     %% Client-side: the Certificate(+CertificateVerify)+Finished payload,
@@ -2580,6 +2594,15 @@ handle_common_event(
     #state{owner_mon = Mon} = State
 ) ->
     {stop, {shutdown, owner_down}, State};
+handle_common_event(
+    info,
+    {server_hs_rtx, Ref},
+    _StateName,
+    #state{server_hs_rtx_timer = Ref, role = server} = State
+) ->
+    {keep_state, server_hs_retransmit(State#state{server_hs_rtx_timer = undefined})};
+handle_common_event(info, {server_hs_rtx, _Stale}, _StateName, State) ->
+    {keep_state, State};
 handle_common_event(info, {'EXIT', _Pid, _Reason}, _StateName, State) ->
     %% EXIT signals are handled in terminate/3 callback
     %% Just ignore here - the process will terminate anyway if it's from parent
@@ -2950,7 +2973,10 @@ ensure_ticket_table() ->
 %% Initial CRYPTO offset (non-zero only after a HelloRetryRequest).
 send_server_hello(ServerHelloMsg, State) ->
     Off = State#state.initial_tx_off,
-    State1 = State#state{initial_tx_off = Off + byte_size(ServerHelloMsg)},
+    State1 = State#state{
+        initial_tx_off = Off + byte_size(ServerHelloMsg),
+        server_flight = {ServerHelloMsg, Off, <<>>}
+    },
     %% Chunk across Initial packets: a hybrid ServerHello Initial is
     %% ~1225 bytes and no longer fits one datagram.
     {_Frames, NewState} = send_initial_crypto(ServerHelloMsg, Off, State1),
@@ -3201,7 +3227,15 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
 
     %% Send the flight, segmented so no datagram exceeds the peer's
     %% max_udp_payload_size (issue #134).
-    send_handshake_crypto(HandshakePayload, State1).
+    State2 = send_handshake_crypto(HandshakePayload, State1),
+    State3 =
+        case State2#state.server_flight of
+            {SH, SHOff, _} ->
+                State2#state{server_flight = {SH, SHOff, HandshakePayload}};
+            undefined ->
+                State2
+        end,
+    arm_server_hs_rtx(State3).
 
 %% @private Send a handshake CRYPTO payload as one or more packets,
 %% each sized to stay within max_udp_payload_size (RFC 9000 §14.1).
@@ -4000,6 +4034,49 @@ amp_flush_budget(#state{amp_deferred = [Packet | Rest]} = State) ->
             State
     end.
 
+%% Arm (or re-arm) the server handshake-flight retransmit timer.
+arm_server_hs_rtx(#state{role = server, server_flight = {_, _, _}} = State) ->
+    case State#state.server_hs_rtx_attempts < ?HS_RTX_MAX_ATTEMPTS of
+        true ->
+            Delay = min(
+                ?HS_RTX_BASE_MS bsl State#state.server_hs_rtx_attempts, ?HS_RTX_MAX_MS
+            ),
+            Ref = make_ref(),
+            erlang:send_after(Delay, self(), {server_hs_rtx, Ref}),
+            State#state{server_hs_rtx_timer = Ref};
+        false ->
+            State#state{server_hs_rtx_timer = undefined}
+    end;
+arm_server_hs_rtx(State) ->
+    State.
+
+%% Replay the retained server flight: ServerHello at its original
+%% Initial CRYPTO offset plus the Handshake payload (offset 0). New
+%% packet numbers, identical crypto stream bytes, so the client's
+%% reassembly is byte-exact regardless of what it already received.
+server_hs_retransmit(#state{tls_state = ?TLS_HANDSHAKE_COMPLETE} = State) ->
+    State#state{server_flight = undefined};
+server_hs_retransmit(#state{server_flight = {SH, SHOff, HsPayload}} = State) ->
+    ?LOG_WARNING(
+        #{
+            what => server_handshake_flight_retransmit,
+            attempt => State#state.server_hs_rtx_attempts + 1
+        },
+        ?QUIC_LOG_META
+    ),
+    {_Frames, State1} = send_initial_crypto(SH, SHOff, State),
+    State2 =
+        case HsPayload of
+            <<>> -> State1;
+            _ -> send_handshake_crypto(HsPayload, State1)
+        end,
+    State3 = State2#state{
+        server_hs_rtx_attempts = State2#state.server_hs_rtx_attempts + 1
+    },
+    arm_server_hs_rtx(flush_dirty_timers(flush_socket_batch(State3)));
+server_hs_retransmit(State) ->
+    State.
+
 %% State-timeout action driving client Initial retransmission while the
 %% handshake is incomplete. Empty for the server, once connected, or once
 %% the attempt budget is spent (the idle timeout then closes).
@@ -4041,13 +4118,23 @@ retransmit_initial_flight(
 retransmit_initial_flight(_StateName, State) ->
     {keep_state, State}.
 
+%% Batched variant of handle_packet/2: same anti-amplification
+%% accounting per datagram, one deferred-flight flush per batch. The
+%% batched delivery path previously skipped accounting entirely, so a
+%% server's amp budget froze at the first datagram under load and
+%% deferred flights never flushed.
+handle_packets_batch(Packets, State) ->
+    State1 = lists:foldl(fun amp_account_recv/2, State, Packets),
+    State2 = do_handle_packets_batch(Packets, State1),
+    amp_flush(State2).
+
 %% Handle batch of packets from GRO - process all without re-entering gen_statem
 %% This is more efficient than receiving multiple messages
-handle_packets_batch([], State) ->
+do_handle_packets_batch([], State) ->
     State;
-handle_packets_batch([Packet | Rest], State) ->
+do_handle_packets_batch([Packet | Rest], State) ->
     NewState = handle_packet_loop(Packet, State),
-    handle_packets_batch(Rest, NewState).
+    do_handle_packets_batch(Rest, NewState).
 
 handle_packet_loop(<<>>, #state{role = client, active_n = N} = State) ->
     %% No more data to process - re-enable socket for client connections
@@ -5948,9 +6035,11 @@ process_tls_message(
                     ),
 
                     %% Application keys are already derived when server sent its Finished
-                    %% Mark handshake as complete
+                    %% Mark handshake as complete; the retained flight is
+                    %% no longer needed for retransmission.
                     State1 = State#state{
                         tls_state = ?TLS_HANDSHAKE_COMPLETE,
+                        server_flight = undefined,
                         tls_transcript = Transcript,
                         resumption_secret = ResumptionSecret
                     },
@@ -11984,6 +12073,17 @@ test_state_for_reset(DCID, PeerCIDPool, Secret) ->
         peer_cid_pool = PeerCIDPool,
         stateless_reset_secret = Secret
     }.
+
+%% Minimal #state{} for pinning the anti-amplification accounting on the
+%% batched receive path. The datagrams fed through it are junk the parser
+%% drops, so only the accounting itself is exercised.
+-spec test_state_amp(client | server, boolean()) -> #state{}.
+test_state_amp(Role, Validated) ->
+    #state{role = Role, address_validated = Validated}.
+
+-spec test_amp_counters(#state{}) -> #{atom() => non_neg_integer()}.
+test_amp_counters(#state{amp_rx = Rx, amp_tx = Tx, amp_deferred = Deferred}) ->
+    #{amp_rx => Rx, amp_tx => Tx, deferred => length(Deferred)}.
 
 %% Minimal #state{} scoped to role for frame-dispatch tests.
 -spec test_state_for_role(client | server) -> #state{}.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -247,6 +247,12 @@
 %% option). See the burst_budget field.
 -define(DEFAULT_MAX_BURST_PACKETS, 64).
 
+%% Bounds on the client Finished retransmission interval. The floor keeps
+%% a near-zero PTO from spinning; the ceiling keeps a long RTT estimate
+%% from parking the flight past the idle timeout.
+-define(HS_FLIGHT_MIN_INTERVAL, 100).
+-define(HS_FLIGHT_MAX_INTERVAL, 3000).
+
 %% Max receive buffer size in bytes (32 MB total across all streams) - protects against malicious peers
 -define(MAX_RECV_BUFFER_BYTES, 33554432).
 
@@ -379,6 +385,12 @@
     %% retained until HANDSHAKE_DONE so a lost Finished can be resent -
     %% nothing else retransmits it once the statem has left `handshaking'.
     client_hs_flight = undefined :: undefined | binary(),
+    %% Retransmission timer for that flight, armed while it is retained.
+    %% The flight has to carry its own timer: once the statem leaves
+    %% `handshaking' nothing else is guaranteed to be in flight to arm a
+    %% PTO, so a lost Finished had no schedule to resend it on.
+    hs_flight_timer = undefined :: reference() | undefined,
+    hs_flight_tries = 0 :: non_neg_integer(),
     tls_ch1_opts :: map() | undefined,
     %% Negotiated values surfaced in the connected event
     negotiated_group :: atom() | undefined,
@@ -2460,6 +2472,24 @@ handle_common_event(cast, handle_timeout, _StateName, State) ->
     %% Handle loss detection / idle timeout
     NewState = check_timeouts(State),
     {keep_state, NewState};
+%% The retained client Finished flight has its own schedule: resend it
+%% until the server confirms the handshake. Nothing else is guaranteed
+%% to be in flight once the statem has left `handshaking', so without
+%% this a Finished lost twice was never resent.
+handle_common_event(
+    info,
+    {hs_flight_timeout, Ref},
+    _StateName,
+    #state{hs_flight_timer = Ref, client_hs_flight = Flight, handshake_keys = HsKeys} = State
+) when Ref =/= undefined andalso Flight =/= undefined andalso HsKeys =/= undefined ->
+    State1 = send_handshake_crypto(Flight, State),
+    State2 = arm_hs_flight_timer(State1#state{
+        hs_flight_tries = State1#state.hs_flight_tries + 1
+    }),
+    {keep_state, flush_dirty_timers(flush_socket_batch(State2))};
+handle_common_event(info, {hs_flight_timeout, _Ref}, _StateName, State) ->
+    %% Stale timer, or the flight is already confirmed.
+    {keep_state, State};
 handle_common_event(info, {pto_timeout, Ref}, StateName, #state{pto_timer = Ref} = State) when
     Ref =/= undefined andalso (StateName =:= connected orelse StateName =:= handshaking)
 ->
@@ -4856,7 +4886,7 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
 %% RFC 9000 Section 19.20: Only server can send, only in 1-RTT (app level)
 process_frame(app, handshake_done, #state{role = client} = State0) ->
     %% Handshake confirmed: the retained Finished flight is done.
-    State = State0#state{client_hs_flight = undefined},
+    State = clear_hs_flight(State0),
     %% Server confirmed handshake complete (client receiving from server)
     State;
 process_frame(app, handshake_done, #state{role = server} = State) ->
@@ -5863,7 +5893,10 @@ process_tls_message(
                     %% Combine Certificate(+CertificateVerify) and Finished into one payload
                     HandshakePayload = <<CertPayload/binary, ClientFinishedMsg/binary>>,
 
-                    State1 = State#state{
+                    State0a = arm_hs_flight_timer(State#state{
+                        client_hs_flight = HandshakePayload
+                    }),
+                    State1 = State0a#state{
                         tls_state = ?TLS_HANDSHAKE_COMPLETE,
                         client_hs_flight = HandshakePayload,
                         tls_transcript = <<Transcript2/binary, ClientFinishedMsg/binary>>,
@@ -11749,6 +11782,27 @@ set_pmtu_probe_timer(#state{pmtu_probe_timer = OldTimer, loss_state = LossState}
     Ref = make_ref(),
     erlang:send_after(Timeout, self(), {pmtu_probe_timeout, Ref}),
     State#state{pmtu_probe_timer = Ref}.
+
+%% Arm the retransmission timer for the retained client Finished flight.
+%% RFC 9002 section 6.2: until the handshake is confirmed the client
+%% probes the handshake space, and the interval doubles on each attempt.
+arm_hs_flight_timer(#state{loss_state = LossState, hs_flight_tries = Tries} = State) ->
+    _ = cancel_timer(State#state.hs_flight_timer),
+    Base = max(?HS_FLIGHT_MIN_INTERVAL, quic_loss:get_pto(LossState)),
+    Timeout = min(?HS_FLIGHT_MAX_INTERVAL, Base bsl min(Tries, 4)),
+    Ref = make_ref(),
+    erlang:send_after(Timeout, self(), {hs_flight_timeout, Ref}),
+    State#state{hs_flight_timer = Ref}.
+
+%% The flight is acknowledged (HANDSHAKE_DONE, or a 1-RTT ack that only a
+%% server holding our Finished could have sent): stop resending it.
+clear_hs_flight(State) ->
+    _ = cancel_timer(State#state.hs_flight_timer),
+    State#state{
+        client_hs_flight = undefined,
+        hs_flight_timer = undefined,
+        hs_flight_tries = 0
+    }.
 
 %% @doc Set the PMTU raise timer for periodic re-probing.
 %% Uses unique reference in message to detect stale timer events

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -219,9 +219,12 @@
 %% so it can flush the deferred flight. Backoff doubles from the base up
 %% to the cap. Localhost handshakes complete well under the base, so the
 %% timer is cancelled by the state change and never fires.
--define(HS_RTX_BASE_MS, 500).
--define(HS_RTX_MAX_MS, 4000).
--define(HS_RTX_MAX_ATTEMPTS, 8).
+%% 200 ms base keeps a lossy handshake moving at something closer to
+%% PTO cadence on low-RTT paths; 12 attempts bound the total effort to
+%% roughly half a minute before the connect timeout owns the outcome.
+-define(HS_RTX_BASE_MS, 200).
+-define(HS_RTX_MAX_MS, 3000).
+-define(HS_RTX_MAX_ATTEMPTS, 12).
 
 %% Max send queue size in bytes (16 MB default) - prevents memory exhaustion from queued data
 -define(MAX_SEND_QUEUE_BYTES, 16777216).

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -919,8 +919,11 @@ decode_handshake_message(<<Type:8, Length:24, Body:Length/binary, Rest/binary>>)
     {ok, {Type, Body}, Rest};
 decode_handshake_message(<<_Type:8, Length:24, Data/binary>>) when byte_size(Data) < Length ->
     {error, incomplete};
+%% Fewer than 4 bytes: the message header itself is split across CRYPTO
+%% frames. There is no invalid framing at this layer, only insufficient
+%% data; malformed content is rejected by the per-message parsers.
 decode_handshake_message(_) ->
-    {error, invalid}.
+    {error, incomplete}.
 
 %%====================================================================
 %% Internal Functions

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -586,9 +586,10 @@ parse_certificate_verify(_) ->
 %% @doc Parse Finished message.
 -spec parse_finished(binary()) -> {ok, binary()} | {error, term()}.
 parse_finished(VerifyData) when byte_size(VerifyData) >= 32 ->
-    %% SHA-256 produces 32 bytes
-    <<Data:32/binary, _/binary>> = VerifyData,
-    {ok, Data};
+    %% The verify_data length depends on the negotiated hash (32 for
+    %% SHA-256, 48 for SHA-384), so return the whole body and let
+    %% verification compare.
+    {ok, VerifyData};
 parse_finished(_) ->
     {error, invalid_finished}.
 
@@ -609,14 +610,21 @@ build_finished(VerifyData) ->
 verify_finished(ReceivedVerifyData, TrafficSecret, TranscriptHash) ->
     FinishedKey = quic_crypto:derive_finished_key(TrafficSecret),
     ExpectedVerifyData = quic_crypto:compute_finished_verify(FinishedKey, TranscriptHash),
-    crypto:hash_equals(ReceivedVerifyData, ExpectedVerifyData).
+    hash_equals(ReceivedVerifyData, ExpectedVerifyData).
 
 %% @doc Verify a Finished message with cipher-specific hash.
 -spec verify_finished(binary(), binary(), binary(), atom()) -> boolean().
 verify_finished(ReceivedVerifyData, TrafficSecret, TranscriptHash, Cipher) ->
     FinishedKey = quic_crypto:derive_finished_key(Cipher, TrafficSecret),
     ExpectedVerifyData = quic_crypto:compute_finished_verify(Cipher, FinishedKey, TranscriptHash),
-    crypto:hash_equals(ReceivedVerifyData, ExpectedVerifyData).
+    hash_equals(ReceivedVerifyData, ExpectedVerifyData).
+
+%% crypto:hash_equals/2 raises badarg on length mismatch; a wrong-length
+%% verify_data is a verification failure, not a crash.
+hash_equals(A, B) when byte_size(A) =:= byte_size(B) ->
+    crypto:hash_equals(A, B);
+hash_equals(_, _) ->
+    false.
 
 %%====================================================================
 %% Transport Parameters
@@ -1574,7 +1582,7 @@ verify_psk_binder(Secret, Cipher, TruncatedHash, OfferedBinder) ->
     Expected = quic_crypto:compute_psk_binder(
         Cipher, EarlySecret, TruncatedHash, external
     ),
-    crypto:hash_equals(Expected, OfferedBinder).
+    hash_equals(Expected, OfferedBinder).
 
 %% @doc Verify a resumption PSK binder against a parsed ClientHello.
 %% `Secret' is the resumption PSK, `PskBindersInfo' is the `psk_binders'
@@ -1589,7 +1597,7 @@ verify_resumption_binder(Secret, Cipher, FullClientHello, PskBindersInfo, Offere
     Expected = quic_crypto:compute_psk_binder(
         Cipher, EarlySecret, TruncatedHash, resumption
     ),
-    crypto:hash_equals(Expected, OfferedBinder);
+    hash_equals(Expected, OfferedBinder);
 verify_resumption_binder(_Secret, _Cipher, _FullClientHello, _PskBindersInfo, _OfferedBinder) ->
     %% Missing binder offset info — cannot verify, fail closed.
     false.

--- a/test/quic_amp_batch_accounting_tests.erl
+++ b/test/quic_amp_batch_accounting_tests.erl
@@ -1,0 +1,53 @@
+%%% -*- erlang -*-
+%%%
+%%% Anti-amplification accounting on the batched receive path
+%%% (RFC 9000 §8.1).
+%%%
+%%% A server must not send more than three times the bytes it has
+%%% received from an unvalidated address. The credit side of that
+%%% budget was only maintained in the single-datagram path
+%%% (handle_packet/2); the batched path the listener uses for GRO
+%%% trains skipped it entirely. A server whose ClientHello arrived in
+%%% a batch kept amp_rx at or near zero, deferred most of its
+%%% handshake flight, and the handshake wedged.
+%%%
+%%% These tests pin the accounting at the handle_packets_batch/2
+%%% boundary, which the listener delivery path uses for servers only:
+%%% every received datagram must be credited for an unvalidated
+%%% server, and must not be for a validated one. The datagrams are
+%%% junk the packet parser drops, so the credit is isolated from
+%%% packet processing.
+%%%
+%%% The end-to-end consequence (a lost first server flight) is covered
+%%% by quic_server_flight_retransmit_SUITE.
+
+-module(quic_amp_batch_accounting_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+datagrams() ->
+    %% Sizes chosen unequal so a partial fold shows up in the sum.
+    [binary:copy(<<16#ff>>, N) || N <- [100, 321, 47]].
+
+total() ->
+    lists:sum([byte_size(D) || D <- datagrams()]).
+
+batch(Role, Validated) ->
+    State = quic_connection:test_state_amp(Role, Validated),
+    NewState = quic_connection:handle_packets_batch(datagrams(), State),
+    quic_connection:test_amp_counters(NewState).
+
+unvalidated_server_credits_every_datagram_test() ->
+    Counters = batch(server, false),
+    ?assertEqual(total(), maps:get(amp_rx, Counters)).
+
+validated_server_does_not_count_test() ->
+    Counters = batch(server, true),
+    ?assertEqual(0, maps:get(amp_rx, Counters)).
+
+%% The batch must not send anything on its own: junk datagrams are
+%% dropped, and with nothing deferred the flush is a no-op.
+batch_does_not_touch_the_spend_side_test() ->
+    Counters = batch(server, false),
+    ?assertEqual(0, maps:get(amp_tx, Counters)),
+    ?assertEqual(0, maps:get(deferred, Counters)).

--- a/test/quic_async_send_loss_tests.erl
+++ b/test/quic_async_send_loss_tests.erl
@@ -1,0 +1,39 @@
+%%% A send that the peer's flow-control window has no room for must be
+%%% queued, not turned into an error.
+%%%
+%%% send_data_async is fire-and-forget, so an error return is silently
+%%% lost, and the loss is invisible to both ends: the bytes never reach
+%%% the wire, so the peer cannot detect a gap, and the next send on the
+%%% stream continues from a later offset. The application stream is then
+%%% missing a chunk with nothing reported anywhere.
+-module(quic_async_send_loss_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+queue(StreamId, Offset, Data, Fin, SendOffset) ->
+    quic_connection:test_queue_blocked_send(StreamId, Offset, Data, Fin, SendOffset).
+
+%% The regression: this used to return {error, {flow_control_blocked, _}}
+%% and drop the payload.
+blocked_send_is_queued_test() ->
+    ?assertMatch({ok, _, 1}, queue(4, 0, <<"payload">>, false, 0)).
+
+%% The offset has to advance at queue time, so a later send on the same
+%% stream orders behind this entry rather than overwriting its range.
+blocked_send_advances_offset_test() ->
+    {ok, NewOffset, _} = queue(4, 100, binary:copy(<<$x>>, 250), false, 100),
+    ?assertEqual(350, NewOffset).
+
+fin_is_preserved_test() ->
+    ?assertMatch({ok, _, 1}, queue(8, 0, <<"last">>, true, 0)).
+
+%% An empty payload still has to queue rather than error: a FIN-only send
+%% carries stream-closing intent.
+empty_payload_is_queued_test() ->
+    {ok, NewOffset, Count} = queue(4, 40, <<>>, true, 40),
+    ?assertEqual(40, NewOffset),
+    ?assertEqual(1, Count).
+
+iodata_is_accepted_test() ->
+    {ok, NewOffset, _} = queue(4, 0, [<<"ab">>, [<<"cd">>, <<"ef">>]], false, 0),
+    ?assertEqual(6, NewOffset).

--- a/test/quic_lost_finished_SUITE.erl
+++ b/test/quic_lost_finished_SUITE.erl
@@ -1,0 +1,201 @@
+%%% -*- erlang -*-
+%%%
+%%% A lost client Finished must still get through.
+%%%
+%%% The client's Certificate(+CertificateVerify)+Finished flight goes out
+%%% at the Handshake encryption level. Once the client state machine
+%%% leaves `handshaking' nothing retransmits it: handshake-space packets
+%%% are not in the 1-RTT loss tracker, and the handshake retransmit timer
+%%% only runs in that state.
+%%%
+%%% So a client whose Finished is dropped considers itself connected and
+%%% starts sending 1-RTT data the server cannot act on before the
+%%% handshake completes, while the server keeps replaying its own flight
+%%% against ACK-only answers. Nothing breaks the tie and the connection
+%%% dies on the idle timer with the Finished never acknowledged.
+%%%
+%%% One dropped datagram is enough, which makes this reachable on any
+%%% lossy path rather than an exotic case.
+%%%
+%%% The bridge here drops the client's first Handshake-level datagrams
+%%% and then lets everything through, so recovery depends entirely on the
+%%% client resending the flight on its own.
+
+-module(quic_lost_finished_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    control_no_loss/1,
+    survives_one_lost_finished/1,
+    survives_two_lost_finished/1
+]).
+
+-define(ECHO, <<"finished came back">>).
+-define(CONNECT_MS, 15000).
+-define(ECHO_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 3}}].
+
+all() ->
+    [control_no_loss, survives_one_lost_finished, survives_two_lost_finished].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: the same path with nothing dropped. Separates a real stall
+%% from a broken harness.
+control_no_loss(_Config) ->
+    ?assertEqual(?ECHO, run(0)).
+
+survives_one_lost_finished(_Config) ->
+    ?assertEqual(?ECHO, run(1)).
+
+survives_two_lost_finished(_Config) ->
+    %% Two consecutive losses, so recovery cannot depend on a single
+    %% retransmission happening to land.
+    ?assertEqual(?ECHO, run(2)).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Connect with the first Drop client Handshake-level datagrams
+%% discarded, then echo a payload. Returns what came back.
+run(Drop) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        Port = maps:get(port, Server),
+        SocketRef = make_ref(),
+        Self = self(),
+        Bridge = spawn_link(fun() -> bridge_init({127, 0, 0, 1}, Port, SocketRef, Drop, Self) end),
+        Adapter = #{
+            send_fun => fun(IP, P, Pkt) ->
+                Bridge ! {send, IP, P, Pkt},
+                ok
+            end,
+            close_fun => fun() ->
+                Bridge ! stop,
+                ok
+            end,
+            local => {{127, 0, 0, 1}, 0},
+            socket_ref => SocketRef
+        },
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            socket_backend => adapter,
+            socket_adapter => Adapter
+        },
+        {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+        Bridge ! {set_conn, Conn},
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after ?CONNECT_MS -> ct:fail("connect timeout with ~p dropped", [Drop])
+        end,
+        Bridge ! {report, self()},
+        receive
+            {dropped, N} -> ct:pal("dropped ~p client Handshake datagram(s)", [N])
+        after 2000 -> ok
+        end,
+        {ok, StreamId} = quic:open_stream(Conn),
+        ok = quic:send_data(Conn, StreamId, ?ECHO, true),
+        Got = await_echo(Conn, StreamId),
+        _ = quic:safe_close(Conn, normal),
+        Got
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+await_echo(Conn, StreamId) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, _Fin}} -> Data;
+        {quic, Conn, _Other} -> await_echo(Conn, StreamId)
+    after ?ECHO_MS -> timeout
+    end.
+
+%%====================================================================
+%% Bridge
+%%====================================================================
+
+%% Relays between the client's socket adapter and a real UDP socket,
+%% discarding the first Drop datagrams the client sends at the Handshake
+%% encryption level. The long-header form and type bits sit outside the
+%% header-protection mask, so the level is readable without keys.
+bridge_init(ServerIP, ServerPort, SocketRef, Drop, Reporter) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        to_drop => Drop,
+        dropped => 0,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef,
+        reporter => Reporter
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {report, To} ->
+            To ! {dropped, maps:get(dropped, Bridge)},
+            bridge_loop(Bridge);
+        {send, _IP, _Port, Pkt} ->
+            Left = maps:get(to_drop, Bridge),
+            case Left > 0 andalso header_level(Pkt) =:= handshake of
+                true ->
+                    bridge_loop(Bridge#{
+                        to_drop := Left - 1,
+                        dropped := maps:get(dropped, Bridge) + 1
+                    });
+                false ->
+                    ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+                    bridge_loop(Bridge)
+            end;
+        {udp, Sock, _IP, _Port, Data} ->
+            case maps:get(conn, Bridge) of
+                undefined ->
+                    bridge_loop(Bridge#{pending := [Data | maps:get(pending, Bridge)]});
+                Conn ->
+                    deliver(Bridge, Conn, Data),
+                    bridge_loop(Bridge)
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.
+
+%% QUIC v1 long-header packet types live in bits 4-5 of the first byte:
+%% Initial 0x00, 0-RTT 0x10, Handshake 0x20, Retry 0x30.
+header_level(Pkt) ->
+    <<First:8, _/binary>> = iolist_to_binary(Pkt),
+    case First band 16#80 of
+        0 ->
+            short;
+        _ ->
+            case First band 16#30 of
+                16#00 -> initial;
+                16#10 -> zero_rtt;
+                16#20 -> handshake;
+                _ -> retry
+            end
+    end.

--- a/test/quic_lost_finished_SUITE.erl
+++ b/test/quic_lost_finished_SUITE.erl
@@ -30,7 +30,8 @@
 -export([
     control_no_loss/1,
     survives_one_lost_finished/1,
-    survives_two_lost_finished/1
+    survives_two_lost_finished/1,
+    survives_four_lost_finished/1
 ]).
 
 -define(ECHO, <<"finished came back">>).
@@ -41,7 +42,12 @@ suite() ->
     [{timetrap, {minutes, 3}}].
 
 all() ->
-    [control_no_loss, survives_one_lost_finished, survives_two_lost_finished].
+    [
+        control_no_loss,
+        survives_one_lost_finished,
+        survives_two_lost_finished,
+        survives_four_lost_finished
+    ].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
@@ -67,6 +73,11 @@ survives_two_lost_finished(_Config) ->
     %% Two consecutive losses, so recovery cannot depend on a single
     %% retransmission happening to land.
     ?assertEqual(?ECHO, run(2)).
+
+%% Past what the server's own retransmissions can prompt: recovery here
+%% needs the client's flight timer to keep firing on its own schedule.
+survives_four_lost_finished(_Config) ->
+    ?assertEqual(?ECHO, run(4)).
 
 %%====================================================================
 %% Harness

--- a/test/quic_server_flight_retransmit_SUITE.erl
+++ b/test/quic_server_flight_retransmit_SUITE.erl
@@ -1,0 +1,201 @@
+%%% -*- erlang -*-
+%%%
+%%% Recovery after the server's first handshake flight is lost.
+%%%
+%%% Initial and Handshake packets are not loss-tracked, so a server
+%%% whose ServerHello-to-Finished flight is dropped never resent it:
+%%% once its TLS state has advanced, the client's Initial retransmits
+%%% only elicit ACKs, and the handshake wedges until the connect
+%%% timeout. The fix retains {ServerHello, Initial offset, Handshake
+%%% payload} until the client's Finished arrives and replays the
+%%% flight on the client Initial's backoff schedule.
+%%%
+%%% The harness drops everything the server sends for a fixed window
+%%% covering the original flight and the first retransmit attempts,
+%%% then heals the path. Without server-side retransmission there is
+%%% nothing left to deliver after the heal, so the case fails on a
+%%% connect timeout; with it the handshake completes on the first
+%%% attempt after the window.
+%%%
+%%% The credit side of the same storm-failure class is pinned in
+%%% quic_amp_batch_accounting_tests.
+%%%
+%%% The window (rather than a fixed drop count) keeps the case
+%%% deterministic against client Initial retransmits: however many
+%%% copies of the flight the client manages to elicit inside the
+%%% window, they are all dropped.
+
+-module(quic_server_flight_retransmit_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([control_plain_handshake/1, completes_after_the_first_flight_is_lost/1]).
+
+%% Covers the original flight plus the first two replay attempts, so
+%% recovery genuinely depends on the timer refiring after the heal.
+-define(DROP_MS, 700).
+%% Budget for the handshake once the path is back. Deliberately loose
+%% so the case fails on a wedge rather than on a slow machine.
+-define(CONNECT_MS, 20000).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [control_plain_handshake, completes_after_the_first_flight_is_lost].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: the same handshake over the same harness with no drop window.
+control_plain_handshake(_Config) ->
+    with_server(fun(Port) ->
+        {Conn, _Bridge} = connect_through_bridge(Port, 0),
+        connected_within(Conn, ?CONNECT_MS),
+        echo_roundtrip(Conn),
+        quic:close(Conn, normal)
+    end).
+
+completes_after_the_first_flight_is_lost(_Config) ->
+    with_server(fun(Port) ->
+        Start = erlang:monotonic_time(millisecond),
+        {Conn, _Bridge} = connect_through_bridge(Port, ?DROP_MS),
+        connected_within(Conn, ?CONNECT_MS),
+        Elapsed = erlang:monotonic_time(millisecond) - Start,
+        ct:pal("handshake completed ~p ms after connect", [Elapsed]),
+        %% The premise: completion required surviving the window. A
+        %% handshake that finished inside it means the drop never
+        %% engaged and the case is not testing the retransmit.
+        ?assert(Elapsed >= ?DROP_MS),
+        echo_roundtrip(Conn),
+        quic:close(Conn, normal)
+    end).
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+with_server(Fun) ->
+    {ok, Server} = quic_test_echo_server:start(),
+    try
+        Fun(maps:get(port, Server))
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+connected_within(Conn, Budget) ->
+    receive
+        {quic, Conn, {connected, _}} -> ok;
+        {quic, Conn, {closed, Reason}} -> ct:fail({closed_during_handshake, Reason})
+    after Budget -> ct:fail("connect timeout")
+    end.
+
+%% One small echo over the finished connection: the retransmitted
+%% flight must yield working application keys, not just a connected
+%% event.
+echo_roundtrip(Conn) ->
+    {ok, StreamId} = quic:open_stream(Conn),
+    Payload = <<"flight check">>,
+    ok = quic:send_data(Conn, StreamId, Payload, true),
+    ?assertEqual(Payload, collect_echo(Conn, StreamId, 5000, <<>>)).
+
+collect_echo(Conn, StreamId, Budget, Acc) ->
+    Start = erlang:monotonic_time(millisecond),
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
+            Acc1 = <<Acc/binary, Data/binary>>,
+            case Fin of
+                true -> Acc1;
+                false -> collect_echo(Conn, StreamId, Budget - spent(Start), Acc1)
+            end;
+        {quic, Conn, _Other} ->
+            collect_echo(Conn, StreamId, Budget - spent(Start), Acc)
+    after max(0, Budget) -> Acc
+    end.
+
+spent(Start) ->
+    max(1, erlang:monotonic_time(millisecond) - Start).
+
+%% Client behind a socket adapter; the bridge relays to the server's
+%% real UDP socket. For the first DropMs milliseconds everything the
+%% server sends back is dropped; the client direction is never touched.
+connect_through_bridge(Port, DropMs) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef, DropMs) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    {Conn, Bridge}.
+
+bridge_init(ServerIP, ServerPort, SocketRef, DropMs) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    Deadline = erlang:monotonic_time(millisecond) + DropMs,
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        drop_until => Deadline,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {send, _IP, _Port, Pkt} ->
+            ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case erlang:monotonic_time(millisecond) < maps:get(drop_until, Bridge) of
+                true ->
+                    bridge_loop(Bridge);
+                false ->
+                    case maps:get(conn, Bridge) of
+                        undefined ->
+                            bridge_loop(Bridge#{
+                                pending := [Data | maps:get(pending, Bridge)]
+                            });
+                        Conn ->
+                            deliver(Bridge, Conn, Data),
+                            bridge_loop(Bridge)
+                    end
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.

--- a/test/quic_tls_compliance_tests.erl
+++ b/test/quic_tls_compliance_tests.erl
@@ -480,3 +480,21 @@ verify_resumption_binder_fails_closed_without_offset_test() ->
             crypto:strong_rand_bytes(32), aes_128_gcm, <<"ch">>, undefined, <<"binder">>
         )
     ).
+
+%% A CRYPTO frame may end anywhere, including inside the four-byte
+%% handshake message header. Every short prefix must report `incomplete'
+%% so the caller buffers it and waits: reporting `invalid' made the
+%% server discard a split client Finished and wedge the handshake.
+split_handshake_header_is_incomplete_test() ->
+    Body = binary:copy(<<$v>>, 32),
+    Msg = <<?TLS_FINISHED:8, 32:24, Body/binary>>,
+    lists:foreach(
+        fun(N) ->
+            ?assertEqual(
+                {N, {error, incomplete}},
+                {N, quic_tls:decode_handshake_message(binary:part(Msg, 0, N))}
+            )
+        end,
+        lists:seq(0, byte_size(Msg) - 1)
+    ),
+    ?assertEqual({ok, {?TLS_FINISHED, Body}, <<>>}, quic_tls:decode_handshake_message(Msg)).

--- a/test/quic_tls_negotiation_tests.erl
+++ b/test/quic_tls_negotiation_tests.erl
@@ -189,3 +189,22 @@ unsupported_scheme_errors_test() ->
         {unsupported_signature_scheme, _},
         quic_tls:build_certificate_verify(16#FFFF, Key, crypto:hash(sha256, <<"x">>))
     ).
+
+%% SHA-384 suites use 48-byte verify_data; parse_finished must not
+%% truncate it and verify_finished must not badarg on length mismatch.
+sha384_finished_roundtrip_test() ->
+    Secret = crypto:strong_rand_bytes(48),
+    Transcript = crypto:strong_rand_bytes(48),
+    Key = quic_crypto:derive_finished_key(aes_256_gcm, Secret),
+    VerifyData = quic_crypto:compute_finished_verify(aes_256_gcm, Key, Transcript),
+    ?assertEqual(48, byte_size(VerifyData)),
+    ?assertEqual({ok, VerifyData}, quic_tls:parse_finished(VerifyData)),
+    ?assert(quic_tls:verify_finished(VerifyData, Secret, Transcript, aes_256_gcm)).
+
+wrong_length_finished_is_false_not_badarg_test() ->
+    Secret = crypto:strong_rand_bytes(48),
+    Transcript = crypto:strong_rand_bytes(48),
+    Key = quic_crypto:derive_finished_key(aes_256_gcm, Secret),
+    VerifyData = quic_crypto:compute_finished_verify(aes_256_gcm, Key, Transcript),
+    <<Truncated:32/binary, _/binary>> = VerifyData,
+    ?assertNot(quic_tls:verify_finished(Truncated, Secret, Transcript, aes_256_gcm)).


### PR DESCRIPTION
Aggregates #222, #247, #253, #259 and #263, commits keeping their authors. #225 and #230 ride along because #259 is branched on them.

#259's suite fails on current main: #264, merged in #266, stopped tracking PMTU probes as ack-eliciting, and the client's Finished retransmit was leaning on those probes to arm a PTO. Bisected to that single line; reverting it makes the suite pass and reverting the loss-side half does not.

Rather than give the probe change back, the retained flight now carries its own timer, doubling per attempt between a 100 ms floor and a 3 s ceiling and cancelled on HANDSHAKE_DONE. `survives_four_lost_finished` is past what the server's own retransmissions can prompt, so it fails if that timer is disarmed.