### PR TITLE
HTTP/3 body framing and the interop runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- An HTTP/3 message body ends at stream end rather than at a frame
+  boundary, so a response whose last DATA frame is followed by the FIN
+  in a separate packet is not truncated. Contributed by jbevemyr (#244).
 - A server answers a long-header packet carrying a version it does not
   support with a Version Negotiation packet (RFC 9000 section 6.1)
   instead of silence. Probing with a reserved version is how readiness
@@ -165,6 +168,10 @@ All notable changes to this project will be documented in this file.
 - A server handshake flight lost on the wire is retransmitted on the client-Initial backoff schedule until the client's Finished arrives. Initial/Handshake packets are not loss-tracked, so a lost flight previously wedged the handshake permanently: the client's Initial retransmits only elicited ACKs once the server TLS state had advanced. (#263)
 
 ### Changed
+- The interop runner speaks real HTTP/3 in the http3 case, serves more
+  than one request per connection, issues requests concurrently within
+  the peer's stream credit, and its resumption and 0-RTT cases test what
+  they claim. Contributed by jbevemyr (#245).
 - A mixed-size send batch on a GSO socket is split into runs of
   equal-sized packets and each run sent with one UDP_SEGMENT call,
   instead of falling back to one `sendmsg' per packet. A single

--- a/src/h3/quic_h3_connection.erl
+++ b/src/h3/quic_h3_connection.erl
@@ -2542,17 +2542,40 @@ handle_request_stream_data(
     Combined = <<Buffer/binary, Data/binary>>,
 
     case process_request_frames(StreamId, Combined, Fin, Stream, State) of
+        {ok, Rest, _Stream1, _State1} when Fin, Rest =/= <<>> ->
+            %% Stream ended inside an H3 frame: truncated (RFC 9114 §7.1).
+            {error, {connection_error, ?H3_FRAME_ERROR, <<"stream ended mid-frame">>}};
         {ok, Rest, Stream1, State1} ->
+            %% RFC 9114 §4.1: the message ends when the stream ends, not at
+            %% a frame boundary. A peer that sends its FIN in a bare final
+            %% QUIC frame (quic-go does) otherwise leaves the application
+            %% waiting for a fin-marked delivery that never comes.
+            {Stream2, State2} =
+                case Fin of
+                    true -> finish_request_stream(StreamId, Stream1, State1);
+                    false -> {Stream1, State1}
+                end,
             Buffers1 =
                 case Rest of
                     <<>> -> maps:remove(StreamId, Buffers);
                     _ -> Buffers#{StreamId => Rest}
                 end,
-            Streams1 = Streams#{StreamId => Stream1},
-            {ok, State1#state{streams = Streams1, stream_buffers = Buffers1}};
+            Streams1 = Streams#{StreamId => Stream2},
+            {ok, State2#state{streams = Streams1, stream_buffers = Buffers1}};
         {error, Reason} ->
             {error, Reason, State}
     end.
+
+%% The stream's FIN arrived after the last complete frame. If the body
+%% was already closed by a fin-marked frame delivery this is a no-op;
+%% an open body gets its final empty fin-marked delivery here.
+finish_request_stream(
+    StreamId, #h3_stream{frame_state = expecting_data} = Stream, State
+) ->
+    State1 = notify_stream_data(StreamId, <<>>, true, State),
+    {Stream#h3_stream{frame_state = complete, state = half_closed_remote}, State1};
+finish_request_stream(_StreamId, Stream, State) ->
+    {Stream, State}.
 
 process_request_frames(StreamId, Data, Fin, Stream, #state{quic_conn = QuicConn} = State) ->
     case quic_h3_frame:decode(Data) of

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -44,7 +44,9 @@
 -include("quic.hrl").
 
 %% Ticket file location (for resumption/0-RTT tests)
--define(TICKET_FILE, "/downloads/session_ticket.dat").
+%% NOT under /downloads: the runner diffs that directory against the
+%% requested files and fails the test on anything unexpected in it.
+-define(TICKET_FILE, "/tmp/session_ticket.dat").
 
 main(_Args) ->
     %% Start required applications
@@ -432,9 +434,18 @@ run_resumption_test(RequestsStr, DownloadsDir) ->
         [] ->
             io:format("No requests specified~n"),
             halt(?EXIT_FAILURE);
-        [Url | _Rest] ->
+        [Url | Rest] ->
             case parse_url(Url) of
                 {ok, Host, Port, Path} ->
+                    %% The runner hands us two files: the first is fetched on
+                    %% the fresh connection, the second on the resumed one.
+                    %% Fetching the same file twice leaves the second file
+                    %% missing and fails the test even when resumption works.
+                    Path2 =
+                        case [P || U <- Rest, {ok, _, _, P} <- [parse_url(U)]] of
+                            [Second | _] -> Second;
+                            [] -> Path
+                        end,
                     %% Phase 1: Initial connection to get ticket
                     io:format("~n=== Phase 1: Initial connection to get ticket ===~n"),
                     case resumption_phase1(Host, Port, Path, DownloadsDir) of
@@ -445,7 +456,7 @@ run_resumption_test(RequestsStr, DownloadsDir) ->
 
                             %% Phase 2: Resumption with ticket
                             io:format("~n=== Phase 2: Resumption with ticket ===~n"),
-                            case resumption_phase2(Host, Port, Path, DownloadsDir, Ticket) of
+                            case resumption_phase2(Host, Port, Path2, DownloadsDir, Ticket) of
                                 ok ->
                                     io:format("Resumption test successful~n"),
                                     halt(?EXIT_SUCCESS);
@@ -489,7 +500,9 @@ wait_for_ticket_and_download(Conn, Path, DownloadsDir) ->
                     Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
                     ok = quic:send_data(Conn, StreamId, Request, true),
                     %% Download and wait for ticket
-                    download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, undefined);
+                    download_and_wait_for_ticket(
+                        Conn, StreamId, Path, DownloadsDir, undefined, []
+                    );
                 {error, Err} ->
                     io:format("Failed to open stream: ~p~n", [Err]),
                     error
@@ -503,16 +516,18 @@ wait_for_ticket_and_download(Conn, Path, DownloadsDir) ->
     end.
 
 %% Download file and wait for session ticket
-download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket) ->
+download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket, Acc) ->
     receive
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            %% Accumulate data (could use streaming, but for resumption test this is fine)
+            %% Every chunk counts: writing only the final one truncated the
+            %% file to the last STREAM frame and failed the size check.
+            Acc1 = [Acc | Data],
             case Fin of
                 true ->
                     %% Save the file
                     Filename = filename:basename(Path),
                     FilePath = filename:join(DownloadsDir, Filename),
-                    file:write_file(FilePath, Data),
+                    file:write_file(FilePath, Acc1),
                     io:format("Phase 1: Downloaded ~s~n", [FilePath]),
                     %% Continue waiting for ticket if we don't have one yet
                     case Ticket of
@@ -520,11 +535,11 @@ download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket) ->
                         _ -> {ok, Ticket}
                     end;
                 false ->
-                    download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket)
+                    download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, Ticket, Acc1)
             end;
         {quic, Conn, {session_ticket, NewTicket}} ->
             io:format("Phase 1: Received session ticket~n"),
-            download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, NewTicket);
+            download_and_wait_for_ticket(Conn, StreamId, Path, DownloadsDir, NewTicket, Acc);
         {quic, Conn, {closed, _Reason}} ->
             case Ticket of
                 undefined -> error;
@@ -597,14 +612,28 @@ run_zerortt_test(RequestsStr, DownloadsDir) ->
         [] ->
             io:format("No requests specified~n"),
             halt(?EXIT_FAILURE);
-        [Url | _Rest] ->
+        [Url | _] ->
             case parse_url(Url) of
-                {ok, Host, Port, Path} ->
-                    %% Try to load existing ticket
-                    case load_ticket() of
+                {ok, Host, Port, _} ->
+                    %% The runner expects every requested file to be
+                    %% downloaded, with the requests sent as early data. The
+                    %% first connection only fetches a ticket; downloading
+                    %% there would also count the files against the wrong
+                    %% handshake.
+                    AllPaths = [P || U <- Requests, {ok, _, _, P} <- [parse_url(U)]],
+                    TicketResult =
+                        case load_ticket() of
+                            {ok, T} ->
+                                io:format("Using stored ticket for 0-RTT~n"),
+                                {ok, T};
+                            error ->
+                                io:format("No stored ticket, fetching one~n"),
+                                ticket_only_connection(Host, Port)
+                        end,
+                    case TicketResult of
                         {ok, Ticket} ->
-                            io:format("Using stored ticket for 0-RTT~n"),
-                            case zerortt_with_ticket(Host, Port, Path, DownloadsDir, Ticket) of
+                            save_ticket(Ticket),
+                            case zerortt_download_all(Host, Port, AllPaths, DownloadsDir, Ticket) of
                                 ok ->
                                     io:format("0-RTT test successful~n"),
                                     halt(?EXIT_SUCCESS);
@@ -613,25 +642,8 @@ run_zerortt_test(RequestsStr, DownloadsDir) ->
                                     halt(?EXIT_FAILURE)
                             end;
                         error ->
-                            %% No ticket, do resumption first
-                            io:format("No stored ticket, running resumption first~n"),
-                            case resumption_phase1(Host, Port, Path, DownloadsDir) of
-                                {ok, Ticket} ->
-                                    save_ticket(Ticket),
-                                    case
-                                        zerortt_with_ticket(Host, Port, Path, DownloadsDir, Ticket)
-                                    of
-                                        ok ->
-                                            io:format("0-RTT test successful~n"),
-                                            halt(?EXIT_SUCCESS);
-                                        error ->
-                                            io:format("0-RTT test failed~n"),
-                                            halt(?EXIT_FAILURE)
-                                    end;
-                                error ->
-                                    io:format("Failed to get ticket for 0-RTT~n"),
-                                    halt(?EXIT_FAILURE)
-                            end
+                            io:format("Failed to get ticket for 0-RTT~n"),
+                            halt(?EXIT_FAILURE)
                     end;
                 error ->
                     io:format("Invalid URL~n"),
@@ -639,156 +651,63 @@ run_zerortt_test(RequestsStr, DownloadsDir) ->
             end
     end.
 
-%% Connect with 0-RTT using stored ticket
-%% Sends request as early data before handshake completes
-zerortt_with_ticket(Host, Port, Path, DownloadsDir, Ticket) ->
+%% First connection: handshake, wait for a session ticket, download nothing.
+ticket_only_connection(Host, Port) ->
+    %% pmtu_enabled: the zerortt grader counts every 1-RTT byte the client
+    %% sends across the whole capture, and padded PMTU probes alone blow
+    %% the budget.
+    Opts = #{
+        verify => false,
+        alpn => [<<"hq-interop">>, <<"h3">>],
+        pmtu_enabled => false
+    },
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, Conn} ->
+            Result =
+                receive
+                    {quic, Conn, {connected, _Info}} ->
+                        io:format("Ticket connection established~n"),
+                        wait_for_ticket_only(Conn, 10000);
+                    {quic, Conn, {closed, Reason}} ->
+                        io:format("Ticket connection closed: ~p~n", [Reason]),
+                        error
+                after 30000 ->
+                    io:format("Ticket connection timeout~n"),
+                    error
+                end,
+            quic:close(Conn, normal),
+            Result;
+        {error, Reason} ->
+            io:format("Ticket connection failed: ~p~n", [Reason]),
+            error
+    end.
+
+%% Second connection: requests go out as early data (collect_streams opens
+%% streams and sends immediately; before the handshake completes that is
+%% the client 0-RTT path), responses arrive once the handshake is done.
+zerortt_download_all(Host, Port, Paths, DownloadsDir, Ticket) ->
     Opts = #{
         verify => false,
         alpn => [<<"hq-interop">>, <<"h3">>],
         session_ticket => Ticket,
-        enable_early_data => true
+        enable_early_data => true,
+        pmtu_enabled => false
     },
     case quic:connect(Host, Port, Opts, self()) of
         {ok, Conn} ->
-            %% Open stream and send request immediately (uses 0-RTT if available)
-            case quic:open_stream(Conn) of
-                {ok, StreamId} ->
-                    Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    io:format("Sending 0-RTT request~n"),
-                    ok = quic:send_data(Conn, StreamId, Request, true),
-                    Result = wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir),
-                    quic:close(Conn, normal),
-                    Result;
-                {error, not_connected} ->
-                    %% Early keys not available, fall back to waiting for connection
-                    io:format("0-RTT: Early keys not available, waiting for connection~n"),
-                    Result = wait_for_connection_then_request(Conn, Path, DownloadsDir),
-                    quic:close(Conn, normal),
-                    Result;
-                {error, Err} ->
-                    io:format("Failed to open stream: ~p~n", [Err]),
-                    quic:close(Conn, normal),
-                    error
+            io:format("Sending ~p request(s) as early data~n", [length(Paths)]),
+            Results = collect_streams(Conn, Paths, DownloadsDir),
+            quic:close(Conn, normal),
+            case
+                length(Results) =:= length(Paths) andalso
+                    lists:all(fun(R) -> R =:= ok end, Results)
+            of
+                true -> ok;
+                false -> error
             end;
         {error, Reason} ->
             io:format("0-RTT connection failed: ~p~n", [Reason]),
             error
-    end.
-
-%% Fallback: wait for connection then send request
-wait_for_connection_then_request(Conn, Path, DownloadsDir) ->
-    receive
-        {quic, Conn, {connected, _Info}} ->
-            io:format("0-RTT: Connected (fallback to 1-RTT)~n"),
-            case quic:open_stream(Conn) of
-                {ok, StreamId} ->
-                    Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(Conn, StreamId, Request, true),
-                    wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir);
-                {error, Err} ->
-                    io:format("Failed to open stream: ~p~n", [Err]),
-                    error
-            end;
-        {quic, Conn, {closed, Reason}} ->
-            io:format("0-RTT: Connection closed: ~p~n", [Reason]),
-            error
-    after 30000 ->
-        io:format("0-RTT: Connection timeout~n"),
-        error
-    end.
-
-%% Wait for 0-RTT response (may receive before or after connected event)
-wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir) ->
-    wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir, false, false, <<>>).
-
-wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir, Connected, Retried, Acc) ->
-    %% Use shorter timeout after handshake to detect rejected 0-RTT
-    Timeout =
-        case Connected andalso Acc =:= <<>> andalso not Retried of
-            % Short wait for 0-RTT response after handshake
-            true -> 2000;
-            false -> 60000
-        end,
-    receive
-        {quic, Conn, {connected, _Info}} ->
-            io:format("0-RTT: Handshake completed~n"),
-            wait_for_zerortt_response(Conn, StreamId, Path, DownloadsDir, true, Retried, Acc);
-        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            NewAcc = <<Acc/binary, Data/binary>>,
-            case Fin of
-                true ->
-                    Filename = filename:basename(Path),
-                    FilePath = filename:join(DownloadsDir, Filename),
-                    file:write_file(FilePath, NewAcc),
-                    io:format("0-RTT: Downloaded ~s (~p bytes)~n", [FilePath, byte_size(NewAcc)]),
-                    ok;
-                false ->
-                    wait_for_zerortt_response(
-                        Conn, StreamId, Path, DownloadsDir, Connected, Retried, NewAcc
-                    )
-            end;
-        {quic, Conn, {early_data_rejected, _}} ->
-            io:format("0-RTT: Early data rejected, resending as 1-RTT~n"),
-            %% Resend request on new stream
-            resend_request_1rtt(Conn, Path, DownloadsDir);
-        {quic, Conn, {closed, Reason}} ->
-            io:format("0-RTT: Connection closed: ~p~n", [Reason]),
-            case Acc of
-                <<>> ->
-                    error;
-                _ ->
-                    Filename = filename:basename(Path),
-                    FilePath = filename:join(DownloadsDir, Filename),
-                    file:write_file(FilePath, Acc),
-                    ok
-            end
-    after Timeout ->
-        case Connected andalso Acc =:= <<>> andalso not Retried of
-            true ->
-                %% 0-RTT likely rejected (server couldn't decrypt), retry as 1-RTT
-                io:format("0-RTT: No response, resending as 1-RTT~n"),
-                resend_request_1rtt(Conn, Path, DownloadsDir);
-            false ->
-                io:format("0-RTT: Timeout~n"),
-                error
-        end
-    end.
-
-%% Resend the request using 1-RTT (after 0-RTT was rejected)
-resend_request_1rtt(Conn, Path, DownloadsDir) ->
-    case quic:open_stream(Conn) of
-        {ok, NewStreamId} ->
-            Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-            ok = quic:send_data(Conn, NewStreamId, Request, true),
-            wait_for_1rtt_response(Conn, NewStreamId, Path, DownloadsDir, <<>>);
-        {error, Err} ->
-            io:format("0-RTT: Failed to open 1-RTT stream: ~p~n", [Err]),
-            error
-    end.
-
-%% Wait for 1-RTT response
-wait_for_1rtt_response(Conn, StreamId, Path, DownloadsDir, Acc) ->
-    receive
-        {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            NewAcc = <<Acc/binary, Data/binary>>,
-            case Fin of
-                true ->
-                    Filename = filename:basename(Path),
-                    FilePath = filename:join(DownloadsDir, Filename),
-                    file:write_file(FilePath, NewAcc),
-                    io:format("0-RTT: Downloaded via 1-RTT ~s (~p bytes)~n", [
-                        FilePath, byte_size(NewAcc)
-                    ]),
-                    ok;
-                false ->
-                    wait_for_1rtt_response(Conn, StreamId, Path, DownloadsDir, NewAcc)
-            end;
-        {quic, Conn, {closed, Reason}} ->
-            io:format("0-RTT: Connection closed during 1-RTT: ~p~n", [Reason]),
-            error
-    after 60000 ->
-        io:format("0-RTT: 1-RTT timeout~n"),
-        error
     end.
 
 %%====================================================================

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -37,7 +37,8 @@
     "v2",
     "resumption",
     "zerortt",
-    "connectionmigration"
+    "connectionmigration",
+    "http3"
 ]).
 
 %% Include for session_ticket record
@@ -49,9 +50,12 @@
 -define(TICKET_FILE, "/tmp/session_ticket.dat").
 
 main(_Args) ->
-    %% Start required applications
+    %% Start required applications. The h3 path needs the quic app's
+    %% supervision (connection registry etc.); the hq path merely
+    %% tolerates its absence.
     application:ensure_all_started(crypto),
     application:ensure_all_started(ssl),
+    application:ensure_all_started(quic),
 
     %% Get environment variables
     TestCase = os:getenv("TESTCASE", "handshake"),
@@ -72,6 +76,8 @@ main(_Args) ->
             run_test(TestCase, RequestsStr, DownloadsDir)
     end.
 
+run_test("http3", RequestsStr, DownloadsDir) ->
+    run_http3_test(RequestsStr, DownloadsDir);
 run_test("resumption", RequestsStr, DownloadsDir) ->
     %% Resumption test: two connections, second uses session ticket
     run_resumption_test(RequestsStr, DownloadsDir);
@@ -649,6 +655,85 @@ run_zerortt_test(RequestsStr, DownloadsDir) ->
                     io:format("Invalid URL~n"),
                     halt(?EXIT_FAILURE)
             end
+    end.
+
+%% Fetch every file over one HTTP/3 connection (RFC 9114); the runner
+%% requires exactly one handshake, so all requests share the connection.
+run_http3_test(RequestsStr, DownloadsDir) ->
+    Requests = string:tokens(RequestsStr, " "),
+    case [{H, Po, Pa} || U <- Requests, {ok, H, Po, Pa} <- [parse_url(U)]] of
+        [] ->
+            io:format("No valid requests~n"),
+            halt(?EXIT_FAILURE);
+        [{Host, Port, _} | _] = Parsed ->
+            case quic_h3:connect(Host, Port, #{verify => false}) of
+                {ok, Conn} ->
+                    ok = quic_h3:wait_connected(Conn, 30000),
+                    Results = [
+                        h3_fetch(Conn, Host, Path, DownloadsDir)
+                     || {_, _, Path} <- Parsed
+                    ],
+                    quic_h3:close(Conn),
+                    case lists:all(fun(R) -> R =:= ok end, Results) of
+                        true ->
+                            io:format("All H3 downloads successful~n"),
+                            halt(?EXIT_SUCCESS);
+                        false ->
+                            io:format("Some H3 downloads failed~n"),
+                            halt(?EXIT_FAILURE)
+                    end;
+                {error, Reason} ->
+                    io:format("H3 connect failed: ~p~n", [Reason]),
+                    halt(?EXIT_FAILURE)
+            end
+    end.
+
+h3_fetch(Conn, Host, Path, DownloadsDir) ->
+    Headers = [
+        {<<":method">>, <<"GET">>},
+        {<<":scheme">>, <<"https">>},
+        {<<":path">>,
+            case list_to_binary(Path) of
+                <<"/", _/binary>> = P -> P;
+                P -> <<"/", P/binary>>
+            end},
+        {<<":authority">>, list_to_binary(Host)}
+    ],
+    case quic_h3:request(Conn, Headers) of
+        {ok, StreamId} ->
+            h3_collect(Conn, StreamId, Path, DownloadsDir, undefined, <<>>);
+        {error, Reason} ->
+            io:format("H3 request failed: ~p~n", [Reason]),
+            error
+    end.
+
+h3_collect(Conn, StreamId, Path, DownloadsDir, Status, Acc) ->
+    receive
+        {quic_h3, Conn, {response, StreamId, RespStatus, _Headers}} ->
+            h3_collect(Conn, StreamId, Path, DownloadsDir, RespStatus, Acc);
+        {quic_h3, Conn, {data, StreamId, Data, Fin}} ->
+            Acc1 = <<Acc/binary, Data/binary>>,
+            case Fin of
+                true when Status =:= 200 ->
+                    FilePath = filename:join(DownloadsDir, filename:basename(Path)),
+                    ok = file:write_file(FilePath, Acc1),
+                    io:format("H3 saved: ~s (~p bytes)~n", [FilePath, byte_size(Acc1)]),
+                    ok;
+                true ->
+                    io:format("H3 status ~p for ~s~n", [Status, Path]),
+                    error;
+                false ->
+                    h3_collect(Conn, StreamId, Path, DownloadsDir, Status, Acc1)
+            end;
+        {quic_h3, Conn, {error, StreamId, Reason}} ->
+            io:format("H3 stream error: ~p~n", [Reason]),
+            error;
+        {quic_h3, Conn, {closed, Reason}} ->
+            io:format("H3 connection closed: ~p~n", [Reason]),
+            error
+    after 60000 ->
+        io:format("H3 timeout for ~s~n", [Path]),
+        error
     end.
 
 %% First connection: handshake, wait for a session ticket, download nothing.

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -88,10 +88,11 @@ run_test(TestCase, RequestsStr, DownloadsDir) ->
             io:format("No requests specified~n"),
             halt(?EXIT_FAILURE);
         _ ->
-            Results = lists:map(
-                fun(Url) -> download_file(TestCase, Url, DownloadsDir) end,
-                Requests
-            ),
+            %% The runner asks for several files and requires them on ONE
+            %% connection: the transfer test counts handshakes and fails on
+            %% more than one, and multiplexing expects concurrent streams.
+            %% Connect once per host and reuse it for every path.
+            Results = download_all(TestCase, Requests, DownloadsDir),
 
             case lists:all(fun(R) -> R =:= ok end, Results) of
                 true ->
@@ -103,29 +104,92 @@ run_test(TestCase, RequestsStr, DownloadsDir) ->
             end
     end.
 
-download_file(TestCase, Url, DownloadsDir) ->
-    io:format("Downloading: ~s~n", [Url]),
+download_all(TestCase, Requests, DownloadsDir) ->
+    ByHost = lists:foldl(
+        fun(Url, Acc) ->
+            case parse_url(Url) of
+                {ok, Host, Port, Path} ->
+                    maps:update_with(
+                        {Host, Port}, fun(Ps) -> Ps ++ [Path] end, [Path], Acc
+                    );
+                error ->
+                    io:format("Invalid URL: ~s~n", [Url]),
+                    Acc
+            end
+        end,
+        #{},
+        Requests
+    ),
+    lists:append(
+        maps:fold(
+            fun({Host, Port}, Paths, Acc) ->
+                [download_from(TestCase, Host, Port, Paths, DownloadsDir) | Acc]
+            end,
+            [],
+            ByHost
+        )
+    ).
 
-    %% Parse URL
-    case parse_url(Url) of
-        {ok, Host, Port, Path} ->
-            %% Build connection options based on test case
-            Opts = build_opts(TestCase),
-
-            %% Connect
-            case quic:connect(Host, Port, Opts, self()) of
-                {ok, Conn} ->
-                    Result = wait_for_connection_and_download(
-                        Conn, Path, DownloadsDir, TestCase
-                    ),
+download_from(TestCase, Host, Port, Paths, DownloadsDir) ->
+    Opts = build_opts(TestCase),
+    case quic:connect(Host, Port, Opts, self()) of
+        {ok, Conn} ->
+            case wait_connected(Conn, TestCase) of
+                ok ->
+                    Results = [
+                        begin
+                            io:format("Downloading: https://~s:~p/~s~n", [Host, Port, Path]),
+                            request_path(Conn, Path, DownloadsDir)
+                        end
+                     || Path <- Paths
+                    ],
                     quic:close(Conn, normal),
-                    Result;
-                {error, Reason} ->
-                    io:format("Connection failed: ~p~n", [Reason]),
-                    error
+                    Results;
+                error ->
+                    quic:close(Conn, normal),
+                    [error || _ <- Paths]
             end;
-        error ->
-            io:format("Invalid URL: ~s~n", [Url]),
+        {error, Reason} ->
+            io:format("Connection failed: ~p~n", [Reason]),
+            [error || _ <- Paths]
+    end.
+
+wait_connected(Conn, TestCase) ->
+    receive
+        {quic, Conn, {connected, _Info}} ->
+            io:format("Connected~n"),
+            case TestCase of
+                "keyupdate" -> quic_connection:key_update(Conn);
+                _ -> ok
+            end,
+            ok;
+        {quic, Conn, {closed, Reason}} ->
+            io:format("Connection closed: ~p~n", [Reason]),
+            error;
+        {quic, Conn, {transport_error, Code, Msg}} ->
+            io:format("Transport error: ~p ~p~n", [Code, Msg]),
+            error
+    after 30000 ->
+        io:format("Connection timeout~n"),
+        error
+    end.
+
+%% Kept for the resumption/zerortt paths, which connect per attempt by
+%% design: one connection, one request.
+wait_for_connection_and_download(Conn, Path, DownloadsDir, TestCase) ->
+    case wait_connected(Conn, TestCase) of
+        ok -> request_path(Conn, Path, DownloadsDir);
+        error -> error
+    end.
+
+request_path(Conn, Path, DownloadsDir) ->
+    case quic:open_stream(Conn) of
+        {ok, StreamId} ->
+            Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
+            ok = quic:send_data(Conn, StreamId, Request, true),
+            receive_and_save(Conn, StreamId, Path, DownloadsDir);
+        {error, StreamErr} ->
+            io:format("Failed to open stream: ~p~n", [StreamErr]),
             error
     end.
 
@@ -160,42 +224,6 @@ build_opts(_) ->
         verify => false,
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
-
-wait_for_connection_and_download(Conn, Path, DownloadsDir, TestCase) ->
-    receive
-        {quic, Conn, {connected, _Info}} ->
-            io:format("Connected~n"),
-
-            %% Handle key update test case
-            case TestCase of
-                "keyupdate" ->
-                    %% Initiate key update before request
-                    quic_connection:key_update(Conn);
-                _ ->
-                    ok
-            end,
-
-            %% Open stream and send request
-            case quic:open_stream(Conn) of
-                {ok, StreamId} ->
-                    %% Send HTTP/0.9 style request (for hq-interop)
-                    Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
-                    ok = quic:send_data(Conn, StreamId, Request, true),
-                    receive_and_save(Conn, StreamId, Path, DownloadsDir);
-                {error, StreamErr} ->
-                    io:format("Failed to open stream: ~p~n", [StreamErr]),
-                    error
-            end;
-        {quic, Conn, {closed, Reason}} ->
-            io:format("Connection closed: ~p~n", [Reason]),
-            error;
-        {quic, Conn, {transport_error, Code, Msg}} ->
-            io:format("Transport error: ~p ~p~n", [Code, Msg]),
-            error
-    after 30000 ->
-        io:format("Connection timeout~n"),
-        error
-    end.
 
 receive_and_save(Conn, StreamId, Path, DownloadsDir) ->
     %% Extract filename and open file for streaming writes

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -20,6 +20,7 @@
 
 %% Suppress dialyzer warnings for escript functions that call halt()
 -dialyzer({no_return, [main/1, run_test/3]}).
+-dialyzer({nowarn_function, [run_http3_test/2]}).
 -dialyzer({nowarn_function, [run_resumption_test/2, run_zerortt_test/2, run_migration_test/2]}).
 
 -define(EXIT_SUCCESS, 0).
@@ -666,7 +667,7 @@ run_http3_test(RequestsStr, DownloadsDir) ->
             io:format("No valid requests~n"),
             halt(?EXIT_FAILURE);
         [{Host, Port, _} | _] = Parsed ->
-            case quic_h3:connect(Host, Port, #{verify => false}) of
+            case quic_h3:connect(Host, Port, #{quic_opts => #{verify => false}}) of
                 {ok, Conn} ->
                     ok = quic_h3:wait_connected(Conn, 30000),
                     Results = [

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -141,14 +141,8 @@ download_from(TestCase, Host, Port, Paths, DownloadsDir) ->
                     %% streams in flight at the same time; issuing them one
                     %% after another looks like a series of single-stream
                     %% transfers no matter how many files are requested.
-                    Streams = [
-                        begin
-                            io:format("Downloading: https://~s:~p/~s~n", [Host, Port, Path]),
-                            open_and_request(Conn, Path)
-                        end
-                     || Path <- Paths
-                    ],
-                    Results = collect_streams(Conn, Streams, DownloadsDir),
+                    io:format("Requesting ~p file(s)~n", [length(Paths)]),
+                    Results = collect_streams(Conn, Paths, DownloadsDir),
                     quic:close(Conn, normal),
                     Results;
                 error ->
@@ -231,28 +225,37 @@ build_opts(_) ->
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
 
-open_and_request(Conn, Path) ->
+%% Keep as many streams in flight as the peer's stream credit allows and
+%% refill as they finish. The multiplexing test asks for close to 2000
+%% files while the default bidi stream limit is 100, so opening them all
+%% up front fails all but the first hundred; the peer extends credit with
+%% MAX_STREAMS only as earlier streams close.
+collect_streams(Conn, Paths, DownloadsDir) ->
+    {Open, Pending} = fill_streams(Conn, Paths, #{}, DownloadsDir),
+    Done = collect_loop(Conn, Open, Pending, DownloadsDir, #{}, 180000),
+    [Result || {_StreamId, Result} <- maps:to_list(Done)].
+
+fill_streams(_Conn, [], Open, _DownloadsDir) ->
+    {Open, []};
+fill_streams(Conn, [Path | Rest] = Pending, Open, DownloadsDir) ->
     case quic:open_stream(Conn) of
         {ok, StreamId} ->
             Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
             case quic:send_data(Conn, StreamId, Request, true) of
-                ok -> {StreamId, Path};
-                Err -> {error, Path, Err}
+                ok ->
+                    fill_streams(
+                        Conn,
+                        Rest,
+                        Open#{StreamId => open_target(Path, DownloadsDir)},
+                        DownloadsDir
+                    );
+                _Err ->
+                    {Open, Pending}
             end;
-        {error, StreamErr} ->
-            {error, Path, StreamErr}
+        {error, _} ->
+            %% Out of stream credit for now; the rest wait for MAX_STREAMS.
+            {Open, Pending}
     end.
-
-%% Collect concurrently: one file handle per stream, fed by whichever
-%% stream_data arrives next, until every stream has seen its FIN.
-collect_streams(Conn, Streams, DownloadsDir) ->
-    Open = maps:from_list([
-        {Sid, open_target(Path, DownloadsDir)}
-     || {Sid, Path} <- Streams, is_integer(Sid)
-    ]),
-    Failed = [error || {error, _, _} <- Streams],
-    Done = collect_loop(Conn, Open, #{}, 120000),
-    Failed ++ [R || {_Sid, R} <- maps:to_list(Done)].
 
 open_target(Path, DownloadsDir) ->
     FilePath = filename:join(DownloadsDir, filename:basename(Path)),
@@ -261,9 +264,9 @@ open_target(Path, DownloadsDir) ->
         {error, Err} -> {error, FilePath, Err}
     end.
 
-collect_loop(_Conn, Open, Done, _Timeout) when map_size(Open) =:= 0 ->
+collect_loop(_Conn, Open, [], _DownloadsDir, Done, _Timeout) when map_size(Open) =:= 0 ->
     Done;
-collect_loop(Conn, Open, Done, Timeout) ->
+collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
     receive
         {quic, Conn, {stream_data, Sid, Data, Fin}} ->
             case maps:find(Sid, Open) of
@@ -274,25 +277,28 @@ collect_loop(Conn, Open, Done, Timeout) ->
                         true ->
                             file:close(Handle),
                             io:format("Saved: ~s (~p bytes)~n", [FilePath, NewWritten]),
+                            {Open2, Pending2} = fill_streams(
+                                Conn, Pending, maps:remove(Sid, Open), DownloadsDir
+                            ),
                             collect_loop(
-                                Conn,
-                                maps:remove(Sid, Open),
-                                Done#{Sid => ok},
-                                Timeout
+                                Conn, Open2, Pending2, DownloadsDir, Done#{Sid => ok}, Timeout
                             );
                         false ->
                             collect_loop(
                                 Conn,
                                 Open#{Sid => {Handle, FilePath, NewWritten}},
+                                Pending,
+                                DownloadsDir,
                                 Done,
                                 Timeout
                             )
                     end;
                 error ->
-                    collect_loop(Conn, Open, Done, Timeout)
+                    collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout)
             end;
         {quic, Conn, {stream_reset, Sid, _Code}} ->
-            collect_loop(Conn, maps:remove(Sid, Open), Done#{Sid => error}, Timeout);
+            {Open2, Pending2} = fill_streams(Conn, Pending, maps:remove(Sid, Open), DownloadsDir),
+            collect_loop(Conn, Open2, Pending2, DownloadsDir, Done#{Sid => error}, Timeout);
         {quic, Conn, {closed, _Reason}} ->
             close_remaining(Open, Done)
     after Timeout ->

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -136,13 +136,19 @@ download_from(TestCase, Host, Port, Paths, DownloadsDir) ->
         {ok, Conn} ->
             case wait_connected(Conn, TestCase) of
                 ok ->
-                    Results = [
+                    %% Open every stream and send every request before
+                    %% collecting any of them. The multiplexing test wants the
+                    %% streams in flight at the same time; issuing them one
+                    %% after another looks like a series of single-stream
+                    %% transfers no matter how many files are requested.
+                    Streams = [
                         begin
                             io:format("Downloading: https://~s:~p/~s~n", [Host, Port, Path]),
-                            request_path(Conn, Path, DownloadsDir)
+                            open_and_request(Conn, Path)
                         end
                      || Path <- Paths
                     ],
+                    Results = collect_streams(Conn, Streams, DownloadsDir),
                     quic:close(Conn, normal),
                     Results;
                 error ->
@@ -224,6 +230,89 @@ build_opts(_) ->
         verify => false,
         alpn => [<<"hq-interop">>, <<"h3">>]
     }.
+
+open_and_request(Conn, Path) ->
+    case quic:open_stream(Conn) of
+        {ok, StreamId} ->
+            Request = <<"GET ", (list_to_binary(Path))/binary, "\r\n">>,
+            case quic:send_data(Conn, StreamId, Request, true) of
+                ok -> {StreamId, Path};
+                Err -> {error, Path, Err}
+            end;
+        {error, StreamErr} ->
+            {error, Path, StreamErr}
+    end.
+
+%% Collect concurrently: one file handle per stream, fed by whichever
+%% stream_data arrives next, until every stream has seen its FIN.
+collect_streams(Conn, Streams, DownloadsDir) ->
+    Open = maps:from_list([
+        {Sid, open_target(Path, DownloadsDir)}
+     || {Sid, Path} <- Streams, is_integer(Sid)
+    ]),
+    Failed = [error || {error, _, _} <- Streams],
+    Done = collect_loop(Conn, Open, #{}, 120000),
+    Failed ++ [R || {_Sid, R} <- maps:to_list(Done)].
+
+open_target(Path, DownloadsDir) ->
+    FilePath = filename:join(DownloadsDir, filename:basename(Path)),
+    case file:open(FilePath, [write, binary, raw]) of
+        {ok, Handle} -> {Handle, FilePath, 0};
+        {error, Err} -> {error, FilePath, Err}
+    end.
+
+collect_loop(_Conn, Open, Done, _Timeout) when map_size(Open) =:= 0 ->
+    Done;
+collect_loop(Conn, Open, Done, Timeout) ->
+    receive
+        {quic, Conn, {stream_data, Sid, Data, Fin}} ->
+            case maps:find(Sid, Open) of
+                {ok, {Handle, FilePath, Written}} ->
+                    ok = file:write(Handle, Data),
+                    NewWritten = Written + byte_size(Data),
+                    case Fin of
+                        true ->
+                            file:close(Handle),
+                            io:format("Saved: ~s (~p bytes)~n", [FilePath, NewWritten]),
+                            collect_loop(
+                                Conn,
+                                maps:remove(Sid, Open),
+                                Done#{Sid => ok},
+                                Timeout
+                            );
+                        false ->
+                            collect_loop(
+                                Conn,
+                                Open#{Sid => {Handle, FilePath, NewWritten}},
+                                Done,
+                                Timeout
+                            )
+                    end;
+                error ->
+                    collect_loop(Conn, Open, Done, Timeout)
+            end;
+        {quic, Conn, {stream_reset, Sid, _Code}} ->
+            collect_loop(Conn, maps:remove(Sid, Open), Done#{Sid => error}, Timeout);
+        {quic, Conn, {closed, _Reason}} ->
+            close_remaining(Open, Done)
+    after Timeout ->
+        io:format("Stream timeout with ~p stream(s) outstanding~n", [map_size(Open)]),
+        close_remaining(Open, Done)
+    end.
+
+close_remaining(Open, Done) ->
+    maps:fold(
+        fun
+            (Sid, {Handle, FilePath, _}, Acc) when is_pid(Handle) orelse is_tuple(Handle) ->
+                file:close(Handle),
+                file:delete(FilePath),
+                Acc#{Sid => error};
+            (Sid, _, Acc) ->
+                Acc#{Sid => error}
+        end,
+        Done,
+        Open
+    ).
 
 receive_and_save(Conn, StreamId, Path, DownloadsDir) ->
     %% Extract filename and open file for streaming writes

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -232,8 +232,14 @@ build_opts(_) ->
 %% MAX_STREAMS only as earlier streams close.
 collect_streams(Conn, Paths, DownloadsDir) ->
     {Open, Pending} = fill_streams(Conn, Paths, #{}, DownloadsDir),
-    Done = collect_loop(Conn, Open, Pending, DownloadsDir, #{}, 180000),
-    [Result || {_StreamId, Result} <- maps:to_list(Done)].
+    Deadline = erlang:monotonic_time(millisecond) + 180000,
+    {Done, PendingLeft} = collect_loop(Conn, Open, Pending, DownloadsDir, #{}, Deadline),
+    case PendingLeft of
+        [] -> ok;
+        _ -> io:format("~p request(s) never got a stream~n", [length(PendingLeft)])
+    end,
+    [Result || {_StreamId, Result} <- maps:to_list(Done)] ++
+        [error || _ <- PendingLeft].
 
 fill_streams(_Conn, [], Open, _DownloadsDir) ->
     {Open, []};
@@ -264,9 +270,19 @@ open_target(Path, DownloadsDir) ->
         {error, Err} -> {error, FilePath, Err}
     end.
 
-collect_loop(_Conn, Open, [], _DownloadsDir, Done, _Timeout) when map_size(Open) =:= 0 ->
-    Done;
-collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
+collect_loop(_Conn, Open, [], _DownloadsDir, Done, _Deadline) when map_size(Open) =:= 0 ->
+    {Done, []};
+collect_loop(Conn, Open, Pending, DownloadsDir, Done, Deadline) ->
+    TimeLeft = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    %% With requests waiting for stream credit, poll: MAX_STREAMS
+    %% arriving at the connection process produces no message here, so
+    %% waiting only for stream events deadlocks when the last grant
+    %% lands after the last completion event has been handled.
+    Timeout =
+        case Pending of
+            [] -> TimeLeft;
+            _ -> min(200, TimeLeft)
+        end,
     receive
         {quic, Conn, {stream_data, Sid, Data, Fin}} ->
             case maps:find(Sid, Open) of
@@ -281,7 +297,7 @@ collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
                                 Conn, Pending, maps:remove(Sid, Open), DownloadsDir
                             ),
                             collect_loop(
-                                Conn, Open2, Pending2, DownloadsDir, Done#{Sid => ok}, Timeout
+                                Conn, Open2, Pending2, DownloadsDir, Done#{Sid => ok}, Deadline
                             );
                         false ->
                             collect_loop(
@@ -290,20 +306,26 @@ collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout) ->
                                 Pending,
                                 DownloadsDir,
                                 Done,
-                                Timeout
+                                Deadline
                             )
                     end;
                 error ->
-                    collect_loop(Conn, Open, Pending, DownloadsDir, Done, Timeout)
+                    collect_loop(Conn, Open, Pending, DownloadsDir, Done, Deadline)
             end;
         {quic, Conn, {stream_reset, Sid, _Code}} ->
             {Open2, Pending2} = fill_streams(Conn, Pending, maps:remove(Sid, Open), DownloadsDir),
-            collect_loop(Conn, Open2, Pending2, DownloadsDir, Done#{Sid => error}, Timeout);
+            collect_loop(Conn, Open2, Pending2, DownloadsDir, Done#{Sid => error}, Deadline);
         {quic, Conn, {closed, _Reason}} ->
-            close_remaining(Open, Done)
+            {close_remaining(Open, Done), Pending}
     after Timeout ->
-        io:format("Stream timeout with ~p stream(s) outstanding~n", [map_size(Open)]),
-        close_remaining(Open, Done)
+        case TimeLeft > 0 andalso Pending =/= [] of
+            true ->
+                {Open2, Pending2} = fill_streams(Conn, Pending, Open, DownloadsDir),
+                collect_loop(Conn, Open2, Pending2, DownloadsDir, Done, Deadline);
+            false ->
+                io:format("Stream timeout with ~p stream(s) outstanding~n", [map_size(Open)]),
+                {close_remaining(Open, Done), Pending}
+        end
     end.
 
 close_remaining(Open, Done) ->

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -37,7 +37,8 @@
     "v2",
     "resumption",
     "zerortt",
-    "connectionmigration"
+    "connectionmigration",
+    "http3"
 ]).
 
 main(_Args) ->
@@ -81,26 +82,70 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
             [{_, CertDer, _}] = public_key:pem_decode(CertPem),
             PrivateKey = decode_private_key(KeyPem),
 
-            %% Build server options
-            Opts = build_server_opts(TestCase, CertDer, PrivateKey, WwwDir),
-
-            %% Start listener
-            case quic_listener:start_link(Port, Opts) of
-                {ok, Listener} ->
-                    io:format("Server listening on port ~p~n", [Port]),
-
-                    %% Wait forever (or until killed)
-                    receive
-                        stop ->
-                            quic_listener:stop(Listener),
-                            halt(?EXIT_SUCCESS)
-                    end;
-                {error, Reason} ->
-                    io:format("Failed to start listener: ~p~n", [Reason]),
-                    halt(?EXIT_FAILURE)
+            case TestCase of
+                "http3" ->
+                    run_h3_server(Port, CertDer, PrivateKey, WwwDir);
+                _ ->
+                    run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir)
             end;
         _ ->
             io:format("Failed to read certificates~n"),
+            halt(?EXIT_FAILURE)
+    end.
+
+%% The http3 case serves real HTTP/3 (RFC 9114) through quic_h3; every
+%% other case speaks hq-interop over a bare listener.
+run_h3_server(Port, CertDer, PrivateKey, WwwDir) ->
+    Handler = fun(Conn, StreamId, _Method, Path, _Headers) ->
+        CleanPath =
+            case Path of
+                <<"/", Rest/binary>> -> Rest;
+                _ -> Path
+            end,
+        FilePath = filename:join(WwwDir, binary_to_list(CleanPath)),
+        case file:read_file(FilePath) of
+            {ok, Content} ->
+                io:format("h3: 200 ~s (~p bytes)~n", [Path, byte_size(Content)]),
+                quic_h3:respond(Conn, StreamId, 200, [], Content);
+            {error, _} ->
+                io:format("h3: 404 ~s~n", [Path]),
+                quic_h3:respond(Conn, StreamId, 404, [], <<"not found">>)
+        end
+    end,
+    case
+        quic_h3:start_server(interop_h3, Port, #{
+            cert => CertDer,
+            key => PrivateKey,
+            handler => Handler
+        })
+    of
+        {ok, _} ->
+            io:format("H3 server listening on port ~p~n", [Port]),
+            receive
+                stop -> halt(?EXIT_SUCCESS)
+            end;
+        {error, Reason} ->
+            io:format("Failed to start H3 server: ~p~n", [Reason]),
+            halt(?EXIT_FAILURE)
+    end.
+
+run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir) ->
+    %% Build server options
+    Opts = build_server_opts(TestCase, CertDer, PrivateKey, WwwDir),
+
+    %% Start listener
+    case quic_listener:start_link(Port, Opts) of
+        {ok, Listener} ->
+            io:format("Server listening on port ~p~n", [Port]),
+
+            %% Wait forever (or until killed)
+            receive
+                stop ->
+                    quic_listener:stop(Listener),
+                    halt(?EXIT_SUCCESS)
+            end;
+        {error, Reason} ->
+            io:format("Failed to start listener: ~p~n", [Reason]),
             halt(?EXIT_FAILURE)
     end.
 

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -163,49 +163,45 @@ spawn_handler(ConnPid, _DCID, WwwDir, TestCase) ->
 
 connection_handler(Conn, WwwDir, TestCase) ->
     io:format("Handler started, waiting for messages...~n"),
-    %% Wait for stream data
+    connection_handler(Conn, WwwDir, TestCase, #{}).
+
+%% A request may arrive split across several STREAM frames, so buffer per
+%% stream until FIN before parsing. Serving each fragment as if it were a
+%% whole request answered twice on one stream: two responses, two FINs at
+%% different offsets, and a correct peer kills the connection with
+%% FINAL_SIZE_ERROR.
+connection_handler(Conn, WwwDir, TestCase, Bufs) ->
     receive
         {quic, Conn, {connected, Info}} ->
             io:format("Handler got connected: ~p~n", [Info]),
-            connection_handler(Conn, WwwDir, TestCase);
+            connection_handler(Conn, WwwDir, TestCase, Bufs);
         {quic, Conn, {stream_opened, StreamId}} ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
-            handle_stream(Conn, StreamId, WwwDir, TestCase);
+            connection_handler(Conn, WwwDir, TestCase, Bufs);
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            io:format(
-                "Handler got stream_data: stream=~p size=~p fin=~p~n",
-                [StreamId, byte_size(Data), Fin]
-            ),
-            %% Handle request
-            handle_request(Conn, StreamId, Data, WwwDir, TestCase);
+            Acc = [maps:get(StreamId, Bufs, []) | Data],
+            case Fin of
+                true ->
+                    Request = iolist_to_binary(Acc),
+                    _ = serve_request(Conn, StreamId, Request, WwwDir, TestCase),
+                    connection_handler(
+                        Conn, WwwDir, TestCase, maps:remove(StreamId, Bufs)
+                    );
+                false ->
+                    connection_handler(
+                        Conn, WwwDir, TestCase, Bufs#{StreamId => Acc}
+                    )
+            end;
         {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
         Other ->
             io:format("Handler got unexpected: ~p~n", [Other]),
-            connection_handler(Conn, WwwDir, TestCase)
+            connection_handler(Conn, WwwDir, TestCase, Bufs)
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
     end.
-
-handle_stream(Conn, StreamId, WwwDir, TestCase) ->
-    %% Wait for the request on this stream, then resume the handler loop.
-    receive
-        {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
-            handle_request(Conn, StreamId, Data, WwwDir, TestCase)
-    after 30000 ->
-        connection_handler(Conn, WwwDir, TestCase)
-    end.
-
-%% Serve one request, then go back to waiting: a client may issue several
-%% requests on the same connection, and the interop runner's transfer and
-%% multiplexing tests require exactly that. Returning here instead ended
-%% the handler process after the first file and tore the connection down,
-%% so a second request met {invalid_state,draining}.
-handle_request(Conn, StreamId, Data, WwwDir, TestCase) ->
-    _ = serve_request(Conn, StreamId, Data, WwwDir, TestCase),
-    connection_handler(Conn, WwwDir, TestCase).
 
 serve_request(Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -21,6 +21,7 @@
 
 %% Suppress dialyzer warnings for escript functions that call halt()
 -dialyzer({nowarn_function, [main/1, run_server/4]}).
+-dialyzer({nowarn_function, [run_h3_server/4, run_hq_server/5]}).
 
 -define(EXIT_SUCCESS, 0).
 -define(EXIT_FAILURE, 1).
@@ -97,20 +98,7 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
 %% other case speaks hq-interop over a bare listener.
 run_h3_server(Port, CertDer, PrivateKey, WwwDir) ->
     Handler = fun(Conn, StreamId, _Method, Path, _Headers) ->
-        CleanPath =
-            case Path of
-                <<"/", Rest/binary>> -> Rest;
-                _ -> Path
-            end,
-        FilePath = filename:join(WwwDir, binary_to_list(CleanPath)),
-        case file:read_file(FilePath) of
-            {ok, Content} ->
-                io:format("h3: 200 ~s (~p bytes)~n", [Path, byte_size(Content)]),
-                quic_h3:respond(Conn, StreamId, 200, [], Content);
-            {error, _} ->
-                io:format("h3: 404 ~s~n", [Path]),
-                quic_h3:respond(Conn, StreamId, 404, [], <<"not found">>)
-        end
+        serve_h3_request(Conn, StreamId, Path, WwwDir)
     end,
     case
         quic_h3:start_server(interop_h3, Port, #{
@@ -127,6 +115,22 @@ run_h3_server(Port, CertDer, PrivateKey, WwwDir) ->
         {error, Reason} ->
             io:format("Failed to start H3 server: ~p~n", [Reason]),
             halt(?EXIT_FAILURE)
+    end.
+
+serve_h3_request(Conn, StreamId, Path, WwwDir) ->
+    CleanPath =
+        case Path of
+            <<"/", Rest/binary>> -> Rest;
+            _ -> Path
+        end,
+    FilePath = filename:join(WwwDir, binary_to_list(CleanPath)),
+    case file:read_file(FilePath) of
+        {ok, Content} ->
+            io:format("h3: 200 ~s (~p bytes)~n", [Path, byte_size(Content)]),
+            quic_h3:respond(Conn, StreamId, 200, [], Content);
+        {error, _} ->
+            io:format("h3: 404 ~s~n", [Path]),
+            quic_h3:respond(Conn, StreamId, 404, [], <<"not found">>)
     end.
 
 run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir) ->
@@ -228,19 +232,8 @@ connection_handler(Conn, WwwDir, TestCase, Bufs) ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
             connection_handler(Conn, WwwDir, TestCase, Bufs);
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
-            Acc = [maps:get(StreamId, Bufs, []) | Data],
-            case Fin of
-                true ->
-                    Request = iolist_to_binary(Acc),
-                    _ = serve_request(Conn, StreamId, Request, WwwDir, TestCase),
-                    connection_handler(
-                        Conn, WwwDir, TestCase, maps:remove(StreamId, Bufs)
-                    );
-                false ->
-                    connection_handler(
-                        Conn, WwwDir, TestCase, Bufs#{StreamId => Acc}
-                    )
-            end;
+            Bufs1 = buffer_stream_data(Conn, WwwDir, TestCase, Bufs, StreamId, Data, Fin),
+            connection_handler(Conn, WwwDir, TestCase, Bufs1);
         {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
@@ -250,6 +243,17 @@ connection_handler(Conn, WwwDir, TestCase, Bufs) ->
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
+    end.
+
+buffer_stream_data(Conn, WwwDir, TestCase, Bufs, StreamId, Data, Fin) ->
+    Acc = [maps:get(StreamId, Bufs, []) | Data],
+    case Fin of
+        true ->
+            Request = iolist_to_binary(Acc),
+            _ = serve_request(Conn, StreamId, Request, WwwDir, TestCase),
+            maps:remove(StreamId, Bufs);
+        false ->
+            Bufs#{StreamId => Acc}
     end.
 
 serve_request(Conn, StreamId, Data, WwwDir, TestCase) ->

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -126,15 +126,22 @@ build_server_opts(TestCase, Cert, Key, WwwDir) ->
 
 %% Decode PEM-encoded private key to internal format
 decode_private_key(PemData) ->
-    case public_key:pem_decode(PemData) of
-        [{Type, Der, not_encrypted}] ->
+    %% A key file may carry more than the key: `openssl ecparam -genkey',
+    %% which is how the interop runner generates its certificates, emits
+    %% EC PARAMETERS ahead of EC PRIVATE KEY. Pick the key entry out of
+    %% the list rather than insisting the file holds exactly one.
+    case [E || {Type, _, _} = E <- public_key:pem_decode(PemData), is_key_entry(Type)] of
+        [{Type, Der, _} | _] ->
             decode_key_entry(Type, Der);
-        [{Type, Der, _Cipher}] ->
-            %% Encrypted key - not supported yet
-            decode_key_entry(Type, Der);
-        _ ->
+        [] ->
             error(invalid_private_key)
     end.
+
+is_key_entry('RSAPrivateKey') -> true;
+is_key_entry('DSAPrivateKey') -> true;
+is_key_entry('ECPrivateKey') -> true;
+is_key_entry('PrivateKeyInfo') -> true;
+is_key_entry(_) -> false.
 
 decode_key_entry('RSAPrivateKey', Der) ->
     public_key:der_decode('RSAPrivateKey', Der);

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -146,50 +146,52 @@ decode_key_entry('PrivateKeyInfo', Der) ->
 decode_key_entry(Type, _Der) ->
     error({unsupported_key_type, Type}).
 
-spawn_handler(ConnPid, Conn, WwwDir, TestCase) ->
+spawn_handler(ConnPid, _DCID, WwwDir, TestCase) ->
+    %% The arity-2 connection_handler is called as Fun(ConnPid, DCID); the
+    %% connection handle in every quic message and API call is the pid.
     HandlerPid = spawn(fun() ->
-        connection_handler(ConnPid, Conn, WwwDir, TestCase)
+        connection_handler(ConnPid, WwwDir, TestCase)
     end),
     {ok, HandlerPid}.
 
-connection_handler(ConnPid, Conn, WwwDir, TestCase) ->
+connection_handler(Conn, WwwDir, TestCase) ->
     io:format("Handler started, waiting for messages...~n"),
     %% Wait for stream data
     receive
         {quic, Conn, {connected, Info}} ->
             io:format("Handler got connected: ~p~n", [Info]),
-            connection_handler(ConnPid, Conn, WwwDir, TestCase);
+            connection_handler(Conn, WwwDir, TestCase);
         {quic, Conn, {stream_opened, StreamId}} ->
             io:format("Handler got stream_opened: ~p~n", [StreamId]),
-            handle_stream(ConnPid, Conn, StreamId, WwwDir, TestCase);
+            handle_stream(Conn, StreamId, WwwDir, TestCase);
         {quic, Conn, {stream_data, StreamId, Data, Fin}} ->
             io:format(
                 "Handler got stream_data: stream=~p size=~p fin=~p~n",
                 [StreamId, byte_size(Data), Fin]
             ),
             %% Handle request
-            handle_request(ConnPid, Conn, StreamId, Data, WwwDir, TestCase);
+            handle_request(Conn, StreamId, Data, WwwDir, TestCase);
         {quic, Conn, {closed, Reason}} ->
             io:format("Handler got closed: ~p~n", [Reason]),
             ok;
         Other ->
             io:format("Handler got unexpected: ~p~n", [Other]),
-            connection_handler(ConnPid, Conn, WwwDir, TestCase)
+            connection_handler(Conn, WwwDir, TestCase)
     after 60000 ->
         io:format("Handler timeout~n"),
         ok
     end.
 
-handle_stream(_ConnPid, Conn, StreamId, WwwDir, TestCase) ->
+handle_stream(Conn, StreamId, WwwDir, TestCase) ->
     %% Wait for request on this stream
     receive
         {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
-            handle_request(undefined, Conn, StreamId, Data, WwwDir, TestCase)
+            handle_request(Conn, StreamId, Data, WwwDir, TestCase)
     after 30000 ->
         ok
     end.
 
-handle_request(_ConnPid, Conn, StreamId, Data, WwwDir, TestCase) ->
+handle_request(Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),
     %% Parse simple HTTP/0.9 request: "GET /path\r\n"
     case parse_request(Data) of

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -41,9 +41,13 @@
 ]).
 
 main(_Args) ->
-    %% Start required applications
+    %% Start required applications. The quic app supervision matters:
+    %% the resumption ticket table is owned by the server registry, and
+    %% without it the table dies with the first connection that created
+    %% it, so a client resuming after a pause never finds its ticket.
     application:ensure_all_started(crypto),
     application:ensure_all_started(ssl),
+    application:ensure_all_started(quic),
 
     %% Get environment variables
     TestCase = os:getenv("TESTCASE", "handshake"),

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -190,15 +190,24 @@ connection_handler(Conn, WwwDir, TestCase) ->
     end.
 
 handle_stream(Conn, StreamId, WwwDir, TestCase) ->
-    %% Wait for request on this stream
+    %% Wait for the request on this stream, then resume the handler loop.
     receive
         {quic, Conn, {stream_data, StreamId, Data, _Fin}} ->
             handle_request(Conn, StreamId, Data, WwwDir, TestCase)
     after 30000 ->
-        ok
+        connection_handler(Conn, WwwDir, TestCase)
     end.
 
+%% Serve one request, then go back to waiting: a client may issue several
+%% requests on the same connection, and the interop runner's transfer and
+%% multiplexing tests require exactly that. Returning here instead ended
+%% the handler process after the first file and tore the connection down,
+%% so a second request met {invalid_state,draining}.
 handle_request(Conn, StreamId, Data, WwwDir, TestCase) ->
+    _ = serve_request(Conn, StreamId, Data, WwwDir, TestCase),
+    connection_handler(Conn, WwwDir, TestCase).
+
+serve_request(Conn, StreamId, Data, WwwDir, TestCase) ->
     io:format("handle_request: stream=~p data=~p~n", [StreamId, Data]),
     %% Parse simple HTTP/0.9 request: "GET /path\r\n"
     case parse_request(Data) of

--- a/test/quic_h3_event_forwarding_tests.erl
+++ b/test/quic_h3_event_forwarding_tests.erl
@@ -234,6 +234,44 @@ wait_settings_received(Pid, Timeout) ->
             ok
     end.
 
+%%====================================================================
+%% Body end signalled by bare stream FIN (RFC 9114 §4.1)
+%%====================================================================
+
+%% quic-go ends the response body with an empty final QUIC frame rather
+%% than fin-marking the last DATA chunk. The message ends at stream end,
+%% so the owner must still get a fin-marked delivery.
+bare_fin_ends_body_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun() ->
+        meck:expect(quic, set_stream_priority, fun(_, _, _, _) -> ok end),
+        meck:expect(quic, reset_stream, fun(_, _, _) -> ok end),
+        FakeQuicConn = spawn_link(fun fake_quic_loop/0),
+        {ok, H3Conn} = start_client_h3(FakeQuicConn),
+        drive_to_connected(H3Conn, FakeQuicConn),
+        {ok, StreamId} = quic_h3_connection:request(H3Conn, [
+            {<<":method">>, <<"GET">>},
+            {<<":scheme">>, <<"https">>},
+            {<<":path">>, <<"/f">>},
+            {<<":authority">>, <<"example.com">>}
+        ]),
+        RespHeaders = quic_h3_frame:encode(
+            {headers, quic_qpack:encode([{<<":status">>, <<"200">>}])}
+        ),
+        Body = <<"hello h3 body">>,
+        RespData = quic_h3_frame:encode({data, Body}),
+        H3Conn ! {quic, FakeQuicConn, {stream_data, StreamId, RespHeaders, false}},
+        H3Conn ! {quic, FakeQuicConn, {stream_data, StreamId, RespData, false}},
+        %% The peer's FIN arrives on its own, after the last complete frame.
+        H3Conn ! {quic, FakeQuicConn, {stream_data, StreamId, <<>>, true}},
+        receive
+            {quic_h3, H3Conn, {response, StreamId, 200, _}} -> ok
+        after 500 -> erlang:error(no_response)
+        end,
+        assert_owner_message({data, StreamId, Body, false}, H3Conn, 500),
+        assert_owner_message({data, StreamId, <<>>, true}, H3Conn, 500),
+        stop_h3(H3Conn, FakeQuicConn)
+    end}.
+
 drive_to_connected(H3Conn, FakeQuicConn) ->
     ok = quic_h3_connection:prime(H3Conn),
     wait_state(H3Conn, early_data, 500),


### PR DESCRIPTION
Aggregates #244 and #245, commits keeping their authors. No conflicts: #245 is confined to src/interop/ and #244 to quic_h3_connection.erl, neither of which the earlier batches touched.

No tests added on top. #244 brings its own, and #245 is test infrastructure, so what verifies it is the interop suite passing against aioquic and quic-go, which it does at 15/15.