### PR TITLE
Let net_kernel kill the losing setup on a simultaneous connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,50 @@ jobs:
           QUIC_ENABLE_GSO_TEST: "1"
         run: rebar3 ct --suite=quic_server_batching_SUITE
 
+  dist:
+    name: Distribution Tests
+    needs: unit-tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24.0'
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            _build
+            ~/.cache/rebar3
+          key: ${{ runner.os }}-dist-otp28-${{ hashFiles('rebar.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-dist-otp28-
+
+      - name: Generate certificates
+        run: |
+          chmod +x ./certs/generate_certs.sh
+          ./certs/generate_certs.sh
+
+      - name: Compile
+        run: rebar3 compile
+
+      # These boot real VMs and speak dist over QUIC, which nothing else
+      # covers: the simultaneous-connect deadlock lived here undetected.
+      #
+      # Two dist suites are deliberately absent. quic_dist_auth_SUITE's
+      # auth_ok_both_sides fails about a fifth of runs for reasons not yet
+      # understood, and a job that is red at random teaches people to
+      # ignore it. quic_dist_basic_SUITE could not be verified here: its
+      # peers fail to boot on macOS, so add it once someone confirms it
+      # runs on Linux.
+      - name: Run distribution tests
+        run: rebar3 ct --suite=quic_dist_psk_SUITE,quic_dist_simultaneous_connect_SUITE
+
   h3-e2e:
     name: HTTP/3 E2E Tests
     needs: unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- Two nodes dialling each other at the same time no longer deadlock over
+  QUIC distribution. `net_kernel` resolves a simultaneous connect by
+  killing the losing setup process and then blocking, with no timeout,
+  until that process dies; the setup process trapped exits, so the signal
+  became an unread message, nothing died, and the node's distribution
+  machinery stayed wedged until both dials timed out. It now acts on that
+  exit while it still owns the connection, and stops trapping once the
+  controller has taken ownership, which is what OTP's own setup processes
+  do.
 - An HTTP/3 message body ends at stream end rather than at a frame
   boundary, so a response whose last DATA frame is followed by the FIN
   in a separate packet is not truncated. Contributed by jbevemyr (#244).

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -1262,7 +1262,30 @@ wait_for_connection(Kernel, Node, Conn, MyNode, Type, Timer, Config) ->
             ?shutdown2(Node, {transport_error, Code, Reason});
         {'EXIT', Timer, setup_timer_timeout} ->
             quic:close(Conn, timeout),
-            ?shutdown2(Node, connect_timeout)
+            ?shutdown2(Node, connect_timeout);
+        {'EXIT', _From, remarked} ->
+            %% net_kernel resolved a simultaneous connect against this
+            %% setup and is now blocked in an unconditional receive
+            %% waiting for us to die (net_kernel.erl, accept_pending).
+            %% Trapping turns that signal into a message, so leaving it
+            %% unread wedges the node's entire dist machinery: no
+            %% handshake, no arbitration, both dials time out.
+            quic:close(Conn, normal),
+            exit(remarked)
+    end.
+
+%% @private
+%% net_kernel resolves a simultaneous connect by killing the losing setup
+%% process and then blocking, with no timeout, until it dies
+%% (net_kernel.erl, accept_pending). This process traps exits, so that
+%% signal arrives as a message and killing it is our job. Trapping cannot
+%% simply be turned off: unlike OTP's socket-based dist, the setup process
+%% is linked to both the QUIC connection and the controller, so an
+%% ordinary linked exit would become lethal mid-handshake.
+exit_if_remarked() ->
+    receive
+        {'EXIT', _From, remarked} -> exit(remarked)
+    after 0 -> ok
     end.
 
 %% @private
@@ -1284,6 +1307,18 @@ start_client_controller(Kernel, Node, Conn, MyNode, Type, Timer) ->
             quic_dist_controller:set_supervisor(DistCtrl, Kernel),
             quic_dist_controller:set_node(DistCtrl, Node),
             HSData = create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer),
+            %% From here the handshake belongs to dist_util, and
+            %% net_kernel resolves a simultaneous connect by killing this
+            %% process and blocking until it dies. It cannot die while it
+            %% traps exits, and it cannot stop trapping while it is linked
+            %% to the connection and the controller, whose ordinary exits
+            %% would then be lethal. The controller owns the connection by
+            %% now, so drop both links and let net_kernel kill us the way
+            %% it kills OTP's own setup processes.
+            _ = unlink(Conn),
+            _ = unlink(DistCtrl),
+            ok = exit_if_remarked(),
+            process_flag(trap_exit, false),
             dist_util:handshake_we_started(HSData);
         {error, Reason} ->
             quic:safe_close(Conn, normal),

--- a/test/quic_dist_race_probe.erl
+++ b/test/quic_dist_race_probe.erl
@@ -1,0 +1,227 @@
+%%% -*- erlang -*-
+%%%
+%%% Diagnostic probe for the simultaneous-connect deadlock. Runs *inside*
+%%% a peer node: arms tracing before the race, snapshots while the dials
+%%% are still blocked, and tears everything down afterwards.
+%%%
+%%% The point is to answer one question with evidence rather than
+%%% inference: which transition stalls. Entry traces alone cannot do it,
+%%% so the interesting functions carry return traces - both branches of
+%%% notify_acceptor/1 return ok, and reaching mark_pending/1 says nothing
+%%% about what do_mark_pending/4 decided.
+
+-module(quic_dist_race_probe).
+
+-export([arm/0, snapshot/0, disarm/0]).
+
+-define(COLLECTOR, quic_dist_race_collector).
+-define(SYS_TIMEOUT, 1000).
+-define(BIG_BINARY, 32).
+
+%%====================================================================
+%% Arming
+%%====================================================================
+
+arm() ->
+    _ = disarm(),
+    Collector = spawn(fun() -> collect([]) end),
+    true = register(?COLLECTOR, Collector),
+    %% new_processes covers the setup and accept workers spawned during
+    %% the race, but misses net_kernel calling accept_connection/5 and
+    %% the listener running notify_acceptor/1: both predate it.
+    Existing = existing_pids(),
+    Traced = [P || P <- Existing, trace_pid(P, Collector)],
+    _ = safe(fun() -> erlang:trace(new_processes, true, [call, procs, {tracer, Collector}]) end),
+    #{traced => Traced, patterns => set_patterns()}.
+
+trace_pid(Pid, Collector) ->
+    try
+        erlang:trace(Pid, true, [call, procs, {tracer, Collector}]),
+        true
+    catch
+        _:_ -> false
+    end.
+
+%% Narrow patterns only: tracing whole modules floods the collector and
+%% can perturb the scheduling race being chased.
+set_patterns() ->
+    Ret = [{'_', [], [{return_trace}]}],
+    Specs = [
+        {{quic_dist, accept_connection, 5}, Ret},
+        {{quic_dist, notify_acceptor, 1}, Ret},
+        {{dist_util, handshake_other_started, 1}, Ret},
+        {{dist_util, mark_pending, 1}, Ret},
+        {{dist_util, do_mark_pending, 4}, Ret},
+        {{dist_util, recv_name, 1}, Ret},
+        %% Only the acceptor lookup, not every persistent_term read.
+        {{persistent_term, get, 2}, [
+            {[{quic_dist_acceptor, '_'}, '_'], [], [{return_trace}]}
+        ]}
+    ],
+    [{MFA, safe(fun() -> erlang:trace_pattern(MFA, MS, [local]) end)} || {MFA, MS} <- Specs].
+
+%%====================================================================
+%% Snapshot
+%%====================================================================
+
+snapshot() ->
+    #{
+        at => erlang:system_time(millisecond),
+        node => node(),
+        nodes => nodes(),
+        traces => drain(),
+        net_kernel => pinfo(whereis(net_kernel)),
+        listeners => [pinfo(P) || P <- listener_pids()],
+        acceptors => [pinfo(P) || P <- acceptor_pids()],
+        controllers => [controller_info(P) || P <- procs_of(quic_dist_controller)],
+        connections => [connection_info(P) || P <- procs_of(quic_connection)]
+    }.
+
+%% Curated map: no key material, no buffers.
+connection_info(Pid) ->
+    State =
+        try quic_connection:get_state(Pid) of
+            {Name, Info} -> #{state => Name, info => Info}
+        catch
+            _:R -> #{error => R}
+        end,
+    maps:merge(#{pid => Pid}, maps:merge(State, pinfo_map(Pid))).
+
+%% The controller record is small, but redact anything binary-and-large
+%% rather than trusting that it stays that way.
+controller_info(Pid) ->
+    Sys =
+        try sys:get_state(Pid, ?SYS_TIMEOUT) of
+            S -> redact(S)
+        catch
+            _:R -> {error, R}
+        end,
+    maps:merge(#{pid => Pid, sys_state => Sys}, pinfo_map(Pid)).
+
+redact(B) when is_binary(B), byte_size(B) > ?BIG_BINARY -> {redacted, byte_size(B)};
+redact(T) when is_tuple(T) -> list_to_tuple([redact(E) || E <- tuple_to_list(T)]);
+redact(L) when is_list(L) -> [redact(E) || E <- L];
+redact(M) when is_map(M) -> maps:map(fun(_, V) -> redact(V) end, M);
+redact(V) -> V.
+
+pinfo(undefined) ->
+    undefined;
+pinfo(Pid) ->
+    maps:merge(#{pid => Pid}, pinfo_map(Pid)).
+
+pinfo_map(Pid) ->
+    case process_info(Pid, [current_function, current_stacktrace, message_queue_len, status]) of
+        undefined ->
+            #{alive => false};
+        Info ->
+            maps:from_list(Info)
+    end.
+
+%%====================================================================
+%% Teardown
+%%====================================================================
+
+disarm() ->
+    _ = safe(fun() -> erlang:trace(new_processes, false, [call, procs]) end),
+    [safe(fun() -> erlang:trace(P, false, [call, procs]) end) || P <- existing_pids()],
+    [
+        safe(fun() -> erlang:trace_pattern(MFA, false, [local]) end)
+     || MFA <- [
+            {quic_dist, accept_connection, 5},
+            {quic_dist, notify_acceptor, 1},
+            {dist_util, handshake_other_started, 1},
+            {dist_util, mark_pending, 1},
+            {dist_util, do_mark_pending, 4},
+            {dist_util, recv_name, 1},
+            {persistent_term, get, 2}
+        ]
+    ],
+    case whereis(?COLLECTOR) of
+        undefined ->
+            ok;
+        Pid ->
+            unregister(?COLLECTOR),
+            exit(Pid, kill),
+            ok
+    end.
+
+safe(F) ->
+    try
+        F()
+    catch
+        _:R -> {error, R}
+    end.
+
+%%====================================================================
+%% Discovery
+%%====================================================================
+
+%% The peers boot distribution before quic_sup exists, so the listener is
+%% a standalone one recorded in persistent_term, not in the registry.
+%% Match the key shape rather than reconstructing the name.
+listener_pids() ->
+    [
+        Pid
+     || {{quic_dist_early_listener, _}, #{pid := Pid}} <- persistent_term:get(),
+        is_pid(Pid),
+        is_process_alive(Pid)
+    ].
+
+acceptor_pids() ->
+    [
+        Pid
+     || {{quic_dist_acceptor, _}, Pid} <- persistent_term:get(),
+        is_pid(Pid),
+        is_process_alive(Pid)
+    ].
+
+existing_pids() ->
+    [P || P <- [whereis(net_kernel)], is_pid(P)] ++ listener_pids() ++ acceptor_pids().
+
+procs_of(Mod) ->
+    [P || P <- processes(), initial_module(P) =:= Mod].
+
+initial_module(Pid) ->
+    case process_info(Pid, dictionary) of
+        {dictionary, D} ->
+            case lists:keyfind('$initial_call', 1, D) of
+                {_, {M, _, _}} -> M;
+                _ -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+%%====================================================================
+%% Collector
+%%====================================================================
+
+collect(Acc) ->
+    receive
+        {drain, From} ->
+            From ! {traces, lists:reverse(Acc)},
+            collect(Acc);
+        Trace when element(1, Trace) =:= trace orelse element(1, Trace) =:= trace_ts ->
+            collect([summarise(Trace) | Acc]);
+        _Other ->
+            collect(Acc)
+    end.
+
+%% Keep the shape, drop the payloads: arguments can carry key material.
+summarise({trace, Pid, call, {M, F, A}}) -> {call, Pid, {M, F, length(A)}};
+summarise({trace, Pid, return_from, MFA, Ret}) -> {return, Pid, MFA, redact(Ret)};
+summarise({trace, Pid, spawned, By, {M, F, A}}) -> {spawned, Pid, By, {M, F, length(A)}};
+summarise({trace, Pid, exit, Reason}) -> {exit, Pid, redact(Reason)};
+summarise(Other) -> {other, element(2, Other), element(3, Other)}.
+
+drain() ->
+    case whereis(?COLLECTOR) of
+        undefined ->
+            [];
+        Pid ->
+            Pid ! {drain, self()},
+            receive
+                {traces, T} -> T
+            after 2000 -> [{error, collector_timeout}]
+            end
+    end.

--- a/test/quic_dist_simultaneous_connect_SUITE.erl
+++ b/test/quic_dist_simultaneous_connect_SUITE.erl
@@ -29,7 +29,8 @@
 ]).
 
 -export([
-    simultaneous_connect_test/1
+    simultaneous_connect_test/1,
+    repeated_simultaneous_connect_test/1
 ]).
 
 -define(DIAL_TIMEOUT, 10000).
@@ -44,7 +45,7 @@ all() ->
     [{group, two_node}].
 
 groups() ->
-    [{two_node, [sequence], [simultaneous_connect_test]}].
+    [{two_node, [sequence], [simultaneous_connect_test, repeated_simultaneous_connect_test]}].
 
 init_per_suite(Config) ->
     {ok, CertDir} = generate_test_certs(Config),
@@ -115,6 +116,30 @@ simultaneous_connect_test(Config) ->
     ?assertEqual({true, true}, {R1, R2}),
     ok = ensure_disconnected(Peer1, Node1, Peer2, Node2),
     ok.
+
+%% The deadlock reproduced about a quarter of the time, so a single race
+%% misses it far too often to be a regression test. Twenty leaves roughly
+%% a 0.3% chance of a false pass. This is stress coverage: the guarantee
+%% comes from the setup process no longer swallowing net_kernel's
+%% `remarked' exit, not from the count.
+repeated_simultaneous_connect_test(Config) ->
+    Node1 = ?config(node1, Config),
+    Node2 = ?config(node2, Config),
+    Peer1 = ?config(peer1, Config),
+    Peer2 = ?config(peer2, Config),
+    lists:foreach(
+        fun(N) ->
+            ok = ensure_disconnected(Peer1, Node1, Peer2, Node2),
+            case race_dial(Peer1, Node1, Peer2, Node2) of
+                {true, true} ->
+                    ok;
+                Other ->
+                    ct:fail({race_stalled_on_attempt, N, Other})
+            end
+        end,
+        lists:seq(1, 20)
+    ),
+    ok = ensure_disconnected(Peer1, Node1, Peer2, Node2).
 
 %%====================================================================
 %% Helpers


### PR DESCRIPTION
Two nodes dialling each other at the same time deadlocked about a quarter of the time. `net_kernel` resolves a simultaneous connect by killing the losing setup process and then blocking, with no timeout, until it dies (`net_kernel.erl`, `accept_pending`). `quic_dist:do_setup/6` traps exits, so that signal arrived as a message nothing read: the process never died, `net_kernel` stayed wedged, and both dials timed out. Raising the dial timeout made it worse, not better.

Trapping cannot simply be turned off. Unlike OTP's socket-based dist, this setup process is linked to both the QUIC connection and the controller, and their ordinary exits would then kill it mid-handshake. The controller owns the connection by the time the dist handshake starts, so both links are dropped there and trapping stops, which lets net_kernel kill the loser as it does for OTP's own setup processes. A `remarked` that arrives earlier, while the QUIC handshake is still running, is handled where it lands.

Found by tracing both peers mid-deadlock rather than by inference: `accept_connection/5` ran on both sides and then nothing, with net_kernel parked at `net_kernel.erl:1525`. `quic_dist_race_probe` is that harness; it is test-only and nothing runs it automatically, so say the word if it should not ship.

The new 20-race case is stress coverage, not a barrier: at the observed rate a single race misses the bug three times in four. It is red on unfixed code and 60 races have run clean with the fix.

Unrelated and still open: `quic_dist_auth_SUITE:auth_ok_both_sides` fails about 4 runs in 10 on unfixed main too.