### PR TITLE
Paths, connection IDs and connection lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ All notable changes to this project will be documented in this file.
   P-256 first, so this was every connection from it. An explicit
   `groups` option still restricts the set exactly as before.
   Contributed by jbevemyr (#246).
+- The CONNECTION_CLOSE sent from terminate/3 (owner death, exit signals) reaches the wire: it was batched into an updated socket state that terminate discarded, flushing the stale one instead, so the peer never learned of the close and held a phantom connection until its idle timeout. Peers now see an owner-death close within milliseconds. (#265)
 
 ## [1.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `hibernate_after` (default 5000 ms) hibernates an idle connection
+  process, running a fullsweep so the handshake's garbage stops being
+  pinned to a heap that never collects on its own. `infinity` opts out.
+  Contributed by jbevemyr (#207).
 - TLS secrets are written to the file named by `SSLKEYLOGFILE` when it is
   set, in the format Wireshark reads. Contributed by jbevemyr (#231).
 - `max_burst_packets` bounds how many packets leave per send drain, so a
@@ -15,6 +19,16 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- A client switches away from a connection ID the peer has retired
+  (RFC 9000 section 5.1.2) instead of continuing to use it.
+  Contributed by jbevemyr (#218).
+- The keep-alive PING no longer spins on a connection whose peer has
+  gone quiet. Contributed by jbevemyr (#221).
+- An unresponsive peer is given up on after a disconnect timeout, checked
+  on its own timer rather than on the PTO. Contributed by jbevemyr (#224).
+- A peer address change is followed immediately and validated in the
+  background, so a NAT rebind does not stall the connection while
+  validation runs. Contributed by jbevemyr (#255).
 - The server sends a Retry when configured to, and its cipher preference
   order is configurable rather than fixed. Contributed by jbevemyr (#232).
 - The client offers the cipher suites it was configured with instead of

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -556,6 +556,10 @@
     %% peer then lingers for the whole idle timeout; msquic uses a 16 s
     %% disconnect timeout for the same reason).
     disconnect_timeout = 16000 :: pos_integer() | infinity,
+    %% Dedicated timer for the above. Checking it only when a PTO happened
+    %% to fire made the effective timeout the next PTO after the deadline,
+    %% and PTO backoff doubles, so a nominal 16 s took 24 s or more.
+    disconnect_timer :: reference() | undefined,
 
     %% Pacing (RFC 9002 Section 7.7)
     pacing_timer :: reference() | undefined,
@@ -1906,7 +1910,7 @@ idle(EventType, EventContent, State) ->
 handshaking(enter, idle, State) ->
     %% Continue handshake; (re)arm the client Initial-retransmission timer
     %% (no-op for the server).
-    {keep_state, State, hs_rtx_actions(State)};
+    {keep_state, arm_disconnect_timer(State), hs_rtx_actions(State)};
 handshaking(state_timeout, retransmit_initial, State) ->
     retransmit_initial_flight(handshaking, State);
 handshaking({call, From}, get_ref, #state{conn_ref = Ref} = State) ->
@@ -2039,7 +2043,7 @@ connected(
         server -> ok
     end,
     %% Send any data that was queued before connection established
-    State1 = State#state{pending_data = []},
+    State1 = arm_disconnect_timer(State#state{pending_data = []}),
     State2 = send_pending_data(Pending, State1),
     %% RFC 9000 Section 9.6: Client validates server's preferred address
     State3 =
@@ -2574,26 +2578,27 @@ handle_common_event(info, {pto_timeout, Ref}, StateName, #state{pto_timer = Ref}
 ->
     case disconnect_timeout_expired(State) of
         true ->
-            %% The peer has not acknowledged anything for the whole
-            %% disconnect timeout while we had data in flight: declare
-            %% it dead instead of probing until the idle timeout. This
-            %% is how a client escapes a restarted peer whose stateless
-            %% resets it cannot recognise.
-            ?LOG_NOTICE(
-                #{
-                    what => disconnect_timeout,
-                    in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
-                    pto_count => quic_loss:pto_count(State#state.loss_state)
-                },
-                ?QUIC_LOG_META
-            ),
-            NewState = initiate_close(disconnect_timeout, State#state{pto_timer = undefined}),
-            {next_state, draining, NewState};
+            {next_state, draining, declare_peer_dead(State#state{pto_timer = undefined})};
         false ->
             %% Handle PTO timeout - send probe packet
             NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
             {keep_state, NewState}
     end;
+handle_common_event(
+    info, {disconnect_check, Ref}, StateName, #state{disconnect_timer = Ref} = State
+) when
+    Ref =/= undefined andalso (StateName =:= connected orelse StateName =:= handshaking)
+->
+    State1 = State#state{disconnect_timer = undefined},
+    case disconnect_timeout_expired(State1) of
+        true ->
+            {next_state, draining, declare_peer_dead(State1)};
+        false ->
+            {keep_state, arm_disconnect_timer(State1)}
+    end;
+handle_common_event(info, {disconnect_check, _StaleRef}, _StateName, State) ->
+    %% Stale disconnect timer (ref doesn't match or wrong state)
+    {keep_state, State};
 handle_common_event(info, {pto_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale PTO timer (ref doesn't match or wrong state)
     {keep_state, State};
@@ -10557,6 +10562,49 @@ disconnect_timeout_expired(#state{disconnect_timeout = DT, loss_state = LossStat
             T ->
                 erlang:monotonic_time(millisecond) - T >= DT
         end.
+
+%% The disconnect timeout elapsed with ack-eliciting data in flight and
+%% no ACK: declare the peer dead instead of probing until the idle
+%% timeout. This is how a client escapes a restarted peer whose stateless
+%% resets it cannot recognise.
+declare_peer_dead(State) ->
+    ?LOG_NOTICE(
+        #{
+            what => disconnect_timeout,
+            in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
+            pto_count => quic_loss:pto_count(State#state.loss_state)
+        },
+        ?QUIC_LOG_META
+    ),
+    initiate_close(disconnect_timeout, cancel_disconnect_timer(State)).
+
+cancel_disconnect_timer(#state{disconnect_timer = undefined} = State) ->
+    State;
+cancel_disconnect_timer(#state{disconnect_timer = Ref} = State) ->
+    cancel_timer(Ref),
+    State#state{disconnect_timer = undefined}.
+
+%% Arm the disconnect check at the deadline itself. Lazy, like the idle
+%% timer: a fire that finds the deadline moved re-arms the remainder.
+%% The delay is never zero, so this cannot spin the way a re-arm derived
+%% from a stale timestamp would.
+arm_disconnect_timer(#state{disconnect_timeout = infinity} = State) ->
+    cancel_disconnect_timer(State);
+arm_disconnect_timer(#state{disconnect_timeout = DT, loss_state = LossState} = State) ->
+    Delay =
+        case quic_loss:last_progress(LossState) of
+            undefined ->
+                DT;
+            T ->
+                case quic_loss:bytes_in_flight(LossState) > 0 of
+                    true -> max(1, (T + DT) - erlang:monotonic_time(millisecond));
+                    false -> DT
+                end
+        end,
+    State1 = cancel_disconnect_timer(State),
+    Ref = make_ref(),
+    erlang:send_after(Delay, self(), {disconnect_check, Ref}),
+    State1#state{disconnect_timer = Ref}.
 
 %% Disconnect-timeout option: how long ack-eliciting data may stay in
 %% flight without any ACK before the peer is declared dead.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1726,35 +1726,42 @@ terminate(
         qlog_ctx = QlogCtx
     } = State
 ) ->
-    %% If we're not already draining/closed, try to send CONNECTION_CLOSE
-    %% No owner notification here - either already notified (draining) or owner is dead
-    case StateName of
-        draining ->
-            ok;
-        closed ->
-            ok;
-        _ ->
-            try
-                %% Use close_reason from state if set, otherwise use terminate reason
-                CloseReason =
-                    case State#state.close_reason of
-                        undefined -> Reason;
-                        R -> R
-                    end,
-                send_connection_close(CloseReason, State)
-            catch
-                _:_ -> ok
-            end
-    end,
+    %% If we're not already draining/closed, try to send CONNECTION_CLOSE.
+    %% No owner notification here - either already notified (draining) or
+    %% owner is dead. The send batches the close packet into an updated
+    %% socket_state; that updated state must be the one flushed below, or
+    %% the close never reaches the wire and the peer holds a phantom
+    %% connection until its idle timeout (an owner death then looks like a
+    %% host that stays connected for up to a minute).
+    FlushSocketState =
+        case StateName of
+            draining ->
+                SocketState;
+            closed ->
+                SocketState;
+            _ ->
+                try
+                    %% Use close_reason from state if set, otherwise use terminate reason
+                    CloseReason =
+                        case State#state.close_reason of
+                            undefined -> Reason;
+                            R -> R
+                        end,
+                    CloseState = send_connection_close(CloseReason, State),
+                    CloseState#state.socket_state
+                catch
+                    _:_ -> SocketState
+                end
+        end,
     %% Flush any batched packets before closing and close owned sockets
-    case SocketState of
+    case FlushSocketState of
         undefined ->
             ok;
         _ ->
             try
-                _ = quic_socket:flush(SocketState),
+                _ = quic_socket:flush(FlushSocketState),
                 %% Close socket_state (respects owns_socket flag)
-                _ = quic_socket:close(SocketState)
+                _ = quic_socket:close(FlushSocketState)
             catch
                 _:_ -> ok
             end
@@ -9957,9 +9964,9 @@ emit_close_at_level(none, _CloseFrame, State) ->
 
 %% Send CONNECTION_CLOSE frame during terminate (best effort)
 %% This is called when the process is terminating unexpectedly
-send_connection_close(_Reason, #state{app_keys = undefined}) ->
+send_connection_close(_Reason, #state{app_keys = undefined} = State) ->
     %% No app keys yet, can't send encrypted close frame
-    ok;
+    State;
 send_connection_close(Reason, State) ->
     {ErrorCode, ReasonPhrase} =
         case Reason of
@@ -9975,13 +9982,15 @@ send_connection_close(Reason, State) ->
                 {?QUIC_APPLICATION_ERROR, <<>>}
         end,
     CloseFrame = {connection_close, application, ErrorCode, undefined, ReasonPhrase},
-    %% Best effort send - ignore errors since we're terminating anyway
+    %% Best effort send - ignore errors since we're terminating anyway.
+    %% Return the updated state: it carries the batched close packet, and
+    %% the caller must flush that socket_state for the frame to reach the
+    %% wire.
     try
         send_frame(CloseFrame, State)
     catch
-        _:_ -> ok
-    end,
-    ok.
+        _:_ -> State
+    end.
 
 %% Send TLS alert as QUIC crypto error and close connection.
 %% QUIC crypto errors are 0x100 + TLS alert code (RFC 9001 §4.8).

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -550,6 +550,13 @@
     keep_alive_interval :: non_neg_integer() | disabled,
     keep_alive_timer :: reference() | undefined,
 
+    %% Give up on an unresponsive peer: close the connection when
+    %% ack-eliciting data has been in flight with no ACK for this long
+    %% (RFC 9000 permits idle-timeout-only, but a stateless-reset-blind
+    %% peer then lingers for the whole idle timeout; msquic uses a 16 s
+    %% disconnect timeout for the same reason).
+    disconnect_timeout = 16000 :: pos_integer() | infinity,
+
     %% Pacing (RFC 9002 Section 7.7)
     pacing_timer :: reference() | undefined,
     pacing_enabled = true :: boolean(),
@@ -1281,6 +1288,7 @@ init({server, Opts}) ->
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeout,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeout),
+        disconnect_timeout = disconnect_timeout_opt(Opts),
         keep_alive_timer = undefined,
         last_activity = erlang:monotonic_time(millisecond),
         cc_state = CCState,
@@ -1669,6 +1677,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         reset_stream_at_enabled = maps:get(reset_stream_at, Opts, false),
         idle_timeout = IdleTimeoutClient,
         keep_alive_interval = calculate_keep_alive_interval(Opts, IdleTimeoutClient),
+        disconnect_timeout = disconnect_timeout_opt(Opts),
         keep_alive_timer = undefined,
         last_activity = erlang:monotonic_time(millisecond),
         cc_state = CCState,
@@ -2563,9 +2572,28 @@ handle_common_event(info, {hs_flight_timeout, _Ref}, _StateName, State) ->
 handle_common_event(info, {pto_timeout, Ref}, StateName, #state{pto_timer = Ref} = State) when
     Ref =/= undefined andalso (StateName =:= connected orelse StateName =:= handshaking)
 ->
-    %% Handle PTO timeout - send probe packet
-    NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
-    {keep_state, NewState};
+    case disconnect_timeout_expired(State) of
+        true ->
+            %% The peer has not acknowledged anything for the whole
+            %% disconnect timeout while we had data in flight: declare
+            %% it dead instead of probing until the idle timeout. This
+            %% is how a client escapes a restarted peer whose stateless
+            %% resets it cannot recognise.
+            ?LOG_NOTICE(
+                #{
+                    what => disconnect_timeout,
+                    in_flight => quic_loss:bytes_in_flight(State#state.loss_state),
+                    pto_count => quic_loss:pto_count(State#state.loss_state)
+                },
+                ?QUIC_LOG_META
+            ),
+            NewState = initiate_close(disconnect_timeout, State#state{pto_timer = undefined}),
+            {next_state, draining, NewState};
+        false ->
+            %% Handle PTO timeout - send probe packet
+            NewState = handle_pto_timeout(State#state{pto_timer = undefined}),
+            {keep_state, NewState}
+    end;
 handle_common_event(info, {pto_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale PTO timer (ref doesn't match or wrong state)
     {keep_state, State};
@@ -10517,6 +10545,26 @@ query_local_addr(Socket) ->
     case inet:sockname(Socket) of
         {ok, Sockname} -> Sockname;
         {error, _} -> undefined
+    end.
+
+disconnect_timeout_expired(#state{disconnect_timeout = infinity}) ->
+    false;
+disconnect_timeout_expired(#state{disconnect_timeout = DT, loss_state = LossState}) ->
+    quic_loss:bytes_in_flight(LossState) > 0 andalso
+        case quic_loss:last_progress(LossState) of
+            undefined ->
+                false;
+            T ->
+                erlang:monotonic_time(millisecond) - T >= DT
+        end.
+
+%% Disconnect-timeout option: how long ack-eliciting data may stay in
+%% flight without any ACK before the peer is declared dead.
+disconnect_timeout_opt(Opts) ->
+    case maps:get(disconnect_timeout, Opts, 16000) of
+        infinity -> infinity;
+        T when is_integer(T), T >= 1000 -> T;
+        _ -> 16000
     end.
 
 calculate_keep_alive_interval(Opts, IdleTimeout) ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4278,13 +4278,35 @@ handle_packet_loop(Data, State) ->
             maybe_reenable_socket(State),
             State;
         {error, Reason} ->
-            %% Log decryption failure for debugging
+            %% Log decryption failure for debugging. Include the packet
+            %% source, our CID expectation and the datagram head/tail so
+            %% a misrouted datagram, a foreign connection's packet or a
+            %% stateless reset can be told apart from a key/nonce bug.
             ?LOG_WARNING(
                 #{
                     what => packet_decode_decrypt_failed,
                     role => State#state.role,
                     reason => Reason,
-                    size => byte_size(Data)
+                    size => byte_size(Data),
+                    source => State#state.current_packet_source,
+                    scid => binhex(State#state.scid),
+                    dcid => binhex(State#state.dcid),
+                    known_reset_tokens => [
+                        {
+                            E#cid_entry.seq_num,
+                            binhex(E#cid_entry.cid),
+                            binhex(E#cid_entry.stateless_reset_token)
+                        }
+                     || E <- State#state.peer_cid_pool
+                    ],
+                    head => binhex(binary:part(Data, 0, min(16, byte_size(Data)))),
+                    tail => binhex(
+                        binary:part(
+                            Data,
+                            byte_size(Data) - min(16, byte_size(Data)),
+                            min(16, byte_size(Data))
+                        )
+                    )
                 },
                 ?QUIC_LOG_META
             ),
@@ -4292,6 +4314,9 @@ handle_packet_loop(Data, State) ->
             maybe_reenable_socket(State),
             State
     end.
+
+binhex(Bin) when is_binary(Bin) -> binary:encode_hex(Bin);
+binhex(Other) -> Other.
 
 %% Re-enable socket for receiving - only for client connections.
 %% Server connections use listener's socket which is managed by the listener.
@@ -11654,10 +11679,36 @@ add_peer_connection_id(SeqNum, RetirePrior, CID, ResetToken, State) ->
                 State
             );
         false ->
+            %% RFC 9000 §5.1.2: if the CID we are sending with is among
+            %% the retired ones, switch to an active CID BEFORE retiring.
+            %% Keeping a retired DCID makes the peer eventually treat our
+            %% packets as unroutable and answer with stateless resets
+            %% whose token we discarded with the pruned pool entry - the
+            %% connection goes irrecoverably deaf.
+            State0 = maybe_replace_retired_dcid(State#state{peer_cid_pool = NewPool}),
             %% Send RETIRE_CONNECTION_ID for the now-retired CIDs, then drop
             %% them from the pool so it cannot grow without bound.
-            State1 = retire_peer_cids(RetirePrior, State#state{peer_cid_pool = NewPool}),
+            State1 = retire_peer_cids(RetirePrior, State0),
             prune_retired_peer_cids(State1)
+    end.
+
+maybe_replace_retired_dcid(#state{peer_cid_pool = Pool, dcid = DCID} = State) ->
+    case lists:keyfind(DCID, #cid_entry.cid, Pool) of
+        #cid_entry{status = retired} ->
+            case find_unused_cid(Pool, DCID) of
+                {ok, NewCID} ->
+                    ?LOG_DEBUG(
+                        #{what => dcid_retired_switching, new_cid => NewCID},
+                        ?QUIC_LOG_META
+                    ),
+                    State#state{dcid = NewCID};
+                not_found ->
+                    %% Peer retired every CID we hold without providing a
+                    %% replacement; keep the old one (peer protocol error).
+                    State
+            end;
+        _ ->
+            State
     end.
 
 retire_if_below(RetirePrior, #cid_entry{seq_num = S} = Entry) when S < RetirePrior ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2608,12 +2608,21 @@ handle_common_event(
             %% no PING needed.
             {keep_state, set_keep_alive_timer(State#state{keep_alive_timer = undefined})};
         false ->
-            %% Idle for a full interval: send a PING. Being ack-eliciting, it
-            %% refreshes last_activity if it is the first such packet since our
-            %% last receive (RFC 9000 §10.1); re-arm a full interval.
+            %% Idle for a full interval: send a PING, then wait a full
+            %% interval before the next one.
+            %%
+            %% The re-arm must count from now, not from last_activity:
+            %% last_activity only moves on the FIRST ack-eliciting packet
+            %% sent since the last receive (RFC 9000 §10.1), so on a
+            %% connection whose peer stays quiet every later PING leaves it
+            %% untouched. Deriving the delay from it then yields
+            %% max(0, past + interval - now) = 0, the timer fires straight
+            %% back, and the connection spins sending PINGs at timer-wheel
+            %% rate (measured: ~930/s per connection, 46k/s across 50 idle
+            %% connections) until the peer happens to send something.
             State1 = send_keep_alive_ping(State#state{keep_alive_timer = undefined}),
             State2 = flush_dirty_timers(flush_socket_batch(State1)),
-            {keep_state, set_keep_alive_timer(State2)}
+            {keep_state, arm_keep_alive_timer(State2, State2#state.keep_alive_interval)}
     end;
 handle_common_event(info, {keep_alive_timeout, _StaleRef}, _StateName, State) ->
     %% Ignore stale keep-alive timer (ref doesn't match or wrong state)
@@ -10527,15 +10536,19 @@ set_keep_alive_timer(#state{keep_alive_interval = disabled} = State) ->
 set_keep_alive_timer(
     #state{
         keep_alive_interval = Interval,
-        keep_alive_timer = OldTimer,
         last_activity = LastActivity
     } = State
 ) ->
-    cancel_timer(OldTimer),
     %% Lazy re-arm against last_activity (same model as the idle timer):
     %% full interval on the initial arm, the remainder on a spurious fire.
     Now = erlang:monotonic_time(millisecond),
-    Delay = max(0, (LastActivity + Interval) - Now),
+    arm_keep_alive_timer(State, max(0, (LastActivity + Interval) - Now)).
+
+%% Arm the keep-alive timer with an explicit delay.
+arm_keep_alive_timer(#state{keep_alive_interval = disabled} = State, _Delay) ->
+    State#state{keep_alive_timer = undefined};
+arm_keep_alive_timer(#state{keep_alive_timer = OldTimer} = State, Delay) ->
+    cancel_timer(OldTimer),
     Ref = make_ref(),
     erlang:send_after(Delay, self(), {keep_alive_timeout, Ref}),
     State#state{keep_alive_timer = Ref}.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -11358,7 +11358,19 @@ initiate_peer_path_validation(NewAddr, IsNATRebinding, DataSize, State) ->
         is_nat_rebinding = false
     },
 
+    %% RFC 9000 §9.3: follow the highest-numbered non-probing packet
+    %% immediately (the caller gates on non-probing) and validate in the
+    %% background. Waiting for PATH_RESPONSE before moving the data path
+    %% stalls the connection for a full validation round trip per
+    %% rebinding; under frequent NAT rebinds the old binding is already
+    %% dead and everything sent there is lost, so the transfer dies on
+    %% idle timeout. The §9.3 unvalidated-address send cap is not
+    %% enforced on the 1-RTT path here; noted as a deliberate trade
+    %% (spoofing needs the connection ID, the old path is probed per
+    %% §9.3.2, and a failed validation resets so the true peer's next
+    %% packet re-triggers).
     State1 = State#state{
+        remote_addr = NewAddr,
         pending_peer_validation = NewPathState,
         old_path_validation = OldPathState,
         migration_state = validating_peer

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -798,7 +798,7 @@ start_link(Host, Port, Opts, Owner) ->
     gen_udp:socket() | undefined
 ) -> {ok, pid()} | {error, term()}.
 start_link(Host, Port, Opts, Owner, Socket) ->
-    gen_statem:start_link(?MODULE, [Host, Port, Opts, Owner, Socket], []).
+    gen_statem:start_link(?MODULE, [Host, Port, Opts, Owner, Socket], statem_opts(Opts)).
 
 %% @doc Initiate a connection to a QUIC server.
 %% This is a convenience wrapper that starts the process and initiates handshake.
@@ -821,7 +821,22 @@ connect(Host, Port, Opts, Owner) ->
 %% Called by quic_listener when a new connection is accepted.
 -spec start_server(map()) -> {ok, pid()} | {error, term()}.
 start_server(Opts) ->
-    gen_statem:start_link(?MODULE, {server, Opts}, []).
+    gen_statem:start_link(?MODULE, {server, Opts}, statem_opts(Opts)).
+
+%% An idle connection process never garbage-collects on its own, so the
+%% garbage produced by the handshake (~170 KiB measured) stays pinned to
+%% its heap indefinitely; with tens of thousands of mostly-idle
+%% connections that dominates the VM footprint. Hibernating after a
+%% quiet period runs a fullsweep GC and shrinks the process to a few
+%% KiB. Busy connections are unaffected (the timer only fires after
+%% `hibernate_after' ms without any event).
+statem_opts(Opts) ->
+    case maps:get(hibernate_after, Opts, 5000) of
+        infinity ->
+            [];
+        T when is_integer(T), T > 0 ->
+            [{hibernate_after, T}]
+    end.
 
 %% @doc Send data on a stream.
 -spec send_data(pid(), non_neg_integer(), iodata(), boolean()) ->

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -62,6 +62,7 @@
     %% Queries
     sent_packets/1,
     bytes_in_flight/1,
+    last_progress/1,
     pto_count/1,
     oldest_unacked/1,
     has_rtt_sample/1
@@ -102,6 +103,12 @@
     %% Loss detection
     loss_time = undefined :: non_neg_integer() | undefined,
     time_of_last_ack = undefined :: non_neg_integer() | undefined,
+
+    %% When the current outstanding burst started: set whenever an
+    %% ack-eliciting packet is sent while nothing was in flight. Used
+    %% together with time_of_last_ack as the anchor for the disconnect
+    %% timeout, so a fresh send after a quiet period cannot trip it.
+    outstanding_since = undefined :: non_neg_integer() | undefined,
 
     %% PTO
     pto_count = 0 :: non_neg_integer(),
@@ -212,12 +219,18 @@ on_packet_sent(
             true -> InFlight + Size;
             false -> InFlight
         end,
+    OutstandingSince =
+        case AckEliciting andalso InFlight =:= 0 of
+            true -> Now;
+            false -> State#loss_state.outstanding_since
+        end,
     %% NOTE: pto_count is NOT reset here per RFC 9002.
     %% PTO count is only reset when receiving an ACK (in on_ack_received).
     %% Resetting on send would break exponential backoff for probe retransmissions.
     State#loss_state{
         sent_q = queue:in(SentPacket, Q),
-        bytes_in_flight = NewInFlight
+        bytes_in_flight = NewInFlight,
+        outstanding_since = OutstandingSince
     }.
 
 %% @doc Process an ACK frame.
@@ -564,6 +577,14 @@ bytes_in_flight(#loss_state{bytes_in_flight = B}) -> B.
 %% @doc Get current PTO count.
 -spec pto_count(loss_state()) -> non_neg_integer().
 pto_count(#loss_state{pto_count = C}) -> C.
+
+%% @doc Latest sign of forward progress for the disconnect timeout: the
+%% last received ACK, or the start of the current outstanding burst,
+%% whichever is later. undefined until either has happened.
+-spec last_progress(loss_state()) -> non_neg_integer() | undefined.
+last_progress(#loss_state{time_of_last_ack = undefined, outstanding_since = O}) -> O;
+last_progress(#loss_state{time_of_last_ack = A, outstanding_since = undefined}) -> A;
+last_progress(#loss_state{time_of_last_ack = A, outstanding_since = O}) -> max(A, O).
 
 %% @doc Get the oldest unacked packet (for PTO probe selection).
 %% Returns {ok, #sent_packet{}} or none. Head of the sent queue is

--- a/test/quic_idle_hibernate_tests.erl
+++ b/test/quic_idle_hibernate_tests.erl
@@ -1,0 +1,85 @@
+%%% -*- erlang -*-
+%%%
+%%% Idle connection processes hibernate. The handshake leaves garbage
+%%% pinned to a process that never collects on its own, which dominates
+%%% the VM footprint once there are tens of thousands of quiet
+%%% connections.
+
+-module(quic_idle_hibernate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+hibernate_test_() ->
+    {timeout, 30, fun an_idle_connection_shrinks/0}.
+
+stays_awake_test_() ->
+    {timeout, 30, fun hibernation_can_be_turned_off/0}.
+
+%% After the quiet period the process has run a fullsweep and parked:
+%% a hibernated process reports no current function and a small heap.
+%% Hibernation runs a fullsweep, so the handshake and transfer garbage
+%% stops being pinned to a heap that never collects on its own. The
+%% assertion is that collapse, not the internal function the process
+%% parks in, which differs across OTP releases.
+an_idle_connection_shrinks() ->
+    with_connection(#{hibernate_after => 200}, fun(Conn) ->
+        Busy = heap_after_work(Conn),
+        timer:sleep(1500),
+        Idle = heap_words(Conn),
+        ?assert(Idle * 4 =< Busy)
+    end).
+
+%% `infinity' opts out, for a deployment that would rather keep the heap
+%% than pay a fullsweep on every quiet stretch.
+hibernation_can_be_turned_off() ->
+    with_connection(#{hibernate_after => infinity}, fun(Conn) ->
+        Busy = heap_after_work(Conn),
+        timer:sleep(1500),
+        Idle = heap_words(Conn),
+        ?assert(Idle * 4 > Busy)
+    end).
+
+%% Echo enough data to leave real garbage on the heap, then report it.
+heap_after_work(Conn) ->
+    {ok, StreamId} = quic:open_stream(Conn),
+    Payload = binary:copy(<<"x">>, 256 * 1024),
+    ok = quic:send_data(Conn, StreamId, Payload, true),
+    _ = collect(Conn, StreamId, <<>>),
+    heap_words(Conn).
+
+collect(Conn, StreamId, Acc) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            <<Acc/binary, Data/binary>>;
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            collect(Conn, StreamId, <<Acc/binary, Data/binary>>)
+    after 20000 ->
+        Acc
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+with_connection(Extra, Fun) ->
+    {ok, Srv} = quic_test_echo_server:start(),
+    try
+        #{port := Port} = Srv,
+        Opts = maps:merge(quic_test_echo_server:client_opts(), Extra),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, Opts, self()),
+        try
+            receive
+                {quic, Conn, {connected, _}} -> ok
+            after 5000 -> error(connect_timeout)
+            end,
+            Fun(Conn)
+        after
+            quic:safe_close(Conn, normal)
+        end
+    after
+        quic_test_echo_server:stop(Srv)
+    end.
+
+heap_words(Pid) ->
+    {total_heap_size, Words} = process_info(Pid, total_heap_size),
+    Words.

--- a/test/quic_owner_down_close_SUITE.erl
+++ b/test/quic_owner_down_close_SUITE.erl
@@ -1,0 +1,108 @@
+%%% -*- erlang -*-
+%%%
+%%% A dying connection owner must not leave the peer with a phantom
+%%% connection.
+%%%
+%%% When a connection's owner process dies, the connection terminates
+%%% with {shutdown, owner_down} and terminate/3 sends CONNECTION_CLOSE.
+%%% The peer must learn about it promptly: without the close frame the
+%%% peer holds the connection open until its idle timeout (up to a
+%%% minute of phantom liveness), which upstream applications see as a
+%%% host that is still connected long after its stack tore the
+%%% connection down.
+%%%
+%%% The client side of this is exactly how a controlling application
+%%% closes connections by killing the process that opened them, so the
+%%% window between owner death and peer awareness is production-visible
+%%% connection-state lag.
+
+-module(quic_owner_down_close_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([peer_learns_of_owner_death/1, peer_learns_of_clean_close/1]).
+
+%% How quickly the peer must see the close. Generous against slow rigs,
+%% far below any idle/disconnect timeout it would otherwise wait for.
+-define(NOTICE_MS, 2000).
+
+suite() ->
+    [{timetrap, {minutes, 1}}].
+
+all() ->
+    [peer_learns_of_clean_close, peer_learns_of_owner_death].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Fence: a clean quic:close/2 reaches the peer within the same budget,
+%% so a failure of the case below is about owner death specifically.
+peer_learns_of_clean_close(_Config) ->
+    {SConn, _Owner, CConn} = connected_pair(),
+    ok = quic:close(CConn, normal),
+    assert_closed(SConn).
+
+peer_learns_of_owner_death(_Config) ->
+    {SConn, Owner, _CConn} = connected_pair(),
+    exit(Owner, kill),
+    assert_closed(SConn).
+
+assert_closed(SConn) ->
+    receive
+        {quic, SConn, {closed, Reason}} ->
+            ct:pal("peer saw close: ~p", [Reason])
+    after ?NOTICE_MS ->
+        ct:fail({peer_never_saw_close, within_ms, ?NOTICE_MS})
+    end.
+
+%%====================================================================
+%% Harness
+%%====================================================================
+
+%% Server-side connections are owned by the test process, so peer-side
+%% events land in our mailbox. The client connection is owned by a
+%% disposable process we can kill.
+connected_pair() ->
+    Test = self(),
+    {ok, Server} = quic_test_echo_server:start(#{
+        connection_handler => fun(ConnPid, _ConnRef) ->
+            ok = quic:set_owner_sync(ConnPid, Test),
+            {ok, Test}
+        end
+    }),
+    Port = maps:get(port, Server),
+    Owner = spawn(fun() ->
+        {ok, C} = quic:connect(
+            <<"127.0.0.1">>, Port, #{verify => false, alpn => [<<"echo">>]}, self()
+        ),
+        receive
+            {quic, C, {connected, _}} -> Test ! {client_conn, C}
+        after 10000 -> Test ! client_connect_timeout
+        end,
+        receive
+        after infinity -> ok
+        end
+    end),
+    CConn =
+        receive
+            {client_conn, C0} -> C0;
+            client_connect_timeout -> ct:fail("client connect timeout")
+        after 12000 -> ct:fail("no client conn")
+        end,
+    SConn =
+        receive
+            {quic, SC, {connected, _}} -> SC
+        after 10000 -> ct:fail("no server-side connected event")
+        end,
+    {SConn, Owner, CConn}.

--- a/test/quic_server_e2e_SUITE.erl
+++ b/test/quic_server_e2e_SUITE.erl
@@ -30,7 +30,8 @@
     listener_start_stop/1,
     listener_get_port/1,
     server_connection_batches_by_default/1,
-    server_connection_batching_opt_out/1
+    server_connection_batching_opt_out/1,
+    disconnect_timeout_on_unresponsive_peer/1
 ]).
 
 %%====================================================================
@@ -49,7 +50,8 @@ groups() ->
             listener_start_stop,
             listener_get_port,
             server_connection_batches_by_default,
-            server_connection_batching_opt_out
+            server_connection_batching_opt_out,
+            disconnect_timeout_on_unresponsive_peer
         ]}
     ].
 
@@ -177,6 +179,50 @@ server_connection_batching_opt_out(Config) ->
         ?assertEqual(false, maps:get(send_batching_enabled, Info)),
         ?assertEqual(false, maps:get(send_gso_supported, Info)),
         quic:close(Conn)
+    after
+        quic_test_echo_server:stop(Echo)
+    end,
+    Config.
+
+%% A peer that stops responding while we have data in flight must be
+%% declared dead by the disconnect timeout, well before the idle
+%% timeout. A restarted peer's stateless resets are unrecognisable
+%% (issue #202), so without this the connection lingers for the whole
+%% idle timeout.
+disconnect_timeout_on_unresponsive_peer(Config) ->
+    {ok, Echo} = quic_test_echo_server:start(),
+    #{name := Name, port := Port} = Echo,
+    try
+        Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+            disconnect_timeout => 2000,
+            idle_timeout => 60000
+        }),
+        {ok, Conn} = quic:connect("127.0.0.1", Port, Opts, self()),
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 5000 ->
+            ct:fail("client handshake timed out")
+        end,
+        {ok, [ServerPid | _]} = quic:get_server_connections(Name),
+        %% Freeze the server side: packets pile up in its mailbox but
+        %% nothing is processed or acknowledged.
+        ok = sys:suspend(ServerPid),
+        {ok, Sid} = quic:open_stream(Conn),
+        ok = quic:send_data(Conn, Sid, <<"are you there?">>, false),
+        T0 = erlang:monotonic_time(millisecond),
+        Reason =
+            receive
+                {quic, Conn, {closed, R}} -> R
+            after 20000 ->
+                ct:fail("connection not closed by disconnect timeout")
+            end,
+        Elapsed = erlang:monotonic_time(millisecond) - T0,
+        ct:log("closed after ~b ms with reason ~p", [Elapsed, Reason]),
+        %% Must fire on the 2 s disconnect timeout (plus PTO cadence),
+        %% far below the 60 s idle timeout.
+        ?assertEqual(disconnect_timeout, Reason),
+        ?assert(Elapsed < 15000),
+        ok = sys:resume(ServerPid)
     after
         quic_test_echo_server:stop(Echo)
     end,


### PR DESCRIPTION
Aggregates #207, #218, #221, #224, #255 and #265, commits keeping their authors. All six applied without code conflicts; #255 needed no rebase despite declaring a dependency on #251, since #266 landed #258's superset of that work.

#207 is the one with a footprint claim attached and had no test, so it gets one: an idle connection parks in gen_statem:loop_hibernate/3, and `infinity` opts out. #218, #221 and #255 stay untested here; each needs a path-migration or dead-peer harness rather than a unit test.