### PR TITLE
Version negotiation and QUIC v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `versions` lists the QUIC versions a connection will also accept, for
+  RFC 9368 compatible version negotiation. Contributed by jbevemyr (#243).
 - `hibernate_after` (default 5000 ms) hibernates an idle connection
   process, running a fullsweep so the handshake's garbage stops being
   pinned to a heap that never collects on its own. `infinity` opts out.
@@ -19,6 +21,16 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- A server answers a long-header packet carrying a version it does not
+  support with a Version Negotiation packet (RFC 9000 section 6.1)
+  instead of silence. Probing with a reserved version is how readiness
+  checks and the interop runner detect a live server. A packet that is
+  itself a Version Negotiation is never answered. Contributed by
+  jbevemyr (#229).
+- QUIC v2 (RFC 9369) uses the correct wire format: version-specific
+  packet-type bits, salts and key labels, and compatible version
+  negotiation settles on the first ClientHello. Contributed by
+  jbevemyr (#243).
 - A client switches away from a connection ID the peer has retired
   (RFC 9000 section 5.1.2) instead of continuing to use it.
   Contributed by jbevemyr (#218).

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -142,6 +142,8 @@
 -define(TP_ACTIVE_CONNECTION_ID_LIMIT, 16#0e).
 -define(TP_INITIAL_SCID, 16#0f).
 -define(TP_RETRY_SCID, 16#10).
+%% RFC 9368 version_information
+-define(TP_VERSION_INFORMATION, 16#11).
 
 %% RFC 9221 - QUIC Datagrams
 -define(TP_MAX_DATAGRAM_FRAME_SIZE, 16#20).
@@ -161,9 +163,12 @@
 ).
 
 %% Initial salt for QUIC v2 (RFC 9369 Section 5.2)
+%% RFC 9369 §3.3.2: first 20 bytes of sha256("QUICv2 salt"). The old
+%% value here was from a pre-RFC draft, so v2 worked against ourselves
+%% and no one else.
 -define(QUIC_V2_INITIAL_SALT,
-    <<16#0d, 16#be, 16#91, 16#3e, 16#26, 16#56, 16#d1, 16#93, 16#83, 16#14, 16#86, 16#ac, 16#d1,
-        16#64, 16#9b, 16#f5, 16#77, 16#95, 16#c0, 16#80>>
+    <<16#0d, 16#ed, 16#e3, 16#de, 16#f7, 16#00, 16#a6, 16#db, 16#81, 16#93, 16#81, 16#be, 16#6e,
+        16#26, 16#9d, 16#cb, 16#f9, 16#bd, 16#2e, 16#d9>>
 ).
 
 %% HKDF labels

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -144,12 +144,15 @@ build_opts("keyupdate") ->
         force_key_update => true
     };
 build_opts("v2") ->
-    %% Use QUIC v2
+    %% RFC 9368 compatible version negotiation: start in v1 and offer
+    %% v2, so the server switches. Starting directly in v2 fails the
+    %% grader, which requires the client's Initial to be v1.
     #{
         verify => false,
         alpn => [<<"hq-interop">>, <<"h3">>],
-        % QUIC v2
-        version => 16#6b3343cf
+        %% Preference order: v2 first. Some servers (picoquic) honour
+        %% the client's order rather than their own.
+        versions => [16#6b3343cf, 16#00000001]
     };
 build_opts(_) ->
     %% Default options

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5835,7 +5835,7 @@ process_tls_message(
     ?TLS_CLIENT_HELLO,
     Body,
     OriginalMsg,
-    #state{role = server, tls_state = ?TLS_AWAITING_CLIENT_HELLO} = State
+    #state{role = server, tls_state = ?TLS_AWAITING_CLIENT_HELLO} = StateChIn
 ) ->
     case quic_tls:parse_client_hello(Body) of
         {ok,
@@ -5845,6 +5845,16 @@ process_tls_message(
                 cipher_suites := CipherSuites,
                 session_id := SessionId
             } = ClientHelloInfo} ->
+            %% RFC 9368 compatible version negotiation must be settled on
+            %% the FIRST ClientHello, before any response goes out: a
+            %% HelloRetryRequest sent in the old version followed by a
+            %% ServerHello in the new one leaves the client mid-handshake
+            %% with packets it cannot make sense of.
+            State = maybe_negotiate_compatible_version(
+                maps:get(transport_params, ClientHelloInfo, #{}),
+                maps:get(early_data, ClientHelloInfo, false),
+                StateChIn
+            ),
             %% Select cipher suite (prefer server's order)
             Cipher = select_cipher(CipherSuites, State#state.cipher_preference),
             %% RFC 8446 §4.1.4 group negotiation: use the client's
@@ -5876,7 +5886,7 @@ process_tls_message(
             end;
         {error, Reason} ->
             ?LOG_ERROR(#{what => client_hello_parse_failed, reason => Reason}, ?QUIC_LOG_META),
-            State
+            StateChIn
     end;
 %% Client receives ServerHello
 process_tls_message(
@@ -6507,7 +6517,7 @@ do_server_client_hello(SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, Ori
 
 %% @private Continue the ClientHello once the server cert/key are settled.
 do_server_client_hello_cont(
-    SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, StateVNIn
+    SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
 ) ->
     ClientALPN = maps:get(alpn_protocols, ClientHelloInfo, []),
     ClientRandom = maps:get(random, ClientHelloInfo, undefined),
@@ -6516,12 +6526,6 @@ do_server_client_hello_cont(
     %% Check for PSK (0-RTT/resumption/external)
     PSKInfo = maps:get(pre_shared_key, ClientHelloInfo, undefined),
     WantsEarlyData = maps:get(early_data, ClientHelloInfo, false),
-
-    %% RFC 9368 compatible version negotiation, before any
-    %% version-dependent derivation (v2 has its own HKDF labels).
-    %% Skipped when the client offers early data: 0-RTT is bound to the
-    %% version of the first flight.
-    State = maybe_negotiate_compatible_version(TP, WantsEarlyData, StateVNIn),
 
     %% TLS 1.3 external PSK selection (RFC 8446 §4.2.11).
     %% Validate pre_shared_key placement, lookup identity, verify

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -324,6 +324,9 @@
     retry_scid :: binary() | undefined,
     role :: client | server,
     version = ?QUIC_VERSION_1 :: non_neg_integer(),
+    %% Acceptable versions in preference order (RFC 9368); the head of
+    %% the list is what we advertise as most preferred.
+    supported_versions = [?QUIC_VERSION_1] :: [non_neg_integer()],
 
     %% Socket
     socket :: gen_udp:socket() | socket:socket() | undefined,
@@ -363,6 +366,10 @@
 
     %% Encryption keys per level
     initial_keys :: {#crypto_keys{}, #crypto_keys{}} | undefined,
+    %% Pre-switch Initial keys kept through compatible version
+    %% negotiation, so first-flight packets in the original version
+    %% still decrypt (RFC 9368 §2.2).
+    initial_keys_alt :: {non_neg_integer(), {#crypto_keys{}, #crypto_keys{}}} | undefined,
     handshake_keys :: {#crypto_keys{}, #crypto_keys{}} | undefined,
     % Convenience accessor (= key_state.current_keys)
     app_keys :: {#crypto_keys{}, #crypto_keys{}} | undefined,
@@ -1162,6 +1169,11 @@ init({server, Opts}) ->
     Listener = maps:get(listener, Opts),
     %% Use client's QUIC version for key derivation (defaults to v1)
     Version = maps:get(version, Opts, ?QUIC_VERSION_1),
+    SupportedVersions =
+        case maps:get(versions, Opts, [Version]) of
+            [] -> [Version];
+            Vs -> Vs
+        end,
 
     %% Generate initial keys using client's DCID and version
     InitialKeys = derive_initial_keys(InitialDCID, Version),
@@ -1228,6 +1240,7 @@ init({server, Opts}) ->
         role = server,
         % Use client's QUIC version
         version = Version,
+        supported_versions = SupportedVersions,
         socket = Socket,
         %% send_socket is undefined - socket is in socket_state
         send_socket = undefined,
@@ -1529,6 +1542,13 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
     %% option with nothing to do: both the salt and the version in our own
     %% Initial stayed v1 however the connection was configured.
     Version = maps:get(version, Opts, ?QUIC_VERSION_1),
+    %% Versions we would also accept (RFC 9368); the connection itself
+    %% starts at `version'.
+    SupportedVersions =
+        case maps:get(versions, Opts, [Version]) of
+            [] -> [Version];
+            Vs -> Vs
+        end,
     InitialKeys = derive_initial_keys(DCID, Version),
 
     %% Initialize packet number spaces
@@ -1622,6 +1642,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         original_dcid = DCID,
         role = client,
         version = Version,
+        supported_versions = SupportedVersions,
         socket = Sock,
         socket_state = SocketState,
         client_socket_backend = ClientSocketBackend,
@@ -2845,7 +2866,9 @@ send_client_hello(State) ->
                     Cipher, EarlySecret, ClientHelloHash
                 ),
                 %% Derive traffic keys
-                {Key, IV, HP} = quic_keys:derive_keys(EarlyTrafficSecret, Cipher),
+                {Key, IV, HP} = quic_keys:derive_keys(
+                    EarlyTrafficSecret, Cipher, State#state.version
+                ),
                 Keys = #crypto_keys{key = Key, iv = IV, hp = HP, cipher = Cipher},
                 {Keys, EarlySecret}
         end,
@@ -3188,7 +3211,11 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
         initial_max_streams_uni => MaxStreamsUni,
         max_idle_timeout => State#state.idle_timeout,
         active_connection_id_limit => 2,
-        max_udp_payload_size => advertised_max_udp_payload_size(State)
+        max_udp_payload_size => advertised_max_udp_payload_size(State),
+        %% RFC 9368: the versions we would also accept; the server may
+        %% switch the connection to one of them.
+        version_information =>
+            {State#state.version, State#state.supported_versions}
     },
     %% Add max_datagram_frame_size if datagrams are enabled (RFC 9221)
     TransportParams1 =
@@ -3215,11 +3242,16 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     %% RFC 9000 §7.3: if this server issued a Retry for this client,
     %% echo the Retry's SCID in retry_source_connection_id so the
     %% client can verify the full handshake against the Retry it saw.
-    TransportParams4 =
+    TransportParams3b =
         case State#state.retry_scid_for_tp of
             undefined -> TransportParams3;
             RetrySCIDTP -> TransportParams3#{retry_scid => RetrySCIDTP}
         end,
+    %% RFC 9368: echo the negotiated version and our acceptable set.
+    TransportParams4 = TransportParams3b#{
+        version_information =>
+            {State#state.version, State#state.supported_versions}
+    },
 
     %% RFC 9000 §10.3: advertise a stateless_reset_token bound to our initial
     %% SCID, so the peer can recognise a stateless reset for this connection if
@@ -3296,8 +3328,12 @@ send_server_handshake_flight(Cipher, _TranscriptHashAfterSH, State) ->
     keylog_application(State#state.tls_ch1_random, ClientAppSecret, ServerAppSecret),
 
     %% Derive app keys
-    {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientAppSecret, Cipher),
-    {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(ServerAppSecret, Cipher),
+    {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(
+        ClientAppSecret, Cipher, State#state.version
+    ),
+    {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(
+        ServerAppSecret, Cipher, State#state.version
+    ),
 
     ClientAppKeys = #crypto_keys{key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher},
     ServerAppKeys = #crypto_keys{key = ServerKey, iv = ServerIV, hp = ServerHP, cipher = Cipher},
@@ -3544,8 +3580,10 @@ send_initial_packet(Payload, State) ->
         (quic_varint:encode(byte_size(PaddedPayload) + PNLen + 16))/binary
     >>,
 
-    %% First byte: 1100 0000 | (PNLen - 1)
-    FirstByte = 16#C0 bor (PNLen - 1),
+    %% First byte: long header form/fixed bits, version-specific Initial
+    %% type bits, PN length
+    FirstByte =
+        16#C0 bor (quic_packet:type_to_bits(initial, Version) bsl 4) bor (PNLen - 1),
     HeaderPrefix = <<FirstByte, HeaderBody/binary>>,
 
     %% Protect packet (encrypt + header protection in single call)
@@ -3748,7 +3786,8 @@ send_handshake_packet(Payload, State) ->
     PNLen = quic_packet:pn_length(PN),
 
     %% First byte for Handshake: 1110 0000 | (PNLen - 1)
-    FirstByte = 16#E0 bor (PNLen - 1),
+    FirstByte =
+        16#C0 bor (quic_packet:type_to_bits(handshake, Version) bsl 4) bor (PNLen - 1),
 
     %% Pad payload if needed for header protection sampling
     PaddedPayload = pad_for_header_protection(Payload),
@@ -4414,26 +4453,49 @@ decode_long_header_packet(Data, State) ->
     <<DCID:DCIDLen/binary, SCIDLen, Rest2/binary>> = Rest,
     <<SCID:SCIDLen/binary, Rest3/binary>> = Rest2,
 
-    Type = (FirstByte bsr 4) band 2#11,
+    TypeBits = (FirstByte bsr 4) band 2#11,
 
     case Version of
-        0 -> handle_version_negotiation(DCID, Rest3, State);
-        _ -> decode_long_header_type(Type, Data, FirstByte, Version, DCID, SCID, Rest3, State)
+        0 ->
+            handle_version_negotiation(DCID, Rest3, State);
+        _ ->
+            %% RFC 9368: a client that offered other acceptable versions
+            %% adopts the one the server switched to.
+            State1 = maybe_adopt_peer_version(Version, State),
+            %% The type bits are version-specific (RFC 9369 §3.2)
+            Type = quic_packet:bits_to_type(TypeBits, Version),
+            decode_long_header_type(Type, Data, FirstByte, Version, DCID, SCID, Rest3, State1)
     end.
+
+%% Client side of compatible version negotiation: the first long-header
+%% packet from the server carrying a version we offered (but did not
+%% start with) moves the connection there. Only before the ServerHello
+%% is processed; later mismatches are left to the normal decode path.
+maybe_adopt_peer_version(
+    Version,
+    #state{
+        role = client,
+        version = Current,
+        tls_state = ?TLS_AWAITING_SERVER_HELLO
+    } = State
+) when Version =/= Current ->
+    case lists:member(Version, State#state.supported_versions) of
+        true -> switch_version(Version, State);
+        false -> State
+    end;
+maybe_adopt_peer_version(_Version, State) ->
+    State.
 
 decode_long_header_type(Type, Data, FirstByte, Version, DCID, SCID, Rest3, State) ->
     case Type of
-        %% Initial
-        0 ->
+        initial ->
             decode_initial_packet(Data, FirstByte, DCID, SCID, Rest3, State);
-        %% 0-RTT
-        1 ->
+        zero_rtt ->
             decode_zero_rtt_packet(Data, FirstByte, DCID, SCID, Rest3, State);
-        %% Handshake
-        2 ->
+        handshake ->
             decode_handshake_packet(Data, FirstByte, DCID, SCID, Rest3, State);
         %% Retry (RFC 9000 Section 17.2.5)
-        3 ->
+        retry ->
             handle_retry_packet(Data, Version, SCID, Rest3, State);
         _ ->
             {error, unsupported_packet_type}
@@ -4473,7 +4535,9 @@ decode_versions(<<Version:32, Rest/binary>>) -> [Version | decode_versions(Rest)
 decode_versions(_) -> [].
 
 decode_initial_packet(FullPacket, FirstByte, _DCID, PeerSCID, Rest, State) ->
-    #state{initial_keys = {ClientKeys, ServerKeys}, role = Role} = State,
+    <<_:8, PacketVersion:32, _/binary>> = FullPacket,
+    {ClientKeys, ServerKeys} = initial_keys_for_version(PacketVersion, State),
+    #state{role = Role} = State,
 
     %% Select correct keys based on role:
     %% - Client receives from server -> use ServerKeys
@@ -5914,9 +5978,9 @@ process_tls_message(
                         Cipher, HandshakeSecret, TranscriptHash
                     ),
                     {ClientKey, ClientIV, ClientHP} =
-                        quic_keys:derive_keys(ClientHsSecret, Cipher),
+                        quic_keys:derive_keys(ClientHsSecret, Cipher, State#state.version),
                     {ServerKey, ServerIV, ServerHP} =
-                        quic_keys:derive_keys(ServerHsSecret, Cipher),
+                        quic_keys:derive_keys(ServerHsSecret, Cipher, State#state.version),
                     ClientHsKeys = #crypto_keys{
                         key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher
                     },
@@ -6099,10 +6163,10 @@ process_tls_message(
 
                     %% Derive app keys
                     {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(
-                        ClientAppSecret, Cipher
+                        ClientAppSecret, Cipher, State#state.version
                     ),
                     {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(
-                        ServerAppSecret, Cipher
+                        ServerAppSecret, Cipher, State#state.version
                     ),
 
                     ClientAppKeys = #crypto_keys{
@@ -6443,7 +6507,7 @@ do_server_client_hello(SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, Ori
 
 %% @private Continue the ClientHello once the server cert/key are settled.
 do_server_client_hello_cont(
-    SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, State
+    SelectedGroup, ClientPubKey, Cipher, ClientHelloInfo, OriginalMsg, StateVNIn
 ) ->
     ClientALPN = maps:get(alpn_protocols, ClientHelloInfo, []),
     ClientRandom = maps:get(random, ClientHelloInfo, undefined),
@@ -6452,6 +6516,12 @@ do_server_client_hello_cont(
     %% Check for PSK (0-RTT/resumption/external)
     PSKInfo = maps:get(pre_shared_key, ClientHelloInfo, undefined),
     WantsEarlyData = maps:get(early_data, ClientHelloInfo, false),
+
+    %% RFC 9368 compatible version negotiation, before any
+    %% version-dependent derivation (v2 has its own HKDF labels).
+    %% Skipped when the client offers early data: 0-RTT is bound to the
+    %% version of the first flight.
+    State = maybe_negotiate_compatible_version(TP, WantsEarlyData, StateVNIn),
 
     %% TLS 1.3 external PSK selection (RFC 8446 §4.2.11).
     %% Validate pre_shared_key placement, lookup identity, verify
@@ -6534,7 +6604,9 @@ do_server_client_hello_cont(
                                                             Cipher, ES, ClientHelloHash
                                                         ),
                                                     {Key, IV, HP} =
-                                                        quic_keys:derive_keys(ETS, Cipher),
+                                                        quic_keys:derive_keys(
+                                                            ETS, Cipher, State#state.version
+                                                        ),
                                                     EKeys = #crypto_keys{
                                                         key = Key,
                                                         iv = IV,
@@ -6649,8 +6721,12 @@ do_server_client_hello_cont(
     ),
 
     %% Derive handshake keys
-    {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(ClientHsSecret, Cipher),
-    {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(ServerHsSecret, Cipher),
+    {ClientKey, ClientIV, ClientHP} = quic_keys:derive_keys(
+        ClientHsSecret, Cipher, State#state.version
+    ),
+    {ServerKey, ServerIV, ServerHP} = quic_keys:derive_keys(
+        ServerHsSecret, Cipher, State#state.version
+    ),
 
     ClientHsKeys = #crypto_keys{
         key = ClientKey, iv = ClientIV, hp = ClientHP, cipher = Cipher
@@ -7660,6 +7736,59 @@ strip_brackets(Host) ->
 
 %% Derive initial encryption keys with specific QUIC version
 %% Version determines which salt to use (v1 vs v2)
+%% RFC 9368: adopt the best mutually acceptable version offered by the
+%% client. v1 and v2 are compatible with each other (RFC 9369 §6).
+maybe_negotiate_compatible_version(_TP, true, State) ->
+    State;
+maybe_negotiate_compatible_version(TP, false, State) ->
+    case maps:get(version_information, TP, undefined) of
+        {_Chosen, Available} when is_list(Available) ->
+            Mutual = [
+                V
+             || V <- State#state.supported_versions,
+                lists:member(V, Available)
+            ],
+            case Mutual of
+                [Best | _] when Best =/= State#state.version ->
+                    switch_version(Best, State);
+                _ ->
+                    State
+            end;
+        _ ->
+            State
+    end.
+
+%% Move the connection to another compatible version mid-handshake. The
+%% Initial keys are version-specific, so re-derive them from the
+%% original DCID for our own sends, keeping the old set so in-flight
+%% packets in the previous version still decrypt.
+switch_version(NewVersion, State) ->
+    ?LOG_INFO(
+        #{
+            what => compatible_version_negotiation,
+            from => State#state.version,
+            to => NewVersion
+        },
+        ?QUIC_LOG_META
+    ),
+    OldVersion = State#state.version,
+    NewKeys = derive_initial_keys(State#state.original_dcid, NewVersion),
+    State#state{
+        version = NewVersion,
+        initial_keys = NewKeys,
+        initial_keys_alt = {OldVersion, State#state.initial_keys}
+    }.
+
+%% Initial keys matching a received packet's version: through a
+%% compatible version switch the peer's first flight is still protected
+%% with the pre-switch version's keys.
+initial_keys_for_version(V, #state{version = V, initial_keys = Keys}) ->
+    Keys;
+initial_keys_for_version(V, #state{initial_keys_alt = {V, Keys}}) ->
+    Keys;
+initial_keys_for_version(_, #state{initial_keys = Keys}) ->
+    Keys.
+
 derive_initial_keys(DCID, Version) ->
     {ClientKey, ClientIV, ClientHP} = quic_keys:derive_initial_client(DCID, Version),
     {ServerKey, ServerIV, ServerHP} = quic_keys:derive_initial_server(DCID, Version),
@@ -8572,10 +8701,9 @@ send_zero_rtt_packet(Payload, Frames, EarlyKeys, State) ->
     %% Pad payload if needed for header protection sampling
     PaddedPayload = pad_for_header_protection(Payload),
 
-    %% Long header for 0-RTT (type 1)
-    %% First byte: 11XX XXXX where XX = type (01 for 0-RTT)
-    % 0xD0 base for 0-RTT
-    FirstByte = 16#C0 bor (1 bsl 4) bor (PNLen - 1),
+    %% Long header for 0-RTT; the type bits are version-specific
+    FirstByte =
+        16#C0 bor (quic_packet:type_to_bits(zero_rtt, Version) bsl 4) bor (PNLen - 1),
 
     %% Build header prefix (includes Length field, but not PN)
     DCIDLen = byte_size(DCID),
@@ -10805,9 +10933,9 @@ initiate_key_update(#state{key_state = KeyState} = State) ->
 
     %% Derive new secrets using "quic ku" label
     {NewClientSecret, {NewClientKey, NewClientIV, _}} =
-        quic_keys:derive_updated_keys(ClientSecret, Cipher),
+        quic_keys:derive_updated_keys(ClientSecret, Cipher, State#state.version),
     {NewServerSecret, {NewServerKey, NewServerIV, _}} =
-        quic_keys:derive_updated_keys(ServerSecret, Cipher),
+        quic_keys:derive_updated_keys(ServerSecret, Cipher, State#state.version),
 
     %% Create new crypto_keys records (preserve HP keys per RFC 9001 Section 6.6)
     NewClientKeys = #crypto_keys{
@@ -10874,9 +11002,9 @@ handle_peer_key_update(#state{key_state = KeyState} = State) ->
 
             %% Derive new secrets
             {NewClientSecret, {NewClientKey, NewClientIV, _}} =
-                quic_keys:derive_updated_keys(ClientSecret, Cipher),
+                quic_keys:derive_updated_keys(ClientSecret, Cipher, State#state.version),
             {NewServerSecret, {NewServerKey, NewServerIV, _}} =
-                quic_keys:derive_updated_keys(ServerSecret, Cipher),
+                quic_keys:derive_updated_keys(ServerSecret, Cipher, State#state.version),
 
             NewClientKeys = #crypto_keys{
                 key = NewClientKey,

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -556,12 +556,13 @@ group_supported(Group) ->
 ).
 
 %% RFC 9001 Section 5.8 - Retry Integrity Key and Nonce for QUIC v2
+%% RFC 9369 §3.3.3; the previous values were from a pre-RFC draft.
 -define(RETRY_INTEGRITY_KEY_V2,
     <<16#8f, 16#b4, 16#b0, 16#1b, 16#56, 16#ac, 16#48, 16#e2, 16#60, 16#fb, 16#cb, 16#ce, 16#ad,
-        16#7c, 16#ba, 16#00>>
+        16#7c, 16#cc, 16#92>>
 ).
 -define(RETRY_INTEGRITY_NONCE_V2,
-    <<16#d8, 16#69, 16#69, 16#50, 16#c9, 16#06, 16#79, 16#a4, 16#da, 16#88, 16#7e, 16#ce>>
+    <<16#d8, 16#69, 16#69, 16#bc, 16#2d, 16#7c, 16#6d, 16#99, 16#90, 16#ef, 16#b0, 16#4a>>
 ).
 
 %% @doc Verify the integrity tag of a Retry packet.

--- a/src/quic_keys.erl
+++ b/src/quic_keys.erl
@@ -36,10 +36,13 @@
     derive_initial_server/1,
     derive_initial_server/2,
     derive_keys/2,
+    derive_keys/3,
     derive_traffic_keys/1,
     %% Key Update (RFC 9001 Section 6)
     derive_updated_secret/2,
-    derive_updated_keys/2
+    derive_updated_secret/3,
+    derive_updated_keys/2,
+    derive_updated_keys/3
 ]).
 
 -export_type([keys/0]).
@@ -73,7 +76,7 @@ derive_initial_client(DCID) ->
 derive_initial_client(DCID, Version) ->
     InitialSecret = derive_initial_secret(DCID, Version),
     ClientSecret = quic_hkdf:expand_label(InitialSecret, ?QUIC_LABEL_CLIENT_IN, <<>>, 32),
-    derive_traffic_keys(ClientSecret).
+    derive_keys(ClientSecret, aes_128_gcm, Version).
 
 %% @doc Derive initial server keys from DCID.
 %% Returns {Key, IV, HP} for server Initial packets.
@@ -86,16 +89,26 @@ derive_initial_server(DCID) ->
 derive_initial_server(DCID, Version) ->
     InitialSecret = derive_initial_secret(DCID, Version),
     ServerSecret = quic_hkdf:expand_label(InitialSecret, ?QUIC_LABEL_SERVER_IN, <<>>, 32),
-    derive_traffic_keys(ServerSecret).
+    derive_keys(ServerSecret, aes_128_gcm, Version).
 
 %% @doc Derive keys from a traffic secret.
 %% Returns {Key, IV, HP} for the given secret.
 -spec derive_keys(binary(), aes_128_gcm | aes_256_gcm | chacha20_poly1305) -> keys().
 derive_keys(Secret, Cipher) ->
+    derive_keys(Secret, Cipher, ?QUIC_VERSION_1).
+
+%% @doc Derive keys from a traffic secret for a specific QUIC version.
+%% QUIC v2 uses its own HKDF labels (RFC 9369 §3.3.1); deriving with the
+%% v1 labels on a v2 connection yields keys no other implementation has.
+-spec derive_keys(
+    binary(), aes_128_gcm | aes_256_gcm | chacha20_poly1305, non_neg_integer()
+) -> keys().
+derive_keys(Secret, Cipher, Version) ->
     {Hash, KeyLen, HPLen} = cipher_params(Cipher),
-    Key = quic_hkdf:expand_label(Hash, Secret, ?QUIC_LABEL_QUIC_KEY, <<>>, KeyLen),
-    IV = quic_hkdf:expand_label(Hash, Secret, ?QUIC_LABEL_QUIC_IV, <<>>, 12),
-    HP = quic_hkdf:expand_label(Hash, Secret, ?QUIC_LABEL_QUIC_HP, <<>>, HPLen),
+    {LKey, LIV, LHP} = packet_labels(Version),
+    Key = quic_hkdf:expand_label(Hash, Secret, LKey, <<>>, KeyLen),
+    IV = quic_hkdf:expand_label(Hash, Secret, LIV, <<>>, 12),
+    HP = quic_hkdf:expand_label(Hash, Secret, LHP, <<>>, HPLen),
     {Key, IV, HP}.
 
 %% @doc Derive traffic keys (Key, IV, HP) from a traffic secret.
@@ -110,12 +123,18 @@ derive_traffic_keys(Secret) ->
 %%   updated_secret = HKDF-Expand-Label(current_secret, "quic ku", "", hash_len)
 %% where "quic ku" is the label for key update.
 -spec derive_updated_secret(binary(), aes_128_gcm | aes_256_gcm | chacha20_poly1305) -> binary().
-derive_updated_secret(CurrentSecret, aes_256_gcm) ->
+derive_updated_secret(CurrentSecret, Cipher) ->
+    derive_updated_secret(CurrentSecret, Cipher, ?QUIC_VERSION_1).
+
+-spec derive_updated_secret(
+    binary(), aes_128_gcm | aes_256_gcm | chacha20_poly1305, non_neg_integer()
+) -> binary().
+derive_updated_secret(CurrentSecret, aes_256_gcm, Version) ->
     %% AES-256-GCM uses SHA-384, so secret length is 48 bytes
-    quic_hkdf:expand_label(sha384, CurrentSecret, <<"quic ku">>, <<>>, 48);
-derive_updated_secret(CurrentSecret, _Cipher) ->
+    quic_hkdf:expand_label(sha384, CurrentSecret, ku_label(Version), <<>>, 48);
+derive_updated_secret(CurrentSecret, _Cipher, Version) ->
     %% AES-128-GCM and ChaCha20-Poly1305 use SHA-256, so secret length is 32 bytes
-    quic_hkdf:expand_label(sha256, CurrentSecret, <<"quic ku">>, <<>>, 32).
+    quic_hkdf:expand_label(sha256, CurrentSecret, ku_label(Version), <<>>, 32).
 
 %% @doc Derive updated keys from an updated application secret.
 %% This performs the full key update: derives the new secret and then derives keys.
@@ -123,13 +142,29 @@ derive_updated_secret(CurrentSecret, _Cipher) ->
 -spec derive_updated_keys(binary(), aes_128_gcm | aes_256_gcm | chacha20_poly1305) ->
     {UpdatedSecret :: binary(), keys()}.
 derive_updated_keys(CurrentSecret, Cipher) ->
-    UpdatedSecret = derive_updated_secret(CurrentSecret, Cipher),
-    Keys = derive_keys(UpdatedSecret, Cipher),
+    derive_updated_keys(CurrentSecret, Cipher, ?QUIC_VERSION_1).
+
+-spec derive_updated_keys(
+    binary(), aes_128_gcm | aes_256_gcm | chacha20_poly1305, non_neg_integer()
+) ->
+    {UpdatedSecret :: binary(), keys()}.
+derive_updated_keys(CurrentSecret, Cipher, Version) ->
+    UpdatedSecret = derive_updated_secret(CurrentSecret, Cipher, Version),
+    Keys = derive_keys(UpdatedSecret, Cipher, Version),
     {UpdatedSecret, Keys}.
 
 %%====================================================================
 %% Internal Functions
 %%====================================================================
+
+%% HKDF labels for packet protection, by version (RFC 9369 §3.3.1)
+packet_labels(?QUIC_VERSION_2) ->
+    {<<"quicv2 key">>, <<"quicv2 iv">>, <<"quicv2 hp">>};
+packet_labels(_) ->
+    {?QUIC_LABEL_QUIC_KEY, ?QUIC_LABEL_QUIC_IV, ?QUIC_LABEL_QUIC_HP}.
+
+ku_label(?QUIC_VERSION_2) -> <<"quicv2 ku">>;
+ku_label(_) -> <<"quic ku">>.
 
 %% Get cipher parameters: {Hash, KeyLen, HPLen}
 cipher_params(aes_128_gcm) -> {sha256, 16, 16};

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -760,11 +760,12 @@ parse_packet_header(
 ) when
     FirstByte band 16#80 =:= 16#80
 ->
-    %% Long header - extract packet type from bits 4-5 of first byte
-    %% Type: 00=Initial, 01=0-RTT, 10=Handshake, 11=Retry
+    %% Long header - extract packet type from bits 4-5 of first byte.
+    %% The bit patterns are version-specific (RFC 9369 §3.2), so map
+    %% through the version before classifying.
     PacketType = (FirstByte bsr 4) band 2#11,
-    case PacketType of
-        0 -> {initial, DCID, SCID, Version, Rest};
+    case quic_packet:bits_to_type(PacketType, Version) of
+        initial -> {initial, DCID, SCID, Version, Rest};
         _ -> {long, DCID, SCID, PacketType, Rest}
     end;
 parse_packet_header(<<0:1, _:7, Rest/binary>>, DCIDLen) ->
@@ -1100,12 +1101,14 @@ decide_address_validation(Packet, _Version, Addr, Secret, always, MaxAge) ->
 %% returns the client's SCID and the DCID (which the client chose as
 %% the original destination CID before any retry).
 parse_initial_token(
-    <<FirstByte, _Version:32, DCIDLen:8, DCID:DCIDLen/binary, SCIDLen:8, SCID:SCIDLen/binary,
+    <<FirstByte, Version:32, DCIDLen:8, DCID:DCIDLen/binary, SCIDLen:8, SCID:SCIDLen/binary,
         Rest/binary>>
 ) when
-    FirstByte band 16#F0 =:= 16#C0
+    FirstByte band 16#C0 =:= 16#C0
 ->
     try
+        %% Accept only Initial packets; the type bits differ per version.
+        initial = quic_packet:bits_to_type((FirstByte bsr 4) band 2#11, Version),
         {TokenLen, Rest1} = quic_varint:decode(Rest),
         <<Token:TokenLen/binary, _/binary>> = Rest1,
         {ok, Token, SCID, DCID}

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -691,7 +691,7 @@ get_tables(_) ->
 
 handle_packet(Packet, RemoteAddr, #listener_state{dcid_len = DCIDLen} = State) ->
     case parse_packet_header(Packet, DCIDLen) of
-        {initial, DCID, _SCID, Version, _Rest} ->
+        {initial, DCID, SCID, Version, _Rest} ->
             %% Per-packet routing trace. Logged at debug: every received packet
             %% hits this path (a short-header packet per 1-RTT datagram), so at
             %% info level a busy listener floods the log and burns CPU.
@@ -704,7 +704,12 @@ handle_packet(Packet, RemoteAddr, #listener_state{dcid_len = DCIDLen} = State) -
                 },
                 ?QUIC_LOG_META
             ),
-            handle_initial_packet(Packet, DCID, Version, RemoteAddr, State);
+            case supported_version(Version) of
+                true ->
+                    handle_initial_packet(Packet, DCID, Version, RemoteAddr, State);
+                false ->
+                    send_version_negotiation(DCID, SCID, Version, RemoteAddr, State)
+            end;
         {short, DCID, _Rest} ->
             ?LOG_DEBUG(#{what => short_header_packet, dcid => DCID}, ?QUIC_LOG_META),
             route_to_connection(DCID, Packet, RemoteAddr, State);
@@ -718,6 +723,33 @@ handle_packet(Packet, RemoteAddr, #listener_state{dcid_len = DCIDLen} = State) -
             ?LOG_WARNING(#{what => packet_parse_failed, reason => Reason}, ?QUIC_LOG_META),
             ok
     end.
+
+%% RFC 9000 Section 6.1: a server that receives a long-header packet with a
+%% version it does not support MUST respond with a Version Negotiation packet
+%% listing the versions it does support. Without this a peer probing with a
+%% reserved version, which is how readiness checks and the QUIC Interop
+%% Runner detect a live server, gets silence.
+supported_version(?QUIC_VERSION_1) -> true;
+supported_version(?QUIC_VERSION_2) -> true;
+supported_version(_) -> false.
+
+send_version_negotiation(_DCID, _SCID, 0, _RemoteAddr, _State) ->
+    %% Version 0 is itself a Version Negotiation packet; never reply to one
+    %% (RFC 9000 Section 6.1), or two servers can trade them forever.
+    ok;
+send_version_negotiation(DCID, SCID, _Version, {IP, Port}, State) ->
+    #listener_state{
+        socket = Socket,
+        socket_state = SocketState,
+        socket_backend = Backend
+    } = State,
+    %% The connection IDs are swapped: our DCID is what the client used as
+    %% its source, so the client can match the reply to its attempt.
+    Packet = quic_packet:encode_version_negotiation(
+        SCID, DCID, [?QUIC_VERSION_1, ?QUIC_VERSION_2]
+    ),
+    send_packet(Socket, SocketState, Backend, IP, Port, Packet),
+    ok.
 
 %% Parse packet header to extract DCID for routing
 %% DCIDLen parameter specifies expected DCID length for short header packets

--- a/src/quic_packet.erl
+++ b/src/quic_packet.erl
@@ -47,6 +47,8 @@
 
 -export([
     encode_long/5,
+    type_to_bits/2,
+    bits_to_type/2,
     encode_short/4,
     encode_short/5,
     encode_retry/5,
@@ -86,7 +88,7 @@
 ) ->
     binary().
 encode_long(Type, Version, DCID, SCID, Opts) ->
-    TypeBits = type_to_bits(Type),
+    TypeBits = type_to_bits(Type, Version),
     Token = maps:get(token, Opts, <<>>),
     PN = maps:get(pn, Opts, 0),
     Payload = maps:get(payload, Opts, <<>>),
@@ -143,10 +145,11 @@ encode_long(Type, Version, DCID, SCID, Opts) ->
     Token :: binary(),
     Version :: non_neg_integer().
 encode_retry(OriginalDCID, DCID, SCID, Token, Version) ->
-    %% 1 | 1 | Type (2 = 11 retry) | Unused (4). Lower 4 bits are
-    %% covered by the integrity tag so they can be anything; pick a
+    %% 1 | 1 | Type | Unused (4). The type bits are version-specific
+    %% (v1 retry = 0b11, v2 retry = 0b00, RFC 9369 §3.2). Lower 4 bits
+    %% are covered by the integrity tag so they can be anything; pick a
     %% fixed value so packet captures are stable.
-    FirstByte = 16#F0,
+    FirstByte = 16#C0 bor (type_to_bits(retry, Version) bsl 4),
     PacketWithoutTag = <<
         FirstByte,
         Version:32,
@@ -272,7 +275,7 @@ decode_long(<<FirstByte, Version:32, DCIDLen, Rest/binary>>) when
             SCIDLen =< ?MAX_CID_LEN
         ->
             <<SCID:SCIDLen/binary, Rest3/binary>> = Rest2,
-            Type = bits_to_type((FirstByte bsr 4) band 2#11),
+            Type = bits_to_type((FirstByte bsr 4) band 2#11, Version),
             PNLenBits = FirstByte band 2#11,
             PNLen = PNLenBits + 1,
             decode_long_body(Type, Version, DCID, SCID, PNLen, Rest3);
@@ -364,15 +367,27 @@ decode_short(<<FirstByte, Rest/binary>>, DCIDLen) ->
     },
     {ok, Packet, <<>>}.
 
-type_to_bits(initial) -> 0;
-type_to_bits(zero_rtt) -> 1;
-type_to_bits(handshake) -> 2;
-type_to_bits(retry) -> 3.
+%% Long-header packet type bits are version-specific: QUIC v2 rotates
+%% them (RFC 9369 §3.2) precisely so that v1-only middleboxes cannot
+%% classify v2 packets. Encoding v1 bits under a v2 version field
+%% produces packets no conforming peer will parse.
+type_to_bits(initial, ?QUIC_VERSION_2) -> 1;
+type_to_bits(zero_rtt, ?QUIC_VERSION_2) -> 2;
+type_to_bits(handshake, ?QUIC_VERSION_2) -> 3;
+type_to_bits(retry, ?QUIC_VERSION_2) -> 0;
+type_to_bits(initial, _) -> 0;
+type_to_bits(zero_rtt, _) -> 1;
+type_to_bits(handshake, _) -> 2;
+type_to_bits(retry, _) -> 3.
 
-bits_to_type(0) -> initial;
-bits_to_type(1) -> zero_rtt;
-bits_to_type(2) -> handshake;
-bits_to_type(3) -> retry.
+bits_to_type(1, ?QUIC_VERSION_2) -> initial;
+bits_to_type(2, ?QUIC_VERSION_2) -> zero_rtt;
+bits_to_type(3, ?QUIC_VERSION_2) -> handshake;
+bits_to_type(0, ?QUIC_VERSION_2) -> retry;
+bits_to_type(0, _) -> initial;
+bits_to_type(1, _) -> zero_rtt;
+bits_to_type(2, _) -> handshake;
+bits_to_type(3, _) -> retry.
 
 %% Encode a list of versions for VN packet
 encode_vn_versions([]) ->

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -661,6 +661,10 @@ encode_transport_params(Params) ->
 
 encode_transport_param(original_dcid, Value) ->
     encode_tp(?TP_ORIGINAL_DCID, Value);
+encode_transport_param(version_information, {Chosen, Available}) ->
+    %% RFC 9368 §3: Chosen Version followed by Available Versions.
+    Avail = <<<<V:32>> || V <- Available>>,
+    encode_tp(?TP_VERSION_INFORMATION, <<Chosen:32, Avail/binary>>);
 encode_transport_param(max_idle_timeout, Value) ->
     encode_tp(?TP_MAX_IDLE_TIMEOUT, quic_varint:encode(Value));
 encode_transport_param(max_udp_payload_size, Value) ->
@@ -797,12 +801,15 @@ tp_id_to_key(?TP_PREFERRED_ADDRESS) -> preferred_address;
 tp_id_to_key(?TP_ACTIVE_CONNECTION_ID_LIMIT) -> active_connection_id_limit;
 tp_id_to_key(?TP_INITIAL_SCID) -> initial_scid;
 tp_id_to_key(?TP_RETRY_SCID) -> retry_scid;
+tp_id_to_key(?TP_VERSION_INFORMATION) -> version_information;
 tp_id_to_key(?TP_MAX_DATAGRAM_FRAME_SIZE) -> max_datagram_frame_size;
 tp_id_to_key(?TP_RESET_STREAM_AT) -> reset_stream_at;
 tp_id_to_key(Id) -> {unknown, Id}.
 
 decode_tp_value(?TP_ORIGINAL_DCID, Value) ->
     Value;
+decode_tp_value(?TP_VERSION_INFORMATION, <<Chosen:32, Rest/binary>>) ->
+    {Chosen, [V || <<V:32>> <= Rest]};
 decode_tp_value(?TP_STATELESS_RESET_TOKEN, Value) ->
     Value;
 decode_tp_value(?TP_INITIAL_SCID, Value) ->

--- a/test/quic_server_version_negotiation_tests.erl
+++ b/test/quic_server_version_negotiation_tests.erl
@@ -1,0 +1,92 @@
+%%% -*- erlang -*-
+%%%
+%%% Server-side Version Negotiation (RFC 9000 section 6.1). A peer that
+%%% probes with a version we do not speak must get a VN packet listing
+%%% what we do speak; probing with a reserved version is how readiness
+%%% checks and the interop runner detect a live server, and silence
+%%% reads as down.
+
+-module(quic_server_version_negotiation_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+%% A GREASE version (RFC 9000 section 15): reserved, never supported.
+-define(GREASE_VERSION, 16#0a0a0a0a).
+
+vn_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun an_unknown_version_gets_a_version_list/1,
+        fun the_reply_swaps_the_connection_ids/1,
+        fun a_version_negotiation_packet_is_not_answered/1
+    ]}.
+
+setup() ->
+    {ok, Srv} = quic_test_echo_server:start(),
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    {Srv, Sock}.
+
+cleanup({Srv, Sock}) ->
+    gen_udp:close(Sock),
+    quic_test_echo_server:stop(Srv).
+
+an_unknown_version_gets_a_version_list({Srv, Sock}) ->
+    fun() ->
+        {ok, {0, _DCID, _SCID, Versions}} = probe(Srv, Sock, ?GREASE_VERSION),
+        ?assert(lists:member(?QUIC_VERSION_1, Versions)),
+        ?assert(lists:member(?QUIC_VERSION_2, Versions)),
+        ?assertNot(lists:member(?GREASE_VERSION, Versions))
+    end.
+
+%% The client matches the reply to its attempt by the connection IDs, so
+%% they come back swapped.
+the_reply_swaps_the_connection_ids({Srv, Sock}) ->
+    fun() ->
+        DCID = <<1, 2, 3, 4, 5, 6, 7, 8>>,
+        SCID = <<9, 10, 11, 12>>,
+        {ok, {0, ReplyDCID, ReplySCID, _}} = probe(Srv, Sock, ?GREASE_VERSION, DCID, SCID),
+        ?assertEqual(SCID, ReplyDCID),
+        ?assertEqual(DCID, ReplySCID)
+    end.
+
+%% Version 0 is itself a VN packet. Answering one lets two servers trade
+%% them forever.
+a_version_negotiation_packet_is_not_answered({Srv, Sock}) ->
+    fun() ->
+        ?assertEqual({error, timeout}, probe(Srv, Sock, 0))
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+probe(Srv, Sock, Version) ->
+    probe(Srv, Sock, Version, <<1, 2, 3, 4, 5, 6, 7, 8>>, <<9, 9, 9, 9>>).
+
+probe(Srv, Sock, Version, DCID, SCID) ->
+    #{port := Port} = Srv,
+    Pkt = long_header(Version, DCID, SCID),
+    ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, Pkt),
+    case gen_udp:recv(Sock, 0, 1000) of
+        {ok, {_, _, Data}} -> {ok, parse_vn(Data)};
+        {error, _} = E -> E
+    end.
+
+%% Minimal long header carrying the probe version, padded to the 1200
+%% bytes a server may require before it will answer an Initial.
+long_header(Version, DCID, SCID) ->
+    Head = <<
+        16#c0,
+        Version:32,
+        (byte_size(DCID)),
+        DCID/binary,
+        (byte_size(SCID)),
+        SCID/binary
+    >>,
+    Pad = binary:copy(<<0>>, max(0, 1200 - byte_size(Head))),
+    <<Head/binary, Pad/binary>>.
+
+parse_vn(<<First, 0:32, DLen, DCID:DLen/binary, SLen, SCID:SLen/binary, Rest/binary>>) when
+    First band 16#80 =:= 16#80
+->
+    {0, DCID, SCID, [V || <<V:32>> <= Rest]}.


### PR DESCRIPTION
Aggregates #229 and #243, commits keeping their authors.

#243 predates the `version` option that #270 landed from #232, so three conflicts needed both sides rather than one: `version` decides the Initial salt while `supported_versions` is the RFC 9368 offer list, and the offer now defaults to the configured version instead of hardcoded v1. The third is 0-RTT key derivation, where #243 made it version-aware and #238 restructured the same block for ticket PSKs; the restructure stays and its derive_keys call becomes the version-aware one.

The three existing version-negotiation suites all test the client. Nothing covered the server answering an unsupported version, which is the path a readiness probe and the interop runner take, so that gets a test: a GREASE-version probe over raw UDP gets a list containing v1 and v2, the connection IDs come back swapped, and a Version Negotiation packet is never answered with another.