### PR TITLE
Make the throughput bench prove delivery

### DIFF
--- a/bench/run_sink_bench.erl
+++ b/bench/run_sink_bench.erl
@@ -1,25 +1,67 @@
 #!/usr/bin/env escript
 %%! -pa _build/default/lib/quic/ebin -pa _build/test/lib/quic/test
-%% Sink-upload benchmark driver: 1 MB, 5 MB, 10 MB, 3 runs each, report mean MB/s.
+%% Sink-upload benchmark driver.
+%%
+%%   ./bench/run_sink_bench.erl [SizeMB] [Runs]
+%%
+%% Discards a warmup run, then reports the median of Runs timed runs with
+%% the spread, because a single number off a loaded machine is not a
+%% measurement. Runs that fail delivery verification are reported as
+%% failures and excluded rather than folded in as 0 MB/s.
 
-main(_) ->
+main(Args) ->
     application:ensure_all_started(quic),
-    Sizes = [
-        {1 * 1024 * 1024, "1 MB"},
-        {5 * 1024 * 1024, "5 MB"},
-        {10 * 1024 * 1024, "10 MB"}
-    ],
-    lists:foreach(fun({Size, Label}) -> run_size(Size, Label) end, Sizes),
+    {SizeMB, Runs} = parse(Args),
+    Size = SizeMB * 1024 * 1024,
+    io:format("~nSink upload: ~p MB x ~p runs (plus 1 warmup)~n", [SizeMB, Runs]),
+    _ = one(Size),
+    Results = [one(Size) || _ <- lists:seq(1, Runs)],
+    report(SizeMB, Results),
     halt(0).
 
-run_size(Size, Label) ->
-    Results = [run_once(Size) || _ <- lists:seq(1, 3)],
-    Mean = lists:sum(Results) / length(Results),
-    Formatted = [io_lib:format("~.2f", [X]) || X <- Results],
-    io:format("~n==> ~s mean: ~.2f MB/s  (runs: ~s)~n~n",
-        [Label, Mean, string:join([lists:flatten(F) || F <- Formatted], ", ")]).
+parse([]) -> {10, 5};
+parse([S]) -> {list_to_integer(S), 5};
+parse([S, R]) -> {list_to_integer(S), list_to_integer(R)}.
 
-run_once(Size) ->
+one(Size) ->
     R = quic_throughput_bench:run_sink(#{data_size => Size}),
     timer:sleep(500),
-    maps:get(mb_per_sec, R, 0.0).
+    case maps:get(status, R, undefined) of
+        ok -> {ok, maps:get(mb_per_sec, R), maps:get(client_stats, R, #{})};
+        Other -> {failed, Other}
+    end.
+
+report(SizeMB, Results) ->
+    Ok = [{V, S} || {ok, V, S} <- Results],
+    Failed = [W || {failed, W} <- Results],
+    case Ok of
+        [] ->
+            io:format("~nAll runs failed: ~p~n", [Failed]);
+        _ ->
+            Rates = lists:sort([V || {V, _} <- Ok]),
+            io:format(
+                "~n==> ~p MB  median ~.2f MB/s  (min ~.2f, max ~.2f, n=~p)~n",
+                [SizeMB, median(Rates), hd(Rates), lists:last(Rates), length(Rates)]
+            ),
+            {_, Stats} = hd(Ok),
+            case maps:get(packets_sent, Stats, undefined) of
+                undefined ->
+                    ok;
+                Packets ->
+                    io:format(
+                        "    packets_sent=~p retransmits=~p~n",
+                        [Packets, maps:get(retransmits, Stats, 0)]
+                    )
+            end
+    end,
+    case Failed of
+        [] -> ok;
+        _ -> io:format("    ~p run(s) FAILED: ~p~n", [length(Failed), Failed])
+    end.
+
+median(Sorted) ->
+    N = length(Sorted),
+    case N rem 2 of
+        1 -> lists:nth((N div 2) + 1, Sorted);
+        0 -> (lists:nth(N div 2, Sorted) + lists:nth((N div 2) + 1, Sorted)) / 2
+    end.

--- a/docker/benchmark/Dockerfile
+++ b/docker/benchmark/Dockerfile
@@ -1,0 +1,36 @@
+# Linux benchmark image.
+#
+#   docker build -f docker/benchmark/Dockerfile -t quic-bench .
+#   docker run --rm quic-bench                    # default: sink, 10 MB, 5 runs
+#   docker run --rm quic-bench 50 9               # 50 MB, 9 runs
+#
+# Linux is where the send path has UDP_SEGMENT and GRO, so it is the only
+# platform on which a per-packet change can be judged against the numbers
+# other implementations publish. cmake and the OpenSSL headers are here so
+# an optional NIF can be built in the same image with QUIC_OFFLOAD=1.
+
+ARG OTP_VERSION=28
+
+FROM erlang:${OTP_VERSION}
+
+WORKDIR /build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends cmake libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q https://github.com/erlang/rebar3/releases/download/3.24.0/rebar3 \
+    && chmod +x rebar3 \
+    && mv rebar3 /usr/local/bin/
+
+COPY src /build/src
+COPY include /build/include
+COPY test /build/test
+COPY bench /build/bench
+COPY rebar.config /build/rebar.config
+COPY rebar.lock /build/rebar.lock
+COPY certs /build/certs
+
+RUN rebar3 compile && rebar3 as test compile
+
+ENTRYPOINT ["escript", "bench/run_sink_bench.erl"]

--- a/test/quic_throughput_bench.erl
+++ b/test/quic_throughput_bench.erl
@@ -14,6 +14,18 @@
 
 -module(quic_throughput_bench).
 
+%% What the sink server sends back once it has the whole stream: the byte
+%% count and CRC32 it actually observed.
+-define(RECEIPT(Bytes, Crc), <<(Bytes):64/big, (Crc):32/big>>).
+
+%% Bytes handed to send_data/4 at a time. The default is one write for
+%% anything the connection's 16 MB send-queue cap can hold, because
+%% splitting a stream across several writes currently collapses
+%% throughput by more than an order of magnitude: same 10 MB, one write
+%% 63 MB/s, two writes 3.3, forty writes 1.4. Set `chunk' explicitly to
+%% measure that; leave it alone to measure the send path.
+-define(CHUNK, 16777216).
+
 -export([
     run/0,
     run/1,
@@ -71,7 +83,7 @@ run_download_sink(Opts) ->
     {ok, Srv} = start_download_server(ServerExtra),
     try
         Start = erlang:monotonic_time(microsecond),
-        ClientExtra = maps:with([socket_backend], Opts),
+        ClientExtra = maps:with([socket_backend, chunk], Opts),
         {Received, ServerStats} = do_download(Srv, Size, ClientExtra),
         End = erlang:monotonic_time(microsecond),
 
@@ -282,8 +294,10 @@ run(Opts) ->
         [RecvBuf / 1048576, SndBuf / 1048576]
     ),
 
-    %% Start server
-    case start_server(Port, RecvBuf, SndBuf, Mode) of
+    %% Start server. Backend and batching are server-side knobs; applying
+    %% them to the client alone silently benchmarks the wrong half.
+    ServerExtra = maps:with([socket_backend, server_send_batching], Opts),
+    case start_server(Port, RecvBuf, SndBuf, Mode, ServerExtra) of
         {ok, ServerPid, ActualPort, ServerBufs} ->
             io:format(
                 "Server actual buffers: recv=~p, send=~p~n",
@@ -435,7 +449,7 @@ compare_cc(Opts) ->
 %% Internal Functions
 %%====================================================================
 
-start_server(Port, RecvBuf, SndBuf, Mode) ->
+start_server(Port, RecvBuf, SndBuf, Mode, Extra) ->
     %% Get test certificates
     case get_test_certs() of
         {ok, Cert, Key} ->
@@ -468,7 +482,7 @@ start_server(Port, RecvBuf, SndBuf, Mode) ->
                 max_stream_data_uni => FlowWindow,
                 connection_handler => Handler
             },
-            case quic:start_server(ServerName, Port, ServerOpts) of
+            case quic:start_server(ServerName, Port, maps:merge(ServerOpts, Extra)) of
                 {ok, Pid} ->
                     {ok, ActualPort} = quic:get_server_port(ServerName),
                     %% Get actual buffer sizes from a test socket
@@ -484,7 +498,9 @@ start_server(Port, RecvBuf, SndBuf, Mode) ->
 stop_server({ServerName, _Pid}) ->
     quic:stop_server(ServerName).
 
-run_client_benchmark(Port, DataSize, RecvBuf, SndBuf, Mode, ClientExtra) ->
+run_client_benchmark(Port, DataSize, RecvBuf, SndBuf, Mode, ClientExtra0) ->
+    Chunk = maps:get(chunk, ClientExtra0, ?CHUNK),
+    ClientExtra = maps:remove(chunk, ClientExtra0),
     %% Large flow control windows for benchmarking (16MB)
     FlowWindow = 16777216,
     ClientOpts = maps:merge(
@@ -520,42 +536,97 @@ run_client_benchmark(Port, DataSize, RecvBuf, SndBuf, Mode, ClientExtra) ->
             %% Open stream and measure transfer time
             {ok, StreamId} = quic:open_stream(Conn),
 
-            Start = erlang:monotonic_time(millisecond),
-            ok = quic:send_data(Conn, StreamId, Data, true),
+            SentCrc = erlang:crc32(Data),
+
+            Start = erlang:monotonic_time(microsecond),
+            ok = send_all(Conn, StreamId, Data, Chunk),
+            Handed = erlang:monotonic_time(microsecond),
 
             %% Wait for completion based on mode
-            case Mode of
-                echo ->
-                    %% Wait for echoed data
-                    wait_stream_close(Conn, StreamId, 30000);
-                sink ->
-                    %% Sink mode: wait for stream close (server closes after receiving FIN)
-                    wait_stream_close_sink(Conn, StreamId, 30000)
-            end,
+            Outcome =
+                case Mode of
+                    echo -> wait_stream_close(Conn, StreamId, 30000);
+                    sink -> wait_stream_close_sink(Conn, StreamId, 30000)
+                end,
 
-            End = erlang:monotonic_time(millisecond),
-            Duration = max(1, End - Start),
+            End = erlang:monotonic_time(microsecond),
+            Duration = End - Start,
 
-            MBps = (DataSize / 1048576) / (Duration / 1000),
+            %% Snapshot before closing: packet counts turn a throughput
+            %% figure into a per-packet cost, which is what any change to
+            %% the per-packet path has to be judged on.
+            Stats = connection_stats(Conn),
 
             quic:close(Conn),
 
-            io:format(
-                "Result: ~.2f MB/s (~p ms for ~.2f MB)~n",
-                [MBps, Duration, DataSize / 1048576]
-            ),
-
-            #{
-                status => ok,
-                data_size => DataSize,
-                duration_ms => Duration,
-                mb_per_sec => MBps,
-                client_buffers => ClientBufs
-            };
+            case check_delivery(Outcome, DataSize, SentCrc) of
+                ok ->
+                    MBps = (DataSize / 1048576) / (Duration / 1000000),
+                    io:format(
+                        "Result: ~.2f MB/s (~p us for ~.2f MB, verified; "
+                        "~p us to hand off, ~p us draining)~n",
+                        [MBps, Duration, DataSize / 1048576, Handed - Start, End - Handed]
+                    ),
+                    #{
+                        status => ok,
+                        data_size => DataSize,
+                        duration_us => Duration,
+                        duration_ms => Duration div 1000,
+                        handoff_us => Handed - Start,
+                        mb_per_sec => MBps,
+                        client_buffers => ClientBufs,
+                        client_stats => Stats
+                    };
+                {error, Why} ->
+                    io:format("Run FAILED after ~p us: ~p~n", [Duration, Why]),
+                    #{status => {error, Why}, data_size => DataSize, duration_us => Duration}
+            end;
         {error, Reason} ->
             io:format("Failed to connect: ~p~n", [Reason]),
             #{status => {error, Reason}}
     end.
+
+connection_stats(Conn) ->
+    Keys = [packets_sent, packets_received, retransmits, ack_sent, bytes_sent],
+    try quic:get_stats(Conn) of
+        {ok, S} -> maps:with(Keys, S);
+        _ -> #{}
+    catch
+        _:_ -> #{}
+    end.
+
+%% quic_connection caps a connection's send queue at
+%% ?MAX_SEND_QUEUE_BYTES (16 MB), so a single send_data/4 of a larger
+%% payload fails outright. Feed it the way a bulk sender would, and wait
+%% out backpressure rather than treating it as an error.
+send_all(Conn, StreamId, Data, Chunk) when byte_size(Data) =< Chunk ->
+    push(Conn, StreamId, Data, true);
+send_all(Conn, StreamId, Data, Chunk) ->
+    <<Head:Chunk/binary, Rest/binary>> = Data,
+    ok = push(Conn, StreamId, Head, false),
+    send_all(Conn, StreamId, Rest, Chunk).
+
+push(Conn, StreamId, Chunk, Fin) ->
+    case quic:send_data(Conn, StreamId, Chunk, Fin) of
+        ok ->
+            ok;
+        {error, send_queue_full} ->
+            erlang:yield(),
+            push(Conn, StreamId, Chunk, Fin);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% A run counts only when the peer confirms every byte. Anything else is
+%% a failure with a reason, never a rate.
+check_delivery({error, Reason}, _Size, _Crc) ->
+    {error, Reason};
+check_delivery({ok, {Size, Crc}}, Size, Crc) ->
+    ok;
+check_delivery({ok, {Bytes, _Crc}}, Size, _Sent) when Bytes =/= Size ->
+    {error, {short_delivery, #{expected => Size, delivered => Bytes}}};
+check_delivery({ok, {_Bytes, Crc}}, _Size, Sent) ->
+    {error, {crc_mismatch, #{expected => Sent, got => Crc}}}.
 
 get_test_certs() ->
     PrivDir = code:priv_dir(quic),
@@ -597,32 +668,44 @@ get_actual_buffers(RequestedRecv, RequestedSnd) ->
             #{recbuf => 0, sndbuf => 0}
     end.
 
-%% Wait for stream to close or receive final data (echo mode)
+%% Collect the echoed stream until FIN, returning size and CRC so the
+%% caller can check the round trip rather than assume it.
 wait_stream_close(Conn, StreamId, Timeout) ->
+    wait_stream_close(Conn, StreamId, Timeout, 0, 0).
+
+wait_stream_close(Conn, StreamId, Timeout, Bytes, Crc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, _Data, true}} ->
-            ok;
-        {quic, Conn, {stream_data, StreamId, _Data, false}} ->
-            wait_stream_close(Conn, StreamId, Timeout)
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            {ok, {Bytes + byte_size(Data), erlang:crc32(Crc, Data)}};
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            wait_stream_close(
+                Conn, StreamId, Timeout, Bytes + byte_size(Data), erlang:crc32(Crc, Data)
+            );
+        {quic, Conn, {closed, Reason}} ->
+            {error, {closed, Reason}}
     after Timeout ->
         {error, timeout}
     end.
 
-%% Wait for stream to close (sink mode - server closes stream after receiving FIN)
+%% Collect the sink server's receipt. A connection that closes before the
+%% receipt arrives is a failed run, not a fast one.
 wait_stream_close_sink(Conn, StreamId, Timeout) ->
+    wait_stream_close_sink(Conn, StreamId, Timeout, <<>>).
+
+wait_stream_close_sink(Conn, StreamId, Timeout, Acc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, _Data, true}} ->
-            %% Server sent FIN (empty response)
-            ok;
-        {quic, Conn, {stream_data, StreamId, _Data, false}} ->
-            %% Should not happen in sink mode, but handle gracefully
-            wait_stream_close_sink(Conn, StreamId, Timeout);
-        {quic, Conn, {closed, _Reason}} ->
-            %% Connection closed
-            ok
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            parse_receipt(<<Acc/binary, Data/binary>>);
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            wait_stream_close_sink(Conn, StreamId, Timeout, <<Acc/binary, Data/binary>>);
+        {quic, Conn, {closed, Reason}} ->
+            {error, {closed, Reason}}
     after Timeout ->
         {error, timeout}
     end.
+
+parse_receipt(?RECEIPT(Bytes, Crc)) -> {ok, {Bytes, Crc}};
+parse_receipt(Other) -> {error, {bad_receipt, Other}}.
 
 %% Echo handler for benchmark server - echoes received data back
 echo_handler(Conn) ->
@@ -644,26 +727,27 @@ echo_handler(Conn) ->
 %% Sink handler for benchmark server - just counts bytes without echoing
 %% This measures raw transport throughput without owner-process message overhead
 sink_handler(Conn) ->
-    sink_handler(Conn, 0).
+    sink_handler(Conn, {0, 0}).
 
-sink_handler(Conn, BytesRecv) ->
+sink_handler(Conn, {BytesRecv, Crc} = Acc) ->
     receive
         {quic, Conn, {connected, _Info}} ->
-            sink_handler(Conn, BytesRecv);
+            sink_handler(Conn, Acc);
         {quic, Conn, {stream_opened, _StreamId}} ->
-            sink_handler(Conn, BytesRecv);
+            sink_handler(Conn, Acc);
         {quic, Conn, {stream_data, _StreamId, Data, false}} ->
-            %% Count bytes, continue receiving
-            sink_handler(Conn, BytesRecv + byte_size(Data));
+            sink_handler(Conn, {BytesRecv + byte_size(Data), erlang:crc32(Crc, Data)});
         {quic, Conn, {stream_data, StreamId, Data, true}} ->
-            %% Final data received, close the stream to signal completion
-            TotalBytes = BytesRecv + byte_size(Data),
-            %% Send empty data with FIN to signal we're done receiving
-            quic:send_data(Conn, StreamId, <<>>, true),
-            io:format("Sink received ~.2f MB~n", [TotalBytes / 1048576]),
-            sink_handler(Conn, 0);
+            %% Answer with what we actually received rather than an empty
+            %% FIN. The client checks it: a rate computed from bytes the
+            %% peer never got is the classic way a throughput harness
+            %% reports a number for a transfer that did not happen.
+            Total = BytesRecv + byte_size(Data),
+            Final = erlang:crc32(Crc, Data),
+            quic:send_data(Conn, StreamId, ?RECEIPT(Total, Final), true),
+            sink_handler(Conn, {0, 0});
         {quic, Conn, {closed, _Reason}} ->
             BytesRecv;
         _Other ->
-            sink_handler(Conn, BytesRecv)
+            sink_handler(Conn, Acc)
     end.


### PR DESCRIPTION
The sink bench computed MB/s from bytes *requested*, not delivered, on a millisecond clock floored at 1 ms, and treated both a 30-second timeout and a mid-transfer close as success. Nothing ever compared what arrived against what was sent. That is the defect class that got the 805 MiB/s figure in #220 retracted, and it means no number the bench produced was evidence.

The sink server now answers with the byte count and CRC32 it actually observed, and the client checks both. A run that does not deliver fails with a reason instead of producing a rate. Timing is in microseconds, the waiter's result is acted on rather than discarded, and the result map carries packet counts so a throughput figure can be turned into a per-packet cost, which is what any change to the per-packet path has to be judged on. `socket_backend` and `server_send_batching` now reach the server, where they apply; previously `run_sink` set them on the client only.

The driver discards a warmup run and reports the median with min and max instead of the mean of three, and excludes failed runs rather than folding them in as 0 MB/s. `docker/benchmark/` restores the Linux runner that produced the published Linux numbers but was never committed; it now also carries cmake and the OpenSSL headers so an optional NIF can be built in the same image.

Verified against the previous harness on Linux, same build, same VM, alternating, distinct ports: median 65.5 MB/s (60.3 to 73.2, n=5) versus 63 to 71 before, so the verification costs nothing and the numbers stay comparable.

Building this turned up a send-path bug, which is why the `chunk` option is here: the same 10 MB delivered in more than one `send_data/4` call collapses throughput. One write 62.9 MB/s, two writes 3.3, four 2.0, ten 1.7, forty 1.4, with zero retransmits and the expected packet count. Not pacing and not the burst budget; both were ruled out by measurement. The bench therefore defaults to a single write, so it measures the send path rather than that cliff, and `chunk` reproduces it on demand. Tracked separately.