### PR TITLE
Flush the TLS alert before the connection process exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- A TLS alert raised during the handshake now reaches the peer. The
+  CONNECTION_CLOSE was batched into the state `send_tls_alert/2` returns,
+  which the six immediate-exit sites discarded before calling `exit/1`;
+  `terminate/3` could not recover it, since it runs with the pre-alert
+  state and its fallback close is skipped entirely while app keys do not
+  exist. The peer saw silence and waited out its idle timeout instead of
+  learning why the handshake failed. Reported by obi458 (#227).
 - An HTTP/3 message body ends at stream end rather than at a frame
   boundary, so a response whose last DATA frame is followed by the FIN
   in a separate packet is not truncated. Contributed by jbevemyr (#244).

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5904,8 +5904,7 @@ process_tls_message(
             case lists:member(Cipher, State#state.cipher_preference) of
                 false ->
                     notify_owner({error, {tls_alert, illegal_parameter}}, State),
-                    send_tls_alert(?TLS_ALERT_ILLEGAL_PARAMETER, State),
-                    exit({tls_alert, illegal_parameter});
+                    alert_and_exit(?TLS_ALERT_ILLEGAL_PARAMETER, State, illegal_parameter);
                 true ->
                     ok
             end,
@@ -5943,12 +5942,10 @@ process_tls_message(
                     case SharedSecret of
                         {error, illegal_parameter} ->
                             notify_owner({error, {tls_alert, illegal_parameter}}, State),
-                            send_tls_alert(?TLS_ALERT_ILLEGAL_PARAMETER, State),
-                            exit({tls_alert, illegal_parameter});
+                            alert_and_exit(?TLS_ALERT_ILLEGAL_PARAMETER, State, illegal_parameter);
                         {error, internal_error} ->
                             notify_owner({error, {tls_alert, internal_error}}, State),
-                            send_tls_alert(?TLS_ALERT_INTERNAL_ERROR, State),
-                            exit({tls_alert, internal_error});
+                            alert_and_exit(?TLS_ALERT_INTERNAL_ERROR, State, internal_error);
                         _ ->
                             ok
                     end,
@@ -6627,8 +6624,9 @@ do_server_client_hello_cont(
                                             #{what => resumption_psk_binder_failed},
                                             ?QUIC_LOG_META
                                         ),
-                                        send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State),
-                                        exit({tls_alert, decrypt_error})
+                                        alert_and_exit(
+                                            ?TLS_ALERT_DECRYPT_ERROR, State, decrypt_error
+                                        )
                                 end;
                             error ->
                                 %% Unknown or expired ticket: fall back to a
@@ -6648,8 +6646,7 @@ do_server_client_hello_cont(
                     #{what => psk_binder_verification_failed},
                     ?QUIC_LOG_META
                 ),
-                send_tls_alert(?TLS_ALERT_DECRYPT_ERROR, State),
-                exit({tls_alert, decrypt_error})
+                alert_and_exit(?TLS_ALERT_DECRYPT_ERROR, State, decrypt_error)
         end,
 
     %% Server side of the key exchange for the negotiated group: an
@@ -6663,8 +6660,7 @@ do_server_client_hello_cont(
                     #{what => bad_key_share, group => SelectedGroup},
                     ?QUIC_LOG_META
                 ),
-                send_tls_alert(?TLS_ALERT_ILLEGAL_PARAMETER, State),
-                exit({tls_alert, illegal_parameter});
+                alert_and_exit(?TLS_ALERT_ILLEGAL_PARAMETER, State, illegal_parameter);
             Exchange ->
                 Exchange
         end,
@@ -10127,6 +10123,24 @@ send_connection_close(Reason, State) ->
 %% Send TLS alert as QUIC crypto error and close connection.
 %% QUIC crypto errors are 0x100 + TLS alert code (RFC 9001 §4.8).
 %% The /2 form defaults the close reason phrase per alert code.
+%% Emit a TLS alert and stop. The alert is batched into the state
+%% send_tls_alert/2 returns, so that state has to be flushed here:
+%% terminate/3 runs with the pre-alert state, and its fallback close is
+%% skipped outright while app_keys are undefined, which is exactly when
+%% alerts happen. Discarding the returned state left the peer with
+%% silence until its idle timeout (issue #227).
+%%
+%% terminate/3 then flushes its own copy of the socket_state, which is
+%% the pre-alert one. Anything batched before the alert therefore goes
+%% out twice: once here and once there. Those are duplicate packets with
+%% packet numbers the peer has already seen, which it discards, so the
+%% cost is a few redundant bytes on a connection that is closing.
+-spec alert_and_exit(non_neg_integer(), #state{}, atom()) -> no_return().
+alert_and_exit(AlertCode, State, Reason) ->
+    Sent = send_tls_alert(AlertCode, State),
+    _ = flush_socket_batch(Sent),
+    exit({tls_alert, Reason}).
+
 send_tls_alert(AlertCode, State) ->
     send_tls_alert(AlertCode, default_alert_phrase(AlertCode), State).
 

--- a/test/quic_psk_e2e_SUITE.erl
+++ b/test/quic_psk_e2e_SUITE.erl
@@ -12,6 +12,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include("quic.hrl").
 
 -export([
     all/0,
@@ -179,10 +180,19 @@ bad_binder_is_fatal(_Config) ->
         with_cert => true
     }),
     try
+        %% The alert has to reach the wire, not just fail locally: assert
+        %% the exact CONNECTION_CLOSE the server owes us, promptly.
+        %% `{error, _}` alone is satisfied by an idle timeout, which is
+        %% how issue #227 shipped unnoticed.
         Result = try_connect(Server, #{
             external_psk => {?IDENTITY, ?WRONG_SECRET}
         }),
-        ?assertMatch({error, _}, Result)
+        ?assertEqual(
+            {error,
+                {peer_closed, transport, ?QUIC_CRYPTO_ERROR_BASE + ?TLS_ALERT_DECRYPT_ERROR, 0,
+                    <<"decrypt error">>}},
+            Result
+        )
     after
         stop_server(Server)
     end.

--- a/test/quic_tls_alert_wire_tests.erl
+++ b/test/quic_tls_alert_wire_tests.erl
@@ -1,0 +1,75 @@
+%%% -*- erlang -*-
+%%%
+%%% A TLS alert raised on the client must reach the server (issue #227).
+%%%
+%%% The alert is batched into the state send_tls_alert/2 returns, and the
+%%% client sites exit immediately afterwards, so the batch has to be
+%%% flushed before the process dies. The oracle here is deliberately the
+%%% server's: the client notifies its owner *before* it tries to send, so
+%%% asserting the client's own error proves nothing about the wire.
+
+-module(quic_tls_alert_wire_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+client_alert_test_() ->
+    {timeout, 30, fun a_client_alert_reaches_the_server/0}.
+
+%% Force the server to answer with a well-formed ServerHello naming a
+%% group the client did not select. That parses cleanly and fails the
+%% negotiated-group check, which is an immediate-exit alert site.
+a_client_alert_reaches_the_server() ->
+    %% quic:connect/4 links the connection to the caller, and the client
+    %% exits with {tls_alert, _} by design here.
+    process_flag(trap_exit, true),
+    Self = self(),
+    ok = meck:new(quic_tls, [passthrough, unstick]),
+    try
+        ok = meck:expect(quic_tls, build_server_hello, fun(Opts) ->
+            KeyPair = quic_crypto:generate_key_pair(secp256r1),
+            meck:passthrough([
+                Opts#{key_pair => KeyPair, key_share_group => secp256r1}
+            ])
+        end),
+        {ok, Srv} = quic_test_echo_server:start(#{
+            connection_handler => fun(ConnPid, _ConnRef) ->
+                Watcher = spawn(fun() -> watch(ConnPid, Self) end),
+                ok = quic:set_owner_sync(ConnPid, Watcher),
+                {ok, Watcher}
+            end
+        }),
+        try
+            #{port := Port} = Srv,
+            %% Default gen_udp backend, so send batching is on: with the
+            %% adapter backend batching is disabled and the alert would
+            %% go out immediately whether or not the flush is there.
+            Opts = quic_test_echo_server:client_opts(),
+            _ = quic:connect("127.0.0.1", Port, Opts, self()),
+            receive
+                {server_closed, Reason} ->
+                    ?assertEqual(
+                        {peer_closed, transport,
+                            ?QUIC_CRYPTO_ERROR_BASE + ?TLS_ALERT_ILLEGAL_PARAMETER, 0,
+                            <<"illegal parameter">>},
+                        Reason
+                    )
+            after 5000 ->
+                error(no_alert_on_the_wire)
+            end
+        after
+            quic_test_echo_server:stop(Srv)
+        end
+    after
+        meck:unload(quic_tls)
+    end.
+
+watch(Conn, Report) ->
+    receive
+        {quic, Conn, {closed, Reason}} ->
+            Report ! {server_closed, Reason};
+        {quic, Conn, _Other} ->
+            watch(Conn, Report)
+    after 20000 ->
+        Report ! {server_closed, timeout}
+    end.


### PR DESCRIPTION
Fixes #227.

`send_tls_alert/2` batches the CONNECTION_CLOSE into the state it returns, and all six immediate-exit sites discarded that state before calling `exit/1`. `terminate/3` cannot recover it: it runs with the pre-alert state, and its fallback close is skipped outright while app keys do not exist, which is exactly when TLS alerts happen. The peer got silence and waited out its idle timeout. `alert_and_exit/3` emits, flushes and exits.

Three of the six sites came from #198 and shipped in 1.8.1.

Both tests were shown red on unfixed code first. `bad_binder_is_fatal` now requires the exact CONNECTION_CLOSE rather than `{error, _}`, which an idle timeout also satisfies and which is how this went unnoticed. The new client-side test mecks a ServerHello naming an unselected group, well-formed so it reaches the exit site rather than a length check, and asserts on the *server's* close event: the client notifies its owner before it tries to send, so a client-side assertion passes on broken main. It stays on the gen_udp backend because the adapter backend disables batching, which would mask the bug.

After the flush, `terminate/3` still flushes its pre-alert copy, so packets batched before the alert go out twice; those are duplicate packet numbers the peer discards, documented at the helper.