### PR TITLE
Give an authenticated dist connection one owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,14 +192,11 @@ jobs:
       # These boot real VMs and speak dist over QUIC, which nothing else
       # covers: the simultaneous-connect deadlock lived here undetected.
       #
-      # Two dist suites are deliberately absent. quic_dist_auth_SUITE's
-      # auth_ok_both_sides fails about a fifth of runs for reasons not yet
-      # understood, and a job that is red at random teaches people to
-      # ignore it. quic_dist_basic_SUITE could not be verified here: its
-      # peers fail to boot on macOS, so add it once someone confirms it
-      # runs on Linux.
+      # quic_dist_basic_SUITE is still absent: it could not be verified
+      # here because its peers fail to boot on macOS, so add it once
+      # someone confirms it runs on Linux.
       - name: Run distribution tests
-        run: rebar3 ct --suite=quic_dist_psk_SUITE,quic_dist_simultaneous_connect_SUITE
+        run: rebar3 ct --suite=quic_dist_psk_SUITE,quic_dist_simultaneous_connect_SUITE,quic_dist_auth_SUITE
 
   h3-e2e:
     name: HTTP/3 E2E Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- An authenticated distribution connection no longer drops the peer's
+  first handshake message about half the time. The `auth_callback` path
+  put a short-lived gatekeeper process in front of the dist controller
+  and replayed its mailbox after the handoff, but the controller took
+  ownership from a `gen_statem` state-enter callback, which runs after
+  `start_link` has already returned; everything the connection emitted in
+  between arrived at a process that had stopped reading. The controller
+  now owns the connection from the first packet on the server and from
+  before `start_link` returns on the client, so there is no handoff to
+  race. Auth callbacks must not open streams, which never worked.
 - A TLS alert raised during the handshake now reaches the peer. The
   CONNECTION_CLOSE was batched into the state `send_tls_alert/2` returns,
   which the six immediate-exit sites discarded before calling `exit/1`;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -516,26 +516,37 @@ in the distribution layer.
 
 A `{Mod, Fun}` pair (or `fun/3`) invoked on both sides between TLS
 completion (the `{quic, Conn, {connected, _}}` event) and the
-`dist_util` handshake. The callback can run any application-level
-challenge / response on the freshly secured QUIC connection — open a
-user stream, send a token, validate certificates — and return `{ok, _}`
-to admit the connection or `{error, Reason}` to refuse it.
+`dist_util` handshake. It inspects the freshly secured connection and
+returns `{ok, _}` to admit it or `{error, Reason}` to refuse it.
 
-On the server side, the callback is hosted by a short-lived
-*gatekeeper* process. The listener installs the gatekeeper as the
-QUIC connection owner via the existing `connection_handler` contract,
-so it receives the `{connected, _}` event and any subsequent stream
-data. After a successful callback, the gatekeeper starts the dist
-controller (which takes ownership atomically via
-`quic:set_owner_sync/2`) and *drains its mailbox* of any QUIC events
-that arrived before the ownership swap, forwarding them to the
-controller. This guarantees the first stream-data event sent by the
-peer cannot be lost between the callback returning and the controller
-becoming the owner. On failure the gatekeeper closes the connection
-and exits; the listener is unaffected.
+On the server side the dist controller owns the connection for its
+whole life. The listener installs whatever pid the
+`connection_handler` returns as the QUIC connection owner *before* it
+hands the connection its first packet, so returning the controller
+means no event can be delivered anywhere else. With a callback
+configured the controller holds the connection in its `init_state`,
+runs the callback when the `{connected, _}` event arrives, and only
+then notifies the acceptor, which is what starts the `dist_util`
+worker, whose sends and receives are calls back into the controller.
+A refusal stops the controller normally and closes the connection.
 
-On the client side, the callback runs inline in the setup process
-that already owns the connection — no gatekeeper is needed.
+The callback must not open a stream. Stream ids are assigned in the
+order streams are opened, and both sides assume the control stream is
+stream 0 with the data streams immediately after it, so a stream
+opened during authentication shifts everything that follows.
+Connection-level checks are what the hook is for: peer certificate,
+ALPN, transport parameters, PSK identity.
+
+Nothing bounds a callback that has already started. The
+`auth_handshake_timeout` guards the wait for the QUIC handshake to
+complete, not the callback's own execution.
+
+On the client side the callback runs inline in the setup process,
+which owns the connection until the controller starts. The controller
+takes ownership in its `init/1`, before `start_link/2` returns, so the
+events the setup process buffered can be handed over with no window in
+which the connection is still delivering to a process that has stopped
+reading.
 
 ### `register_with_epmd`
 

--- a/docs/QUIC_DIST.md
+++ b/docs/QUIC_DIST.md
@@ -496,7 +496,7 @@ The input handler:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `auth_callback` | `{Mod,Fun}` \| `fun/3` | `undefined` | Optional auth handshake run after the QUIC handshake but before `dist_util` |
-| `auth_handshake_timeout` | integer | 10000 | Deadline (ms) passed to the callback; gatekeeper aborts at expiry |
+| `auth_handshake_timeout` | integer | 10000 | Deadline (ms) for the QUIC handshake to complete before the callback runs; also passed to the callback |
 | `register_with_epmd` | boolean | `false` | When `true`, register the listening port via the configured `epmd_module` so external tooling (e.g. `epmd -names`) can resolve it |
 
 #### `auth_callback`
@@ -509,16 +509,21 @@ authenticate(Conn, Side :: client | server, Timeout) ->
     {ok, Info :: term()} | {error, Reason :: term()}.
 ```
 
-`{error, Reason}` closes the QUIC connection without ever starting
-the dist controller; the peer's `net_kernel:connect_node/1` returns
-`false`. Implementations typically open a user stream
-(`quic_dist:open_stream/2`) for a challenge/response. See the
+`{error, Reason}` refuses the connection and closes it; the peer's
+`net_kernel:connect_node/1` returns `false`. Use connection-level
+checks: peer certificate, ALPN, transport parameters, PSK identity.
+Do not open a stream: stream ids are assigned in open order and both
+sides assume the control stream is stream 0, so an extra stream opened
+during authentication shifts every stream after it. See the
 `quic_dist_auth` behaviour module.
 
-On the server, the callback is hosted by a short-lived gatekeeper
-process that owns the connection until the callback resolves. Any
-QUIC events buffered in its mailbox (e.g. the first stream-data) are
-forwarded to the dist controller after a successful handoff.
+On the server the callback runs in the dist controller, which owns the
+connection from the first packet; the acceptor is notified only once
+the callback admits the peer. On the client it runs in the setup
+process, which owns the connection until the controller starts.
+
+The timeout bounds the wait for the QUIC handshake, not the callback.
+A callback that never returns blocks the process running it.
 
 Boot-arg form: `-quic_dist auth_callback Mod:Fun`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -316,9 +316,9 @@ QUIC-based Erlang distribution protocol implementation.
 ### Extension Hooks
 - `auth_callback` (default `undefined`): `{Mod, Fun}` or `fun/3` invoked
   on both sides after the QUIC handshake but before the dist_util
-  handshake. Returning `{error, _}` closes the connection without ever
-  starting the dist controller. See `quic_dist_auth` and the
-  Configuration Reference in `docs/QUIC_DIST.md`.
+  handshake. Returning `{error, _}` closes the connection without the
+  node ever joining. See `quic_dist_auth` and the Configuration
+  Reference in `docs/QUIC_DIST.md`.
 - `register_with_epmd` (default `false`): when `true`, the listener
   registers its port via the configured `epmd_module` so external
   tooling (e.g. `epmd -names`) can resolve the node.

--- a/src/dist/quic_dist.erl
+++ b/src/dist/quic_dist.erl
@@ -102,8 +102,15 @@
 %% Internal exports
 -export([
     acceptor_loop/2,
-    do_setup/6
+    do_setup/6,
+    notify_acceptor/1
 ]).
+
+-type auth_callback() ::
+    {module(), atom()}
+    | fun((pid(), client | server, timeout()) -> {ok, term()} | {error, term()}).
+
+-export_type([auth_callback/0]).
 
 %% Per-node connect-time option overrides
 -export([
@@ -840,91 +847,29 @@ resolve_psk_callback(_) ->
 %% @private
 %% Handle a new incoming QUIC connection.
 %%
-%% Two paths:
-%% - No auth_callback configured (default): start the dist controller
-%%   immediately, hand it ownership of the QUIC connection, and notify
-%%   the acceptor.
-%% - auth_callback configured: spawn a short-lived gatekeeper process
-%%   that takes ownership, waits for `{quic, Conn, {connected, _}}',
-%%   runs the callback, and only on `{ok, _}' starts the dist
-%%   controller. Any QUIC events the gatekeeper buffered between the
-%%   `connected' event and the ownership swap are forwarded to the
-%%   controller so the first stream-data event is not lost.
+%% The listener installs whatever pid we return as the connection owner
+%% before it hands the connection its first packet, so returning the dist
+%% controller gives it the connection from packet zero. With an auth
+%% callback configured the controller holds the connection in `init_state'
+%% until the callback admits the peer, and notifies the acceptor itself;
+%% without one there is nothing to wait for and we notify here.
 handle_new_connection(Conn) ->
     Config = load_config(),
-    case Config#quic_dist_config.auth_callback of
-        undefined ->
-            handle_new_connection_direct(Conn);
-        Callback ->
-            handle_new_connection_with_auth(
-                Conn, Callback, Config#quic_dist_config.auth_handshake_timeout
-            )
-    end.
-
-%% @private
-handle_new_connection_direct(Conn) ->
-    case quic_dist_controller:start_link(Conn, server) of
+    Auth =
+        case Config#quic_dist_config.auth_callback of
+            undefined -> undefined;
+            Callback -> {Callback, Config#quic_dist_config.auth_handshake_timeout}
+        end,
+    case quic_dist_controller:start_link(Conn, server, Auth) of
         {ok, ControllerPid} ->
-            notify_acceptor(ControllerPid),
+            case Auth of
+                undefined -> notify_acceptor(ControllerPid);
+                _ -> ok
+            end,
             {ok, ControllerPid};
         Error ->
             logger:error("quic_dist: failed to start controller: ~p~n", [Error]),
             Error
-    end.
-
-%% @private
-%% Spawn the gatekeeper unlinked: a crash here must not propagate to
-%% the listener. It owns the connection, so if it dies the QUIC
-%% connection process will clean up on owner DOWN.
-handle_new_connection_with_auth(Conn, Callback, Timeout) ->
-    Gatekeeper = spawn(fun() ->
-        gatekeeper(Conn, Callback, Timeout)
-    end),
-    {ok, Gatekeeper}.
-
-%% @private
-gatekeeper(Conn, Callback, Timeout) ->
-    receive
-        {quic, Conn, {connected, _Info}} ->
-            case run_auth_callback(Callback, Conn, server, Timeout) of
-                {ok, _} ->
-                    finalize_server_handoff(Conn);
-                {error, Reason} ->
-                    quic:safe_close(Conn, normal),
-                    exit({auth_failed, Reason})
-            end;
-        {quic, Conn, {closed, Reason}} ->
-            exit({connection_closed, Reason});
-        {quic, Conn, {transport_error, Code, Reason}} ->
-            exit({transport_error, Code, Reason})
-    after Timeout ->
-        quic:safe_close(Conn, normal),
-        exit({auth_failed, handshake_timeout})
-    end.
-
-%% @private
-%% Start the dist controller (which takes ownership of the connection),
-%% drain any QUIC events that arrived in our mailbox before the
-%% ownership swap and forward them to the controller, then notify the
-%% acceptor and exit normally.
-finalize_server_handoff(Conn) ->
-    case quic_dist_controller:start_link(Conn, server) of
-        {ok, ControllerPid} ->
-            drain_quic_events(Conn, ControllerPid),
-            notify_acceptor(ControllerPid);
-        {error, Reason} ->
-            quic:safe_close(Conn, normal),
-            exit({controller_failed, Reason})
-    end.
-
-%% @private
-drain_quic_events(Conn, Target) ->
-    receive
-        {quic, Conn, _} = Msg ->
-            Target ! Msg,
-            drain_quic_events(Conn, Target)
-    after 0 ->
-        ok
     end.
 
 %% @private
@@ -950,27 +895,6 @@ notify_acceptor(ControllerPid) ->
         AcceptorPid when is_pid(AcceptorPid) ->
             AcceptorPid ! {accept, ControllerPid, undefined},
             ok
-    end.
-
-%% @private
-%% Invoke the configured auth callback. Crashes are turned into
-%% `{error, {crash, _}}' so a buggy callback cannot bring down the
-%% process running it. Callers must filter out `undefined' before
-%% calling.
-run_auth_callback({Mod, Fun}, Conn, Side, Timeout) when is_atom(Mod), is_atom(Fun) ->
-    safe_call(fun() -> Mod:Fun(Conn, Side, Timeout) end);
-run_auth_callback(F, Conn, Side, Timeout) when is_function(F, 3) ->
-    safe_call(fun() -> F(Conn, Side, Timeout) end).
-
-%% @private
-safe_call(Thunk) ->
-    try Thunk() of
-        {ok, _} = Ok -> Ok;
-        {error, _} = Err -> Err;
-        Other -> {error, {auth_callback_bad_return, Other}}
-    catch
-        Class:Reason:Stack ->
-            {error, {auth_callback_crash, Class, Reason, Stack}}
     end.
 
 %%====================================================================
@@ -1295,7 +1219,7 @@ maybe_run_client_auth(Conn, #quic_dist_config{
     auth_callback = Callback,
     auth_handshake_timeout = Timeout
 }) ->
-    case run_auth_callback(Callback, Conn, client, Timeout) of
+    case quic_dist_auth:run(Callback, Conn, client, Timeout) of
         {ok, _} -> ok;
         {error, _} = Err -> Err
     end.
@@ -1304,6 +1228,11 @@ maybe_run_client_auth(Conn, #quic_dist_config{
 start_client_controller(Kernel, Node, Conn, MyNode, Type, Timer) ->
     case quic_dist_controller:start_link(Conn, client) of
         {ok, DistCtrl} ->
+            %% The controller took ownership inside its init/1, so this
+            %% mailbox holds exactly what the connection delivered before
+            %% the swap and can receive nothing further. Hand that over
+            %% before the controller has any work to do.
+            _ = quic_dist_controller:adopt_owner_events(Conn, DistCtrl),
             quic_dist_controller:set_supervisor(DistCtrl, Kernel),
             quic_dist_controller:set_node(DistCtrl, Node),
             HSData = create_hs_data_setup(Kernel, DistCtrl, Node, MyNode, Type, Timer),

--- a/src/dist/quic_dist_auth.erl
+++ b/src/dist/quic_dist_auth.erl
@@ -27,13 +27,44 @@
 -module(quic_dist_auth).
 
 %% Implementations validate the freshly-established QUIC connection
-%% (e.g. inspect peer certificates, run a challenge/response on a user
-%% stream) and return `{ok, Info}' on success or `{error, Reason}' to
-%% refuse it. `Timeout' is the deadline configured via
-%% `auth_handshake_timeout'.
+%% (peer certificate, ALPN, transport parameters, PSK identity) and
+%% return `{ok, Info}' on success or `{error, Reason}' to refuse it.
+%% Do not open a stream: stream ids are assigned in open order and both
+%% sides assume the control stream is stream 0, so an extra stream
+%% opened here shifts every stream after it. `Timeout' is the value
+%% configured via `auth_handshake_timeout'; it bounds the wait for the
+%% QUIC handshake, not this callback.
 -callback authenticate(
     Conn :: pid(),
     Side :: client | server,
     Timeout :: timeout()
 ) ->
     {ok, Info :: term()} | {error, Reason :: term()}.
+
+-export([run/4]).
+
+%% @doc Invoke a configured callback, turning a crash or a bad return
+%% into `{error, _}' so a buggy implementation cannot take down the
+%% process running it. Callers must filter out `undefined' first.
+-spec run(
+    Callback :: quic_dist:auth_callback(),
+    Conn :: pid(),
+    Side :: client | server,
+    Timeout :: timeout()
+) ->
+    {ok, term()} | {error, term()}.
+run({Mod, Fun}, Conn, Side, Timeout) when is_atom(Mod), is_atom(Fun) ->
+    safe_call(fun() -> Mod:Fun(Conn, Side, Timeout) end);
+run(F, Conn, Side, Timeout) when is_function(F, 3) ->
+    safe_call(fun() -> F(Conn, Side, Timeout) end).
+
+%% @private
+safe_call(Thunk) ->
+    try Thunk() of
+        {ok, _} = Ok -> Ok;
+        {error, _} = Err -> Err;
+        Other -> {error, {auth_callback_bad_return, Other}}
+    catch
+        Class:Reason:Stack ->
+            {error, {auth_callback_crash, Class, Reason, Stack}}
+    end.

--- a/src/dist/quic_dist_controller.erl
+++ b/src/dist/quic_dist_controller.erl
@@ -53,6 +53,8 @@
 %% API
 -export([
     start_link/2,
+    start_link/3,
+    adopt_owner_events/2,
     send/2,
     recv/3,
     tick/1,
@@ -174,7 +176,11 @@
     %% Acceptor pool: list of {Pid, MonitorRef} for processes accepting incoming streams
     acceptor_pool = [] :: [{pid(), reference()}],
     %% Round-robin index for acceptor selection
-    acceptor_idx = 0 :: non_neg_integer()
+    acceptor_idx = 0 :: non_neg_integer(),
+
+    %% Pending auth handshake (server role). `undefined' means the
+    %% connection is admitted as soon as it is set up.
+    auth = undefined :: undefined | {quic_dist:auth_callback(), timeout()}
 }).
 
 %%====================================================================
@@ -184,8 +190,63 @@
 %% @doc Start a controller for a QUIC distribution connection.
 -spec start_link(Conn :: pid(), Role :: client | server) ->
     {ok, pid()} | {error, term()}.
-start_link(Conn, Role) when Role =:= client; Role =:= server ->
-    gen_statem:start_link(?MODULE, {Conn, Role}, []).
+start_link(Conn, Role) ->
+    start_link(Conn, Role, undefined).
+
+%% @doc Start a controller, optionally gating it behind an auth handshake.
+%%
+%% With an auth spec the server-role controller stays in `init_state'
+%% until the QUIC handshake completes, runs the callback, and only then
+%% admits the connection to `dist_util'.
+-spec start_link(
+    Conn :: pid(),
+    Role :: client | server,
+    Auth :: undefined | {quic_dist:auth_callback(), timeout()}
+) ->
+    {ok, pid()} | {error, term()}.
+start_link(Conn, Role, Auth) when Role =:= client; Role =:= server ->
+    gen_statem:start_link(?MODULE, {Conn, Role, Auth}, []).
+
+%% @doc Hand QUIC events buffered by a previous owner to a controller.
+%%
+%% The connecting setup process owns the connection until the controller
+%% starts, and the controller takes ownership in its `init/1', so by the
+%% time this runs the caller's mailbox holds exactly what arrived before
+%% the swap and can receive nothing further.
+%%
+%% Only events the controller understands cross over. A setup process may
+%% also have run an auth callback on a stream of its own; those bytes are
+%% not distribution traffic, and `forward_pending_data/1' would feed them
+%% to the VM's dist input. Anything not matched here stays in the caller's
+%% mailbox, which is what `{'EXIT', _, remarked}' and the setup timer
+%% depend on.
+-spec adopt_owner_events(Conn :: pid(), Controller :: pid()) -> non_neg_integer().
+adopt_owner_events(Conn, Controller) ->
+    adopt_owner_events(Conn, Controller, 0).
+
+adopt_owner_events(Conn, Controller, N) ->
+    receive
+        {quic, C, {stream_data, ?QUIC_DIST_CONTROL_STREAM, _, _}} = Msg when C =:= Conn ->
+            Controller ! Msg,
+            adopt_owner_events(Conn, Controller, N + 1);
+        {quic, C, {connected, _}} = Msg when C =:= Conn ->
+            Controller ! Msg,
+            adopt_owner_events(Conn, Controller, N + 1);
+        {quic, C, {stream_opened, _}} = Msg when C =:= Conn ->
+            Controller ! Msg,
+            adopt_owner_events(Conn, Controller, N + 1);
+        {quic, C, {session_ticket, _}} = Msg when C =:= Conn ->
+            Controller ! Msg,
+            adopt_owner_events(Conn, Controller, N + 1);
+        {quic, C, {closed, _}} = Msg when C =:= Conn ->
+            Controller ! Msg,
+            adopt_owner_events(Conn, Controller, N + 1);
+        {quic, C, {transport_error, _, _}} = Msg when C =:= Conn ->
+            Controller ! Msg,
+            adopt_owner_events(Conn, Controller, N + 1)
+    after 0 ->
+        N
+    end.
 
 %% @doc Send data on the control stream.
 -spec send(Controller :: pid(), Data :: iodata()) -> ok | {error, term()}.
@@ -330,18 +391,37 @@ list_user_streams(Controller) ->
 callback_mode() ->
     [state_functions, state_enter].
 
-%% Initialize for client role
-init({Conn, client}) ->
+%% Initialize for client role.
+%%
+%% The setup process owns the connection until this call, and it forwards
+%% whatever it buffered once we return. Take ownership here rather than in
+%% the `init_state' enter callback: gen_statem answers `start_link' before
+%% running a state-enter callback, so a swap made there leaves a window in
+%% which the connection still delivers to a process that has stopped
+%% reading. Swapping in `init/1' makes the setup process's drain final.
+init({Conn, client, _Auth}) ->
+    case quic:set_owner_sync(Conn, self()) of
+        ok ->
+            State = init_backpressure_config(#state{
+                conn = Conn,
+                role = client
+            }),
+            {ok, init_state, State};
+        {error, Reason} ->
+            %% The peer can close during a slow auth callback, and a
+            %% draining connection refuses the swap. `{error, _}' is
+            %% gen_statem's silent termination: no crash report for a
+            %% connection that simply went away.
+            {error, {set_owner_failed, Reason}}
+    end;
+%% Initialize for server role. The listener installs us as the connection
+%% owner before it hands the connection its first packet, so there is
+%% nothing to take over here.
+init({Conn, server, Auth}) ->
     State = init_backpressure_config(#state{
         conn = Conn,
-        role = client
-    }),
-    {ok, init_state, State};
-%% Initialize for server role
-init({Conn, server}) ->
-    State = init_backpressure_config(#state{
-        conn = Conn,
-        role = server
+        role = server,
+        auth = Auth
     }),
     {ok, init_state, State}.
 
@@ -400,11 +480,9 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %% State: init_state
 %%====================================================================
 
-init_state(enter, _OldState, #state{role = client, conn = Conn} = State) ->
-    %% Client: connection is already established (we received connected message)
-    %% Take over ownership synchronously to ensure we receive stream_data messages
-    ok = quic:set_owner_sync(Conn, self()),
-    %% Can proceed to open streams immediately
+init_state(enter, _OldState, #state{role = client} = State) ->
+    %% Client: ownership was taken in init/1; the connection is already
+    %% established, so we can open our streams immediately.
     case setup_streams(State) of
         {ok, State1} ->
             {keep_state, State1, [{state_timeout, 0, start_handshake}]};
@@ -412,11 +490,10 @@ init_state(enter, _OldState, #state{role = client, conn = Conn} = State) ->
             {stop, {stream_setup_failed, Reason}}
     end;
 init_state(enter, _OldState, #state{role = server, conn = Conn} = State) ->
-    %% Server: take ownership synchronously and proceed immediately
-    %% The connection_handler callback is called during QUIC handshake,
-    %% and the listener transfers ownership to us. We don't need to wait
-    %% for {connected, _} since we use stream 0 (client-initiated).
-    %% Take over as owner synchronously to ensure we receive stream_data
+    %% Server: the listener made us the owner before the connection saw
+    %% its first packet. This call is redundant, and is kept only so a
+    %% controller started any other way still ends up owning its
+    %% connection; nothing depends on its timing any more.
     ok = quic:set_owner_sync(Conn, self()),
     %% Setup streams - transition via timeout since enter can't change state
     case setup_streams(State) of
@@ -425,10 +502,46 @@ init_state(enter, _OldState, #state{role = server, conn = Conn} = State) ->
         {error, Reason} ->
             {stop, {stream_setup_failed, Reason}}
     end;
-%% Server proceeds to handshaking after setup
-init_state(state_timeout, proceed_to_handshaking, State) ->
+%% Without an auth callback the connection is admitted straight away. We
+%% do not wait for `{connected, _}': the control stream is stream 0,
+%% opened by the client.
+init_state(state_timeout, proceed_to_handshaking, #state{auth = undefined} = State) ->
     {next_state, handshaking, State};
-%% Server receives connected message - just ignore, we already transitioned
+%% With one, hold here until the QUIC handshake completes and the
+%% callback admits the peer. The deadline guards that wait, exactly as
+%% the gatekeeper process it replaces did; it does not bound a callback
+%% that has already started.
+init_state(state_timeout, proceed_to_handshaking, #state{auth = {_, Timeout}} = State) ->
+    {keep_state, State, [{state_timeout, Timeout, auth_timeout}]};
+init_state(state_timeout, auth_timeout, #state{conn = Conn} = State) ->
+    ?LOG_WARNING(
+        #{what => dist_auth_handshake_timeout, conn => Conn},
+        ?QUIC_LOG_META
+    ),
+    {stop, normal, State};
+%% Handshake complete. With auth pending this is the gate; otherwise we
+%% have already moved on and this is a late duplicate.
+init_state(
+    info,
+    {quic, Conn, {connected, _Info}},
+    #state{conn = Conn, auth = {Callback, Timeout}} = State
+) ->
+    case quic_dist_auth:run(Callback, Conn, server, Timeout) of
+        {ok, _} ->
+            %% Only now: notify_acceptor/1 starts the dist_util worker,
+            %% whose f_send/f_recv are calls into this process. Notifying
+            %% before the callback returns would deadlock them against it.
+            quic_dist:notify_acceptor(self()),
+            {next_state, handshaking, State#state{auth = undefined}};
+        {error, Reason} ->
+            ?LOG_WARNING(
+                #{what => dist_auth_refused, conn => Conn, reason => Reason},
+                ?QUIC_LOG_META
+            ),
+            %% terminate/3 closes the connection. Stop normal: a refused
+            %% peer is an outcome, not a crash.
+            {stop, normal, State}
+    end;
 init_state(info, {quic, Conn, {connected, _Info}}, #state{conn = Conn} = State) ->
     {keep_state, State};
 init_state(state_timeout, start_handshake, State) ->

--- a/src/quic.erl
+++ b/src/quic.erl
@@ -809,7 +809,12 @@ get_peer_transport_params(Conn) when is_pid(Conn) ->
 %%       client also offered. `rsa_pkcs1_*' is never selected for
 %%       CertificateVerify (RFC 8446 §4.4.3).</li>
 %%   <li>`pool_size' - Number of listener processes (default: 1)</li>
-%%   <li>`connection_handler' - Fun(Conn) -> {ok, HandlerPid} where Conn is the pid</li>
+%%   <li>`connection_handler' - `fun((Conn) -> {ok, HandlerPid})'.
+%%       `HandlerPid' becomes the connection's owner, and so receives its
+%%       `{quic, Conn, _}' events, before the connection sees its first
+%%       packet. Return the process that will consume those events, not a
+%%       broker that hands off later; see the ownership rules in
+%%       `quic_listener'.</li>
 %%   <li>`sni_callback' -
 %%       `fun((ServerName :: binary() | undefined) -> {ok, CertMap} | {error, term()})'
 %%       where `CertMap :: #{cert := binary(), key := term(), cert_chain => [binary()]}'.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -957,7 +957,9 @@ set_owner(Conn, NewOwner) ->
 
 %% @doc Set new owner process (synchronous).
 %% Use this when you need to ensure ownership is transferred before continuing.
--spec set_owner_sync(pid(), pid()) -> ok.
+%% A connection that is already draining or closed refuses the swap with
+%% `{error, {invalid_state, StateName}}'.
+-spec set_owner_sync(pid(), pid()) -> ok | {error, term()}.
 set_owner_sync(Conn, NewOwner) ->
     gen_statem:call(Conn, {set_owner, NewOwner}).
 

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -16,20 +16,70 @@
 %%%
 %%% == Connection Handler Callback ==
 %%%
-%%% The `connection_handler' option allows custom handling of new connections:
+%%% The `connection_handler' option decides which process owns each new
+%%% connection, and so which process receives its `{quic, Conn, _}'
+%%% events. Use it when you accept connections yourself rather than
+%%% through a higher-level server such as `quic_h3'.
+%%%
 %%% ```
 %%% Opts = #{
 %%%     cert => Cert,
 %%%     key => Key,
 %%%     connection_handler => fun(Conn) ->
-%%%         %% Conn is the connection pid
-%%%         %% Spawn your handler and return its pid
-%%%         HandlerPid = spawn(fun() -> my_handler(Conn) end),
-%%%         %% Ownership will be transferred to HandlerPid
+%%%         %% Return the process that will consume this connection's
+%%%         %% events. It becomes the owner before the connection sees
+%%%         %% its first packet.
 %%%         {ok, HandlerPid}
 %%%     end
 %%% }
 %%% '''
+%%%
+%%% Return `{ok, HandlerPid}' to take the connection, or `{error, Reason}'
+%%% to decline it, in which case the listener logs a warning and keeps
+%%% ownership. An arity-2 fun is called as `Fun(Conn, DCID)'.
+%%%
+%%% === Return the final owner ===
+%%%
+%%% The listener calls `quic:set_owner_sync/2' on the pid you return and
+%%% only then hands the connection its first packet. That is the one
+%%% moment at which ownership moves with nothing in flight.
+%%%
+%%% Do not return a short-lived broker that later transfers ownership to
+%%% a worker. Between the broker's last read and the worker's
+%%% `set_owner_sync' the connection is still delivering to the broker, and
+%%% those events die with it. Draining the broker's mailbox does not close
+%%% that window: the connection can emit into it after the drain returns.
+%%%
+%%% When the owner is an OTP process, take ownership in `init/1', or in
+%%% the handler itself before returning:
+%%%
+%%% ```
+%%% connection_handler => fun(Conn) ->
+%%%     {ok, Pid} = my_conn:start_link(Conn),
+%%%     ok = quic:set_owner_sync(Conn, Pid),
+%%%     {ok, Pid}
+%%% end
+%%% '''
+%%%
+%%% `gen_server' and `gen_statem' both answer `start_link' before running
+%%% any post-init callback, so a `set_owner_sync' in `handle_continue' or
+%%% in a `state_enter' callback runs once the starter is already back in
+%%% control, which reopens the same window.
+%%%
+%%% === Do not assume `connected' arrives first ===
+%%%
+%%% A datagram is processed before the connection changes state, so stream
+%%% events from that datagram reach the owner ahead of
+%%% `{quic, Conn, {connected, Info}}'. A client that coalesces its
+%%% Finished with a 1-RTT packet does exactly this. An owner that waits
+%%% for `connected' before entering its main loop mis-orders or swallows
+%%% whatever came first.
+%%%
+%%% === Close what you own ===
+%%%
+%%% Listener-created connections do not monitor their owner. If your
+%%% handler dies the connection stays up until its idle timeout, so close
+%%% it explicitly on the way out.
 
 -module(quic_listener).
 -behaviour(gen_server).

--- a/test/quic_dist_auth_SUITE.erl
+++ b/test/quic_dist_auth_SUITE.erl
@@ -24,7 +24,8 @@
     default_no_callback/1,
     auth_ok_both_sides/1,
     auth_server_denies/1,
-    auth_timeout/1,
+    auth_callback_hang_unbounded/1,
+    auth_ok_repeated_connects/1,
     register_with_epmd_visible/1
 ]).
 
@@ -36,7 +37,8 @@ all() ->
         default_no_callback,
         auth_ok_both_sides,
         auth_server_denies,
-        auth_timeout,
+        auth_callback_hang_unbounded,
+        auth_ok_repeated_connects,
         register_with_epmd_visible
     ].
 
@@ -85,6 +87,9 @@ auth_ok_both_sides(Config) ->
     Spec = #{tag => "ok", auth_cb => Cb},
     {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
     Result = run_probe(Config, "ok_probe", Target, TargetUdp, Cookie, Cb, 10000),
+    %% The target is where the server-side handoff happens, so its output
+    %% is what says whether the controller ever got the dist bytes.
+    ct:log("target output:~n~s", [drain_port(TargetUdp)]),
     ?assertEqual(connected, Result).
 
 auth_server_denies(Config) ->
@@ -94,15 +99,29 @@ auth_server_denies(Config) ->
     Result = run_probe(Config, "deny_probe", Target, TargetUdp, Cookie, Cb, 10000),
     ?assertEqual(refused, Result).
 
-auth_timeout(Config) ->
-    %% Both sides hang in the callback. The configured timeout fires
-    %% on the server gatekeeper; the client setup process eventually
-    %% sees the connection close.
+auth_callback_hang_unbounded(Config) ->
+    %% Nothing bounds a callback that has already started. The configured
+    %% timeout guards only the wait for the QUIC handshake to complete, so
+    %% with a callback that never returns the server controller blocks in
+    %% it and the client setup process blocks in its own, which means
+    %% net_kernel:connect_node/1 never returns and the probe is killed
+    %% without writing a verdict at all.
     Cb = "quic_dist_auth_test_cb:hangs_forever",
     Spec = #{tag => "tmo", auth_cb => Cb, auth_timeout => 1500},
     {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
     Result = run_probe(Config, "tmo_probe", Target, TargetUdp, Cookie, Cb, 1500),
-    ?assertEqual(refused, Result).
+    ?assertEqual(no_result, Result).
+
+auth_ok_repeated_connects(Config) ->
+    %% One connect can pass on luck. Each reconnect is a fresh inbound
+    %% connection through the whole accept path, and the handoff race this
+    %% guards against lost about half of them.
+    Cb = "quic_dist_auth_test_cb:always_ok",
+    Spec = #{tag => "rpt", auth_cb => Cb},
+    {Target, _Port, Cookie, TargetUdp} = start_target(Config, Spec),
+    Result = run_probe(Config, "rpt_probe", Target, TargetUdp, Cookie, Cb, 10000, 10),
+    ct:log("target output:~n~s", [drain_port(TargetUdp)]),
+    ?assertEqual(connected, Result).
 
 register_with_epmd_visible(Config) ->
     %% Boot a target with register_with_epmd=true and have it write its
@@ -229,7 +248,10 @@ start_target(Config, Spec) ->
             ct:fail("target ~s not ready. output:~n~s", [Tag, Log])
     end.
 
-run_probe(Config, Tag, Target, _TargetUdp, Cookie, AuthCb, AuthTimeout) ->
+run_probe(Config, Tag, Target, TargetUdp, Cookie, AuthCb, AuthTimeout) ->
+    run_probe(Config, Tag, Target, TargetUdp, Cookie, AuthCb, AuthTimeout, 1).
+
+run_probe(Config, Tag, Target, _TargetUdp, Cookie, AuthCb, AuthTimeout, Repeat) ->
     CertDir = ?config(cert_dir, Config),
     PrivDir = ?config(priv_dir, Config),
     CertFile = filename:join(CertDir, "cert.pem"),
@@ -258,18 +280,32 @@ run_probe(Config, Tag, Target, _TargetUdp, Cookie, AuthCb, AuthTimeout) ->
     TargetStr = atom_to_list(Target),
     TargetPort = get({?MODULE, target_port_for, TargetStr}),
 
+    %% Between iterations wait for the previous connection to be gone
+    %% rather than sleeping a fixed interval, so each attempt is a clean
+    %% accept and not an overlap with the last teardown.
     Eval = lists:flatten(
         io_lib:format(
             "{ok,_}=application:ensure_all_started(quic),"
-            "Nodes=[{'~s',{\"127.0.0.1\",~b}}],"
+            "Target='~s',"
+            "Nodes=[{Target,{\"127.0.0.1\",~b}}],"
             "{ok,_}=quic_discovery_static:init([{nodes,Nodes}]),"
-            "Verdict = case net_kernel:connect_node('~s') of"
+            "Gone=fun G(0)->timeout;"
+            "G(N)->case lists:member(Target,nodes(connected)) of"
+            " false->ok;"
+            " true->timer:sleep(50),G(N-1)"
+            " end end,"
+            "Results=[begin"
+            " R=net_kernel:connect_node(Target),"
+            " _=erlang:disconnect_node(Target),"
+            " _=Gone(40),"
+            " R end||_<-lists:seq(1,~b)],"
+            "Verdict = case lists:all(fun(X)->X=:=true end,Results) of"
             " true -> connected;"
             " _ -> refused"
             " end,"
             "ok=file:write_file(\"~s\",atom_to_list(Verdict)),"
             "erlang:halt(0).",
-            [TargetStr, TargetPort, TargetStr, ResultFile]
+            [TargetStr, TargetPort, Repeat, ResultFile]
         )
     ),
     Args =
@@ -318,7 +354,7 @@ run_probe(Config, Tag, Target, _TargetUdp, Cookie, AuthCb, AuthTimeout) ->
         {ok, Bin} ->
             list_to_atom(string:trim(binary_to_list(Bin)));
         {error, _} ->
-            refused
+            no_result
     end.
 
 %%====================================================================

--- a/test/quic_dist_auth_gate_tests.erl
+++ b/test/quic_dist_auth_gate_tests.erl
@@ -1,0 +1,243 @@
+%%% -*- erlang -*-
+%%%
+%%% Tests for the distribution auth gate and the connection handoff.
+%%%
+%%% Copyright (c) 2024-2026 Benoit Chesneau
+%%% Apache License 2.0
+%%%
+
+-module(quic_dist_auth_gate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic_dist.hrl").
+
+%%====================================================================
+%% Fake connection
+%%====================================================================
+
+%% Answers the handful of gen_statem calls a controller makes during
+%% startup, and reports every ownership change to Watcher so a test can
+%% tell when it happened relative to start_link/2 returning.
+fake_conn(Watcher) ->
+    fake_conn(Watcher, 0).
+
+fake_conn(Watcher, SetOwnerDelay) ->
+    spawn(fun() -> fake_conn_loop(Watcher, SetOwnerDelay, 0) end).
+
+fake_conn_loop(Watcher, Delay, NextStream) ->
+    receive
+        {'$gen_call', From, {set_owner, Owner}} ->
+            %% Announce before replying, and hold the reply, so a caller
+            %% can tell whether it was blocked on this call.
+            Watcher ! {owner_set, Owner},
+            timer:sleep(Delay),
+            gen_statem:reply(From, ok),
+            fake_conn_loop(Watcher, Delay, NextStream);
+        {'$gen_call', From, open_stream} ->
+            gen_statem:reply(From, {ok, NextStream}),
+            fake_conn_loop(Watcher, Delay, NextStream + 4);
+        {'$gen_call', From, _Other} ->
+            gen_statem:reply(From, ok),
+            fake_conn_loop(Watcher, Delay, NextStream);
+        stop ->
+            ok;
+        _ ->
+            fake_conn_loop(Watcher, Delay, NextStream)
+    end.
+
+start_server_controller(Conn, Auth) ->
+    quic_dist_controller:start_link(Conn, server, Auth).
+
+%%====================================================================
+%% Server auth gate
+%%====================================================================
+
+%% Without a `connected' event the controller must not admit the peer,
+%% and it must not run the callback either.
+auth_gate_waits_for_connected_test() ->
+    Conn = fake_conn(self()),
+    Marker = self(),
+    Cb = fun(_C, _Side, _T) ->
+        Marker ! callback_ran,
+        {ok, ok}
+    end,
+    {ok, Ctrl} = start_server_controller(Conn, {Cb, 5000}),
+    timer:sleep(200),
+    ?assertEqual(init_state, current_state(Ctrl)),
+    ?assertNot(got(callback_ran)),
+    gen_statem:stop(Ctrl),
+    Conn ! stop.
+
+auth_gate_admits_on_ok_test() ->
+    Conn = fake_conn(self()),
+    Cb = fun(_C, Side, _T) -> {ok, Side} end,
+    {ok, Ctrl} = start_server_controller(Conn, {Cb, 5000}),
+    Ctrl ! {quic, Conn, {connected, #{}}},
+    ?assertEqual(handshaking, wait_for_state(Ctrl, handshaking, 40)),
+    gen_statem:stop(Ctrl),
+    Conn ! stop.
+
+%% A refusal is an outcome, not a crash: the controller stops `normal' so
+%% it produces no crash report and cannot take a trapping listener with it.
+auth_gate_refuses_on_error_test() ->
+    Conn = fake_conn(self()),
+    Cb = fun(_C, _Side, _T) -> {error, denied} end,
+    {ok, Ctrl} = start_server_controller(Conn, {Cb, 5000}),
+    MRef = erlang:monitor(process, Ctrl),
+    Ctrl ! {quic, Conn, {connected, #{}}},
+    receive
+        {'DOWN', MRef, process, Ctrl, Reason} ->
+            ?assertEqual(normal, Reason)
+    after 2000 ->
+        ?assert(false)
+    end,
+    Conn ! stop.
+
+%% The deadline guards the wait for the QUIC handshake. It is what the
+%% gatekeeper's `after Timeout' used to be.
+auth_gate_times_out_without_connected_test() ->
+    Conn = fake_conn(self()),
+    Cb = fun(_C, _Side, _T) -> {ok, ok} end,
+    {ok, Ctrl} = start_server_controller(Conn, {Cb, 150}),
+    MRef = erlang:monitor(process, Ctrl),
+    receive
+        {'DOWN', MRef, process, Ctrl, Reason} ->
+            ?assertEqual(normal, Reason)
+    after 2000 ->
+        ?assert(false)
+    end,
+    Conn ! stop.
+
+%% No callback configured: no gate at all.
+no_auth_proceeds_without_connected_test() ->
+    Conn = fake_conn(self()),
+    {ok, Ctrl} = start_server_controller(Conn, undefined),
+    ?assertEqual(handshaking, wait_for_state(Ctrl, handshaking, 40)),
+    gen_statem:stop(Ctrl),
+    Conn ! stop.
+
+%%====================================================================
+%% Client handoff
+%%====================================================================
+
+%% The whole client fix rests on this: ownership must move inside init/1,
+%% not in the state_enter callback, so that the setup process's drain
+%% cannot race the connection. An `after 0' receive proves the ownership
+%% message was already in our mailbox when start_link/2 returned.
+client_takes_ownership_before_start_link_returns_test() ->
+    flush_owner_sets(),
+    %% The fake connection holds the set_owner reply. If the swap were in
+    %% the state_enter callback, start_link/2 would answer first and this
+    %% mailbox would still be empty.
+    Conn = fake_conn(self(), 150),
+    {ok, Ctrl} = quic_dist_controller:start_link(Conn, client),
+    Moved =
+        receive
+            {owner_set, Owner} -> Owner
+        after 0 ->
+            none
+        end,
+    ?assertEqual(Ctrl, Moved),
+    gen_statem:stop(Ctrl),
+    Conn ! stop.
+
+%%====================================================================
+%% Selective drain
+%%====================================================================
+
+%% Distribution events cross to the controller; an auth callback's own
+%% stream data does not, because forward_pending_data/1 would feed it to
+%% the VM's dist input. Exit signals the setup process still needs stay
+%% where they are.
+forward_owner_events_is_selective_test() ->
+    Conn = self(),
+    Parent = self(),
+    Collector = spawn(fun() -> collect([], Parent) end),
+    Timer = spawn(fun() -> ok end),
+    Loser = spawn(fun() -> ok end),
+    Drainer = spawn(fun() ->
+        receive
+            go -> ok
+        end,
+        N = quic_dist_controller:adopt_owner_events(Conn, Collector),
+        Left = element(2, process_info(self(), messages)),
+        Parent ! {drained, N, Left}
+    end),
+    Drainer ! {quic, Conn, {stream_opened, ?QUIC_DIST_CONTROL_STREAM}},
+    Drainer ! {quic, Conn, {stream_data, ?QUIC_DIST_CONTROL_STREAM, <<"name">>, false}},
+    Drainer ! {quic, Conn, {stream_data, ?USER_STREAM_THRESHOLD_SERVER, <<"auth">>, true}},
+    Drainer ! {'EXIT', Timer, setup_timer_timeout},
+    Drainer ! {'EXIT', Loser, remarked},
+    Drainer ! {quic, Conn, {session_ticket, <<"t">>}},
+    Drainer ! go,
+
+    {N, Left} =
+        receive
+            {drained, Count, Rest} -> {Count, Rest}
+        after 2000 ->
+            {timeout, []}
+        end,
+    ?assertEqual(3, N),
+    ?assertEqual(
+        [
+            {'EXIT', Timer, setup_timer_timeout},
+            {'EXIT', Loser, remarked},
+            {quic, Conn, {stream_data, ?USER_STREAM_THRESHOLD_SERVER, <<"auth">>, true}}
+        ],
+        lists:sort(Left)
+    ),
+
+    Collector ! flush,
+    Forwarded =
+        receive
+            {collected, Msgs} -> Msgs
+        after 2000 ->
+            []
+        end,
+    ?assertEqual(
+        [
+            {quic, Conn, {stream_opened, ?QUIC_DIST_CONTROL_STREAM}},
+            {quic, Conn, {stream_data, ?QUIC_DIST_CONTROL_STREAM, <<"name">>, false}},
+            {quic, Conn, {session_ticket, <<"t">>}}
+        ],
+        Forwarded
+    ).
+
+collect(Acc, Parent) ->
+    receive
+        flush -> Parent ! {collected, lists:reverse(Acc)};
+        Msg -> collect([Msg | Acc], Parent)
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+current_state(Pid) ->
+    {State, _Data} = sys:get_state(Pid),
+    State.
+
+wait_for_state(_Pid, Want, 0) ->
+    {timeout, Want};
+wait_for_state(Pid, Want, N) ->
+    case current_state(Pid) of
+        Want ->
+            Want;
+        _ ->
+            timer:sleep(25),
+            wait_for_state(Pid, Want, N - 1)
+    end.
+
+flush_owner_sets() ->
+    receive
+        {owner_set, _} -> flush_owner_sets()
+    after 0 ->
+        ok
+    end.
+
+got(Msg) ->
+    receive
+        Msg -> true
+    after 0 ->
+        false
+    end.


### PR DESCRIPTION
`quic_dist_auth_SUITE:auth_ok_both_sides` failed about half its runs. With `auth_callback` configured the server accept path had two owners in sequence: a gatekeeper process took the connection, ran the callback, then started the dist controller and replayed its mailbox into it. But the controller took ownership from a `gen_statem` state-enter callback, and OTP answers `start_link` before running one, so the gatekeeper was still the owner when its drain returned. Whatever the connection emitted between that drain and the controller's `set_owner_sync` landed in a mailbox that was about to be collected, and that is where the peer's `send_name` went.

The replay was not a safety net; it was the only reason the handshake worked, and it won a coin flip. Logging on the target VM showed passing runs replaying `[stream_opened, {stream_data,0,49,false}]` and failing runs replaying `[]`; making the gatekeeper linger past the handoff took it from 10 pass / 10 fail to 18 pass / 0.

So the gatekeeper is gone rather than widened. The listener already installs whatever the `connection_handler` returns as the connection owner before it delivers the first packet, which is why the no-auth path never had this problem, so the handler now returns the controller and the callback runs inside it. The client keeps its handoff but the ownership swap moves into `init/1`, which makes the setup process's drain final; that drain is now selective, so an auth callback's own stream bytes stay out of the VM's distribution input.

Two things the investigation turned up that are worth knowing. Nothing bounds a callback that has already started, on either side; `auth_handshake_timeout` guards the wait for the QUIC handshake. And an auth callback must not open a stream, which the docs used to recommend: stream ids are assigned in open order and both sides assume the control stream is stream 0, so an extra stream shifts everything after it. Docs corrected; the stream-numbering problem is pre-existing and filed separately.

`quic_dist_auth_SUITE` rejoins the CI dist job.