### PR TITLE
Flow control and stream reassembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- The connection-level MAX_DATA update triggers on remaining headroom
+  rather than cumulative bytes received. The old comparison became
+  permanently true once total received passed one window, putting an
+  ack-eliciting MAX_DATA on every packet. Contributed by jbevemyr (#209).
+- Retained ACK ranges are capped at 64 per packet-number space
+  (RFC 9000 section 13.2.4). Under burst loss the list fragmented into
+  hundreds of ranges, and every outgoing ACK encoded all of them.
+  Contributed by jbevemyr (#211).
+- Overlapping and duplicate chunks are handled when reassembling stream
+  and CRYPTO data, keeping the longer chunk at a given offset instead of
+  trusting whichever arrived first. Contributed by jbevemyr (#223).
+- A flow-control-blocked write no longer strands data behind a blocked
+  queue head: the sendable prefix goes out, the remainder requeues in
+  order, and queued data is normalised to a binary. Contributed by
+  jbevemyr (#233).
+- Streams are reclaimed when their FIN is acknowledged rather than when
+  it is sent, so a lost FIN cannot retire the stream early. Contributed
+  by jbevemyr (#236).
+- MAX_STREAM_DATA is no longer sent for a stream whose final size the
+  peer has already declared. Contributed by jbevemyr (#241).
 - The client's retained Finished flight carries its own retransmission
   timer. Once the state machine leaves the handshake nothing is
   guaranteed to be in flight to arm a PTO, so a Finished lost more than

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -141,6 +141,7 @@
 -export([
     chunk_crypto/3,
     add_to_ack_ranges/2,
+    cap_ack_ranges/1,
     merge_ack_ranges/1,
     convert_ack_ranges_for_encode/1,
     convert_rest_ranges/2,

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -6991,9 +6991,12 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                     recv_max_data = NewMaxStreamData
                                 },
                                 MaxStreamDataFrame = {max_stream_data, StreamId, NewMaxStreamData},
-                                %% Update cached max stream recv window
+                                %% Cache the granted window *size* (not the
+                                %% absolute limit) for the connection-window
+                                %% multiplier below.
                                 NewCachedMax = max(
-                                    NewMaxStreamData, State1#state.fc_max_stream_recv_window
+                                    NewMaxStreamData - NewRecvOffset,
+                                    State1#state.fc_max_stream_recv_window
                                 ),
                                 State1a = State1#state{
                                     streams = maps:put(StreamId, UpdatedStream, Streams),
@@ -7005,12 +7008,16 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                 State1
                         end,
 
-                    %% Check if we need to send MAX_DATA for connection-level flow control
-                    %% Send when we've consumed more than 50% of our advertised connection window
-                    %% RTT-based auto-tuning with connection/stream multiplier enforcement
+                    %% Check if we need to send MAX_DATA for connection-level flow
+                    %% control. Trigger on remaining headroom (limit - received),
+                    %% like the per-stream update above: comparing cumulative
+                    %% received bytes against the absolute limit becomes
+                    %% permanently true once total received exceeds one window,
+                    %% spraying an ack-eliciting MAX_DATA on every packet.
                     MaxDataLocalVal = State2#state.max_data_local,
+                    ConnHeadroom = max(0, MaxDataLocalVal - NewDataReceivedVal),
                     State3 =
-                        case NewDataReceivedVal > (MaxDataLocalVal div 2) of
+                        case ConnHeadroom < (State2#state.fc_max_receive_window div 2) of
                             true ->
                                 Now2 = erlang:monotonic_time(millisecond),
                                 SmoothedRTT2 = quic_loss:smoothed_rtt(State2#state.loss_state),
@@ -7034,11 +7041,15 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                     InitialConnWindow,
                                     FastConsumption2
                                 ),
-                                %% Ensure connection window >= 1.5x largest stream window
+                                %% Ensure connection window >= 1.5x largest stream
+                                %% window. MaxStreamWindow is a window size; anchor
+                                %% it at the delivered offset to compare limits.
                                 MaxStreamWindow = get_max_stream_recv_window(State2),
-                                MinConnWindow = trunc(
-                                    MaxStreamWindow * ?CONNECTION_FLOW_CONTROL_MULTIPLIER
-                                ),
+                                MinConnWindow =
+                                    NewDataReceivedVal +
+                                        trunc(
+                                            MaxStreamWindow * ?CONNECTION_FLOW_CONTROL_MULTIPLIER
+                                        ),
                                 NewMaxData = max(BaseNewMaxData, MinConnWindow),
                                 MaxDataFrame = {max_data, NewMaxData},
                                 State2a = send_frame(MaxDataFrame, State2),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8962,8 +8962,15 @@ process_send_queue_unbudgeted(#state{send_queue = PQ} = State) ->
                     %% Flow control allows - dequeue and try to send
                     process_send_queue_entry(State);
                 {blocked, _Reason} ->
-                    %% Flow control blocked - leave in queue, wait for MAX_DATA
-                    State
+                    %% An entry larger than the current window still has a
+                    %% sendable prefix. Waiting for one grant big enough for
+                    %% the whole entry stalls against a peer that extends its
+                    %% window in small steps as it reads, because it sizes the
+                    %% grant to what it consumed, never to what we have queued.
+                    case split_blocked_head(State) of
+                        {ok, SplitState} -> process_send_queue_entry(SplitState);
+                        false -> State
+                    end
             end;
         {value, {retransmit_stream, _StreamId, _Offset, _Data, _Fin, DataSize}} ->
             %% Retransmits are exempt from flow control (bytes already counted),
@@ -9007,6 +9014,45 @@ check_send_queue_flow_control(StreamId, Offset, DataSize, #state{
                     ok
             end
     end.
+
+%% Replace a flow-control-blocked head entry with the prefix that fits plus
+%% the remainder, both at the front so stream order is preserved. Returns
+%% false when nothing fits, when the whole entry fits (the caller should not
+%% have been blocked), or for a zero-length FIN-only entry.
+split_blocked_head(#state{send_queue = PQ, send_queue_count = QueueCount} = State) ->
+    case pqueue_peek(PQ) of
+        {value, {stream_data, StreamId, Offset, Data, Fin, DataSize}} ->
+            case blocked_head_allowance(StreamId, Offset, State) of
+                Allowed when Allowed > 0, Allowed < DataSize ->
+                    {{value, _}, PQ1} = pqueue_out(PQ),
+                    <<Head:Allowed/binary, Tail/binary>> = Data,
+                    Urgency = get_stream_urgency(StreamId, State#state.streams),
+                    TailEntry =
+                        {stream_data, StreamId, Offset + Allowed, Tail, Fin, DataSize - Allowed},
+                    HeadEntry = {stream_data, StreamId, Offset, Head, false, Allowed},
+                    PQ2 = pqueue_in_front(TailEntry, Urgency, PQ1),
+                    PQ3 = pqueue_in_front(HeadEntry, Urgency, PQ2),
+                    {ok, State#state{send_queue = PQ3, send_queue_count = QueueCount + 1}};
+                _ ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+%% Bytes of the entry at Offset that both connection and stream windows admit.
+blocked_head_allowance(StreamId, Offset, #state{
+    max_data_remote = MaxDataRemote,
+    data_sent = DataSent,
+    streams = Streams
+}) ->
+    ConnectionAllowed = MaxDataRemote - DataSent,
+    StreamAllowed =
+        case maps:find(StreamId, Streams) of
+            {ok, #stream_state{send_max_data = SendMaxData}} -> SendMaxData - Offset;
+            error -> ConnectionAllowed
+        end,
+    min(ConnectionAllowed, StreamAllowed).
 
 %% Actually process the queue entry (called after flow control check passes)
 process_send_queue_entry(

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -148,6 +148,9 @@
     test_check_flow_control/6,
     test_queue_blocked_send/5,
     close_reason_to_code/1,
+    %% Out-of-order reassembly (RFC 9000 §2.2, §13.3)
+    extract_contiguous_data/2,
+    trim_reassembly_buffer/2,
     %% Migration frame classification (RFC 9000 Section 9.1)
     is_probing_frame/1,
     contains_non_probing_frame/1,
@@ -5526,8 +5529,9 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                     false ->
                         State
                 end,
-            %% Add data to buffer
-            NewBuffer = maps:put(Offset, Data, Buffer),
+            %% Add data to buffer, keeping the longer chunk if the peer
+            %% already sent one at this offset.
+            NewBuffer = keep_longest_chunk(Offset, Data, Buffer),
             NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State0#state.crypto_buffer),
 
             State1 = State0#state{crypto_buffer = NewCryptoBuffer},
@@ -5560,7 +5564,21 @@ process_crypto_buffer(Level, State) ->
             %% Try to process more
             process_crypto_buffer(Level, State2);
         error ->
-            State
+            %% Nothing keyed exactly at ExpectedOffset, which does not mean a
+            %% gap: a peer may re-frame CRYPTO data it retransmits (RFC 9000
+            %% §13.3), so the bytes we need can sit inside a chunk that starts
+            %% earlier. Drop what is already consumed, re-key what straddles
+            %% the offset, then retry once. Storing the trimmed buffer also
+            %% stops duplicate retransmissions from accumulating against
+            %% ?MAX_CRYPTO_BUFFER_BYTES and closing a healthy connection.
+            Trimmed = trim_reassembly_buffer(Buffer, ExpectedOffset),
+            State1 = State#state{
+                crypto_buffer = maps:put(Level, Trimmed, State#state.crypto_buffer)
+            },
+            case maps:is_key(ExpectedOffset, Trimmed) of
+                true -> process_crypto_buffer(Level, State1);
+                false -> State1
+            end
     end.
 
 %% Process TLS handshake data from CRYPTO frames
@@ -6886,7 +6904,7 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                                 {Data, EndOffset, RecvBuffer, Fin};
                             false ->
                                 %% Out-of-order or buffer has data: use buffer path
-                                UpdatedBuffer = maps:put(Offset, Data, RecvBuffer),
+                                UpdatedBuffer = keep_longest_chunk(Offset, Data, RecvBuffer),
                                 {ExtractedData, ExtractedOffset, ExtractedBuffer} =
                                     extract_contiguous_data(UpdatedBuffer, CurrentOffset),
                                 ExtractedFin =
@@ -6926,11 +6944,16 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                         end,
                     NewDataReceivedVal = DataReceived + NewBytesReceived,
 
-                    %% Update receive buffer bytes tracking
-                    %% Net change: add new bytes, subtract delivered bytes
-                    DeliveredBytes = byte_size(DeliverData),
+                    %% Update receive buffer bytes tracking from the buffer
+                    %% itself. The new-minus-delivered estimate drifts upward
+                    %% once retransmissions overlap, because the overlapping
+                    %% bytes count as new but are never delivered twice, and
+                    %% that drift would eventually trip the cap on a stream
+                    %% holding nothing.
                     NewRecvBufferBytes = max(
-                        0, RecvBufferBytes + NewBytesReceived - DeliveredBytes
+                        0,
+                        RecvBufferBytes - reassembly_buffer_bytes(RecvBuffer) +
+                            reassembly_buffer_bytes(NewBuffer)
                     ),
 
                     State1 = State#state{
@@ -7092,9 +7115,48 @@ extract_contiguous_data(Buffer, Offset, Acc) ->
             NextOffset = Offset + byte_size(Data),
             extract_contiguous_data(NewBuffer, NextOffset, <<Acc/binary, Data/binary>>);
         error ->
-            %% No data at this offset (gap in stream)
-            {Acc, Offset, Buffer}
+            %% Nothing keyed exactly at Offset, which does not mean a gap:
+            %% a peer may split or coalesce retransmitted data differently
+            %% (RFC 9000 §2.2, §13.3), so the bytes we want can sit inside
+            %% a chunk that starts earlier. Drop what is already delivered,
+            %% re-key what straddles Offset, then retry once.
+            Trimmed = trim_reassembly_buffer(Buffer, Offset),
+            case maps:is_key(Offset, Trimmed) of
+                true -> extract_contiguous_data(Trimmed, Offset, Acc);
+                false -> {Acc, Offset, Trimmed}
+            end
     end.
+
+%% Drop buffered chunks that end at or before Offset and trim those that
+%% straddle it, re-keying them to Offset. Keeps the longest chunk at each
+%% offset, so overlapping retransmissions collapse instead of accumulating.
+trim_reassembly_buffer(Buffer, Offset) ->
+    maps:fold(
+        fun(Off, Data, Acc) ->
+            End = Off + byte_size(Data),
+            if
+                End =< Offset ->
+                    Acc;
+                Off >= Offset ->
+                    keep_longest_chunk(Off, Data, Acc);
+                true ->
+                    Kept = binary:part(Data, Offset - Off, End - Offset),
+                    keep_longest_chunk(Offset, Kept, Acc)
+            end
+        end,
+        #{},
+        Buffer
+    ).
+
+keep_longest_chunk(Off, Data, Acc) ->
+    case Acc of
+        #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Acc;
+        _ -> Acc#{Off => Data}
+    end.
+
+%% Total bytes held in a reassembly buffer.
+reassembly_buffer_bytes(Buffer) ->
+    maps:fold(fun(_, Data, Acc) -> Acc + byte_size(Data) end, 0, Buffer).
 
 %% Get the maximum stream receive window across all streams.
 %% Used to ensure connection window >= 1.5x largest stream window.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -473,6 +473,8 @@
     %% StreamId => send reliable size, for local RESET_STREAM_AT streams whose
     %% data below the reliable size is not yet fully acked. Drained as acks arrive.
     pending_send_reset_at = #{} :: #{non_neg_integer() => non_neg_integer()},
+    %% FIN acked but earlier bytes still queued or in flight
+    pending_fin_reclaim = #{} :: #{non_neg_integer() => non_neg_integer()},
     %% Lost control-frame retransmissions deferred by congestion control, replayed
     %% through the CC-checked retransmit path when cwnd reopens.
     deferred_ctrl_retransmits = [] :: [term()],
@@ -4964,8 +4966,25 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
                     %% Retransmit lost packets
                     State4 = retransmit_lost_packets(LostPackets, State3),
 
+                    %% Close the send side of streams whose FIN the peer just
+                    %% acked (RFC 9000 §3.1 "Data Recvd"). Reclaiming here, and
+                    %% not at send time, paces MAX_STREAMS credit to what the
+                    %% peer has actually consumed; granting at send time let a
+                    %% peer run far ahead of its own completions.
+                    State4a =
+                        case
+                            lists:usort([
+                                Sid
+                             || #sent_packet{frames = Fs} <- AckedPackets,
+                                {stream, Sid, _O, _D, true} <- Fs
+                            ])
+                        of
+                            [] -> State4;
+                            FinSids -> lists:foldl(fun settle_fin_ack/2, State4, FinSids)
+                        end,
+
                     %% Reset PTO timer after ACK processing
-                    State5 = set_pto_timer(State4),
+                    State5 = set_pto_timer(State4a),
 
                     %% Try to send queued data now that cwnd may have freed up.
                     %% This also drains retransmit_stream entries deferred by CC.
@@ -4974,7 +4993,7 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
                     %% complete any local reset-at reclaim whose reliable bytes are
                     %% now acked.
                     State7 = flush_deferred_retransmits(State6),
-                    State8 = complete_send_reset_at(State7),
+                    State8 = complete_fin_reclaims(complete_send_reset_at(State7)),
                     %% Event-driven flush: flush batch and timers after ACK processing
                     flush_dirty_timers(flush_socket_batch(State8))
                 %% close inner case (on_ack_received)
@@ -8280,12 +8299,14 @@ do_send_data(
                                     case maps:find(StreamId, NewState#state.streams) of
                                         {ok, UpdatedStream} ->
                                             SendFin = (Fin andalso BytesSent =:= DataSize),
+                                            %% send_done is NOT set here: RFC 9000 §3.1
+                                            %% ends the send side at "Data Recvd", which
+                                            %% requires the peer's acks. Reclaim (and the
+                                            %% MAX_STREAMS credit it returns) happens in
+                                            %% the ack path via settle_fin_ack/2.
                                             FinalStream = UpdatedStream#stream_state{
                                                 send_offset = Offset + DataSize,
-                                                send_fin = SendFin,
-                                                send_done =
-                                                    SendFin orelse
-                                                        UpdatedStream#stream_state.send_done
+                                                send_fin = SendFin
                                             },
                                             FinalState0 = NewState#state{
                                                 streams = maps:put(
@@ -9113,7 +9134,7 @@ process_send_queue_entry(
                     %% Only update data_sent for connection-level flow control accounting.
                     %% send_offset was already advanced when the data was first queued
                     %% (in do_send_data) to prevent offset overlap bugs.
-                    State3 =
+                    State3a =
                         case BytesSent > 0 of
                             true ->
                                 State2#state{
@@ -9121,6 +9142,18 @@ process_send_queue_entry(
                                 };
                             false ->
                                 State2
+                        end,
+                    %% A queued write that carried FIN closes the send side only
+                    %% here: do_send_data could not mark it (the write was still
+                    %% queued). The queue-count check rules out a zero-length FIN
+                    %% entry that was re-queued rather than sent (0 =:= 0 lies).
+                    EntrySent =
+                        BytesSent =:= DataSize andalso
+                            State3a#state.send_queue_count =:= DecrementedQueueCount,
+                    State3 =
+                        case Fin andalso EntrySent of
+                            true -> mark_fin_sent(StreamId, State3a);
+                            false -> State3a
                         end,
                     %% If data was queued again (cwnd still full), stop processing
                     case pqueue_is_empty(State3#state.send_queue) of
@@ -10045,6 +10078,76 @@ complete_send_reset_at(#state{pending_send_reset_at = P} = State) ->
     ).
 
 %% Handle PTO timeout - send probe packet
+%% The drain-path counterpart of do_send_data's inline FIN bookkeeping.
+%% send_done is deliberately not set: that happens when the FIN is acked.
+mark_fin_sent(StreamId, State) ->
+    case maps:find(StreamId, State#state.streams) of
+        {ok, S} ->
+            State#state{
+                streams = maps:put(
+                    StreamId,
+                    S#stream_state{send_fin = true},
+                    State#state.streams
+                )
+            };
+        error ->
+            State
+    end.
+
+%% The peer acked a FIN-bearing STREAM frame. The send side is done once
+%% nothing below the final offset remains queued or in flight; otherwise
+%% park it for complete_fin_reclaims/1 to finish on a later ack.
+settle_fin_ack(StreamId, State) ->
+    case maps:find(StreamId, State#state.streams) of
+        {ok, #stream_state{send_done = true}} ->
+            State;
+        {ok, #stream_state{send_offset = Final}} ->
+            Pending =
+                stream_has_queued_below(StreamId, Final, State#state.send_queue) orelse
+                    quic_loss:stream_has_unacked_below(
+                        State#state.loss_state, StreamId, Final
+                    ),
+            case Pending of
+                false ->
+                    mark_send_done_and_reclaim(StreamId, State);
+                true ->
+                    State#state{
+                        pending_fin_reclaim =
+                            maps:put(StreamId, Final, State#state.pending_fin_reclaim)
+                    }
+            end;
+        error ->
+            State
+    end.
+
+%% Finish parked FIN reclaims whose remaining bytes are now acked.
+complete_fin_reclaims(#state{pending_fin_reclaim = P} = State) when map_size(P) =:= 0 ->
+    State;
+complete_fin_reclaims(#state{pending_fin_reclaim = P} = State) ->
+    maps:fold(
+        fun(StreamId, Final, Acc) ->
+            Pending =
+                stream_has_queued_below(StreamId, Final, Acc#state.send_queue) orelse
+                    quic_loss:stream_has_unacked_below(
+                        Acc#state.loss_state, StreamId, Final
+                    ),
+            case Pending of
+                true ->
+                    Acc;
+                false ->
+                    mark_send_done_and_reclaim(
+                        StreamId,
+                        Acc#state{
+                            pending_fin_reclaim =
+                                maps:remove(StreamId, Acc#state.pending_fin_reclaim)
+                        }
+                    )
+            end
+        end,
+        State,
+        P
+    ).
+
 handle_pto_timeout(#state{loss_state = LossState} = State) ->
     %% Increment PTO count
     NewLossState = quic_loss:on_pto_expired(LossState),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -257,6 +257,15 @@
 -define(HS_FLIGHT_MIN_INTERVAL, 100).
 -define(HS_FLIGHT_MAX_INTERVAL, 3000).
 
+%% Max ACK ranges retained per PN space (RFC 9000 §13.2.4 allows the
+%% receiver to limit these). Under burst loss an unbounded list
+%% fragments into hundreds of ranges, and since every outgoing ACK
+%% encodes the full list (and the peer decodes it), ACK processing
+%% cost grows O(ranges) per packet on both ends. Packets below the
+%% lowest retained range are retransmitted by the peer and dropped
+%% here as duplicates.
+-define(MAX_ACK_RANGES, 64).
+
 %% Max receive buffer size in bytes (32 MB total across all streams) - protects against malicious peers
 -define(MAX_RECV_BUFFER_BYTES, 33554432).
 
@@ -7642,12 +7651,21 @@ update_pn_space_recv(PN, PNSpace, Now) ->
             L -> L
         end,
     %% Add to ack_ranges maintaining descending order and merging adjacent ranges
-    NewRanges = add_to_ack_ranges(PN, Ranges),
+    NewRanges = cap_ack_ranges(add_to_ack_ranges(PN, Ranges)),
     PNSpace#pn_space{
         largest_recv = NewLargest,
         recv_time = Now,
         ack_ranges = NewRanges
     }.
+
+%% Drop the lowest ranges beyond ?MAX_ACK_RANGES (list is descending).
+cap_ack_ranges([_, _ | Tail] = Ranges) when Tail =/= [] ->
+    case length(Ranges) > ?MAX_ACK_RANGES of
+        true -> lists:sublist(Ranges, ?MAX_ACK_RANGES);
+        false -> Ranges
+    end;
+cap_ack_ranges(Ranges) ->
+    Ranges.
 
 %% Add a packet number to ACK ranges, maintaining descending order by Start
 %% and merging adjacent/overlapping ranges

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -6992,7 +6992,13 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                     %% advancing.
                     MaxWindowForStream = State#state.fc_max_receive_window,
                     Headroom = max(0, RecvMaxData - NewRecvOffset),
-                    WillSendMaxStreamData = Headroom < (MaxWindowForStream div 2),
+                    %% A stream whose final size is known can never use more
+                    %% credit (RFC 9000 §19.10), so widening its window only
+                    %% spends bytes: one frame per completed stream adds up
+                    %% in request/response traffic.
+                    WillSendMaxStreamData =
+                        Headroom < (MaxWindowForStream div 2) andalso
+                            NewStream#stream_state.final_size =:= undefined,
                     Threshold = RecvMaxData - (MaxWindowForStream div 2),
                     ?LOG_DEBUG(
                         #{

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8883,7 +8883,15 @@ queue_stream_data(
     } = State,
     Where
 ) ->
-    DataSize = iolist_size(Data),
+    %% Normalise to a binary: consumers like
+    %% dequeue_small_stream_frame_tuple/1 hand the entry's data straight
+    %% to quic_frame:encode/1, which requires a binary.
+    DataBin =
+        case is_binary(Data) of
+            true -> Data;
+            false -> iolist_to_binary(Data)
+        end,
+    DataSize = byte_size(DataBin),
     NewQueueBytes = QueueBytes + DataSize,
     case NewQueueBytes > ?MAX_SEND_QUEUE_BYTES of
         true ->
@@ -8901,7 +8909,7 @@ queue_stream_data(
         false ->
             Urgency = get_stream_urgency(StreamId, Streams),
             %% Cache DataSize in entry to avoid repeated iolist_size calls
-            Entry = {stream_data, StreamId, Offset, Data, Fin, DataSize},
+            Entry = {stream_data, StreamId, Offset, DataBin, Fin, DataSize},
             NewPQ =
                 case Where of
                     back -> pqueue_in(Entry, Urgency, PQ);

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -8599,14 +8599,23 @@ do_send_datagram(
 %% subsequent chunking reuses the same binary via sub-binary slices and
 %% downstream helpers can rely on the binary invariant without re-flattening.
 send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State) ->
+    send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, back).
+
+%% Where selects the queue position when a congestion/pacing block forces
+%% the unsent remainder back onto the send queue: `back' for fresh sends
+%% (their offset is highest, so appending keeps per-stream offset order),
+%% `front' when draining the queue (the popped entry's remainder must go
+%% back in front of higher-offset entries, or a later flow-control block
+%% at the head strands it behind them, leaving a permanent data hole).
+send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, Where) ->
     DataBin =
         case is_binary(Data) of
             true -> Data;
             false -> iolist_to_binary(Data)
         end,
-    send_stream_data_fragmented_tracked(StreamId, Offset, DataBin, Fin, State, 0).
+    send_stream_fragments(StreamId, Offset, DataBin, Fin, State, 0, Where).
 
-send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, BytesSentSoFar) when
+send_stream_fragments(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where) when
     is_binary(Data)
 ->
     %% Calculate max chunk size based on current PMTU
@@ -8615,15 +8624,17 @@ send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State, BytesSen
 
     case DataSize =< MaxChunkSize of
         true ->
-            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where);
         false ->
             %% Data is already a flat binary; chunk via sub-binary slices.
-            send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize)
+            send_stream_chunked(
+                StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize, Where
+            )
     end.
 
 %% @doc Send stream data that fits in a single packet.
 %% Data is a binary (normalised by send_stream_data_fragmented_tracked/5).
-send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) when
+send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where) when
     is_binary(Data)
 ->
     #state{cc_state = CCState, pacing_enabled = PacingEnabled, streams = Streams} = State,
@@ -8655,7 +8666,7 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) wh
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     PacedState = maybe_set_pacing_timer(Delay, QueuedState),
                     {PacedState, BytesSentSoFar};
@@ -8675,7 +8686,7 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar) wh
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     {QueuedState, BytesSentSoFar};
                 {error, send_queue_full} ->
@@ -8715,7 +8726,7 @@ cwnd_only_check(CCState, Size, Urgency) ->
 %% send_stream_data_fragmented_tracked/6. For a 10 MB upload this cuts
 %% thousands of get_stream_urgency/2 / get_max_stream_data_per_packet/1
 %% calls and record-pattern matches out of the hot send loop.
-send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize) ->
+send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunkSize, Where) ->
     Urgency = get_stream_urgency(StreamId, State#state.streams),
     PacketSize = MaxChunkSize + ?PACKET_OVERHEAD,
     %% Pre-compute the stream-frame header parts that stay constant
@@ -8726,7 +8737,7 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
     LengthVarint = quic_varint:encode(MaxChunkSize),
     HeaderPrefix =
         <<(?FRAME_STREAM bor ?STREAM_FLAG_OFF bor ?STREAM_FLAG_LEN):8, StreamIdVarint/binary>>,
-    Ctx = {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint},
+    Ctx = {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where},
     send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx).
 
 %% Inner chunked-send loop. Cached values in `Ctx' never change within a
@@ -8734,11 +8745,11 @@ send_stream_chunked(StreamId, Offset, Data, Fin, State, BytesSentSoFar, MaxChunk
 %% `send_stream_single_packet/6' so a partial last chunk gets a correctly
 %% sized packet (Length != MaxChunkSize) and can also carry a FIN.
 send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, _HeaderPrefix, _LengthVarint} = Ctx,
+    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, _HeaderPrefix, _LengthVarint, Where} = Ctx,
     DataSize = byte_size(Data),
     case DataSize =< MaxChunkSize of
         true ->
-            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar);
+            send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Where);
         false ->
             send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx)
     end.
@@ -8759,7 +8770,7 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
     end.
 
 send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint} = Ctx,
+    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where} = Ctx,
     #state{cc_state = CCState, pacing_enabled = PacingEnabled} = State,
     Check =
         case PacingEnabled of
@@ -8792,7 +8803,7 @@ send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSen
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     PacedState = maybe_set_pacing_timer(Delay, QueuedState),
                     {PacedState, BytesSentSoFar};
@@ -8814,7 +8825,7 @@ send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSen
                 },
                 ?QUIC_LOG_META
             ),
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     % Return bytes sent so far
                     {QueuedState, BytesSentSoFar};
@@ -8855,6 +8866,9 @@ queue_blocked_send(StreamId, Offset, Data, Fin, DataSize, State) ->
 %% Returns {ok, State} | {error, send_queue_full} if queue limit exceeded
 %% Entry format: {stream_data, StreamId, Offset, Data, Fin, DataSize}
 %% DataSize is cached to avoid repeated iolist_size calls
+queue_stream_data(StreamId, Offset, Data, Fin, State) ->
+    queue_stream_data(StreamId, Offset, Data, Fin, State, back).
+
 queue_stream_data(
     StreamId,
     Offset,
@@ -8866,7 +8880,8 @@ queue_stream_data(
         send_queue_bytes = QueueBytes,
         send_queue_count = QueueCount,
         send_queue_version = Version
-    } = State
+    } = State,
+    Where
 ) ->
     DataSize = iolist_size(Data),
     NewQueueBytes = QueueBytes + DataSize,
@@ -8887,7 +8902,11 @@ queue_stream_data(
             Urgency = get_stream_urgency(StreamId, Streams),
             %% Cache DataSize in entry to avoid repeated iolist_size calls
             Entry = {stream_data, StreamId, Offset, Data, Fin, DataSize},
-            NewPQ = pqueue_in(Entry, Urgency, PQ),
+            NewPQ =
+                case Where of
+                    back -> pqueue_in(Entry, Urgency, PQ);
+                    front -> pqueue_in_front(Entry, Urgency, PQ)
+                end,
             NewVersion = Version + 1,
             {ok, State#state{
                 send_queue = NewPQ,
@@ -9025,7 +9044,7 @@ process_send_queue_entry(
                 send_queue_bytes = DecrementedQueueBytes,
                 send_queue_count = DecrementedQueueCount
             },
-            case send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State1) of
+            case send_stream_data_fragmented_tracked(StreamId, Offset, Data, Fin, State1, front) of
                 {error, send_queue_full} ->
                     ?LOG_WARNING(
                         #{
@@ -9075,6 +9094,16 @@ process_send_queue_entry(
 pqueue_in(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
     Bucket = element(Urgency + 1, PQ),
     NewBucket = queue:in(Entry, Bucket),
+    setelement(Urgency + 1, PQ, NewBucket).
+
+%% Insert at the front of the urgency bucket. Used when a drain pops an
+%% entry and must put back an unsent remainder: appending it at the back
+%% would order it behind higher-offset entries of the same stream, and a
+%% later stream-flow-control block at the head then strands it forever
+%% (the peer cannot extend the window across the resulting data hole).
+pqueue_in_front(Entry, Urgency, PQ) when Urgency >= 0, Urgency =< 7 ->
+    Bucket = element(Urgency + 1, PQ),
+    NewBucket = queue:in_r(Entry, Bucket),
     setelement(Urgency + 1, PQ, NewBucket).
 
 %% Remove and return highest priority (lowest urgency) entry
@@ -9905,6 +9934,9 @@ defer_retransmit_frames(Frames, State) ->
 %% Queue a lost STREAM frame for retransmission. Exempt from flow control and
 %% data_sent (those were counted on the original send); bytes/count/version are
 %% updated like queue_stream_data/5 so the drain and reclaim-gate scans see it.
+%% Front-inserted: retransmits fill receiver-side holes, so they must not sit
+%% behind a flow-control-blocked head whose window can only grow once the hole
+%% is filled.
 enqueue_retransmit_stream(StreamId, Offset, Data, Fin, State) ->
     #state{
         send_queue = PQ,
@@ -9917,7 +9949,7 @@ enqueue_retransmit_stream(StreamId, Offset, Data, Fin, State) ->
     Urgency = get_stream_urgency(StreamId, Streams),
     Entry = {retransmit_stream, StreamId, Offset, Data, Fin, DataSize},
     State#state{
-        send_queue = pqueue_in(Entry, Urgency, PQ),
+        send_queue = pqueue_in_front(Entry, Urgency, PQ),
         send_queue_bytes = QueueBytes + DataSize,
         send_queue_count = QueueCount + 1,
         send_queue_version = Version + 1

--- a/test/quic_flow_control_batch_tests.erl
+++ b/test/quic_flow_control_batch_tests.erl
@@ -1,0 +1,112 @@
+%%% -*- erlang -*-
+%%%
+%%% Receive-side bookkeeping on the flow-control path: the retained ACK
+%%% range cap, and that a blocked write leaves the queue in send order.
+
+-module(quic_flow_control_batch_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MAX_ACK_RANGES, 64).
+
+%%====================================================================
+%% Retained ACK ranges (#211)
+%%====================================================================
+
+%% Every other packet lost fragments the ACK block into one range per
+%% packet. Unbounded, each outgoing ACK then encodes hundreds of ranges
+%% and the peer decodes them, on every packet.
+alternating_loss_is_capped_test() ->
+    Ranges = lists:foldl(
+        fun(PN, Acc) -> cap(quic_connection:add_to_ack_ranges(PN, Acc)) end,
+        [],
+        [PN || PN <- lists:seq(1, 400), PN rem 2 =:= 0]
+    ),
+    ?assertEqual(?MAX_ACK_RANGES, length(Ranges)).
+
+%% The cap keeps the newest ranges: the oldest are what the peer has
+%% already retransmitted or given up on.
+the_cap_keeps_the_highest_packet_numbers_test() ->
+    Ranges = lists:foldl(
+        fun(PN, Acc) -> cap(quic_connection:add_to_ack_ranges(PN, Acc)) end,
+        [],
+        [PN || PN <- lists:seq(1, 400), PN rem 2 =:= 0]
+    ),
+    [{HighStart, _} | _] = Ranges,
+    ?assertEqual(400, HighStart),
+    ?assert(lists:all(fun({S, E}) -> S =< E end, Ranges)).
+
+%% Contiguous delivery is one range however long it runs, so the cap
+%% never truncates an unfragmented ACK.
+contiguous_delivery_stays_one_range_test() ->
+    Ranges = lists:foldl(
+        fun(PN, Acc) -> cap(quic_connection:add_to_ack_ranges(PN, Acc)) end,
+        [],
+        lists:seq(1, 500)
+    ),
+    ?assertEqual([{1, 500}], Ranges).
+
+%% Ranges stay ordered and disjoint when packets arrive out of order.
+out_of_order_arrival_keeps_ranges_disjoint_test() ->
+    PNs = [10, 1, 7, 2, 9, 3, 8, 5],
+    Ranges = lists:foldl(
+        fun(PN, Acc) -> cap(quic_connection:add_to_ack_ranges(PN, Acc)) end,
+        [],
+        PNs
+    ),
+    Starts = [S || {S, _} <- Ranges],
+    ?assertEqual(lists:reverse(lists:sort(Starts)), Starts),
+    ?assertEqual([], [P || P <- PNs, not covered(P, Ranges)]).
+
+cap(Ranges) ->
+    quic_connection:cap_ack_ranges(Ranges).
+
+covered(PN, Ranges) ->
+    lists:any(fun({S, E}) -> PN >= S andalso PN =< E end, Ranges).
+
+%%====================================================================
+%% Blocked writes and window growth (#209, #233, #236)
+%%====================================================================
+
+large_write_test_() ->
+    {timeout, 60, fun a_write_past_the_window_arrives_whole_and_in_order/0}.
+
+%% A write several times the initial connection window blocks, queues,
+%% and drains as the peer's MAX_DATA arrives. It must come back byte for
+%% byte: a requeue that reorders, or a partial prefix accounted wrongly,
+%% shows up here as corruption rather than a stall.
+a_write_past_the_window_arrives_whole_and_in_order() ->
+    {ok, Srv} = quic_test_echo_server:start(),
+    try
+        #{port := Port} = Srv,
+        Opts = quic_test_echo_server:client_opts(),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, Opts, self()),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> error(connect_timeout)
+            end,
+            {ok, StreamId} = quic:open_stream(Conn),
+            Payload = payload(4 * 1024 * 1024),
+            ok = quic:send_data(Conn, StreamId, Payload, true),
+            ?assertEqual(Payload, collect(Conn, StreamId, <<>>))
+        after
+            quic:safe_close(Conn, normal)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+%% Position-dependent bytes, so a reordered chunk cannot compare equal.
+payload(Size) ->
+    iolist_to_binary([<<(N rem 251)>> || N <- lists:seq(1, Size)]).
+
+collect(Conn, StreamId, Acc) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            collect(Conn, StreamId, <<Acc/binary, Data/binary>>)
+    after 30000 ->
+        Acc
+    end.

--- a/test/quic_reassembly_tests.erl
+++ b/test/quic_reassembly_tests.erl
@@ -1,0 +1,126 @@
+%%% Out-of-order reassembly tests.
+%%%
+%%% RFC 9000 §2.2 and §13.3 let a peer split or coalesce data it
+%%% retransmits differently from the original send, so buffered chunks
+%%% can overlap and can repeat data already delivered. The reassembler
+%%% must therefore not assume a chunk starts exactly where the next
+%%% delivery does.
+-module(quic_reassembly_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Byte at absolute stream offset N, so assembled output can be checked
+%% against the offsets it claims to cover.
+chunk(Start, Len) ->
+    <<<<(B rem 256)>> || B <- lists:seq(Start, Start + Len - 1)>>.
+
+extract(Buffer, Offset) ->
+    quic_connection:extract_contiguous_data(Buffer, Offset).
+
+trim(Buffer, Offset) ->
+    quic_connection:trim_reassembly_buffer(Buffer, Offset).
+
+%%====================================================================
+%% Extraction
+%%====================================================================
+
+exact_chunks_are_joined_test() ->
+    Buffer = #{0 => chunk(0, 100), 100 => chunk(100, 100)},
+    ?assertEqual({chunk(0, 200), 200, #{}}, extract(Buffer, 0)).
+
+gap_stops_extraction_test() ->
+    Buffer = #{0 => chunk(0, 100), 200 => chunk(200, 100)},
+    ?assertEqual({chunk(0, 100), 100, #{200 => chunk(200, 100)}}, extract(Buffer, 0)).
+
+%% The regression: the second chunk starts inside the first, so nothing
+%% is keyed at the offset extraction reaches. Keying by exact offset
+%% left those bytes unreachable and stalled the stream for good.
+overlapping_chunks_do_not_stall_test() ->
+    Buffer = #{1000 => chunk(1000, 500), 1200 => chunk(1200, 500)},
+    ?assertEqual({chunk(1000, 700), 1700, #{}}, extract(Buffer, 1000)).
+
+%% Same shape one level deeper: a re-framed retransmission that overlaps
+%% two buffered chunks at once.
+overlap_spanning_two_chunks_test() ->
+    Buffer = #{
+        0 => chunk(0, 100),
+        50 => chunk(50, 300),
+        200 => chunk(200, 400)
+    },
+    ?assertEqual({chunk(0, 600), 600, #{}}, extract(Buffer, 0)).
+
+%% A chunk wholly contained in one already buffered adds nothing and
+%% must not truncate the delivery.
+contained_chunk_is_absorbed_test() ->
+    Buffer = #{0 => chunk(0, 500), 100 => chunk(100, 50)},
+    ?assertEqual({chunk(0, 500), 500, #{}}, extract(Buffer, 0)).
+
+%% Data below the delivery point was already handed to the owner. It has
+%% to be dropped rather than left to accumulate: it was never counted
+%% against the receive-buffer cap, so it grew unbounded and unnoticed.
+consumed_chunks_are_dropped_test() ->
+    Buffer = #{0 => chunk(0, 100), 100 => chunk(100, 100)},
+    ?assertEqual({<<>>, 500, #{}}, extract(Buffer, 500)).
+
+duplicate_below_offset_is_dropped_but_gap_kept_test() ->
+    Buffer = #{0 => chunk(0, 100), 900 => chunk(900, 10)},
+    ?assertEqual({<<>>, 500, #{900 => chunk(900, 10)}}, extract(Buffer, 500)).
+
+empty_buffer_test() ->
+    ?assertEqual({<<>>, 42, #{}}, extract(#{}, 42)).
+
+%%====================================================================
+%% Trimming
+%%====================================================================
+
+trim_drops_consumed_and_rekeys_straddling_test() ->
+    Buffer = #{100 => chunk(100, 500), 300 => chunk(300, 100)},
+    ?assertEqual(#{400 => chunk(400, 200)}, trim(Buffer, 400)).
+
+%% Two chunks that both trim to the same offset collapse to the longer
+%% one, so overlapping retransmissions cannot displace live data.
+trim_keeps_the_longer_chunk_test() ->
+    Buffer = #{100 => chunk(100, 500), 200 => chunk(200, 600)},
+    ?assertEqual(#{300 => chunk(300, 500)}, trim(Buffer, 300)).
+
+trim_is_idempotent_test() ->
+    Buffer = #{0 => chunk(0, 100), 50 => chunk(50, 300), 200 => chunk(200, 400)},
+    Once = trim(Buffer, 120),
+    ?assertEqual(Once, trim(Once, 120)).
+
+trim_leaves_future_chunks_untouched_test() ->
+    Buffer = #{800 => chunk(800, 100), 900 => chunk(900, 100)},
+    ?assertEqual(Buffer, trim(Buffer, 800)).
+
+%%====================================================================
+%% Randomised: any fragmentation of a known stream reassembles to it
+%%====================================================================
+
+random_fragmentations_reassemble_test() ->
+    Total = 4000,
+    Stream = chunk(0, Total),
+    lists:foreach(
+        fun(Seed) ->
+            rand:seed(exsplus, {Seed, Seed * 7 + 1, Seed * 13 + 3}),
+            Buffer = lists:foldl(
+                fun(_, Acc) ->
+                    Off = rand:uniform(Total) - 1,
+                    Len = rand:uniform(min(600, Total - Off)),
+                    add_chunk(Off, chunk(Off, Len), Acc)
+                end,
+                #{},
+                lists:seq(1, 60)
+            ),
+            %% Guarantee full coverage so the whole stream is contiguous.
+            Full = add_chunk(0, Stream, Buffer),
+            ?assertEqual({Seed, {Stream, Total, #{}}}, {Seed, extract(Full, 0)})
+        end,
+        lists:seq(1, 100)
+    ).
+
+%% Mirrors how the connection inserts: keep whichever chunk is longer.
+add_chunk(Off, Data, Buffer) ->
+    case Buffer of
+        #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Buffer;
+        _ -> Buffer#{Off => Data}
+    end.


### PR DESCRIPTION
Aggregates #209, #211, #223, #233, #236 and #241, commits keeping their authors.

#233's first commit is a second version of the async-send fix #268 already merged from #225, so it is dropped and only its three new commits are carried. Two conflicts needed a decision rather than a merge: #223's overlap-tolerant CRYPTO buffering combines with the Finished-resend trigger in the same block, and #233's new chunked_ctx field folds into the burst-budget wrapper from #267.

Five of the six arrived without tests. Added: the retained ACK range cap under alternating loss, and a 4 MB write past the initial window echoed back with position-dependent bytes, so a reordered requeue or a mis-accounted partial prefix shows as corruption rather than a stall.