### PR TITLE
Requeue a drained stream remainder in front, not at the back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project will be documented in this file.
   Contributed by jbevemyr (#213).
 
 ### Fixed
+- A stream written in more than one `send_data/4` call no longer goes out
+  interleaved. When the per-drain burst budget was spent, the unsent
+  remainder was requeued at the back of its priority bucket instead of the
+  front, so the drain round-robined between the queued entries and the
+  stream stayed out of order for the rest of the transfer. The receiver
+  then buffered nearly the whole stream for reassembly. The same 10 MB
+  delivered in 40 writes went at 1.4 MB/s against 63 for a single write;
+  it is now 69.5. Single writes were never affected, which is why bulk
+  benchmarks did not show it.
 - An authenticated distribution connection no longer drops the peer's
   first handshake message about half the time. The `auth_callback` path
   put a short-lived gatekeeper process in front of the dist controller

--- a/bench/run_sink_bench.erl
+++ b/bench/run_sink_bench.erl
@@ -1,25 +1,67 @@
 #!/usr/bin/env escript
 %%! -pa _build/default/lib/quic/ebin -pa _build/test/lib/quic/test
-%% Sink-upload benchmark driver: 1 MB, 5 MB, 10 MB, 3 runs each, report mean MB/s.
+%% Sink-upload benchmark driver.
+%%
+%%   ./bench/run_sink_bench.erl [SizeMB] [Runs]
+%%
+%% Discards a warmup run, then reports the median of Runs timed runs with
+%% the spread, because a single number off a loaded machine is not a
+%% measurement. Runs that fail delivery verification are reported as
+%% failures and excluded rather than folded in as 0 MB/s.
 
-main(_) ->
+main(Args) ->
     application:ensure_all_started(quic),
-    Sizes = [
-        {1 * 1024 * 1024, "1 MB"},
-        {5 * 1024 * 1024, "5 MB"},
-        {10 * 1024 * 1024, "10 MB"}
-    ],
-    lists:foreach(fun({Size, Label}) -> run_size(Size, Label) end, Sizes),
+    {SizeMB, Runs} = parse(Args),
+    Size = SizeMB * 1024 * 1024,
+    io:format("~nSink upload: ~p MB x ~p runs (plus 1 warmup)~n", [SizeMB, Runs]),
+    _ = one(Size),
+    Results = [one(Size) || _ <- lists:seq(1, Runs)],
+    report(SizeMB, Results),
     halt(0).
 
-run_size(Size, Label) ->
-    Results = [run_once(Size) || _ <- lists:seq(1, 3)],
-    Mean = lists:sum(Results) / length(Results),
-    Formatted = [io_lib:format("~.2f", [X]) || X <- Results],
-    io:format("~n==> ~s mean: ~.2f MB/s  (runs: ~s)~n~n",
-        [Label, Mean, string:join([lists:flatten(F) || F <- Formatted], ", ")]).
+parse([]) -> {10, 5};
+parse([S]) -> {list_to_integer(S), 5};
+parse([S, R]) -> {list_to_integer(S), list_to_integer(R)}.
 
-run_once(Size) ->
+one(Size) ->
     R = quic_throughput_bench:run_sink(#{data_size => Size}),
     timer:sleep(500),
-    maps:get(mb_per_sec, R, 0.0).
+    case maps:get(status, R, undefined) of
+        ok -> {ok, maps:get(mb_per_sec, R), maps:get(client_stats, R, #{})};
+        Other -> {failed, Other}
+    end.
+
+report(SizeMB, Results) ->
+    Ok = [{V, S} || {ok, V, S} <- Results],
+    Failed = [W || {failed, W} <- Results],
+    case Ok of
+        [] ->
+            io:format("~nAll runs failed: ~p~n", [Failed]);
+        _ ->
+            Rates = lists:sort([V || {V, _} <- Ok]),
+            io:format(
+                "~n==> ~p MB  median ~.2f MB/s  (min ~.2f, max ~.2f, n=~p)~n",
+                [SizeMB, median(Rates), hd(Rates), lists:last(Rates), length(Rates)]
+            ),
+            {_, Stats} = hd(Ok),
+            case maps:get(packets_sent, Stats, undefined) of
+                undefined ->
+                    ok;
+                Packets ->
+                    io:format(
+                        "    packets_sent=~p retransmits=~p~n",
+                        [Packets, maps:get(retransmits, Stats, 0)]
+                    )
+            end
+    end,
+    case Failed of
+        [] -> ok;
+        _ -> io:format("    ~p run(s) FAILED: ~p~n", [length(Failed), Failed])
+    end.
+
+median(Sorted) ->
+    N = length(Sorted),
+    case N rem 2 of
+        1 -> lists:nth((N div 2) + 1, Sorted);
+        0 -> (lists:nth(N div 2, Sorted) + lists:nth((N div 2) + 1, Sorted)) / 2
+    end.

--- a/docker/benchmark/Dockerfile
+++ b/docker/benchmark/Dockerfile
@@ -1,0 +1,36 @@
+# Linux benchmark image.
+#
+#   docker build -f docker/benchmark/Dockerfile -t quic-bench .
+#   docker run --rm quic-bench                    # default: sink, 10 MB, 5 runs
+#   docker run --rm quic-bench 50 9               # 50 MB, 9 runs
+#
+# Linux is where the send path has UDP_SEGMENT and GRO, so it is the only
+# platform on which a per-packet change can be judged against the numbers
+# other implementations publish. cmake and the OpenSSL headers are here so
+# an optional NIF can be built in the same image with QUIC_OFFLOAD=1.
+
+ARG OTP_VERSION=28
+
+FROM erlang:${OTP_VERSION}
+
+WORKDIR /build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends cmake libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q https://github.com/erlang/rebar3/releases/download/3.24.0/rebar3 \
+    && chmod +x rebar3 \
+    && mv rebar3 /usr/local/bin/
+
+COPY src /build/src
+COPY include /build/include
+COPY test /build/test
+COPY bench /build/bench
+COPY rebar.config /build/rebar.config
+COPY rebar.lock /build/rebar.lock
+COPY certs /build/certs
+
+RUN rebar3 compile && rebar3 as test compile
+
+ENTRYPOINT ["escript", "bench/run_sink_bench.erl"]

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -9104,9 +9104,14 @@ send_stream_chunked_loop(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
     end.
 
 send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
+    %% Requeue where the caller says, not always at the back: a remainder
+    %% popped off the queue has to go back in front of the higher-offset
+    %% entries it was ahead of, or the stream goes out on the wire
+    %% interleaved for the rest of the transfer.
+    {chunked_ctx, _, _, _, _, _, Where} = Ctx,
     case burst_exhausted(State) of
         true ->
-            case queue_stream_data(StreamId, Offset, Data, Fin, State) of
+            case queue_stream_data(StreamId, Offset, Data, Fin, State, Where) of
                 {ok, QueuedState} ->
                     {arm_burst_continuation(QueuedState), BytesSentSoFar};
                 {error, send_queue_full} ->

--- a/test/quic_e2e_SUITE.erl
+++ b/test/quic_e2e_SUITE.erl
@@ -40,7 +40,8 @@
     stream_send_receive/1,
     stream_bidirectional/1,
     stream_multiple/1,
-    stream_large_data/1
+    stream_large_data/1,
+    stream_many_writes_stay_in_order/1
 ]).
 
 %% Test cases - Connection Lifecycle
@@ -76,7 +77,8 @@ groups() ->
             stream_send_receive,
             stream_bidirectional,
             stream_multiple,
-            stream_large_data
+            stream_large_data,
+            stream_many_writes_stay_in_order
         ]},
         {connection_lifecycle, [sequence], [
             connection_close_normal,
@@ -329,6 +331,81 @@ stream_large_data(Config) ->
     after 60000 ->
         quic:close(ConnRef, timeout),
         ct:fail("Connection timeout")
+    end.
+
+%% @doc A stream written in many calls must still go out in offset order.
+%%
+%% Asserts the mechanism rather than a stopwatch: on a lossless loopback
+%% path an in-order stream never buffers anything at the receiver, so the
+%% server connection's reassembly buffer stays empty for the whole
+%% transfer. When the drain requeued a remainder behind the entries it was
+%% ahead of, the stream interleaved permanently and this buffer grew to
+%% hold almost the entire transfer.
+stream_many_writes_stay_in_order(Config) ->
+    Host = ?config(host, Config),
+    Port = ?config(port, Config),
+    #{name := ServerName} = ?config(echo_server, Config),
+
+    Opts = maps:merge(quic_test_echo_server:client_opts(), #{alpn => [<<"echo">>]}),
+    {ok, ConnRef} = quic:connect(Host, Port, Opts, self()),
+
+    receive
+        {quic, ConnRef, {connected, _Info}} ->
+            {ok, StreamId} = quic:open_stream(ConnRef),
+
+            Writes = 16,
+            ChunkSize = 128 * 1024,
+            Data = crypto:strong_rand_bytes(Writes * ChunkSize),
+
+            Poller = spawn_link(fun() -> poll_recv_buffer(ServerName, self(), 0) end),
+            ok = send_in_chunks(ConnRef, StreamId, Data, ChunkSize),
+            Echoed = collect_stream_data(ConnRef, StreamId, <<>>, 60000),
+            Poller ! {stop, self()},
+            MaxBuffered =
+                receive
+                    {max_buffered, N} -> N
+                after 5000 -> ct:fail("poller did not report")
+                end,
+
+            ct:pal("~p writes, peak server reassembly buffer ~p bytes", [Writes, MaxBuffered]),
+            ?assertEqual(byte_size(Data), byte_size(Echoed)),
+            ?assertEqual(Data, Echoed),
+            %% A stray reordered packet would be a couple of kB; the bug
+            %% buffered megabytes.
+            ?assert(MaxBuffered < 128 * 1024),
+
+            quic:close(ConnRef, normal),
+            ok
+    after 60000 ->
+        quic:close(ConnRef, timeout),
+        ct:fail("Connection timeout")
+    end.
+
+send_in_chunks(Conn, StreamId, Data, ChunkSize) when byte_size(Data) =< ChunkSize ->
+    quic:send_data(Conn, StreamId, Data, true);
+send_in_chunks(Conn, StreamId, Data, ChunkSize) ->
+    <<Head:ChunkSize/binary, Rest/binary>> = Data,
+    ok = quic:send_data(Conn, StreamId, Head, false),
+    send_in_chunks(Conn, StreamId, Rest, ChunkSize).
+
+poll_recv_buffer(ServerName, Parent, Max) ->
+    receive
+        {stop, From} -> From ! {max_buffered, Max}
+    after 2 ->
+        poll_recv_buffer(ServerName, Parent, max(Max, server_recv_buffered(ServerName)))
+    end.
+
+server_recv_buffered(ServerName) ->
+    case quic:get_server_connections(ServerName) of
+        {ok, [Conn | _]} ->
+            try quic_connection:get_state(Conn) of
+                {_StateName, #{recv_buffer_bytes := Bytes}} -> Bytes;
+                _ -> 0
+            catch
+                _:_ -> 0
+            end;
+        _ ->
+            0
     end.
 
 %%====================================================================

--- a/test/quic_throughput_bench.erl
+++ b/test/quic_throughput_bench.erl
@@ -14,6 +14,18 @@
 
 -module(quic_throughput_bench).
 
+%% What the sink server sends back once it has the whole stream: the byte
+%% count and CRC32 it actually observed.
+-define(RECEIPT(Bytes, Crc), <<(Bytes):64/big, (Crc):32/big>>).
+
+%% Bytes handed to send_data/4 at a time. The default is one write for
+%% anything the connection's 16 MB send-queue cap can hold, because
+%% splitting a stream across several writes currently collapses
+%% throughput by more than an order of magnitude: same 10 MB, one write
+%% 63 MB/s, two writes 3.3, forty writes 1.4. Set `chunk' explicitly to
+%% measure that; leave it alone to measure the send path.
+-define(CHUNK, 16777216).
+
 -export([
     run/0,
     run/1,
@@ -71,7 +83,7 @@ run_download_sink(Opts) ->
     {ok, Srv} = start_download_server(ServerExtra),
     try
         Start = erlang:monotonic_time(microsecond),
-        ClientExtra = maps:with([socket_backend], Opts),
+        ClientExtra = maps:with([socket_backend, chunk], Opts),
         {Received, ServerStats} = do_download(Srv, Size, ClientExtra),
         End = erlang:monotonic_time(microsecond),
 
@@ -282,8 +294,10 @@ run(Opts) ->
         [RecvBuf / 1048576, SndBuf / 1048576]
     ),
 
-    %% Start server
-    case start_server(Port, RecvBuf, SndBuf, Mode) of
+    %% Start server. Backend and batching are server-side knobs; applying
+    %% them to the client alone silently benchmarks the wrong half.
+    ServerExtra = maps:with([socket_backend, server_send_batching], Opts),
+    case start_server(Port, RecvBuf, SndBuf, Mode, ServerExtra) of
         {ok, ServerPid, ActualPort, ServerBufs} ->
             io:format(
                 "Server actual buffers: recv=~p, send=~p~n",
@@ -435,7 +449,7 @@ compare_cc(Opts) ->
 %% Internal Functions
 %%====================================================================
 
-start_server(Port, RecvBuf, SndBuf, Mode) ->
+start_server(Port, RecvBuf, SndBuf, Mode, Extra) ->
     %% Get test certificates
     case get_test_certs() of
         {ok, Cert, Key} ->
@@ -468,7 +482,7 @@ start_server(Port, RecvBuf, SndBuf, Mode) ->
                 max_stream_data_uni => FlowWindow,
                 connection_handler => Handler
             },
-            case quic:start_server(ServerName, Port, ServerOpts) of
+            case quic:start_server(ServerName, Port, maps:merge(ServerOpts, Extra)) of
                 {ok, Pid} ->
                     {ok, ActualPort} = quic:get_server_port(ServerName),
                     %% Get actual buffer sizes from a test socket
@@ -484,7 +498,9 @@ start_server(Port, RecvBuf, SndBuf, Mode) ->
 stop_server({ServerName, _Pid}) ->
     quic:stop_server(ServerName).
 
-run_client_benchmark(Port, DataSize, RecvBuf, SndBuf, Mode, ClientExtra) ->
+run_client_benchmark(Port, DataSize, RecvBuf, SndBuf, Mode, ClientExtra0) ->
+    Chunk = maps:get(chunk, ClientExtra0, ?CHUNK),
+    ClientExtra = maps:remove(chunk, ClientExtra0),
     %% Large flow control windows for benchmarking (16MB)
     FlowWindow = 16777216,
     ClientOpts = maps:merge(
@@ -520,42 +536,97 @@ run_client_benchmark(Port, DataSize, RecvBuf, SndBuf, Mode, ClientExtra) ->
             %% Open stream and measure transfer time
             {ok, StreamId} = quic:open_stream(Conn),
 
-            Start = erlang:monotonic_time(millisecond),
-            ok = quic:send_data(Conn, StreamId, Data, true),
+            SentCrc = erlang:crc32(Data),
+
+            Start = erlang:monotonic_time(microsecond),
+            ok = send_all(Conn, StreamId, Data, Chunk),
+            Handed = erlang:monotonic_time(microsecond),
 
             %% Wait for completion based on mode
-            case Mode of
-                echo ->
-                    %% Wait for echoed data
-                    wait_stream_close(Conn, StreamId, 30000);
-                sink ->
-                    %% Sink mode: wait for stream close (server closes after receiving FIN)
-                    wait_stream_close_sink(Conn, StreamId, 30000)
-            end,
+            Outcome =
+                case Mode of
+                    echo -> wait_stream_close(Conn, StreamId, 30000);
+                    sink -> wait_stream_close_sink(Conn, StreamId, 30000)
+                end,
 
-            End = erlang:monotonic_time(millisecond),
-            Duration = max(1, End - Start),
+            End = erlang:monotonic_time(microsecond),
+            Duration = End - Start,
 
-            MBps = (DataSize / 1048576) / (Duration / 1000),
+            %% Snapshot before closing: packet counts turn a throughput
+            %% figure into a per-packet cost, which is what any change to
+            %% the per-packet path has to be judged on.
+            Stats = connection_stats(Conn),
 
             quic:close(Conn),
 
-            io:format(
-                "Result: ~.2f MB/s (~p ms for ~.2f MB)~n",
-                [MBps, Duration, DataSize / 1048576]
-            ),
-
-            #{
-                status => ok,
-                data_size => DataSize,
-                duration_ms => Duration,
-                mb_per_sec => MBps,
-                client_buffers => ClientBufs
-            };
+            case check_delivery(Outcome, DataSize, SentCrc) of
+                ok ->
+                    MBps = (DataSize / 1048576) / (Duration / 1000000),
+                    io:format(
+                        "Result: ~.2f MB/s (~p us for ~.2f MB, verified; "
+                        "~p us to hand off, ~p us draining)~n",
+                        [MBps, Duration, DataSize / 1048576, Handed - Start, End - Handed]
+                    ),
+                    #{
+                        status => ok,
+                        data_size => DataSize,
+                        duration_us => Duration,
+                        duration_ms => Duration div 1000,
+                        handoff_us => Handed - Start,
+                        mb_per_sec => MBps,
+                        client_buffers => ClientBufs,
+                        client_stats => Stats
+                    };
+                {error, Why} ->
+                    io:format("Run FAILED after ~p us: ~p~n", [Duration, Why]),
+                    #{status => {error, Why}, data_size => DataSize, duration_us => Duration}
+            end;
         {error, Reason} ->
             io:format("Failed to connect: ~p~n", [Reason]),
             #{status => {error, Reason}}
     end.
+
+connection_stats(Conn) ->
+    Keys = [packets_sent, packets_received, retransmits, ack_sent, bytes_sent],
+    try quic:get_stats(Conn) of
+        {ok, S} -> maps:with(Keys, S);
+        _ -> #{}
+    catch
+        _:_ -> #{}
+    end.
+
+%% quic_connection caps a connection's send queue at
+%% ?MAX_SEND_QUEUE_BYTES (16 MB), so a single send_data/4 of a larger
+%% payload fails outright. Feed it the way a bulk sender would, and wait
+%% out backpressure rather than treating it as an error.
+send_all(Conn, StreamId, Data, Chunk) when byte_size(Data) =< Chunk ->
+    push(Conn, StreamId, Data, true);
+send_all(Conn, StreamId, Data, Chunk) ->
+    <<Head:Chunk/binary, Rest/binary>> = Data,
+    ok = push(Conn, StreamId, Head, false),
+    send_all(Conn, StreamId, Rest, Chunk).
+
+push(Conn, StreamId, Chunk, Fin) ->
+    case quic:send_data(Conn, StreamId, Chunk, Fin) of
+        ok ->
+            ok;
+        {error, send_queue_full} ->
+            erlang:yield(),
+            push(Conn, StreamId, Chunk, Fin);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% A run counts only when the peer confirms every byte. Anything else is
+%% a failure with a reason, never a rate.
+check_delivery({error, Reason}, _Size, _Crc) ->
+    {error, Reason};
+check_delivery({ok, {Size, Crc}}, Size, Crc) ->
+    ok;
+check_delivery({ok, {Bytes, _Crc}}, Size, _Sent) when Bytes =/= Size ->
+    {error, {short_delivery, #{expected => Size, delivered => Bytes}}};
+check_delivery({ok, {_Bytes, Crc}}, _Size, Sent) ->
+    {error, {crc_mismatch, #{expected => Sent, got => Crc}}}.
 
 get_test_certs() ->
     PrivDir = code:priv_dir(quic),
@@ -597,32 +668,44 @@ get_actual_buffers(RequestedRecv, RequestedSnd) ->
             #{recbuf => 0, sndbuf => 0}
     end.
 
-%% Wait for stream to close or receive final data (echo mode)
+%% Collect the echoed stream until FIN, returning size and CRC so the
+%% caller can check the round trip rather than assume it.
 wait_stream_close(Conn, StreamId, Timeout) ->
+    wait_stream_close(Conn, StreamId, Timeout, 0, 0).
+
+wait_stream_close(Conn, StreamId, Timeout, Bytes, Crc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, _Data, true}} ->
-            ok;
-        {quic, Conn, {stream_data, StreamId, _Data, false}} ->
-            wait_stream_close(Conn, StreamId, Timeout)
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            {ok, {Bytes + byte_size(Data), erlang:crc32(Crc, Data)}};
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            wait_stream_close(
+                Conn, StreamId, Timeout, Bytes + byte_size(Data), erlang:crc32(Crc, Data)
+            );
+        {quic, Conn, {closed, Reason}} ->
+            {error, {closed, Reason}}
     after Timeout ->
         {error, timeout}
     end.
 
-%% Wait for stream to close (sink mode - server closes stream after receiving FIN)
+%% Collect the sink server's receipt. A connection that closes before the
+%% receipt arrives is a failed run, not a fast one.
 wait_stream_close_sink(Conn, StreamId, Timeout) ->
+    wait_stream_close_sink(Conn, StreamId, Timeout, <<>>).
+
+wait_stream_close_sink(Conn, StreamId, Timeout, Acc) ->
     receive
-        {quic, Conn, {stream_data, StreamId, _Data, true}} ->
-            %% Server sent FIN (empty response)
-            ok;
-        {quic, Conn, {stream_data, StreamId, _Data, false}} ->
-            %% Should not happen in sink mode, but handle gracefully
-            wait_stream_close_sink(Conn, StreamId, Timeout);
-        {quic, Conn, {closed, _Reason}} ->
-            %% Connection closed
-            ok
+        {quic, Conn, {stream_data, StreamId, Data, true}} ->
+            parse_receipt(<<Acc/binary, Data/binary>>);
+        {quic, Conn, {stream_data, StreamId, Data, false}} ->
+            wait_stream_close_sink(Conn, StreamId, Timeout, <<Acc/binary, Data/binary>>);
+        {quic, Conn, {closed, Reason}} ->
+            {error, {closed, Reason}}
     after Timeout ->
         {error, timeout}
     end.
+
+parse_receipt(?RECEIPT(Bytes, Crc)) -> {ok, {Bytes, Crc}};
+parse_receipt(Other) -> {error, {bad_receipt, Other}}.
 
 %% Echo handler for benchmark server - echoes received data back
 echo_handler(Conn) ->
@@ -644,26 +727,27 @@ echo_handler(Conn) ->
 %% Sink handler for benchmark server - just counts bytes without echoing
 %% This measures raw transport throughput without owner-process message overhead
 sink_handler(Conn) ->
-    sink_handler(Conn, 0).
+    sink_handler(Conn, {0, 0}).
 
-sink_handler(Conn, BytesRecv) ->
+sink_handler(Conn, {BytesRecv, Crc} = Acc) ->
     receive
         {quic, Conn, {connected, _Info}} ->
-            sink_handler(Conn, BytesRecv);
+            sink_handler(Conn, Acc);
         {quic, Conn, {stream_opened, _StreamId}} ->
-            sink_handler(Conn, BytesRecv);
+            sink_handler(Conn, Acc);
         {quic, Conn, {stream_data, _StreamId, Data, false}} ->
-            %% Count bytes, continue receiving
-            sink_handler(Conn, BytesRecv + byte_size(Data));
+            sink_handler(Conn, {BytesRecv + byte_size(Data), erlang:crc32(Crc, Data)});
         {quic, Conn, {stream_data, StreamId, Data, true}} ->
-            %% Final data received, close the stream to signal completion
-            TotalBytes = BytesRecv + byte_size(Data),
-            %% Send empty data with FIN to signal we're done receiving
-            quic:send_data(Conn, StreamId, <<>>, true),
-            io:format("Sink received ~.2f MB~n", [TotalBytes / 1048576]),
-            sink_handler(Conn, 0);
+            %% Answer with what we actually received rather than an empty
+            %% FIN. The client checks it: a rate computed from bytes the
+            %% peer never got is the classic way a throughput harness
+            %% reports a number for a transfer that did not happen.
+            Total = BytesRecv + byte_size(Data),
+            Final = erlang:crc32(Crc, Data),
+            quic:send_data(Conn, StreamId, ?RECEIPT(Total, Final), true),
+            sink_handler(Conn, {0, 0});
         {quic, Conn, {closed, _Reason}} ->
             BytesRecv;
         _Other ->
-            sink_handler(Conn, BytesRecv)
+            sink_handler(Conn, Acc)
     end.


### PR DESCRIPTION
A stream written in more than one `send_data/4` call collapses. Same 10 MB on one stream, Linux, delivery verified:

| writes | before | after |
|---|---|---|
| 1 | 62.9 | 77.4 |
| 2 | **3.3** | 73.0 |
| 10 | 1.7 | 73.8 |
| 40 | 1.4 | 69.5 |

Zero retransmits and exactly the expected packet count throughout, so nothing was being lost or resent. It is also not pacing and not the burst budget: `pacing_enabled => false` and `max_burst_packets => 1024` each change nothing, which is what pointed at ordering rather than rate.

When the per-drain burst budget is spent mid-chunk, `send_stream_chunked_step/7` puts the unsent remainder back on the send queue. It appended it. Every other blocked branch threads the caller's position and the chunk context already carries it; this one clause dropped it and took the 5-arity default. The contract a few functions up says why that matters: `back` for a fresh send, whose offset is highest, and `front` for a remainder popped off the queue, "or a later flow-control block at the head strands it behind them, leaving a permanent data hole".

With one queued entry the two coincide, which is why a single write was never affected and why bulk benchmarks never showed it. With two, the drain round-robins between them and the stream goes out interleaved for the rest of the transfer, so the receiver leaves its in-order fast path and reassembles nearly the whole stream.

The fix threads the position rather than hardcoding `front`, since a fresh inline send still needs `back` or its remainder jumps ahead of lower-offset entries and opens a hole in the other direction.

The burst budget itself is untouched. Bounding a drain so ACK and loss feedback interleaves is right, and the retransmit improvement it was introduced for stands; only the requeue position was wrong. This is a regression from that commit (2026-08-19), released through #266, #267 and #269.

The new case asserts the mechanism, not a stopwatch: on a lossless loopback an in-order stream never buffers at the receiver, so it polls the server connection's reassembly buffer during a 16-write transfer and requires it to stay empty. It reads 0 bytes with the fix and 736871 without, so it fails for the right reason.

One thing left out on purpose. The receiver's reassembly is O(buffer) per packet, which is what turns reordering into a 45x collapse rather than a few percent, and real loss will re-expose it. PR #274 rewrites exactly those functions onto `gb_trees`, so it belongs there rather than in a conflicting change here.

Stacked on #280, which contributes the `chunk` option used to measure this. Retargets to main when that merges.