### PR TITLE
TLS configuration, sessions and 0-RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- TLS secrets are written to the file named by `SSLKEYLOGFILE` when it is
+  set, in the format Wireshark reads. Contributed by jbevemyr (#231).
 - `max_burst_packets` bounds how many packets leave per send drain, so a
   large queued write cannot monopolise the scheduler. Contributed by
   jbevemyr (#214).
@@ -13,6 +15,24 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- The server sends a Retry when configured to, and its cipher preference
+  order is configurable rather than fixed. Contributed by jbevemyr (#232).
+- The client offers the cipher suites it was configured with instead of
+  always the built-in list, and honours the `version` option.
+  Contributed by jbevemyr (#232, #235).
+- Short headers are unprotected with the negotiated cipher, so a
+  connection that negotiated ChaCha20-Poly1305 no longer fails to
+  decrypt. Contributed by jbevemyr (#234).
+- A session ticket selects the PSK it belongs to rather than only
+  feeding 0-RTT, so resumption works on its own. Contributed by
+  jbevemyr (#238).
+- The session-ticket table is owned by the server registry rather than
+  whichever connection created it: it used to vanish with that
+  connection, and a client resuming afterwards fell back to a full
+  handshake. Contributed by jbevemyr (#239).
+- Only the client sends 0-RTT, and 0-RTT data lost in flight is resent.
+  Oversized 0-RTT writes are split, and the idle-state send path is
+  gated too. Contributed by jbevemyr (#240).
 - The connection-level MAX_DATA update triggers on remaining headroom
   rather than cumulative bytes received. The old comparison became
   permanently true once total received passed one window, putting an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,16 @@ All notable changes to this project will be documented in this file.
   millisecond resolution, so the fixed bucket capped throughput at 12
   packets per wakeup whenever the sender outran the ACK clock,
   regardless of the configured rate. Contributed by jbevemyr (#219).
+### Changed
+- A server with no explicit `groups` option now offers every classical
+  group the crypto layer supports (x25519, secp256r1, secp384r1) instead
+  of x25519 alone. A preference list holding only x25519 sent a
+  HelloRetryRequest to any client whose key_share led with another
+  curve, costing a full extra round trip on every such connection and
+  exercising the HRR path in flows that did not need it. picoquic shares
+  P-256 first, so this was every connection from it. An explicit
+  `groups` option still restricts the set exactly as before.
+  Contributed by jbevemyr (#246).
 
 ## [1.8.1] - 2026-08-15
 

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -113,7 +113,9 @@ build_server_opts(TestCase, Cert, Key, WwwDir) ->
     %% Test case specific options
     case TestCase of
         "retry" ->
-            BaseOpts#{retry => true};
+            %% The listener reads address_validation; `retry' was set here
+            %% but nothing ever looked at it, so no Retry was sent.
+            BaseOpts#{address_validation => always};
         "chacha20" ->
             BaseOpts#{ciphers => [chacha20_poly1305]};
         "v2" ->

--- a/src/quic_aead.erl
+++ b/src/quic_aead.erl
@@ -46,6 +46,7 @@
     unprotect_long_packet/7,
     %% 2-stage short header receive API (for key-phase handling)
     unprotect_short_header/4,
+    unprotect_short_header/5,
     decrypt_short_payload/8
 ]).
 
@@ -475,7 +476,18 @@ unprotect_packet_common(Cipher, Key, IV, HP, Header, EncryptedPayload, LargestRe
 -spec unprotect_short_header(binary(), binary(), binary(), non_neg_integer()) ->
     {ok, 0 | 1, 1..4, non_neg_integer(), binary()} | {error, term()}.
 unprotect_short_header(HP, Header, EncryptedPayload, PNOffset) ->
-    case unprotect_header(HP, Header, EncryptedPayload, PNOffset) of
+    %% Guesses the cipher from the HP key length, which cannot tell
+    %% AES-256-GCM from ChaCha20-Poly1305. Prefer the /5 variant.
+    unprotect_short_header(cipher_for_key(HP), HP, Header, EncryptedPayload, PNOffset).
+
+%% @doc Like unprotect_short_header/4 but with the cipher given by the
+%% caller, which is required when ChaCha20-Poly1305 is negotiated: its
+%% 32-byte HP key is indistinguishable from AES-256-GCM's, and the two
+%% mask constructions are unrelated.
+-spec unprotect_short_header(cipher(), binary(), binary(), binary(), non_neg_integer()) ->
+    {ok, 0 | 1, 1..4, non_neg_integer(), binary()} | {error, term()}.
+unprotect_short_header(Cipher, HP, Header, EncryptedPayload, PNOffset) ->
+    case unprotect_header(Cipher, HP, Header, EncryptedPayload, PNOffset) of
         {error, Reason} ->
             {error, {header_unprotect_failed, Reason}};
         {UnprotectedHeader, PNLen} ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1804,12 +1804,25 @@ idle({call, From}, open_unidirectional_stream, #state{early_keys = _EarlyKeys} =
         {error, Reason} ->
             {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
-%% 0-RTT: Allow sending data in idle state if early keys are available
+%% 0-RTT sending is client-only (RFC 9000 §17.2.3), here as in the
+%% handshaking state: a server handler answering early data delivered
+%% before the handshake completes must queue, or the response goes out
+%% as a 0-RTT packet the client can never decrypt.
+idle(
+    {call, From},
+    {send_data, StreamId, Data, Fin},
+    #state{role = client, early_keys = EarlyKeys} = State
+) when EarlyKeys =/= undefined ->
+    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
+        {ok, NewState} ->
+            {keep_state, NewState, [{reply, From, ok}]};
+        {error, Reason} ->
+            {keep_state, State, [{reply, From, {error, Reason}}]}
+    end;
 idle(
     {call, From},
     {send_data, StreamId, Data, Fin},
     #state{
-        early_keys = undefined,
         pending_data = Pending
     } = State
 ) ->
@@ -1819,13 +1832,6 @@ idle(
         false ->
             NewPending = Pending ++ [{StreamId, Data, Fin}],
             {keep_state, State#state{pending_data = NewPending}, [{reply, From, ok}]}
-    end;
-idle({call, From}, {send_data, StreamId, Data, Fin}, #state{early_keys = _} = State) ->
-    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            {keep_state, NewState, [{reply, From, ok}]};
-        {error, Reason} ->
-            {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
 idle(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     NewState = handle_packet(Data, State),
@@ -8413,12 +8419,13 @@ do_send_zero_rtt_data(
             DataBin = iolist_to_binary(Data),
             Offset = StreamState#stream_state.send_offset,
 
-            %% Build STREAM frame
-            Frame = {stream, StreamId, Offset, DataBin, Fin},
-            Payload = quic_frame:encode(Frame),
-
-            %% Send as 0-RTT packet
-            NewState = send_zero_rtt_packet(Payload, [Frame], EarlyKeys, State),
+            %% A write larger than one packet must be split like any
+            %% 1-RTT send; a single oversized 0-RTT packet leaves as one
+            %% IP-fragmented datagram, which QUIC forbids (RFC 9000 §14).
+            MaxChunk = get_max_stream_data_per_packet(State),
+            NewState = send_zero_rtt_chunks(
+                StreamId, Offset, DataBin, Fin, MaxChunk, EarlyKeys, State
+            ),
 
             %% Update stream state and track early data sent
             NewStreamState = StreamState#stream_state{
@@ -8442,6 +8449,18 @@ do_send_zero_rtt_data(
         error ->
             {error, unknown_stream}
     end.
+
+%% Split a 0-RTT write into per-packet STREAM frames, FIN on the last.
+send_zero_rtt_chunks(StreamId, Offset, Data, Fin, MaxChunk, EarlyKeys, State) when
+    byte_size(Data) =< MaxChunk
+->
+    Frame = {stream, StreamId, Offset, Data, Fin},
+    send_zero_rtt_packet(quic_frame:encode(Frame), [Frame], EarlyKeys, State);
+send_zero_rtt_chunks(StreamId, Offset, Data, Fin, MaxChunk, EarlyKeys, State) ->
+    <<Chunk:MaxChunk/binary, Rest/binary>> = Data,
+    Frame = {stream, StreamId, Offset, Chunk, false},
+    State1 = send_zero_rtt_packet(quic_frame:encode(Frame), [Frame], EarlyKeys, State),
+    send_zero_rtt_chunks(StreamId, Offset + MaxChunk, Rest, Fin, MaxChunk, EarlyKeys, State1).
 
 %% Send a 0-RTT packet (long header, type 1)
 %% RFC 9001 Section 5.3: 0-RTT packets use early traffic keys

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -46,7 +46,7 @@
 -dialyzer(
     {nowarn_function, [
         send_initial_ack/1,
-        select_cipher/1,
+        select_cipher/2,
         %% Reachable from the new TLS_SERVER_HELLO handler via the
         %% selected_psk_identity branch — but no eunit path currently
         %% exercises a PSK handshake end-to-end. The forthcoming
@@ -418,6 +418,7 @@
     %% PTO, so a lost Finished had no schedule to resend it on.
     hs_flight_timer = undefined :: reference() | undefined,
     hs_flight_tries = 0 :: non_neg_integer(),
+    cipher_preference = [aes_128_gcm, aes_256_gcm, chacha20_poly1305] :: [atom()],
     tls_ch1_opts :: map() | undefined,
     %% Negotiated values surfaced in the connected event
     negotiated_group :: atom() | undefined,
@@ -1245,6 +1246,7 @@ init({server, Opts}) ->
         next_stream_id_bidi = 1,
         % Server-initiated uni: 3, 7, 11, ...
         next_stream_id_uni = 3,
+        cipher_preference = maps:get(ciphers, Opts, default_cipher_preference()),
         max_streams_bidi_local = maps:get(max_streams_bidi, Opts, ?DEFAULT_MAX_STREAMS_BIDI),
         max_streams_bidi_remote = ?DEFAULT_MAX_STREAMS_BIDI,
         max_streams_uni_local = maps:get(max_streams_uni, Opts, ?DEFAULT_MAX_STREAMS_UNI),
@@ -1629,6 +1631,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         next_stream_id_bidi = 0,
         % Client-initiated uni: 2, 6, 10, ...
         next_stream_id_uni = 2,
+        cipher_preference = maps:get(ciphers, Opts, default_cipher_preference()),
         max_streams_bidi_local = maps:get(max_streams_bidi, Opts, ?DEFAULT_MAX_STREAMS_BIDI),
         max_streams_bidi_remote = ?DEFAULT_MAX_STREAMS_BIDI,
         max_streams_uni_local = maps:get(max_streams_uni, Opts, ?DEFAULT_MAX_STREAMS_UNI),
@@ -2789,11 +2792,15 @@ send_client_hello(State) ->
 %% Server: Select cipher suite from client's list (server preference)
 %% ClientCipherSuites is a list of TLS cipher suite codes (integers)
 %% Convert to atoms for internal use
-select_cipher(ClientCipherSuites) ->
-    %% Convert client's cipher suite codes to atoms
+%% The server's own order decides, so a deployment that must not negotiate
+%% a particular suite can say so; without this the preference was fixed in
+%% code and a `ciphers' option had nowhere to take effect.
+select_cipher(ClientCipherSuites, ServerPreference) ->
     ClientCiphers = [cipher_code_to_atom(C) || C <- ClientCipherSuites],
-    ServerPreference = [aes_128_gcm, aes_256_gcm, chacha20_poly1305],
     select_first_match(ServerPreference, ClientCiphers).
+
+default_cipher_preference() ->
+    [aes_128_gcm, aes_256_gcm, chacha20_poly1305].
 
 % Default
 select_first_match([], _) ->
@@ -5659,7 +5666,7 @@ process_tls_message(
                 session_id := SessionId
             } = ClientHelloInfo} ->
             %% Select cipher suite (prefer server's order)
-            Cipher = select_cipher(CipherSuites),
+            Cipher = select_cipher(CipherSuites, State#state.cipher_preference),
             %% RFC 8446 §4.1.4 group negotiation: use the client's
             %% key_share directly when possible, otherwise send a
             %% HelloRetryRequest for a mutually-supported group.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -3198,6 +3198,7 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     ServerAppSecret = quic_crypto:derive_server_app_secret(
         Cipher, MasterSecret, TranscriptHashFinal
     ),
+    keylog_application(State#state.tls_ch1_random, ClientAppSecret, ServerAppSecret),
 
     %% Derive app keys
     {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientAppSecret, Cipher),
@@ -5601,6 +5602,16 @@ process_crypto_buffer(Level, State) ->
             end
     end.
 
+%% Key logging is opt-in via SSLKEYLOGFILE and off otherwise; see
+%% quic_keylog for why it exists and what it exposes.
+keylog_handshake(ClientRandom, ClientSecret, ServerSecret) ->
+    quic_keylog:log(client_handshake, ClientRandom, ClientSecret),
+    quic_keylog:log(server_handshake, ClientRandom, ServerSecret).
+
+keylog_application(ClientRandom, ClientSecret, ServerSecret) ->
+    quic_keylog:log(client_application, ClientRandom, ClientSecret),
+    quic_keylog:log(server_application, ClientRandom, ServerSecret).
+
 %% Process TLS handshake data from CRYPTO frames
 process_tls_data(Level, Data, State) ->
     %% Prepend any buffered incomplete TLS data
@@ -5949,6 +5960,9 @@ process_tls_message(
                     ),
                     ServerAppSecret = quic_crypto:derive_server_app_secret(
                         Cipher, MasterSecret, TranscriptHashFinal
+                    ),
+                    keylog_application(
+                        State#state.tls_ch1_random, ClientAppSecret, ServerAppSecret
                     ),
 
                     %% Derive app keys
@@ -6300,6 +6314,7 @@ do_server_client_hello_cont(
     SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
 ) ->
     ClientALPN = maps:get(alpn_protocols, ClientHelloInfo, []),
+    ClientRandom = maps:get(random, ClientHelloInfo, undefined),
     TP = maps:get(transport_params, ClientHelloInfo, #{}),
     SessionId = maps:get(session_id, ClientHelloInfo, <<>>),
     %% Check for PSK (0-RTT/resumption/external)
@@ -6506,6 +6521,7 @@ do_server_client_hello_cont(
         negotiated_group = SelectedGroup,
         handshake_secret = HandshakeSecret,
         client_hs_secret = ClientHsSecret,
+        tls_ch1_random = ClientRandom,
         server_hs_secret = ServerHsSecret,
         handshake_keys = {ClientHsKeys, ServerHsKeys},
         alpn = ALPN,
@@ -6513,6 +6529,8 @@ do_server_client_hello_cont(
         early_data_accepted = (EarlyKeys =/= undefined andalso WantsEarlyData),
         selected_psk = SelectedPsk
     },
+    keylog_handshake(State#state.tls_ch1_random, ClientHsSecret, ServerHsSecret),
+    keylog_handshake(ClientRandom, ClientHsSecret, ServerHsSecret),
     %% Negotiate the CertificateVerify scheme up front (cert
     %% path only). No common scheme is fatal (RFC 8446 §4.4.3).
     case negotiate_cert_verify(SelectedPsk, State0) of

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1223,7 +1223,11 @@ init({server, Opts}) ->
             psk_callback => maps:get(psk_callback, Opts, undefined),
             psks => maps:get(psks, Opts, undefined)
         },
-        tls_groups = maps:get(groups, Opts, [x25519]),
+        %% Accept every group the crypto layer supports: a preference
+        %% list holding only x25519 forced a HelloRetryRequest round
+        %% trip on any client whose key_share leads with another group
+        %% (picoquic shares P-256 first).
+        tls_groups = maps:get(groups, Opts, [x25519, secp256r1, secp384r1]),
         tls_sig_algs = maps:get(signature_algs, Opts, undefined),
         alpn_list = normalize_alpn_list(ALPNList),
         pn_initial = PNSpace,

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -680,6 +680,7 @@
         undefined
         | #{
             identity => binary(),
+            identity_idx => non_neg_integer(),
             secret => binary(),
             mode => psk_dhe_ke | psk_ke
         },
@@ -6363,9 +6364,6 @@ do_server_client_hello_cont(
         end,
     ok,
 
-    %% For normal handshake, derive early secret from zero PSK
-    %% PSK-based resumption with full 0-RTT support requires additional changes
-    %% to skip Certificate/CertificateVerify - implementing basic 0-RTT decryption only
     HashLen0 =
         case Cipher of
             aes_256_gcm -> 48;
@@ -6373,13 +6371,14 @@ do_server_client_hello_cont(
         end,
     ZeroPSK = <<0:HashLen0/unit:8>>,
 
-    %% Derive early secret. External-PSK selection wins over both
-    %% resumption-PSK 0-RTT and the standard zero-PSK path.
+    %% Derive early secret. External-PSK selection wins over
+    %% resumption-PSK, which wins over the standard zero-PSK path.
     {EarlyKeys, EarlySecret, SelectedPsk} =
         case ExternalPskResult of
             {ok, #{secret := PSKSecret, mode := Mode} = Sel} ->
                 Selected = #{
                     identity => maps:get(identity, Sel),
+                    identity_idx => maps:get(identity_idx, Sel),
                     secret => PSKSecret,
                     mode => Mode
                 },
@@ -6390,9 +6389,7 @@ do_server_client_hello_cont(
                 };
             none ->
                 case PSKInfo of
-                    #{identities := [{Identity, _Age}], binders := [Binder]} when
-                        WantsEarlyData
-                    ->
+                    #{identities := [{Identity, _Age} | _], binders := [Binder | _]} ->
                         case validate_psk(Identity, Cipher, OriginalMsg, State) of
                             {ok, PSK, ResumptionSecret} ->
                                 PskBindersInfo = maps:get(psk_binders, ClientHelloInfo, undefined),
@@ -6407,21 +6404,42 @@ do_server_client_hello_cont(
                                         %% replayed (RFC 9001 §9.2).
                                         consume_ticket_globally(Identity),
                                         ES = quic_crypto:derive_early_secret(Cipher, PSK),
-                                        ClientHelloHash = quic_crypto:transcript_hash(
-                                            Cipher, OriginalMsg
-                                        ),
-                                        ETS = quic_crypto:derive_client_early_traffic_secret(
-                                            Cipher, ES, ClientHelloHash
-                                        ),
-                                        {Key, IV, HP} = quic_keys:derive_keys(ETS, Cipher),
-                                        EK = #crypto_keys{
-                                            key = Key, iv = IV, hp = HP, cipher = Cipher
+                                        %% The ticket's PSK carries the whole
+                                        %% handshake (psk_dhe_ke), so the cert
+                                        %% flight is skipped; before, it only
+                                        %% fed the 0-RTT keys and the
+                                        %% handshake fell back to a full
+                                        %% cert exchange on a zero PSK.
+                                        Selected = #{
+                                            identity => Identity,
+                                            identity_idx => 0,
+                                            secret => PSK,
+                                            mode => psk_dhe_ke
                                         },
-                                        {
-                                            {EK, ResumptionSecret},
-                                            quic_crypto:derive_early_secret(Cipher, ZeroPSK),
-                                            undefined
-                                        };
+                                        EK =
+                                            case WantsEarlyData of
+                                                true ->
+                                                    ClientHelloHash =
+                                                        quic_crypto:transcript_hash(
+                                                            Cipher, OriginalMsg
+                                                        ),
+                                                    ETS =
+                                                        quic_crypto:derive_client_early_traffic_secret(
+                                                            Cipher, ES, ClientHelloHash
+                                                        ),
+                                                    {Key, IV, HP} =
+                                                        quic_keys:derive_keys(ETS, Cipher),
+                                                    EKeys = #crypto_keys{
+                                                        key = Key,
+                                                        iv = IV,
+                                                        hp = HP,
+                                                        cipher = Cipher
+                                                    },
+                                                    {EKeys, ResumptionSecret};
+                                                false ->
+                                                    undefined
+                                            end,
+                                        {EK, ES, Selected};
                                     false ->
                                         ?LOG_WARNING(
                                             #{what => resumption_psk_binder_failed},
@@ -6431,6 +6449,8 @@ do_server_client_hello_cont(
                                         exit({tls_alert, decrypt_error})
                                 end;
                             error ->
+                                %% Unknown or expired ticket: fall back to a
+                                %% full handshake (RFC 8446 §4.2.11).
                                 {undefined, quic_crypto:derive_early_secret(Cipher, ZeroPSK),
                                     undefined}
                         end;
@@ -6480,10 +6500,10 @@ do_server_client_hello_cont(
         session_id => SessionId
     },
     ServerHelloOpts =
-        case {SelectedPsk, ExternalPskResult} of
-            {undefined, _} ->
+        case SelectedPsk of
+            undefined ->
                 ServerHelloOpts0;
-            {_, {ok, #{identity_idx := Idx, mode := SelMode}}} ->
+            #{identity_idx := Idx, mode := SelMode} ->
                 ServerHelloOpts0#{
                     selected_psk_identity => Idx,
                     selected_psk_mode => SelMode

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4651,11 +4651,14 @@ decode_short_header_packet(Data, State) ->
 %% Decrypt an application (1-RTT) packet with key phase handling
 %% Uses 2-stage API: unprotect header to get key_phase, then decrypt with selected keys
 decrypt_app_packet(Header, EncryptedPayload, CurrentKeys, State) ->
-    #crypto_keys{hp = HP} = CurrentKeys,
+    %% The cipher must come from the negotiated keys: inferring it from
+    %% the HP key length mistakes ChaCha20-Poly1305 for AES-256-GCM and
+    %% drops every received 1-RTT packet on such connections.
+    #crypto_keys{hp = HP, cipher = HpCipher} = CurrentKeys,
     PNOffset = byte_size(Header),
 
     %% Stage 1: Unprotect header to get key_phase and PN info
-    case quic_aead:unprotect_short_header(HP, Header, EncryptedPayload, PNOffset) of
+    case quic_aead:unprotect_short_header(HpCipher, HP, Header, EncryptedPayload, PNOffset) of
         {error, Reason} ->
             {error, Reason};
         {ok, KeyPhase, PNLen, TruncatedPN, UnprotectedHeader} ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2730,7 +2730,8 @@ send_client_hello(State) ->
         alpn => AlpnList,
         transport_params => TransportParams,
         session_ticket => SessionTicket,
-        groups => State#state.tls_groups
+        groups => State#state.tls_groups,
+        ciphers => State#state.cipher_preference
     },
     ClientHelloOpts1 =
         case State#state.tls_sig_algs of
@@ -5718,6 +5719,15 @@ process_tls_message(
         {hrr, HrrInfo} ->
             handle_hello_retry_request(HrrInfo, OriginalMsg, State);
         {ok, #{cipher := Cipher} = ServerHelloMap} ->
+            %% RFC 8446 §4.1.3: the selected suite must be one we offered.
+            case lists:member(Cipher, State#state.cipher_preference) of
+                false ->
+                    notify_owner({error, {tls_alert, illegal_parameter}}, State),
+                    send_tls_alert(?TLS_ALERT_ILLEGAL_PARAMETER, State),
+                    exit({tls_alert, illegal_parameter});
+                true ->
+                    ok
+            end,
             %% Determine handshake type: PSK (with or without DHE) vs
             %% standard cert-auth. PSK selection is signalled by the
             %% `selected_psk_identity' extension echoed in ServerHello.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1903,26 +1903,33 @@ handshaking({call, From}, open_stream, #state{early_keys = _EarlyKeys} = State) 
 handshaking(
     {call, From},
     {send_data, StreamId, Data, Fin},
-    #state{
-        early_keys = undefined,
-        pending_data = Pending
-    } = State
+    #state{role = client, early_keys = EarlyKeys} = State
+) when EarlyKeys =/= undefined ->
+    %% Send as 0-RTT data. 0-RTT sending is a client-only affair (RFC
+    %% 9000 §17.2.3): a server also holds early keys, but only for
+    %% receiving. Answering early data before the handshake completes
+    %% must not go out in a 0-RTT packet the client can never decrypt,
+    %% so the server queues below and the data goes out 1-RTT on
+    %% connected.
+    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
+        {ok, NewState} ->
+            {keep_state, NewState, [{reply, From, ok}]};
+        {error, Reason} ->
+            {keep_state, State, [{reply, From, {error, Reason}}]}
+    end;
+handshaking(
+    {call, From},
+    {send_data, StreamId, Data, Fin},
+    #state{pending_data = Pending} = State
 ) ->
-    %% No early keys, queue the data for later (with limit to prevent memory exhaustion)
+    %% No usable send keys yet, queue the data for later (with limit to
+    %% prevent memory exhaustion)
     case length(Pending) >= ?MAX_PENDING_DATA_ENTRIES of
         true ->
             {keep_state, State, [{reply, From, {error, pending_data_limit}}]};
         false ->
             NewPending = Pending ++ [{StreamId, Data, Fin}],
             {keep_state, State#state{pending_data = NewPending}, [{reply, From, ok}]}
-    end;
-handshaking({call, From}, {send_data, StreamId, Data, Fin}, #state{early_keys = _} = State) ->
-    %% Send as 0-RTT data
-    case do_send_zero_rtt_data(StreamId, Data, Fin, State) of
-        {ok, NewState} ->
-            {keep_state, NewState, [{reply, From, ok}]};
-        {error, Reason} ->
-            {keep_state, State, [{reply, From, {error, Reason}}]}
     end;
 handshaking(info, {udp, Socket, _IP, _Port, Data}, #state{socket = Socket} = State) ->
     NewState = handle_packet(Data, State),
@@ -8411,7 +8418,7 @@ do_send_zero_rtt_data(
             Payload = quic_frame:encode(Frame),
 
             %% Send as 0-RTT packet
-            NewState = send_zero_rtt_packet(Payload, EarlyKeys, State),
+            NewState = send_zero_rtt_packet(Payload, [Frame], EarlyKeys, State),
 
             %% Update stream state and track early data sent
             NewStreamState = StreamState#stream_state{
@@ -8438,7 +8445,7 @@ do_send_zero_rtt_data(
 
 %% Send a 0-RTT packet (long header, type 1)
 %% RFC 9001 Section 5.3: 0-RTT packets use early traffic keys
-send_zero_rtt_packet(Payload, EarlyKeys, State) ->
+send_zero_rtt_packet(Payload, Frames, EarlyKeys, State) ->
     #state{
         scid = SCID,
         dcid = DCID,
@@ -8474,12 +8481,25 @@ send_zero_rtt_packet(Payload, EarlyKeys, State) ->
     ),
     NewSocketState = send_and_take_socket_state(Packet, State),
 
+    %% 0-RTT shares the application PN space, so it must be tracked for
+    %% loss detection like any 1-RTT packet: a dropped 0-RTT request was
+    %% otherwise never retransmitted and the stream hung forever (RFC
+    %% 9001 §4.1.1 expects lost 0-RTT data to be resent).
+    Now = erlang:monotonic_time(millisecond),
+    NewLossState = quic_loss:on_packet_sent(
+        State#state.loss_state, PN, byte_size(Packet), true, Frames, Now
+    ),
+    NewCCState = quic_cc:on_packet_sent(State#state.cc_state, byte_size(Packet)),
+
     %% Update PN space and packet counter
     NewPNSpace = PNSpace#pn_space{next_pn = PN + 1},
     State#state{
         pn_app = NewPNSpace,
         packets_sent = State#state.packets_sent + 1,
-        socket_state = NewSocketState
+        socket_state = NewSocketState,
+        loss_state = NewLossState,
+        cc_state = NewCCState,
+        pto_dirty = true
     }.
 
 %% Reset local state for all streams that carried 0-RTT data when the
@@ -10250,6 +10270,12 @@ handle_pto_timeout(#state{loss_state = LossState} = State) ->
 
 %% Send a probe packet for PTO
 %% PTO probes are allowed to use control_allowance per RFC 9002
+%% App-space PTO can fire before 1-RTT keys exist when tracked 0-RTT
+%% packets are outstanding. Handshake-space recovery drives progress
+%% until the keys arrive; sending nothing here avoids building an app
+%% packet without keys.
+send_probe_packet(#state{app_keys = undefined} = State) ->
+    State;
 send_probe_packet(State) ->
     case get_oldest_unacked_frames(State) of
         {ok, Frames} ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1492,8 +1492,12 @@ reown(#state{owner_mon = OldMon} = State, NewOwner) ->
 
 %% Continue client initialization after socket is ready
 init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
-    %% Generate initial keys
-    InitialKeys = derive_initial_keys(DCID),
+    %% The version decides the Initial salt, so it has to be settled before
+    %% any key is derived. This was fixed at v1, which left the `version'
+    %% option with nothing to do: both the salt and the version in our own
+    %% Initial stayed v1 however the connection was configured.
+    Version = maps:get(version, Opts, ?QUIC_VERSION_1),
+    InitialKeys = derive_initial_keys(DCID, Version),
 
     %% Initialize packet number spaces
     PNSpace = #pn_space{
@@ -1585,6 +1589,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         dcid = DCID,
         original_dcid = DCID,
         role = client,
+        version = Version,
         socket = Sock,
         socket_state = SocketState,
         client_socket_backend = ClientSocketBackend,
@@ -7513,10 +7518,6 @@ strip_brackets([$[ | Rest]) ->
     end;
 strip_brackets(Host) ->
     Host.
-
-%% Derive initial encryption keys
-derive_initial_keys(DCID) ->
-    derive_initial_keys(DCID, ?QUIC_VERSION_1).
 
 %% Derive initial encryption keys with specific QUIC version
 %% Version determines which salt to use (v1 vs v2)

--- a/src/quic_keylog.erl
+++ b/src/quic_keylog.erl
@@ -1,0 +1,66 @@
+%%% TLS key logging in the NSS Key Log format.
+%%%
+%%% Wireshark, and through it the QUIC Interop Runner, decrypts a capture
+%%% by reading the traffic secrets from a file named by the SSLKEYLOGFILE
+%%% environment variable. Several interop test cases refuse to grade a
+%%% run without one: they return "unsupported" before looking at whether
+%%% the transfer actually worked.
+%%%
+%%% Writing this file hands anyone who reads it the ability to decrypt the
+%%% connection, so it stays off unless SSLKEYLOGFILE is set, and nothing
+%%% here logs the secrets anywhere else.
+-module(quic_keylog).
+
+-export([log/3, enabled/0]).
+
+-define(CLIENT_HANDSHAKE, "CLIENT_HANDSHAKE_TRAFFIC_SECRET").
+-define(SERVER_HANDSHAKE, "SERVER_HANDSHAKE_TRAFFIC_SECRET").
+-define(CLIENT_APP, "CLIENT_TRAFFIC_SECRET_0").
+-define(SERVER_APP, "SERVER_TRAFFIC_SECRET_0").
+
+-type label() ::
+    client_handshake | server_handshake | client_application | server_application.
+
+-spec enabled() -> boolean().
+enabled() ->
+    case os:getenv("SSLKEYLOGFILE") of
+        false -> false;
+        "" -> false;
+        _ -> true
+    end.
+
+%% @doc Append one secret to the key log. ClientRandom is the 32-byte
+%% random from the ClientHello, which is what ties the line to a
+%% connection; a missing one means the line cannot be matched to anything,
+%% so it is dropped rather than written misleadingly.
+-spec log(label(), binary() | undefined, binary() | undefined) -> ok.
+log(Label, ClientRandom, Secret) when
+    is_binary(ClientRandom), is_binary(Secret), byte_size(Secret) > 0
+->
+    case os:getenv("SSLKEYLOGFILE") of
+        false ->
+            ok;
+        "" ->
+            ok;
+        Path ->
+            Line = [
+                label_text(Label),
+                $\s,
+                hex(ClientRandom),
+                $\s,
+                hex(Secret),
+                $\n
+            ],
+            _ = file:write_file(Path, Line, [append]),
+            ok
+    end;
+log(_Label, _ClientRandom, _Secret) ->
+    ok.
+
+label_text(client_handshake) -> ?CLIENT_HANDSHAKE;
+label_text(server_handshake) -> ?SERVER_HANDSHAKE;
+label_text(client_application) -> ?CLIENT_APP;
+label_text(server_application) -> ?SERVER_APP.
+
+hex(Bin) ->
+    string:lowercase(binary:encode_hex(Bin)).

--- a/src/quic_keylog.erl
+++ b/src/quic_keylog.erl
@@ -21,6 +21,8 @@
 -type label() ::
     client_handshake | server_handshake | client_application | server_application.
 
+-export_type([label/0]).
+
 -spec enabled() -> boolean().
 enabled() ->
     case os:getenv("SSLKEYLOGFILE") of

--- a/src/quic_server_registry.erl
+++ b/src/quic_server_registry.erl
@@ -176,6 +176,21 @@ init([]) ->
         protected,
         {read_concurrency, true}
     ]),
+    %% The session-ticket table must outlive the connection that happens
+    %% to create it: with a connection process as owner it vanished when
+    %% that connection ended, so a client resuming after the issuing
+    %% connection was gone always fell back to a full handshake. The
+    %% registry is permanent, so own it here; quic_connection's
+    %% ensure_ticket_table/0 stays as a fallback for embedded use.
+    case ets:whereis(quic_server_tickets) of
+        undefined ->
+            _ = ets:new(quic_server_tickets, [
+                named_table, public, ordered_set, {read_concurrency, true}
+            ]),
+            ok;
+        _ ->
+            ok
+    end,
     {ok, #state{}}.
 
 handle_call({register, Name, Pid, Port, Opts}, _From, State = #state{monitors = Monitors}) ->

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -201,6 +201,17 @@ validate_psk_modes(Modes) ->
         Bad -> error({bad_opts, {unsupported_psk_modes, Bad}})
     end.
 
+%% The offered suites come from the `ciphers' option; the hardcoded
+%% AES-128-only offer meant the server's choice was never really a
+%% choice, and a peer that requires another suite failed the handshake.
+client_cipher_suites(Opts) ->
+    Ciphers = maps:get(ciphers, Opts, [aes_128_gcm, aes_256_gcm, chacha20_poly1305]),
+    <<<<(suite_from_cipher(C)):16>> || C <- Ciphers>>.
+
+suite_from_cipher(aes_128_gcm) -> ?TLS_AES_128_GCM_SHA256;
+suite_from_cipher(aes_256_gcm) -> ?TLS_AES_256_GCM_SHA384;
+suite_from_cipher(chacha20_poly1305) -> ?TLS_CHACHA20_POLY1305_SHA256.
+
 %% Build standard ClientHello without PSK
 build_client_hello_standard(Random, PubKey, PrivKey, Opts) ->
     %% Build extensions
@@ -210,7 +221,7 @@ build_client_hello_standard(Random, PubKey, PrivKey, Opts) ->
     SessionId = maps:get(session_id, Opts, <<>>),
 
     %% Cipher suites (TLS 1.3 only)
-    CipherSuites = <<?TLS_AES_128_GCM_SHA256:16>>,
+    CipherSuites = client_cipher_suites(Opts),
 
     %% Legacy compression methods (null only)
     CompressionMethods = <<1, 0>>,
@@ -294,7 +305,7 @@ build_client_hello_with_psk(Random, PubKey, PrivKey, Opts, #psk_offer{} = Offer)
     ExtensionsLen = byte_size(AllExtensions),
 
     SessionId = maps:get(session_id, Opts, <<>>),
-    CipherSuites = <<?TLS_AES_128_GCM_SHA256:16>>,
+    CipherSuites = client_cipher_suites(Opts),
     CompressionMethods = <<1, 0>>,
 
     ClientHelloBody = <<

--- a/test/quic_aead_tests.erl
+++ b/test/quic_aead_tests.erl
@@ -267,6 +267,38 @@ header_protection_roundtrip_short_test() ->
     ?assertEqual(PNLen, UnprotPNLen),
     ?assertEqual(Header, Unprotected).
 
+%% RFC 9001 Appendix A.5: ChaCha20-Poly1305 short header packet.
+%% The HP key is 32 bytes, so the cipher cannot be inferred from its
+%% length; the caller has to supply it or the AES-256 mask is used.
+rfc9001_chacha20_short_header_test() ->
+    Key = hexstr_to_bin(
+        "c6d98ff3441c3fe1b2182094f69caa2e"
+        "d4b716b65488960a7a984979fb23e1c8"
+    ),
+    IV = hexstr_to_bin("e0459b3474bdd0e44a41c144"),
+    HP = hexstr_to_bin(
+        "25a282b9e82f06f21f488917a4fc8f1b"
+        "73573685608597d0efcb076b0ab7a7a4"
+    ),
+    Packet = hexstr_to_bin("4cfe4189655e5cd55c41f69080575d7999c25a5bfb"),
+
+    %% Zero-length DCID: the header before the PN is just the first byte
+    <<Header:1/binary, EncryptedPayload/binary>> = Packet,
+    {ok, KeyPhase, PNLen, TruncPN, UnprotHdr} =
+        quic_aead:unprotect_short_header(
+            chacha20_poly1305, HP, Header, EncryptedPayload, 1
+        ),
+    ?assertEqual(0, KeyPhase),
+    ?assertEqual(3, PNLen),
+    ?assertEqual(49140, TruncPN),
+    ?assertEqual(hexstr_to_bin("4200bff4"), UnprotHdr),
+
+    {ok, PN, Plaintext} = quic_aead:decrypt_short_payload(
+        chacha20_poly1305, Key, IV, UnprotHdr, PNLen, TruncPN, EncryptedPayload, 654360563
+    ),
+    ?assertEqual(654360564, PN),
+    ?assertEqual(<<16#01>>, Plaintext).
+
 %%====================================================================
 %% Helper Functions
 %%====================================================================

--- a/test/quic_cipher_offer_tests.erl
+++ b/test/quic_cipher_offer_tests.erl
@@ -1,0 +1,44 @@
+%%% -*- erlang -*-
+%%%
+%%% Cipher suites on the wire. The `ciphers' option has to reach the
+%%% ClientHello in the order given: a client that always offered the
+%%% built-in list could not be restricted to one suite, and the order
+%%% is what a server's preference selects against.
+
+-module(quic_cipher_offer_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+%% The suites offered are the ones configured, in that order.
+configured_ciphers_reach_the_hello_test() ->
+    ?assertEqual(
+        [?TLS_CHACHA20_POLY1305_SHA256, ?TLS_AES_128_GCM_SHA256],
+        offered(#{ciphers => [chacha20_poly1305, aes_128_gcm]})
+    ).
+
+%% A single configured suite is the whole offer, which is what pins a
+%% deployment to one cipher.
+a_single_cipher_is_offered_alone_test() ->
+    ?assertEqual([?TLS_AES_256_GCM_SHA384], offered(#{ciphers => [aes_256_gcm]})).
+
+%% Without the option the built-in list is offered, so existing callers
+%% see no change.
+the_default_offer_is_unchanged_test() ->
+    ?assertEqual(
+        [
+            ?TLS_AES_128_GCM_SHA256,
+            ?TLS_AES_256_GCM_SHA384,
+            ?TLS_CHACHA20_POLY1305_SHA256
+        ],
+        offered(#{})
+    ).
+
+%% Parse the cipher_suites vector back out of a built ClientHello.
+offered(Opts) ->
+    Base = #{server_name => <<"localhost">>, alpn => [<<"h3">>], transport_params => #{}},
+    {Msg, _Priv, _Random} = quic_tls:build_client_hello(maps:merge(Base, Opts)),
+    <<_MsgType:8, _Len:24, Body/binary>> = Msg,
+    <<_Version:16, _CHRandom:32/binary, SessLen:8, Rest/binary>> = Body,
+    <<_Sess:SessLen/binary, SuitesLen:16, Suites:SuitesLen/binary, _/binary>> = Rest,
+    [Code || <<Code:16>> <= Suites].

--- a/test/quic_keylog_tests.erl
+++ b/test/quic_keylog_tests.erl
@@ -1,0 +1,68 @@
+%%% -*- erlang -*-
+%%%
+%%% SSLKEYLOGFILE output. The format is what Wireshark reads, so the
+%%% label, the client random and the secret have to appear in that order,
+%%% lowercase hex, one line per secret.
+
+-module(quic_keylog_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+keylog_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun writes_a_wireshark_line/1,
+        fun appends_rather_than_truncating/1,
+        fun skips_a_secret_it_cannot_match/1
+    ]}.
+
+setup() ->
+    Path = filename:join(
+        "/tmp",
+        "quic_keylog_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    Old = os:getenv("SSLKEYLOGFILE"),
+    os:putenv("SSLKEYLOGFILE", Path),
+    {Path, Old}.
+
+cleanup({Path, Old}) ->
+    file:delete(Path),
+    case Old of
+        false -> os:unsetenv("SSLKEYLOGFILE");
+        _ -> os:putenv("SSLKEYLOGFILE", Old)
+    end,
+    ok.
+
+writes_a_wireshark_line({Path, _}) ->
+    fun() ->
+        ?assert(quic_keylog:enabled()),
+        Random = binary:copy(<<16#ab>>, 32),
+        Secret = binary:copy(<<16#cd>>, 32),
+        ok = quic_keylog:log(client_handshake, Random, Secret),
+        {ok, Bin} = file:read_file(Path),
+        [Label, RandomHex, SecretHex] = string:lexemes(string:trim(binary_to_list(Bin)), " "),
+        ?assertEqual("CLIENT_HANDSHAKE_TRAFFIC_SECRET", Label),
+        ?assertEqual(string:copies("ab", 32), RandomHex),
+        ?assertEqual(string:copies("cd", 32), SecretHex)
+    end.
+
+%% A connection writes four secrets; truncating would leave only the last
+%% and make the capture undecryptable.
+appends_rather_than_truncating({Path, _}) ->
+    fun() ->
+        Random = binary:copy(<<1>>, 32),
+        [
+            ok = quic_keylog:log(L, Random, binary:copy(<<2>>, 32))
+         || L <- [client_handshake, server_handshake, client_application, server_application]
+        ],
+        {ok, Bin} = file:read_file(Path),
+        ?assertEqual(4, length(string:lexemes(binary_to_list(Bin), "\n")))
+    end.
+
+%% Without the client random the line matches no connection, so it is
+%% dropped rather than written misleadingly.
+skips_a_secret_it_cannot_match({Path, _}) ->
+    fun() ->
+        ok = quic_keylog:log(client_handshake, undefined, binary:copy(<<3>>, 32)),
+        ok = quic_keylog:log(client_handshake, binary:copy(<<3>>, 32), <<>>),
+        ?assertEqual({error, enoent}, file:read_file(Path))
+    end.

--- a/test/quic_server_default_groups_SUITE.erl
+++ b/test/quic_server_default_groups_SUITE.erl
@@ -1,0 +1,250 @@
+%%% -*- erlang -*-
+%%%
+%%% The server's default group preference.
+%%%
+%%% A server whose preference list holds only x25519 sends a
+%%% HelloRetryRequest to any client whose key_share leads with another
+%%% curve, even when the crypto layer speaks that curve perfectly well.
+%%% The handshake still completes, so nothing looks broken, but it costs
+%%% a full extra round trip on every such connection and drags the
+%%% rarely-exercised HRR path into flows that do not need it. picoquic
+%%% shares P-256 first, so this was every connection from it.
+%%%
+%%% Both outcomes connect successfully, so the cases here also count the
+%%% Initial-level datagrams the client puts on the wire before the
+%%% connection is up. A client must expand every datagram carrying an
+%%% Initial to 1200 bytes while it is unvalidated (RFC 9000 §14.1), so
+%%% the count is a direct read on how many Initial-level exchanges the
+%%% handshake needed. An HRR adds a round trip and the count goes up.
+%%% The assertions are made against a same-run baseline rather than
+%%% against a fixed number, so they survive unrelated changes to the
+%%% handshake shape.
+
+-module(quic_server_default_groups_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    p256_first_client_is_accepted_directly/1,
+    p384_first_client_is_accepted_directly/1,
+    x25519_client_is_still_accepted_directly/1,
+    explicit_groups_still_restrict_and_force_hrr/1,
+    explicit_groups_still_reject_a_disjoint_client/1
+]).
+
+%% A client pads every datagram carrying an Initial to this while it is
+%% unvalidated (RFC 9000 §14.1).
+-define(PADDED_INITIAL, 1200).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [
+        p256_first_client_is_accepted_directly,
+        p384_first_client_is_accepted_directly,
+        x25519_client_is_still_accepted_directly,
+        explicit_groups_still_restrict_and_force_hrr,
+        explicit_groups_still_reject_a_disjoint_client
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Default server: no HRR for any classical group
+%%====================================================================
+
+p256_first_client_is_accepted_directly(_Config) ->
+    {_, Baseline} = handshake(#{}, [x25519]),
+    {Group, Count} = handshake(#{}, [secp256r1, x25519]),
+    %% The server takes the client's lead group instead of steering it
+    %% back to x25519 ...
+    ?assertEqual(secp256r1, Group),
+    %% ... and does it without an extra Initial-level round trip.
+    ?assertEqual(Baseline, Count).
+
+p384_first_client_is_accepted_directly(_Config) ->
+    {_, Baseline} = handshake(#{}, [x25519]),
+    {Group, Count} = handshake(#{}, [secp384r1, x25519]),
+    ?assertEqual(secp384r1, Group),
+    ?assertEqual(Baseline, Count).
+
+x25519_client_is_still_accepted_directly(_Config) ->
+    %% The case that already worked. Broadening the default must not
+    %% cost the common client its direct acceptance.
+    {Group, _Count} = handshake(#{}, [x25519]),
+    ?assertEqual(x25519, Group).
+
+%%====================================================================
+%% An explicit preference still means what it says
+%%====================================================================
+
+explicit_groups_still_restrict_and_force_hrr(_Config) ->
+    %% Server pinned to secp256r1, client leading with x25519. The HRR
+    %% is correct here, and this is also the fence that proves the
+    %% detector above can actually see a second flight.
+    {_, Baseline} = handshake(#{}, [x25519]),
+    {Group, Count} = handshake(#{groups => [secp256r1]}, [x25519, secp256r1]),
+    ?assertEqual(secp256r1, Group),
+    %% Strictly more than a direct handshake: this is the fence proving
+    %% the counter can see an HRR at all, so the equalities above are
+    %% not vacuous.
+    ?assert(Count > Baseline).
+
+explicit_groups_still_reject_a_disjoint_client(_Config) ->
+    {ok, Server} = quic_test_echo_server:start(#{groups => [secp384r1]}),
+    try
+        Port = maps:get(port, Server),
+        Opts = #{verify => false, alpn => [<<"echo">>], groups => [x25519]},
+        ?assertMatch({error, _}, connect_plain(Port, Opts))
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Run one handshake through a recording bridge. Returns the negotiated
+%% group and the number of Initial-level datagrams the client sent.
+handshake(ServerOpts, ClientGroups) ->
+    {ok, Server} = quic_test_echo_server:start(ServerOpts),
+    try
+        Port = maps:get(port, Server),
+        SocketRef = make_ref(),
+        Self = self(),
+        Bridge = spawn_link(fun() -> bridge_init({127, 0, 0, 1}, Port, SocketRef, Self) end),
+        Adapter = #{
+            send_fun => fun(IP, P, Pkt) ->
+                Bridge ! {send, IP, P, Pkt},
+                ok
+            end,
+            close_fun => fun() ->
+                Bridge ! stop,
+                ok
+            end,
+            local => {{127, 0, 0, 1}, 0},
+            socket_ref => SocketRef
+        },
+        Opts = #{
+            verify => false,
+            alpn => [<<"echo">>],
+            groups => ClientGroups,
+            socket_backend => adapter,
+            socket_adapter => Adapter
+        },
+        {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+        Bridge ! {set_conn, Conn},
+        Info =
+            receive
+                {quic, Conn, {connected, I}} -> I
+            after 10000 -> ct:fail("connect timeout")
+            end,
+        Count = count_initials(0),
+        ct:pal("server ~p / client ~p: negotiated ~p over ~p client Initial datagram(s)", [
+            maps:get(groups, ServerOpts, default),
+            ClientGroups,
+            maps:get(negotiated_group, Info, undefined),
+            Count
+        ]),
+        _ = quic:safe_close(Conn, normal),
+        {maps:get(negotiated_group, Info, undefined), Count}
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+connect_plain(Port, Opts) ->
+    case quic:connect(<<"127.0.0.1">>, Port, Opts, self()) of
+        {ok, Conn} ->
+            receive
+                {quic, Conn, {connected, _}} ->
+                    _ = quic:safe_close(Conn, normal),
+                    ok;
+                {quic, Conn, {error, Reason}} ->
+                    {error, Reason};
+                {quic, Conn, {closed, Reason}} ->
+                    {error, Reason}
+            after 10000 ->
+                _ = quic:safe_close(Conn, timeout),
+                {error, timeout}
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+count_initials(N) ->
+    receive
+        {client_initial, Size} when Size >= ?PADDED_INITIAL -> count_initials(N + 1);
+        {client_initial, _Small} -> count_initials(N)
+    after 300 -> N
+    end.
+
+%%====================================================================
+%% Bridge
+%%====================================================================
+
+%% Relays between the client's socket adapter and a real UDP socket,
+%% reporting the size of every client Initial. The long-header form bit
+%% and packet-type bits are outside the header-protection mask, so the
+%% type is readable without keys.
+bridge_init(ServerIP, ServerPort, SocketRef, Reporter) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef,
+        reporter => Reporter
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        {send, _IP, _Port, Pkt} ->
+            case header_type(Pkt) of
+                initial ->
+                    maps:get(reporter, Bridge) ! {client_initial, iolist_size(Pkt)};
+                _ ->
+                    ok
+            end,
+            ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt),
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case maps:get(conn, Bridge) of
+                undefined ->
+                    bridge_loop(Bridge#{pending := [Data | maps:get(pending, Bridge)]});
+                Conn ->
+                    deliver(Bridge, Conn, Data),
+                    bridge_loop(Bridge)
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.
+
+header_type(Pkt) ->
+    <<First:8, _/binary>> = iolist_to_binary(Pkt),
+    case First band 16#80 of
+        0 ->
+            short;
+        _ ->
+            case First band 16#30 of
+                16#00 -> initial;
+                _ -> other_long
+            end
+    end.


### PR DESCRIPTION
Aggregates #231, #232, #234, #235, #238, #239, #240 and #257, commits keeping their authors. #235 is branched on #232 and #234 builds on it, so the shared commits are carried once and the stack order is preserved.

Two of these are things a deployment configures and neither had a test, so they get one: the SSLKEYLOGFILE line format, including that four secrets append rather than truncate, and that the `ciphers` option reaches the ClientHello in the order given.

#238, #239 and #240 are untested here; each needs a two-connection resumption harness, which is larger than this batch.