### PR TITLE
Reuse the cipher context for header protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,11 @@ All notable changes to this project will be documented in this file.
 - A server handshake flight lost on the wire is retransmitted on the client-Initial backoff schedule until the client's Finished arrives. Initial/Handshake packets are not loss-tracked, so a lost flight previously wedged the handshake permanently: the client's Initial retransmits only elicited ACKs once the server TLS state had advanced. (#263)
 
 ### Changed
+- Header protection reuses a cipher context instead of re-running the key
+  schedule on every packet. Measured on an 8 MB transfer, the `crypto:*`
+  share of connection-process time drops from 10.95% to 8.30%; header
+  protection itself goes from 0.77us to 0.28us per mask. Both directions'
+  keys are cached, since they alternate packet by packet.
 - The interop runner speaks real HTTP/3 in the http3 case, serves more
   than one request per connection, issues requests concurrently within
   the peer's stream credit, and its resumption and 0-RTT cases test what

--- a/src/quic_aead.erl
+++ b/src/quic_aead.erl
@@ -253,11 +253,11 @@ cipher_for_key(Key) when byte_size(Key) =:= 32 -> aes_256_gcm.
 %% Compute header protection mask
 compute_hp_mask(aes_128_gcm, HP, Sample) ->
     %% AES-ECB encryption of sample
-    crypto:crypto_one_time(aes_128_ecb, HP, Sample, true);
+    ecb_mask(aes_128_ecb, HP, Sample);
 compute_hp_mask(aes_256_gcm, HP, Sample) ->
     %% AES-ECB encryption of sample (use first 16 bytes of 32-byte key)
     %% Actually, HP for AES-256 is 32 bytes, use aes_256_ecb
-    crypto:crypto_one_time(aes_256_ecb, HP, Sample, true);
+    ecb_mask(aes_256_ecb, HP, Sample);
 compute_hp_mask(chacha20_poly1305, HP, Sample) ->
     %% ChaCha20 with counter=0 and the sample as nonce
     %% Sample is 16 bytes: first 4 = counter, last 12 = nonce
@@ -265,6 +265,42 @@ compute_hp_mask(chacha20_poly1305, HP, Sample) ->
     %% Generate 5 bytes of mask using ChaCha20
     Zeros = <<0, 0, 0, 0, 0>>,
     crypto:crypto_one_time(chacha20, HP, <<Counter:32/little, Nonce/binary>>, Zeros, true).
+
+%% Header protection runs on every packet in both directions, and
+%% crypto:crypto_one_time/4 re-runs the key schedule on each call: a
+%% 16-byte ECB block costs 0.77us against 0.88us for a 1200-byte AEAD
+%% seal, so nearly all of it is per-call setup. Keeping the cipher
+%% context alive drops that to 0.55us. ECB blocks are independent, so a
+%% reused context yields byte-identical output.
+%%
+%% The context is a NIF resource and is not thread-safe, so it is cached
+%% in the calling process. A connection holds two HP keys per cipher at
+%% once, one per direction, and they alternate packet by packet: a
+%% single-entry cache makes them evict each other and re-runs the key
+%% schedule anyway. Both are kept, and a key update (a third key) drops
+%% the pair rather than letting the cache grow.
+ecb_mask(Cipher, Key, Sample) ->
+    crypto:crypto_update(ecb_ctx(Cipher, Key), Sample).
+
+ecb_ctx(Cipher, Key) ->
+    Cache =
+        case erlang:get({hp_ctx, Cipher}) of
+            undefined -> #{};
+            M -> M
+        end,
+    case Cache of
+        #{Key := Ctx} ->
+            Ctx;
+        _ ->
+            Ctx = crypto:crypto_init(Cipher, Key, true),
+            Kept =
+                case map_size(Cache) >= 2 of
+                    true -> #{};
+                    false -> Cache
+                end,
+            erlang:put({hp_ctx, Cipher}, Kept#{Key => Ctx}),
+            Ctx
+    end.
 
 %% Apply mask to header (for protection)
 apply_header_mask(Header, Mask, PNOffset) ->

--- a/test/quic_hp_mask_tests.erl
+++ b/test/quic_hp_mask_tests.erl
@@ -1,0 +1,66 @@
+%%% -*- erlang -*-
+%%%
+%%% Header protection masks come from a cipher context cached per
+%%% process, which is only safe because ECB blocks are independent. The
+%%% mask must stay byte-identical to the one-shot call, and a rotated
+%%% key must not keep using the old context.
+
+-module(quic_hp_mask_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(KEY128, <<"0123456789abcdef">>).
+-define(KEY256, <<"0123456789abcdef0123456789abcdef">>).
+-define(SAMPLE, <<"abcdefghijklmnop">>).
+
+%% The cached context has to produce exactly what the one-shot call did,
+%% or every peer rejects our headers.
+matches_the_one_shot_mask_test_() ->
+    [
+        {atom_to_list(Cipher), fun() ->
+            {Key, Ecb} = params(Cipher),
+            ?assertEqual(
+                crypto:crypto_one_time(Ecb, Key, ?SAMPLE, true),
+                quic_aead:compute_hp_mask(Cipher, Key, ?SAMPLE)
+            )
+        end}
+     || Cipher <- [aes_128_gcm, aes_256_gcm]
+    ].
+
+%% Repeated use of one context must not chain state: each sample is an
+%% independent block.
+repeated_samples_do_not_chain_test() ->
+    A = quic_aead:compute_hp_mask(aes_128_gcm, ?KEY128, ?SAMPLE),
+    _ = quic_aead:compute_hp_mask(aes_128_gcm, ?KEY128, <<"different sample">>),
+    B = quic_aead:compute_hp_mask(aes_128_gcm, ?KEY128, ?SAMPLE),
+    ?assertEqual(A, B).
+
+%% A key update installs a new HP key; the cache must follow it rather
+%% than keep masking with the retired one.
+a_rotated_key_replaces_the_context_test() ->
+    Old = quic_aead:compute_hp_mask(aes_128_gcm, ?KEY128, ?SAMPLE),
+    New = <<"fedcba9876543210">>,
+    Got = quic_aead:compute_hp_mask(aes_128_gcm, New, ?SAMPLE),
+    ?assertNotEqual(Old, Got),
+    ?assertEqual(crypto:crypto_one_time(aes_128_ecb, New, ?SAMPLE, true), Got),
+    %% and back again, so the swap is not one-way
+    ?assertEqual(Old, quic_aead:compute_hp_mask(aes_128_gcm, ?KEY128, ?SAMPLE)).
+
+%% The two AES sizes cache separately.
+the_two_aes_sizes_do_not_share_a_context_test() ->
+    M128 = quic_aead:compute_hp_mask(aes_128_gcm, ?KEY128, ?SAMPLE),
+    M256 = quic_aead:compute_hp_mask(aes_256_gcm, ?KEY256, ?SAMPLE),
+    ?assertEqual(crypto:crypto_one_time(aes_128_ecb, ?KEY128, ?SAMPLE, true), M128),
+    ?assertEqual(crypto:crypto_one_time(aes_256_ecb, ?KEY256, ?SAMPLE, true), M256).
+
+%% ChaCha20 keeps the one-shot path: its mask depends on the sample as
+%% nonce, so there is no context to reuse.
+chacha_mask_is_unchanged_test() ->
+    Sample = <<1:32/little, 2:96>>,
+    ?assertEqual(
+        crypto:crypto_one_time(chacha20, ?KEY256, Sample, <<0, 0, 0, 0, 0>>, true),
+        quic_aead:compute_hp_mask(chacha20_poly1305, ?KEY256, Sample)
+    ).
+
+params(aes_128_gcm) -> {?KEY128, aes_128_ecb};
+params(aes_256_gcm) -> {?KEY256, aes_256_ecb}.


### PR DESCRIPTION
Replaces #216. Profiling that PR showed the AEAD is ~9% of connection-process CPU and the NIF's ceiling ~2%, half of which needs no C: `crypto:crypto_one_time/4` re-runs the key schedule on every call, and a 16-byte ECB block cost 0.77us against 0.88us for a 1200-byte AEAD seal, so nearly all of it was setup.

Keeping the context alive drops header protection to 0.28us per mask and the `crypto:*` share of an 8 MB transfer from 10.95% to 8.30%. Both directions' keys are cached: they alternate packet by packet, and a single-entry cache made them evict each other, which the profile showed as 13,024 `crypto_init` calls for 36,934 masks.

Throughput is unchanged on loopback (252/257ms before, 256/263ms after) since the transfer is not CPU-bound there; the saving is CPU, not wall clock. The send syscall remains the largest single cost at 17.8%.