### PR TITLE
Opt-in delivery coalescing: one owner message per stream per receive pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,14 @@ All notable changes to this project will be documented in this file.
   GSO batches near size 1. The max_ack_delay timer still bounds ACK
   latency for below-tolerance remainders and the reordering
   immediate-ACK path is unchanged.
+- The out-of-order reassembly buffers (stream data and CRYPTO) are
+  ordered trees instead of maps. A miss at the delivery point, which
+  happens once per received packet while a hole is outstanding, is now
+  answered with one smallest-key lookup, and the trim walk for
+  repacketized overlaps visits only chunks below the delivery point.
+  The map version rebuilt the whole buffer on every miss; with a
+  multi-megabyte hole under loss recovery that walk dominated receiver
+  CPU.
 ### Changed
 - A server with no explicit `groups` option now offers every classical
   group the crypto layer supports (x25519, secp256r1, secp384r1) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,14 @@ All notable changes to this project will be documented in this file.
   bit, activity stamp) is one state update instead of three; the three
   separate helpers each rebuilt the full connection state and together
   cost about a tenth of receive CPU on bulk flows.
+- Receive-side fast paths for the dominant bulk shape: an in-order
+  stream frame on an existing stream with an empty reassembly buffer
+  and both flow-control windows comfortably open is one stream-record
+  update and one map put, falling back to the general path for every
+  other shape; a sequential packet number extends the head ACK range
+  without the range-cap scan; a packet led by a stream frame skips the
+  datagram-only delayed-ACK check. The per-frame `max_stream_data_check`
+  debug log is gone, it cost a logger allow-check per frame.
 ### Changed
 - A server with no explicit `groups` option now offers every classical
   group the crypto layer supports (x25519, secp256r1, secp384r1) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,17 @@ All notable changes to this project will be documented in this file.
   millisecond resolution, so the fixed bucket capped throughput at 12
   packets per wakeup whenever the sender outran the ACK clock,
   regardless of the configured rate. Contributed by jbevemyr (#219).
+- The connected-state receive pass drains the datagram messages already
+  queued in the connection's mailbox (up to 64) before flushing ACKs,
+  socket batches and timers, so those flushes amortize over a train
+  instead of running once per datagram. On the socket backend the
+  listener and the client receiver now emulate a bounded kernel receive
+  buffer: trains are forwarded in chunks of at most 8 packets and
+  tail-dropped once the connection's mailbox holds more than 32
+  messages, keeping the head packet so the peer still gets a timely
+  ACK. An unbounded mailbox turned receiver overload into queueing
+  delay instead of loss, which inflated the peer's RTT samples and
+  destabilized its loss detector.
 ### Changed
 - A server with no explicit `groups` option now offers every classical
   group the crypto layer supports (x25519, secp256r1, secp384r1) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,15 @@ All notable changes to this project will be documented in this file.
   ACK. An unbounded mailbox turned receiver overload into queueing
   delay instead of loss, which inflated the peer's RTT samples and
   destabilized its loss detector.
+- Count-based ACK decimation defers its flush while a receive pass is
+  active, so one ACK covers the whole drained train instead of one per
+  `ack_packet_tolerance` packets. A 64-packet pass previously emitted
+  about 32 ACKs, each costing a packet build, an AEAD seal and a send
+  on the receiver and a decrypt plus ACK-frame pass on the sender; it
+  also released the sender's window in 2-3 packet quanta, which kept
+  GSO batches near size 1. The max_ack_delay timer still bounds ACK
+  latency for below-tolerance remainders and the reordering
+  immediate-ACK path is unchanged.
 ### Changed
 - A server with no explicit `groups` option now offers every classical
   group the crypto layer supports (x25519, secp256r1, secp384r1) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `delivery_coalescing` (default `false`) merges consecutive
+  same-stream `stream_data` deliveries of one receive pass into a
+  single owner message, flushed at the end of the pass or as soon as
+  another stream delivers, so arrival order across streams is kept and
+  a `stream_reset` never overtakes data delivered before it. Owners
+  otherwise wake once per packet on bulk flows. QUIC gives no
+  message-boundary guarantee, but owners that decode each delivery as
+  one complete application message break when deliveries merge, so it
+  is opt-in.
 - `versions` lists the QUIC versions a connection will also accept, for
   RFC 9368 compatible version negotiation. Contributed by jbevemyr (#243).
 - `hibernate_after` (default 5000 ms) hibernates an idle connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,10 @@ All notable changes to this project will be documented in this file.
   The map version rebuilt the whole buffer on every miss; with a
   multi-megabyte hole under loss recovery that walk dominated receiver
   CPU.
+- The per-packet receive bookkeeping on the 1-RTT path (PN space, spin
+  bit, activity stamp) is one state update instead of three; the three
+  separate helpers each rebuilt the full connection state and together
+  cost about a tenth of receive CPU on bulk flows.
 ### Changed
 - A server with no explicit `groups` option now offers every classical
   group the crypto layer supports (x25519, secp256r1, secp384r1) instead

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -409,6 +409,23 @@
 -define(DEFAULT_MAX_BATCH_PACKETS, 64).
 %% Default GSO segment size (QUIC packet size for batching)
 -define(DEFAULT_GSO_SEGMENT_SIZE, 1200).
+
+%% Max messages allowed in a connection process mailbox before the
+%% socket-backend receive path tail-drops incoming datagrams, emulating
+%% a bounded kernel receive buffer. Without a bound a fast sender turns
+%% receiver overload into unbounded queueing delay instead of loss;
+%% inflated RTT samples and spurious loss detection then destabilize
+%% the peer's congestion controller. Early tail drop gives it a clean
+%% loss signal at a bounded queue depth, like gen_udp + kernel rcvbuf.
+-define(MAX_CONN_RECV_QUEUE_MSGS, 32).
+
+%% Max packets per {quic_packets, ...} message forwarded to a
+%% connection. GRO can aggregate trains of ~44 packets; forwarded
+%% whole, the mailbox bound above cannot cap queueing DELAY (a message
+%% may be 1 or 44 packets). Splitting trains keeps the worst-case
+%% queued backlog, and thus the RTT inflation seen by the peer's loss
+%% detector, small and predictable.
+-define(MAX_PACKETS_PER_CONN_MSG, 8).
 %% Kernel limits on a single UDP_SEGMENT write: UDP_MAX_SEGMENTS segments,
 %% and a payload that still fits a 16-bit UDP length. A run larger than
 %% either is split across writes.

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -591,8 +591,11 @@
     recv_offset :: non_neg_integer(),
     recv_max_data :: non_neg_integer(),
     recv_fin :: boolean(),
-    %% #{Offset => Data} for out-of-order reassembly
-    recv_buffer :: map(),
+    %% Offset => Data, ordered, for out-of-order reassembly. Ordering
+    %% keeps the per-packet gap check O(log n) and lets the trim walk
+    %% stop at the delivered point instead of visiting every buffered
+    %% chunk, which matters once loss recovery has megabytes buffered.
+    recv_buffer :: gb_trees:tree(non_neg_integer(), binary()),
     %% Our recv side is terminal: FIN read (buffer empty) or peer RESET_STREAM.
     recv_done = false :: boolean(),
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -190,6 +190,8 @@
     drain_recv_msgs/2,
     test_state_closing/2,
     test_state_with_socket/2,
+    test_state_in_recv_pass/1,
+    test_finish_recv_pass/1,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
     test_coalesce_small_stream/1,
     %% Regression helper for zero-byte FIN entries stranded in the send queue
@@ -771,6 +773,13 @@
     %% (GSO bursts especially) before any loss signal is seen.
     burst_budget = ?DEFAULT_MAX_BURST_PACKETS :: pos_integer(),
     burst_sent = 0 :: non_neg_integer(),
+    %% True while a connected-state receive pass (first datagram plus
+    %% drained mailbox train) is being processed. Count-based ACK
+    %% decimation defers its flush to the end of the pass, so one ACK
+    %% covers the whole train instead of one per ack_packet_tolerance
+    %% packets. The max_ack_delay timer still bounds latency; the
+    %% reordering immediate-ACK path bypasses this.
+    recv_pass = false :: boolean(),
     ack_elicited_count = 0 :: non_neg_integer(),
     %% How many ack-eliciting 1-RTT packets to accumulate before
     %% flushing an ACK. 2 is the RFC 9000 §13.2.1 recommendation;
@@ -2371,11 +2380,11 @@ connected({call, From}, {migrate, _Opts}, #state{remote_addr = RemoteAddr} = Sta
     end;
 connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) ->
     %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
-    State1 = State#state{current_packet_source = {IP, Port}},
+    State1 = State#state{current_packet_source = {IP, Port}, recv_pass = true},
     NewState = handle_packet(Data, State1),
     %% Drain any further datagrams already in the mailbox into this
     %% pass, then flush ACKs / batches / timers once for the lot.
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
@@ -2383,16 +2392,16 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
 %% message; processing it in one pass amortizes the per-event flushes
 %% over the train.
 connected(info, {udp_batch, Socket, IP, Port, Packets}, #state{socket = Socket} = State) ->
-    State1 = State#state{current_packet_source = {IP, Port}},
+    State1 = State#state{current_packet_source = {IP, Port}, recv_pass = true},
     NewState = handle_packets_batch(Packets, State1),
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
 %% Server receives packets from listener
 connected(info, {quic_packet, Data, RemoteAddr}, #state{role = server} = State) ->
-    NewState = server_recv_pass([Data], RemoteAddr, State),
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    NewState = server_recv_pass([Data], RemoteAddr, State#state{recv_pass = true}),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
@@ -2400,8 +2409,8 @@ connected(info, {quic_packet, Data, RemoteAddr}, #state{role = server} = State) 
     check_state_transition(connected, FinalState);
 %% Server receives batched packets from listener (GRO optimization)
 connected(info, {quic_packets, Packets, RemoteAddr}, #state{role = server} = State) ->
-    NewState = server_recv_pass(Packets, RemoteAddr, State),
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    NewState = server_recv_pass(Packets, RemoteAddr, State#state{recv_pass = true}),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
@@ -7634,6 +7643,10 @@ maybe_send_ack(_, _, State) ->
 %% When `?ACK_PACKET_TOLERANCE' ack-eliciting packets have been seen
 %% since the last emitted ACK, flush immediately. Otherwise increment
 %% the counter and arm a max_ack_delay timer (if not already armed).
+maybe_decimate_app_ack(#state{recv_pass = true} = State) ->
+    %% Inside a receive pass: only count; finish_recv_pass/1 flushes
+    %% one ACK for the whole train.
+    arm_ack_timer(State#state{ack_elicited_count = State#state.ack_elicited_count + 1});
 maybe_decimate_app_ack(State) ->
     NewCount = State#state.ack_elicited_count + 1,
     case NewCount >= State#state.ack_packet_tolerance of
@@ -7642,6 +7655,19 @@ maybe_decimate_app_ack(State) ->
         false ->
             arm_ack_timer(State#state{ack_elicited_count = NewCount})
     end.
+
+%% End of a connected-state receive pass: emit the deferred ACK (one
+%% per train) if enough ack-eliciting packets accumulated, then clear
+%% the pass flag. Below-tolerance remainders keep their ack_timer.
+finish_recv_pass(
+    #state{ack_elicited_count = Count, ack_packet_tolerance = Tol, close_reason = undefined} =
+        State
+) when
+    Count >= Tol
+->
+    send_app_ack(State#state{recv_pass = false});
+finish_recv_pass(State) ->
+    State#state{recv_pass = false}.
 
 %% Arm the max_ack_delay timer if not already armed.
 arm_ack_timer(#state{ack_timer = Ref} = State) when Ref =/= undefined ->
@@ -13079,6 +13105,27 @@ test_decimate_step(State) ->
     {NewState, #{
         ack_elicited_count => NewState#state.ack_elicited_count,
         ack_timer_armed => NewState#state.ack_timer =/= undefined
+    }}.
+
+%% Mark the state as inside a connected-state receive pass, as the
+%% datagram handlers do before processing a train.
+-spec test_state_in_recv_pass(#state{}) -> #state{}.
+test_state_in_recv_pass(State) ->
+    State#state{recv_pass = true}.
+
+%% Run finish_recv_pass/1 and return the observable decimation fields.
+-spec test_finish_recv_pass(#state{}) ->
+    {#state{}, #{
+        ack_elicited_count := non_neg_integer(),
+        ack_timer_armed := boolean(),
+        recv_pass := boolean()
+    }}.
+test_finish_recv_pass(State) ->
+    NewState = finish_recv_pass(State),
+    {NewState, #{
+        ack_elicited_count => NewState#state.ack_elicited_count,
+        ack_timer_armed => NewState#state.ack_timer =/= undefined,
+        recv_pass => NewState#state.recv_pass
     }}.
 
 %% Simulate the delayed-ack timer firing by routing through

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -167,6 +167,7 @@
     do_process_stream_data_buffered/5,
     do_process_stream_data_slow/5,
     test_recv_stream_state/4,
+    test_add_recv_stream/3,
     update_pn_space_recv/3,
     should_delay_ack/1,
     short_header_first_byte/3,
@@ -201,6 +202,8 @@
     test_state_closing/2,
     test_state_with_socket/2,
     test_state_in_recv_pass/1,
+    test_state_coalescing/2,
+    test_pending_delivery/1,
     test_finish_recv_pass/1,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
     test_coalesce_small_stream/1,
@@ -792,6 +795,19 @@
     %% packets. The max_ack_delay timer still bounds latency; the
     %% reordering immediate-ACK path bypasses this.
     recv_pass = false :: boolean(),
+    %% Opt-in (delivery_coalescing option): merge consecutive
+    %% same-stream stream_data deliveries of one receive pass into a
+    %% single owner message. QUIC gives no message-boundary guarantee,
+    %% but owners that decode each delivery as one complete
+    %% application message (rather than length-framing the byte
+    %% stream) break when deliveries merge, so the default keeps the
+    %% one-message-per-packet behaviour.
+    delivery_coalescing = false :: boolean(),
+    %% Pending run for the above: stream id, reversed chunk list, fin.
+    %% A delivery for a DIFFERENT stream flushes the pending one
+    %% first, so the owner observes stream_data messages in exact
+    %% arrival order; only adjacent chunks of one stream merge.
+    pend_deliver = none :: none | {non_neg_integer(), [binary()], boolean()},
     ack_elicited_count = 0 :: non_neg_integer(),
     %% How many ack-eliciting 1-RTT packets to accumulate before
     %% flushing an ACK. 2 is the RFC 9000 §13.2.1 recommendation;
@@ -1317,6 +1333,7 @@ init({server, Opts}) ->
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
         ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
         burst_budget = maps:get(max_burst_packets, Opts, ?DEFAULT_MAX_BURST_PACKETS),
+        delivery_coalescing = bool_opt(delivery_coalescing, Opts),
         % Server-initiated bidi: 1, 5, 9, ...
         next_stream_id_bidi = 1,
         % Server-initiated uni: 3, 7, 11, ...
@@ -1716,6 +1733,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
         ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
         burst_budget = maps:get(max_burst_packets, Opts, ?DEFAULT_MAX_BURST_PACKETS),
+        delivery_coalescing = bool_opt(delivery_coalescing, Opts),
         % Client-initiated bidi: 0, 4, 8, ...
         next_stream_id_bidi = 0,
         % Client-initiated uni: 2, 6, 10, ...
@@ -5426,8 +5444,11 @@ process_frame(
                 },
                 Streams
             ),
+            %% Data delivered earlier in this receive pass reaches the
+            %% owner before the reset notification.
+            StateFl = flush_pending_delivery(State),
             Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
-            maybe_reclaim_stream(StreamId, State#state{streams = NewStreams});
+            maybe_reclaim_stream(StreamId, StateFl#state{streams = NewStreams});
         error ->
             case is_reclaimed_frame(StreamId, State) of
                 true ->
@@ -5449,8 +5470,9 @@ process_frame(
                                 },
                                 Streams
                             ),
+                            StateFl = flush_pending_delivery(State),
                             Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
-                            State#state{streams = NewStreams}
+                            StateFl#state{streams = NewStreams}
                     end
             end
     end;
@@ -5507,8 +5529,9 @@ process_frame(
                         Streams
                     ),
                     %% Notify owner - same message as RESET_STREAM
+                    StateFl = flush_pending_delivery(State),
                     Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
-                    maybe_reclaim_stream(StreamId, State#state{streams = NewStreams});
+                    maybe_reclaim_stream(StreamId, StateFl#state{streams = NewStreams});
                 error ->
                     case is_reclaimed_frame(StreamId, State) of
                         true ->
@@ -5535,9 +5558,10 @@ process_frame(
                                         },
                                         Streams
                                     ),
+                                    StateFl = flush_pending_delivery(State),
                                     Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
                                     maybe_reclaim_stream(
-                                        StreamId, State#state{streams = NewStreams}
+                                        StreamId, StateFl#state{streams = NewStreams}
                                     )
                             end
                     end
@@ -7092,14 +7116,15 @@ do_process_stream_data_buffered(StreamId, Offset, Data, false = Fin, State) ->
                     State#state.recv_buffer_bytes + DataSize =< ?MAX_RECV_BUFFER_BYTES
             of
                 true ->
-                    State#state.owner ! {quic, self(), {stream_data, StreamId, Data, false}},
+                    PendDeliver = deliver_stream_data(StreamId, Data, false, State),
                     State#state{
                         streams = maps:put(
                             StreamId,
                             Stream#stream_state{recv_offset = EndOffset},
                             State#state.streams
                         ),
-                        data_received = NewDataReceived
+                        data_received = NewDataReceived,
+                        pend_deliver = PendDeliver
                     };
                 false ->
                     do_process_stream_data_slow(StreamId, Offset, Data, Fin, State)
@@ -7278,16 +7303,14 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
 
                     %% Deliver contiguous data to owner
                     %% RFC 9000: Also deliver FIN-only notification when no data but FIN received
-                    case {DeliverData, DeliverFin, Fin} of
-                        {<<>>, false, _} ->
-                            %% No contiguous data to deliver yet
-                            ok;
-                        {<<>>, true, _} ->
-                            %% FIN-only delivery (all data already delivered)
-                            Owner ! {quic, self(), {stream_data, StreamId, <<>>, true}};
-                        {_, _, _} ->
-                            Owner ! {quic, self(), {stream_data, StreamId, DeliverData, DeliverFin}}
-                    end,
+                    PendDeliver1 =
+                        case {DeliverData, DeliverFin} of
+                            {<<>>, false} ->
+                                %% No contiguous data to deliver yet
+                                State#state.pend_deliver;
+                            _ ->
+                                deliver_stream_data(StreamId, DeliverData, DeliverFin, State)
+                        end,
 
                     NewStream = Stream#stream_state{
                         recv_offset = NewRecvOffset,
@@ -7323,7 +7346,8 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
                     State1 = State#state{
                         streams = maps:put(StreamId, NewStream, Streams),
                         data_received = NewDataReceivedVal,
-                        recv_buffer_bytes = NewRecvBufferBytes
+                        recv_buffer_bytes = NewRecvBufferBytes,
+                        pend_deliver = PendDeliver1
                     },
                     %% The stream is reclaimed at the end of this clause (after the
                     %% MAX_STREAM_DATA / MAX_DATA updates, which re-put the stream),
@@ -7712,18 +7736,62 @@ maybe_decimate_app_ack(State) ->
             arm_ack_timer(State#state{ack_elicited_count = NewCount})
     end.
 
-%% End of a connected-state receive pass: emit the deferred ACK (one
-%% per train) if enough ack-eliciting packets accumulated, then clear
-%% the pass flag. Below-tolerance remainders keep their ack_timer.
-finish_recv_pass(
-    #state{ack_elicited_count = Count, ack_packet_tolerance = Tol, close_reason = undefined} =
-        State
-) when
-    Count >= Tol
-->
-    send_app_ack(State#state{recv_pass = false});
-finish_recv_pass(State) ->
-    State#state{recv_pass = false}.
+%% End of a connected-state receive pass: flush the accumulated stream
+%% delivery, emit the deferred ACK (one per train) if enough
+%% ack-eliciting packets accumulated, then clear the pass flag.
+%% Below-tolerance remainders keep their ack_timer. The delivery
+%% flushes even when the pass initiated a close: the data arrived
+%% before it.
+finish_recv_pass(State0) ->
+    State = flush_pending_delivery(State0),
+    case State of
+        #state{
+            ack_elicited_count = Count, ack_packet_tolerance = Tol, close_reason = undefined
+        } when
+            Count >= Tol
+        ->
+            send_app_ack(State#state{recv_pass = false});
+        _ ->
+            State#state{recv_pass = false}
+    end.
+
+%% A boolean option: true only when set to exactly `true'.
+bool_opt(Key, Opts) ->
+    case maps:get(Key, Opts, false) of
+        true -> true;
+        _ -> false
+    end.
+
+%% Hand stream data to the owner. With delivery coalescing on and a
+%% receive pass active, consecutive deliveries for the same stream
+%% merge into one pending message, flushed at the end of the pass or
+%% as soon as another stream delivers (exact arrival order is kept:
+%% only adjacent chunks of one stream merge). Otherwise one message
+%% per delivery, as before. Returns the new pend_deliver.
+deliver_stream_data(
+    StreamId, Data, Fin, #state{recv_pass = true, delivery_coalescing = true} = State
+) ->
+    case State#state.pend_deliver of
+        {StreamId, Acc, F} ->
+            {StreamId, [Data | Acc], F orelse Fin};
+        none ->
+            {StreamId, [Data], Fin};
+        {OtherId, Acc, F} ->
+            State#state.owner ! {quic, self(), {stream_data, OtherId, run_binary(Acc), F}},
+            {StreamId, [Data], Fin}
+    end;
+deliver_stream_data(StreamId, Data, Fin, State) ->
+    State#state.owner ! {quic, self(), {stream_data, StreamId, Data, Fin}},
+    State#state.pend_deliver.
+
+run_binary([Single]) -> Single;
+run_binary(RevChunks) -> iolist_to_binary(lists:reverse(RevChunks)).
+
+flush_pending_delivery(#state{pend_deliver = none} = State) ->
+    State;
+flush_pending_delivery(#state{pend_deliver = {StreamId, Acc, Fin}, owner = Owner} = State) ->
+    Owner ! {quic, self(), {stream_data, StreamId, run_binary(Acc), Fin}},
+    State#state{pend_deliver = none}.
 
 %% Arm the max_ack_delay timer if not already armed.
 arm_ack_timer(#state{ack_timer = Ref} = State) when Ref =/= undefined ->
@@ -12996,6 +13064,24 @@ test_recv_stream_state(StreamId, RecvOffset, StreamCredit, ConnCredit) ->
         recv_buffer_bytes = 0
     }.
 
+%% Add another peer-initiated stream at offset 0 to a test state.
+-spec test_add_recv_stream(#state{}, non_neg_integer(), non_neg_integer()) -> #state{}.
+test_add_recv_stream(#state{streams = Streams} = State, StreamId, StreamCredit) ->
+    Stream = #stream_state{
+        id = StreamId,
+        state = open,
+        send_offset = 0,
+        send_max_data = 0,
+        send_fin = false,
+        send_buffer = [],
+        recv_offset = 0,
+        recv_max_data = StreamCredit,
+        recv_fin = false,
+        recv_buffer = gb_trees:empty(),
+        final_size = undefined
+    },
+    State#state{streams = Streams#{StreamId => Stream}}.
+
 %% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
 %% tests that run record_app_recv/4 against its unfused parts.
 -spec test_app_recv_state(client | server, boolean()) -> #state{}.
@@ -13253,6 +13339,13 @@ test_decimate_step(State) ->
 -spec test_state_in_recv_pass(#state{}) -> #state{}.
 test_state_in_recv_pass(State) ->
     State#state{recv_pass = true}.
+
+-spec test_state_coalescing(#state{}, boolean()) -> #state{}.
+test_state_coalescing(State, On) ->
+    State#state{delivery_coalescing = On}.
+
+-spec test_pending_delivery(#state{}) -> none | {non_neg_integer(), [binary()], boolean()}.
+test_pending_delivery(#state{pend_deliver = P}) -> P.
 
 %% Run finish_recv_pass/1 and return the observable decimation fields.
 -spec test_finish_recv_pass(#state{}) ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -442,7 +442,9 @@
     negotiated_scheme :: atom() | undefined,
 
     %% CRYPTO frame buffer (per level: initial, handshake, app)
-    crypto_buffer = #{initial => #{}, handshake => #{}, app => #{}} :: map(),
+    crypto_buffer = #{
+        initial => gb_trees:empty(), handshake => gb_trees:empty(), app => gb_trees:empty()
+    } :: map(),
     crypto_offset = #{initial => 0, handshake => 0, app => 0} :: map(),
     %% Incomplete TLS message buffer (data that couldn't be parsed yet)
     tls_buffer = #{initial => <<>>, handshake => <<>>, app => <<>>} :: map(),
@@ -5739,16 +5741,16 @@ buffer_crypto_data(Level, Offset, Data, State) ->
         end,
 
     %% Get current buffer
-    Buffer = maps:get(LevelAtom, State#state.crypto_buffer, #{}),
+    Buffer = maps:get(LevelAtom, State#state.crypto_buffer, gb_trees:empty()),
 
     %% Bound out-of-order CRYPTO reassembly so a peer cannot grow memory
     %% before the handshake completes (RFC 9000 §7.5). Offsets beyond the
     %% cap can never become contiguous, so reject them too.
-    BufferedBytes = maps:fold(fun(_, V, Acc) -> Acc + byte_size(V) end, 0, Buffer),
+    BufferedBytes = reassembly_buffer_bytes(Buffer),
     Overflow =
         (Offset > ?MAX_CRYPTO_BUFFER_BYTES) orelse
             ((BufferedBytes + byte_size(Data)) > ?MAX_CRYPTO_BUFFER_BYTES) orelse
-            (maps:size(Buffer) >= ?MAX_CRYPTO_BUFFER_ENTRIES),
+            (gb_trees:size(Buffer) >= ?MAX_CRYPTO_BUFFER_ENTRIES),
     case Overflow of
         true ->
             ?LOG_WARNING(
@@ -5756,7 +5758,7 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                     what => crypto_buffer_exceeded,
                     level => LevelAtom,
                     buffered_bytes => BufferedBytes,
-                    entries => maps:size(Buffer)
+                    entries => gb_trees:size(Buffer)
                 },
                 ?QUIC_LOG_META
             ),
@@ -5795,17 +5797,17 @@ buffer_crypto_data(Level, Offset, Data, State) ->
 
 %% Process contiguous CRYPTO data
 process_crypto_buffer(Level, State) ->
-    Buffer = maps:get(Level, State#state.crypto_buffer, #{}),
+    Buffer = maps:get(Level, State#state.crypto_buffer, gb_trees:empty()),
     ExpectedOffset = maps:get(Level, State#state.crypto_offset, 0),
 
-    case maps:find(ExpectedOffset, Buffer) of
-        {ok, Data} ->
+    case gb_trees:lookup(ExpectedOffset, Buffer) of
+        {value, Data} ->
             %% Process this data
             State1 = process_tls_data(Level, Data, State),
 
             %% Update offset and remove from buffer
             NewOffset = ExpectedOffset + byte_size(Data),
-            NewBuffer = maps:remove(ExpectedOffset, Buffer),
+            NewBuffer = gb_trees:delete(ExpectedOffset, Buffer),
             NewCryptoBuffer = maps:put(Level, NewBuffer, State1#state.crypto_buffer),
             NewCryptoOffset = maps:put(Level, NewOffset, State1#state.crypto_offset),
 
@@ -5816,7 +5818,7 @@ process_crypto_buffer(Level, State) ->
 
             %% Try to process more
             process_crypto_buffer(Level, State2);
-        error ->
+        none ->
             %% Nothing keyed exactly at ExpectedOffset, which does not mean a
             %% gap: a peer may re-frame CRYPTO data it retransmits (RFC 9000
             %% §13.3), so the bytes we need can sit inside a chunk that starts
@@ -5828,7 +5830,7 @@ process_crypto_buffer(Level, State) ->
             State1 = State#state{
                 crypto_buffer = maps:put(Level, Trimmed, State#state.crypto_buffer)
             },
-            case maps:is_key(ExpectedOffset, Trimmed) of
+            case gb_trees:is_defined(ExpectedOffset, Trimmed) of
                 true -> process_crypto_buffer(Level, State1);
                 false -> State1
             end
@@ -7097,7 +7099,7 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                     recv_offset = 0,
                     recv_max_data = InitRecvMaxData,
                     recv_fin = false,
-                    recv_buffer = #{},
+                    recv_buffer = gb_trees:empty(),
                     final_size = undefined
                 }
         end,
@@ -7109,11 +7111,11 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
     %% Check if this would exceed our receive buffer limit (malicious peer protection)
     RecvBuffer =
         case Stream#stream_state.recv_buffer of
-            B when is_map(B) -> B;
-            _ -> #{}
+            undefined -> gb_trees:empty();
+            B -> B
         end,
     CurrentOffset = Stream#stream_state.recv_offset,
-    IsDuplicate = Offset < CurrentOffset orelse maps:is_key(Offset, RecvBuffer),
+    IsDuplicate = Offset < CurrentOffset orelse gb_trees:is_defined(Offset, RecvBuffer),
 
     %% Only check buffer limit for new (non-duplicate) data
     BufferOverflow =
@@ -7206,9 +7208,9 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                         end,
 
                     %% Fast path: in-order delivery with empty buffer
-                    %% Avoids maps:put and extract_contiguous_data for common case
+                    %% Avoids the buffer insert and extract_contiguous_data for common case
                     {DeliverData, NewRecvOffset, NewBuffer, DeliverFin} =
-                        case Offset =:= CurrentOffset andalso map_size(RecvBuffer) =:= 0 of
+                        case Offset =:= CurrentOffset andalso gb_trees:is_empty(RecvBuffer) of
                             true ->
                                 %% In-order with empty buffer: deliver directly
                                 {Data, EndOffset, RecvBuffer, Fin};
@@ -7241,7 +7243,7 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                         recv_buffer = NewBuffer,
                         final_size = FinalSize,
                         recv_done =
-                            (DeliverFin andalso map_size(NewBuffer) =:= 0) orelse
+                            (DeliverFin andalso gb_trees:is_empty(NewBuffer)) orelse
                                 recv_reset_at_met(Stream, NewRecvOffset) orelse
                                 Stream#stream_state.recv_done
                     },
@@ -7424,7 +7426,7 @@ extract_contiguous_data(Buffer, Offset) ->
     extract_contiguous_data(Buffer, Offset, <<>>).
 
 extract_contiguous_data(Buffer, Offset, Acc) ->
-    case maps:take(Offset, Buffer) of
+    case gb_trees:take_any(Offset, Buffer) of
         {Data, NewBuffer} ->
             %% Found data at this offset, continue looking for next chunk
             %% Binary append is O(1) amortized due to Erlang's pre-allocation
@@ -7435,44 +7437,58 @@ extract_contiguous_data(Buffer, Offset, Acc) ->
             %% a peer may split or coalesce retransmitted data differently
             %% (RFC 9000 §2.2, §13.3), so the bytes we want can sit inside
             %% a chunk that starts earlier. Drop what is already delivered,
-            %% re-key what straddles Offset, then retry once.
-            Trimmed = trim_reassembly_buffer(Buffer, Offset),
-            case maps:is_key(Offset, Trimmed) of
-                true -> extract_contiguous_data(Trimmed, Offset, Acc);
-                false -> {Acc, Offset, Trimmed}
+            %% re-key what straddles Offset, then retry once. When every
+            %% buffered chunk starts above Offset (the normal shape while
+            %% waiting on a hole, and this runs once per received packet
+            %% until the hole fills) the ordered tree answers that with one
+            %% smallest-key lookup and no walk.
+            case gb_trees:is_empty(Buffer) orelse element(1, gb_trees:smallest(Buffer)) > Offset of
+                true ->
+                    {Acc, Offset, Buffer};
+                false ->
+                    Trimmed = trim_reassembly_buffer(Buffer, Offset),
+                    case gb_trees:is_defined(Offset, Trimmed) of
+                        true -> extract_contiguous_data(Trimmed, Offset, Acc);
+                        false -> {Acc, Offset, Trimmed}
+                    end
             end
     end.
 
 %% Drop buffered chunks that end at or before Offset and trim those that
 %% straddle it, re-keying them to Offset. Keeps the longest chunk at each
 %% offset, so overlapping retransmissions collapse instead of accumulating.
+%% Only chunks keyed below Offset can qualify, so the ordered walk stops
+%% there; everything above is left untouched.
 trim_reassembly_buffer(Buffer, Offset) ->
-    maps:fold(
-        fun(Off, Data, Acc) ->
-            End = Off + byte_size(Data),
-            if
-                End =< Offset ->
-                    Acc;
-                Off >= Offset ->
-                    keep_longest_chunk(Off, Data, Acc);
-                true ->
-                    Kept = binary:part(Data, Offset - Off, End - Offset),
-                    keep_longest_chunk(Offset, Kept, Acc)
-            end
-        end,
-        #{},
-        Buffer
-    ).
+    trim_reassembly_buffer(gb_trees:iterator(Buffer), Buffer, Offset).
 
-keep_longest_chunk(Off, Data, Acc) ->
-    case Acc of
-        #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Acc;
-        _ -> Acc#{Off => Data}
+trim_reassembly_buffer(Iter0, Buffer, Offset) ->
+    case gb_trees:next(Iter0) of
+        {Off, Data, Iter} when Off < Offset ->
+            End = Off + byte_size(Data),
+            Buffer1 = gb_trees:delete(Off, Buffer),
+            Buffer2 =
+                case End > Offset of
+                    true ->
+                        Kept = binary:part(Data, Offset - Off, End - Offset),
+                        keep_longest_chunk(Offset, Kept, Buffer1);
+                    false ->
+                        Buffer1
+                end,
+            trim_reassembly_buffer(Iter, Buffer2, Offset);
+        _ ->
+            Buffer
+    end.
+
+keep_longest_chunk(Off, Data, Buffer) ->
+    case gb_trees:lookup(Off, Buffer) of
+        {value, Existing} when byte_size(Existing) >= byte_size(Data) -> Buffer;
+        _ -> gb_trees:enter(Off, Data, Buffer)
     end.
 
 %% Total bytes held in a reassembly buffer.
 reassembly_buffer_bytes(Buffer) ->
-    maps:fold(fun(_, Data, Acc) -> Acc + byte_size(Data) end, 0, Buffer).
+    lists:foldl(fun(Data, Acc) -> Acc + byte_size(Data) end, 0, gb_trees:values(Buffer)).
 
 %% Get the maximum stream receive window across all streams.
 %% Used to ensure connection window >= 1.5x largest stream window.
@@ -8353,7 +8369,7 @@ do_open_stream(
                 recv_offset = 0,
                 recv_max_data = RecvMaxData,
                 recv_fin = false,
-                recv_buffer = #{},
+                recv_buffer = gb_trees:empty(),
                 final_size = undefined
             },
             NewState = State#state{
@@ -8404,7 +8420,7 @@ do_open_unidirectional_stream(
                 recv_max_data = 0,
                 % No incoming data expected
                 recv_fin = true,
-                recv_buffer = #{},
+                recv_buffer = gb_trees:empty(),
                 final_size = undefined
             },
             NewState = State#state{

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -163,6 +163,12 @@
     record_received_pn/4,
     update_last_activity/2,
     test_app_recv_state/2,
+    %% Stream-data receive paths (lean vs general)
+    do_process_stream_data_buffered/5,
+    do_process_stream_data_slow/5,
+    test_recv_stream_state/4,
+    update_pn_space_recv/3,
+    should_delay_ack/1,
     short_header_first_byte/3,
     test_spin_state/1,
     test_spin_state_for/2,
@@ -7057,7 +7063,54 @@ clamp_recv_reset_at(StreamId, Offset, Data, Fin, State) ->
 recv_reset_at_met(#stream_state{recv_reset_at = R}, Off) ->
     R =/= undefined andalso Off >= R.
 
+%% Lean path for the dominant bulk shape: existing stream, exactly
+%% in-order, empty reassembly buffer, no FIN in sight, no pending reset,
+%% both flow-control windows comfortably open (so neither
+%% MAX_STREAM_DATA nor MAX_DATA fires). One stream-record update and one
+%% map put. Every other shape takes the general path below with
+%% identical semantics; on bulk flows 97+ percent of frames land here.
+do_process_stream_data_buffered(StreamId, Offset, Data, false = Fin, State) ->
+    case State#state.streams of
+        #{
+            StreamId := #stream_state{
+                recv_offset = Offset,
+                recv_max_data = RecvMaxData,
+                final_size = undefined,
+                recv_reset_at = undefined,
+                recv_buffer = RB
+            } = Stream
+        } ->
+            DataSize = byte_size(Data),
+            EndOffset = Offset + DataSize,
+            NewDataReceived = State#state.data_received + DataSize,
+            HalfWindow = State#state.fc_max_receive_window div 2,
+            case
+                DataSize > 0 andalso
+                    gb_trees:is_empty(RB) andalso
+                    RecvMaxData - EndOffset >= HalfWindow andalso
+                    State#state.max_data_local - NewDataReceived >= HalfWindow andalso
+                    State#state.recv_buffer_bytes + DataSize =< ?MAX_RECV_BUFFER_BYTES
+            of
+                true ->
+                    State#state.owner ! {quic, self(), {stream_data, StreamId, Data, false}},
+                    State#state{
+                        streams = maps:put(
+                            StreamId,
+                            Stream#stream_state{recv_offset = EndOffset},
+                            State#state.streams
+                        ),
+                        data_received = NewDataReceived
+                    };
+                false ->
+                    do_process_stream_data_slow(StreamId, Offset, Data, Fin, State)
+            end;
+        _ ->
+            do_process_stream_data_slow(StreamId, Offset, Data, Fin, State)
+    end;
 do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
+    do_process_stream_data_slow(StreamId, Offset, Data, Fin, State).
+
+do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
     #state{
         owner = Owner,
         streams = Streams,
@@ -7291,18 +7344,6 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                     WillSendMaxStreamData =
                         Headroom < (MaxWindowForStream div 2) andalso
                             NewStream#stream_state.final_size =:= undefined,
-                    Threshold = RecvMaxData - (MaxWindowForStream div 2),
-                    ?LOG_DEBUG(
-                        #{
-                            what => max_stream_data_check,
-                            stream_id => StreamId,
-                            recv_offset => NewRecvOffset,
-                            recv_max_data => RecvMaxData,
-                            threshold => Threshold,
-                            will_send => WillSendMaxStreamData
-                        },
-                        ?QUIC_LOG_META
-                    ),
                     State2 =
                         case WillSendMaxStreamData of
                             true ->
@@ -7695,6 +7736,10 @@ arm_ack_timer(#state{ack_timer = undefined} = State) ->
 
 %% Per RFC 9221 Section 5.2: Delay ACKs for packets containing only
 %% non-retransmittable ack-eliciting frames (like DATAGRAM).
+should_delay_ack([{stream, _, _, _, _} | _]) ->
+    %% Hot path: a stream frame is ack-eliciting and retransmittable,
+    %% so the packet never qualifies for the datagram-only delay.
+    false;
 should_delay_ack(Frames) ->
     AckEliciting = [F || F <- Frames, is_ack_eliciting_frame(F)],
     Retransmittable = quic_loss:retransmittable_frames(AckEliciting),
@@ -8109,8 +8154,14 @@ update_pn_space_recv(PN, PNSpace, Now) ->
             L when PN > L -> PN;
             L -> L
         end,
-    %% Add to ack_ranges maintaining descending order and merging adjacent ranges
-    NewRanges = cap_ack_ranges(add_to_ack_ranges(PN, Ranges)),
+    %% Add to ack_ranges maintaining descending order and merging adjacent
+    %% ranges. A sequential PN extends the head range in place, so the
+    %% range count cannot grow and the cap scan is skipped.
+    NewRanges =
+        case LargestRecv =/= undefined andalso PN =:= LargestRecv + 1 of
+            true -> add_to_ack_ranges(PN, Ranges);
+            false -> cap_ack_ranges(add_to_ack_ranges(PN, Ranges))
+        end,
     PNSpace#pn_space{
         largest_recv = NewLargest,
         recv_time = Now,
@@ -12913,6 +12964,37 @@ test_spin_state(#state{
 -spec test_spin_state_for(client | server, boolean()) -> #state{}.
 test_spin_state_for(Role, Enabled) ->
     #state{role = Role, spin_bit_enabled = Enabled}.
+
+%% #state{} holding one peer-initiated stream at RecvOffset with the
+%% given stream and connection receive credit, the caller as owner.
+%% For the tests that run the lean stream-data path against the
+%% general one.
+-spec test_recv_stream_state(
+    non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()
+) -> #state{}.
+test_recv_stream_state(StreamId, RecvOffset, StreamCredit, ConnCredit) ->
+    Stream = #stream_state{
+        id = StreamId,
+        state = open,
+        send_offset = 0,
+        send_max_data = 0,
+        send_fin = false,
+        send_buffer = [],
+        recv_offset = RecvOffset,
+        recv_max_data = RecvOffset + StreamCredit,
+        recv_fin = false,
+        recv_buffer = gb_trees:empty(),
+        final_size = undefined
+    },
+    #state{
+        role = server,
+        owner = self(),
+        streams = #{StreamId => Stream},
+        data_received = RecvOffset,
+        max_data_local = RecvOffset + ConnCredit,
+        fc_max_receive_window = ?DEFAULT_MAX_RECEIVE_WINDOW,
+        recv_buffer_bytes = 0
+    }.
 
 %% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
 %% tests that run record_app_recv/4 against its unfused parts.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -159,6 +159,10 @@
     test_complete_migration/3,
     %% Spin bit (RFC 9000 §17.4)
     update_spin_from_recv/3,
+    record_app_recv/4,
+    record_received_pn/4,
+    update_last_activity/2,
+    test_app_recv_state/2,
     short_header_first_byte/3,
     test_spin_state/1,
     test_spin_state_for/2,
@@ -4912,12 +4916,7 @@ decrypt_app_packet(Header, EncryptedPayload, CurrentKeys, State) ->
                     %% recv_time and last_activity to save one BIF
                     %% call per received packet on the hot path.
                     Now = erlang:monotonic_time(millisecond),
-                    State2 = update_spin_from_recv(
-                        UnprotectedFirstByte,
-                        PN,
-                        record_received_pn(app, PN, State1, Now)
-                    ),
-                    State3 = update_last_activity(State2, Now),
+                    State3 = record_app_recv(UnprotectedFirstByte, PN, State1, Now),
                     %% Use streaming decode for efficiency
                     case decode_and_process_streaming(app, Plaintext, State3) of
                         {ok, NewState, Frames} ->
@@ -8890,10 +8889,46 @@ short_header_first_byte(KeyPhase, PNLen, #state{
 short_header_first_byte(KeyPhase, PNLen, #state{spin_bit_enabled = false}) ->
     16#40 bor (KeyPhase bsl 2) bor (PNLen - 1).
 
+%% Per-packet receive bookkeeping for the 1-RTT hot path: PN-space
+%% update, spin-bit tracking and the activity stamp in one #state{}
+%% rebuild. As three separate helpers (record_received_pn +
+%% update_spin_from_recv + update_last_activity) each rebuilt the full
+%% state record, together ~10% of receive CPU on bulk flows. Same
+%% logic as those helpers; the spin part mirrors update_spin_from_recv.
+record_app_recv(FirstByte, PN, #state{pn_app = PNSpace} = State, Now) ->
+    Trigger = classify_recv_trigger(PN, PNSpace),
+    NewPNSpace = update_pn_space_recv(PN, PNSpace, Now),
+    {SpinRecv, SpinLargest, SpinOut} =
+        case PN > State#state.spin_recv_largest_pn of
+            true ->
+                R = (FirstByte bsr 5) band 1,
+                Out =
+                    case State#state.spin_bit_enabled of
+                        false -> State#state.spin_outgoing;
+                        true when State#state.role =:= client -> R;
+                        true -> 1 - R
+                    end,
+                {R, PN, Out};
+            false ->
+                {State#state.spin_recv, State#state.spin_recv_largest_pn, State#state.spin_outgoing}
+        end,
+    State#state{
+        pn_app = NewPNSpace,
+        last_recv_trigger = Trigger,
+        spin_recv = SpinRecv,
+        spin_recv_largest_pn = SpinLargest,
+        spin_outgoing = SpinOut,
+        last_activity = Now,
+        ack_eliciting_since_recv = false
+    }.
+
 %% Update the spin-bit tracking state from a received 1-RTT packet.
 %% RFC 9000 §17.4 only updates on packets whose PN is greater than any
 %% previously received on this path so that reorderings don't flip the
 %% edge. Client mirrors the received bit; server inverts it.
+%% Kept for the spin-bit unit tests and as the reference the fused
+%% record_app_recv/4 is checked against.
+-ifdef(TEST).
 update_spin_from_recv(
     FirstByte, PN, #state{spin_recv_largest_pn = Largest, role = Role} = State
 ) when PN > Largest ->
@@ -8911,6 +8946,7 @@ update_spin_from_recv(
     };
 update_spin_from_recv(_FirstByte, _PN, State) ->
     State.
+-endif.
 
 %% Short-header packet overhead for a DATAGRAM frame on the 1-RTT level:
 %%   1 byte flags
@@ -12877,6 +12913,13 @@ test_spin_state(#state{
 -spec test_spin_state_for(client | server, boolean()) -> #state{}.
 test_spin_state_for(Role, Enabled) ->
     #state{role = Role, spin_bit_enabled = Enabled}.
+
+%% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
+%% tests that run record_app_recv/4 against its unfused parts.
+-spec test_app_recv_state(client | server, boolean()) -> #state{}.
+test_app_recv_state(Role, SpinEnabled) ->
+    S = test_decimate_initial_state(),
+    S#state{role = Role, spin_bit_enabled = SpinEnabled}.
 
 %% Minimal #state{} for stateless-reset tests.
 -spec test_state_with_secret(binary() | undefined) -> #state{}.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -186,6 +186,10 @@
     decode_and_process_streaming/3,
     maybe_validate_initial_token/2,
     test_state_for_server/3,
+    %% Mailbox drain of the connected-state receive pass
+    drain_recv_msgs/2,
+    test_state_closing/2,
+    test_state_with_socket/2,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
     test_coalesce_small_stream/1,
     %% Regression helper for zero-byte FIN entries stranded in the send queue
@@ -260,6 +264,10 @@
 %% from parking the flight past the idle timeout.
 -define(HS_FLIGHT_MIN_INTERVAL, 100).
 -define(HS_FLIGHT_MAX_INTERVAL, 3000).
+
+%% Max additional datagram messages drained from the mailbox in one
+%% connected-state receive pass (see drain_recv_msgs/2).
+-define(RECV_DRAIN_MAX, 64).
 
 %% Max ACK ranges retained per PN space (RFC 9000 §13.2.4 allows the
 %% receiver to limit these). Under burst loss an unbounded list
@@ -2365,8 +2373,10 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
     %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
     State1 = State#state{current_packet_source = {IP, Port}},
     NewState = handle_packet(Data, State1),
-    %% Clear packet source and flush
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    %% Drain any further datagrams already in the mailbox into this
+    %% pass, then flush ACKs / batches / timers once for the lot.
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
 %% Client receives a whole GRO train from the receiver process as one
@@ -2375,46 +2385,24 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
 connected(info, {udp_batch, Socket, IP, Port, Packets}, #state{socket = Socket} = State) ->
     State1 = State#state{current_packet_source = {IP, Port}},
     NewState = handle_packets_batch(Packets, State1),
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
 %% Server receives packets from listener
 connected(info, {quic_packet, Data, RemoteAddr}, #state{role = server} = State) ->
-    %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
-    %% Clear has_non_probing_frame before processing - will be set by process_frame_track_probing
-    State1 = State#state{current_packet_source = RemoteAddr, has_non_probing_frame = false},
-    %% Process packet FIRST to classify frames
-    NewState = handle_packet(Data, State1),
-    %% RFC 9000 Section 9.1: Only trigger migration if packet contains non-probing frames
-    NewState2 =
-        case NewState#state.has_non_probing_frame of
-            true -> maybe_handle_address_change(RemoteAddr, byte_size(Data), NewState);
-            false -> NewState
-        end,
-    %% Clear transient fields and flush
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState2)),
+    NewState = server_recv_pass([Data], RemoteAddr, State),
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
     },
     check_state_transition(connected, FinalState);
 %% Server receives batched packets from listener (GRO optimization)
 connected(info, {quic_packets, Packets, RemoteAddr}, #state{role = server} = State) ->
-    %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
-    %% Clear has_non_probing_frame before processing - will be set by process_frame_track_probing
-    State1 = State#state{current_packet_source = RemoteAddr, has_non_probing_frame = false},
-    %% Process packets FIRST to classify frames
-    NewState = handle_packets_batch(Packets, State1),
-    %% RFC 9000 Section 9.1: Only trigger migration if any packet contains non-probing frames
-    NewState2 =
-        case NewState#state.has_non_probing_frame of
-            true ->
-                TotalSize = lists:sum([byte_size(P) || P <- Packets]),
-                maybe_handle_address_change(RemoteAddr, TotalSize, NewState);
-            false ->
-                NewState
-        end,
-    %% Clear transient fields and flush
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState2)),
+    NewState = server_recv_pass(Packets, RemoteAddr, State),
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
     },
@@ -4287,6 +4275,52 @@ do_handle_packets_batch([], State) ->
 do_handle_packets_batch([Packet | Rest], State) ->
     NewState = handle_packet_loop(Packet, State),
     do_handle_packets_batch(Rest, NewState).
+
+%% One server receive pass: process the packets of a listener message
+%% (source tracking, frame classification, RFC 9000 §9.1 migration
+%% check) without the per-message flushes - the caller flushes once
+%% per drain.
+server_recv_pass(Packets, RemoteAddr, State) ->
+    State1 = State#state{current_packet_source = RemoteAddr, has_non_probing_frame = false},
+    NewState = handle_packets_batch(Packets, State1),
+    case NewState#state.has_non_probing_frame of
+        true ->
+            TotalSize = lists:sum([byte_size(P) || P <- Packets]),
+            maybe_handle_address_change(RemoteAddr, TotalSize, NewState);
+        false ->
+            NewState
+    end.
+
+%% Drain datagram messages already queued in the mailbox into the
+%% current receive pass, so ACK emission, socket-batch flushing and
+%% timer resets amortize over the whole train instead of running per
+%% datagram. Stops as soon as a close is initiated (the remaining
+%% messages are handled as ordinary events by the next state) or the
+%% cap is hit (bounds time away from the event loop).
+drain_recv_msgs(#state{close_reason = CR} = State, _N) when CR =/= undefined ->
+    State;
+drain_recv_msgs(State, 0) ->
+    State;
+drain_recv_msgs(#state{role = client, socket = Socket} = State, N) ->
+    receive
+        {udp, Socket, IP, Port, Data} ->
+            State1 = State#state{current_packet_source = {IP, Port}},
+            drain_recv_msgs(handle_packet(Data, State1), N - 1);
+        {udp_batch, Socket, IP, Port, Packets} ->
+            State1 = State#state{current_packet_source = {IP, Port}},
+            drain_recv_msgs(handle_packets_batch(Packets, State1), N - 1)
+    after 0 ->
+        State
+    end;
+drain_recv_msgs(#state{role = server} = State, N) ->
+    receive
+        {quic_packet, Data, RemoteAddr} ->
+            drain_recv_msgs(server_recv_pass([Data], RemoteAddr, State), N - 1);
+        {quic_packets, Packets, RemoteAddr} ->
+            drain_recv_msgs(server_recv_pass(Packets, RemoteAddr, State), N - 1)
+    after 0 ->
+        State
+    end.
 
 handle_packet_loop(<<>>, #state{role = client, active_n = N} = State) ->
     %% No more data to process - re-enable socket for client connections
@@ -12859,6 +12893,12 @@ test_state_for_server(RemoteAddr, Secret, ODCID) ->
 
 -spec test_close_reason(#state{}) -> term().
 test_close_reason(#state{close_reason = R}) -> R.
+
+-spec test_state_closing(#state{}, term()) -> #state{}.
+test_state_closing(State, Reason) -> State#state{close_reason = Reason}.
+
+-spec test_state_with_socket(#state{}, gen_udp:socket()) -> #state{}.
+test_state_with_socket(State, Socket) -> State#state{socket = Socket}.
 
 %% Minimal #state{} carrying a caller-supplied loss tracker, for tests
 %% that need to observe what an incoming frame does to it.

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -111,8 +111,15 @@
 ]).
 
 -ifdef(TEST).
--export([send_packet/6, compute_stateless_reset_token/2, build_stateless_reset/2]).
+-export([
+    send_packet/6,
+    compute_stateless_reset_token/2,
+    build_stateless_reset/2,
+    send_packets_to_connection/3
+]).
 -endif.
+
+-export([recv_drops/0]).
 
 -include("quic.hrl").
 -include_lib("kernel/include/logger.hrl").
@@ -600,13 +607,60 @@ group_packets_by_conn([Packet | Rest], DCIDLen, Conns, Acc) ->
             group_packets_by_conn(Rest, DCIDLen, Conns, Acc)
     end.
 
-%% Send batched packets to a connection
-send_packets_to_connection(ConnPid, [Packet], RemoteAddr) ->
-    %% Single packet - use existing message format
-    ConnPid ! {quic_packet, Packet, RemoteAddr};
+%% Send batched packets to a connection. Tail-drops when the
+%% connection's mailbox is over ?MAX_CONN_RECV_QUEUE_MSGS - see the
+%% define for rationale.
 send_packets_to_connection(ConnPid, Packets, RemoteAddr) ->
-    %% Multiple packets - use batched message
-    ConnPid ! {quic_packets, Packets, RemoteAddr}.
+    case erlang:process_info(ConnPid, message_queue_len) of
+        {message_queue_len, QLen} when QLen > ?MAX_CONN_RECV_QUEUE_MSGS ->
+            %% Over the bound: keep one packet of the train so the peer
+            %% still gets a timely (dup-)ACK carrying the loss signal,
+            %% drop the rest - per-packet-ish drops beat losing whole
+            %% GRO trains, which fragments ACK ranges and provokes
+            %% retransmit storms.
+            count_recv_drop(length(Packets) - 1),
+            ConnPid ! {quic_packet, hd(Packets), RemoteAddr},
+            ok;
+        _ ->
+            forward_packet_chunks(ConnPid, Packets, RemoteAddr)
+    end.
+
+%% Forward a train in =< ?MAX_PACKETS_PER_CONN_MSG chunks so the
+%% mailbox bound above translates to a bounded packet backlog.
+forward_packet_chunks(ConnPid, [Packet], RemoteAddr) ->
+    ConnPid ! {quic_packet, Packet, RemoteAddr},
+    ok;
+forward_packet_chunks(ConnPid, Packets, RemoteAddr) ->
+    case length(Packets) =< ?MAX_PACKETS_PER_CONN_MSG of
+        true ->
+            ConnPid ! {quic_packets, Packets, RemoteAddr},
+            ok;
+        false ->
+            {Chunk, Rest} = lists:split(?MAX_PACKETS_PER_CONN_MSG, Packets),
+            ConnPid ! {quic_packets, Chunk, RemoteAddr},
+            forward_packet_chunks(ConnPid, Rest, RemoteAddr)
+    end.
+
+%% Bench diagnostic: global tail-drop counter, readable via
+%% quic_listener:recv_drops/0.
+count_recv_drop(N) ->
+    Ref =
+        case persistent_term:get({?MODULE, recv_drops}, undefined) of
+            undefined ->
+                R = atomics:new(1, []),
+                persistent_term:put({?MODULE, recv_drops}, R),
+                R;
+            R ->
+                R
+        end,
+    atomics:add(Ref, 1, N).
+
+-spec recv_drops() -> non_neg_integer().
+recv_drops() ->
+    case persistent_term:get({?MODULE, recv_drops}, undefined) of
+        undefined -> 0;
+        Ref -> atomics:get(Ref, 1)
+    end.
 
 %% @doc false
 terminate(_Reason, #listener_state{

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -59,7 +59,8 @@
     info/1,
     start_client_receiver/2,
     stop_client_receiver/1,
-    set_socket/2
+    set_socket/2,
+    client_recv_drops/0
 ]).
 
 -include("quic.hrl").
@@ -135,7 +136,8 @@
 -export([
     extract_gro_segment_size/1,
     split_gro_packets/2,
-    split_uniform_runs/1
+    split_uniform_runs/1,
+    forward_to_owner/5
 ]).
 -endif.
 
@@ -688,11 +690,8 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
     %% trains, not packets, and the whole train is processed in one
     %% receive pass.
     case recv_gro(Socket, 100) of
-        {ok, {IP, Port}, [Single]} ->
-            Owner ! {udp, Socket, IP, Port, Single},
-            client_recv_loop(SocketState, Owner);
         {ok, {IP, Port}, Packets} ->
-            Owner ! {udp_batch, Socket, IP, Port, Packets},
+            forward_to_owner(Owner, Socket, IP, Port, Packets),
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -701,6 +700,40 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
         {error, Reason} ->
             ?LOG_WARNING(#{what => client_recv_loop_exit, reason => Reason}),
             ok
+    end.
+
+%% Bench diagnostic: client-receiver tail-drop counter.
+%% Tail-drop over ?MAX_CONN_RECV_QUEUE_MSGS, emulating a bounded
+%% kernel rcvbuf (see the define for rationale).
+forward_to_owner(Owner, Socket, IP, Port, Packets) ->
+    case erlang:process_info(Owner, message_queue_len) of
+        {message_queue_len, QLen} when QLen > ?MAX_CONN_RECV_QUEUE_MSGS ->
+            count_client_recv_drop(length(Packets));
+        _ ->
+            case Packets of
+                [Single] -> Owner ! {udp, Socket, IP, Port, Single};
+                _ -> Owner ! {udp_batch, Socket, IP, Port, Packets}
+            end,
+            ok
+    end.
+
+count_client_recv_drop(N) ->
+    Ref =
+        case persistent_term:get({?MODULE, recv_drops}, undefined) of
+            undefined ->
+                R = atomics:new(1, []),
+                persistent_term:put({?MODULE, recv_drops}, R),
+                R;
+            R ->
+                R
+        end,
+    atomics:add(Ref, 1, N).
+
+-spec client_recv_drops() -> non_neg_integer().
+client_recv_drops() ->
+    case persistent_term:get({?MODULE, recv_drops}, undefined) of
+        undefined -> 0;
+        Ref -> atomics:get(Ref, 1)
     end.
 
 %% @doc Detect platform capabilities for GSO/GRO. Context-free wrapper that

--- a/test/quic_delivery_coalescing_tests.erl
+++ b/test/quic_delivery_coalescing_tests.erl
@@ -1,0 +1,120 @@
+%% With delivery_coalescing on, consecutive same-stream deliveries of
+%% one receive pass reach the owner as one message; everything else
+%% about delivery (order across streams, FIN, the default) is unchanged.
+-module(quic_delivery_coalescing_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(WIN, ?DEFAULT_MAX_RECEIVE_WINDOW).
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+messages() ->
+    {messages, Msgs} = process_info(self(), messages),
+    Msgs.
+
+%% Streams 4 and 8 at offset 0, wide windows, inside a receive pass.
+state(Coalescing) ->
+    flush(),
+    S0 = quic_connection:test_recv_stream_state(4, 0, ?WIN, 2 * ?WIN),
+    S1 = quic_connection:test_add_recv_stream(S0, 8, ?WIN),
+    quic_connection:test_state_coalescing(quic_connection:test_state_in_recv_pass(S1), Coalescing).
+
+deliver(S, StreamId, Offset, Data, Fin) ->
+    quic_connection:do_process_stream_data_buffered(StreamId, Offset, Data, Fin, S).
+
+finish(S) ->
+    {S1, _} = quic_connection:test_finish_recv_pass(S),
+    S1.
+
+data(StreamId, Msgs) ->
+    [{D, F} || {quic, _, {stream_data, Id, D, F}} <- Msgs, Id =:= StreamId].
+
+adjacent_chunks_merge_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = deliver(S1, 4, 3, <<"bbb">>, false),
+    S3 = deliver(S2, 4, 6, <<"ccc">>, false),
+    ?assertEqual([], messages()),
+    ?assertMatch(
+        {4, [<<"ccc">>, <<"bbb">>, <<"aaa">>], false}, quic_connection:test_pending_delivery(S3)
+    ),
+    S4 = finish(S3),
+    ?assertEqual([{<<"aaabbbccc">>, false}], data(4, messages())),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S4)).
+
+fin_merges_into_the_run_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = deliver(S1, 4, 3, <<"bbb">>, true),
+    _ = finish(S2),
+    ?assertEqual([{<<"aaabbb">>, true}], data(4, messages())).
+
+%% Only adjacent chunks of one stream merge: another stream's delivery
+%% flushes the pending run first, so arrival order is preserved.
+another_stream_flushes_first_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"a1">>, false),
+    S2 = deliver(S1, 8, 0, <<"b1">>, false),
+    S3 = deliver(S2, 4, 2, <<"a2">>, false),
+    _ = finish(S3),
+    Msgs = [M || {quic, _, M} <- messages(), element(1, M) =:= stream_data],
+    ?assertEqual(
+        [
+            {stream_data, 4, <<"a1">>, false},
+            {stream_data, 8, <<"b1">>, false},
+            {stream_data, 4, <<"a2">>, false}
+        ],
+        Msgs
+    ).
+
+%% Flushing a run that grew through the general path (a gap filled
+%% mid-pass) still yields the bytes in order.
+out_of_order_fill_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 3, <<"bbb">>, false),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S1)),
+    S2 = deliver(S1, 4, 0, <<"aaa">>, false),
+    S3 = deliver(S2, 4, 6, <<"ccc">>, false),
+    _ = finish(S3),
+    ?assertEqual([{<<"aaabbbccc">>, false}], data(4, messages())).
+
+off_by_default_delivers_per_frame_test() ->
+    S0 = state(false),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = deliver(S1, 4, 3, <<"bbb">>, false),
+    ?assertEqual([{<<"aaa">>, false}, {<<"bbb">>, false}], data(4, messages())),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S2)).
+
+outside_a_pass_delivers_per_frame_test() ->
+    flush(),
+    S0 = quic_connection:test_recv_stream_state(4, 0, ?WIN, 2 * ?WIN),
+    S = quic_connection:test_state_coalescing(S0, true),
+    S1 = deliver(S, 4, 0, <<"aaa">>, false),
+    _ = deliver(S1, 4, 3, <<"bbb">>, false),
+    ?assertEqual([{<<"aaa">>, false}, {<<"bbb">>, false}], data(4, messages())).
+
+%% The run flushes even when the pass initiated a close: the data
+%% arrived before the close did.
+flushes_when_the_pass_closes_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = quic_connection:test_state_closing(S1, {application, 0, <<>>}),
+    _ = finish(S2),
+    ?assertEqual([{<<"aaa">>, false}], data(4, messages())).
+
+%% A RESET_STREAM arriving mid-pass must not overtake data the stream
+%% delivered earlier in the same pass.
+reset_does_not_overtake_pending_data_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    ?assertEqual([], messages()),
+    S2 = quic_connection:process_frame(app, {reset_stream, 4, 7, 3}, S1),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S2)),
+    Msgs = [M || {quic, _, M} <- messages(), element(2, M) =:= 4],
+    ?assertEqual([{stream_data, 4, <<"aaa">>, false}, {stream_reset, 4, 7}], Msgs).

--- a/test/quic_reassembly_tests.erl
+++ b/test/quic_reassembly_tests.erl
@@ -14,11 +14,17 @@
 chunk(Start, Len) ->
     <<<<(B rem 256)>> || B <- lists:seq(Start, Start + Len - 1)>>.
 
+%% The buffer is an ordered tree; tests build and compare it as a map
+%% so the fixtures stay readable.
+tree(Map) ->
+    gb_trees:from_orddict(lists:sort(maps:to_list(Map))).
+
 extract(Buffer, Offset) ->
-    quic_connection:extract_contiguous_data(Buffer, Offset).
+    {Data, Off, Rest} = quic_connection:extract_contiguous_data(tree(Buffer), Offset),
+    {Data, Off, maps:from_list(gb_trees:to_list(Rest))}.
 
 trim(Buffer, Offset) ->
-    quic_connection:trim_reassembly_buffer(Buffer, Offset).
+    maps:from_list(gb_trees:to_list(quic_connection:trim_reassembly_buffer(tree(Buffer), Offset))).
 
 %%====================================================================
 %% Extraction
@@ -91,6 +97,21 @@ trim_is_idempotent_test() ->
 trim_leaves_future_chunks_untouched_test() ->
     Buffer = #{800 => chunk(800, 100), 900 => chunk(900, 100)},
     ?assertEqual(Buffer, trim(Buffer, 800)).
+
+%% The walk stops at the delivery point: with a large hole and many
+%% chunks buffered above it, a miss at the hole is answered without
+%% rebuilding the buffer (the returned tree is the input, unchanged).
+gap_below_a_large_buffer_is_answered_without_a_walk_test() ->
+    Above = tree(maps:from_list([{Off, chunk(Off, 100)} || Off <- lists:seq(1000, 100000, 100)])),
+    ?assertMatch({<<>>, 500, Above}, quic_connection:extract_contiguous_data(Above, 500)).
+
+%% With one straddling chunk below the point, only that chunk is
+%% touched; the chunks above come back as they were.
+trim_touches_only_chunks_below_the_point_test() ->
+    Above = [{Off, chunk(Off, 100)} || Off <- lists:seq(1000, 5000, 100)],
+    Buffer = maps:from_list([{300, chunk(300, 400)} | Above]),
+    Expected = maps:from_list([{500, chunk(500, 200)} | Above]),
+    ?assertEqual(Expected, trim(Buffer, 500)).
 
 %%====================================================================
 %% Randomised: any fragmentation of a known stream reassembles to it

--- a/test/quic_record_app_recv_tests.erl
+++ b/test/quic_record_app_recv_tests.erl
@@ -1,0 +1,47 @@
+%% record_app_recv/4 fuses the three per-packet receive updates of the
+%% 1-RTT hot path (PN space, spin bit, activity stamp) into one state
+%% rebuild. It must stay observably identical to running the three
+%% helpers in sequence, which these tests check over random packet
+%% sequences for every role and spin-bit setting.
+-module(quic_record_app_recv_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+reference(FirstByte, PN, State, Now) ->
+    S1 = quic_connection:record_received_pn(app, PN, State, Now),
+    S2 = quic_connection:update_spin_from_recv(FirstByte, PN, S1),
+    quic_connection:update_last_activity(S2, Now).
+
+%% Short-header first byte with the spin bit set or clear.
+first_byte(Spin) -> 16#40 bor (Spin bsl 5).
+
+run(Role, SpinEnabled, Seed) ->
+    rand:seed(exsplus, {Seed, Seed * 3 + 1, Seed * 5 + 2}),
+    S0 = quic_connection:test_app_recv_state(Role, SpinEnabled),
+    lists:foldl(
+        fun(I, {Fused, Ref}) ->
+            %% Mostly sequential with occasional reordering and duplicates.
+            PN =
+                case rand:uniform(10) of
+                    1 -> max(0, I - rand:uniform(4));
+                    2 -> I + rand:uniform(3);
+                    _ -> I
+                end,
+            FB = first_byte(rand:uniform(2) - 1),
+            Now = 1000 + I,
+            NewFused = quic_connection:record_app_recv(FB, PN, Fused, Now),
+            NewRef = reference(FB, PN, Ref, Now),
+            ?assertEqual(NewRef, NewFused),
+            {NewFused, NewRef}
+        end,
+        {S0, S0},
+        lists:seq(0, 200)
+    ).
+
+fused_matches_reference_test_() ->
+    [
+        {lists:flatten(io_lib:format("~p spin=~p seed=~p", [Role, Spin, Seed])), fun() ->
+            run(Role, Spin, Seed)
+        end}
+     || Role <- [client, server], Spin <- [true, false], Seed <- lists:seq(1, 5)
+    ].

--- a/test/quic_recv_drain_tests.erl
+++ b/test/quic_recv_drain_tests.erl
@@ -1,0 +1,77 @@
+%% drain_recv_msgs/2 pulls datagram messages already queued in the
+%% connection's mailbox into the current receive pass, so the ACK,
+%% socket-batch and timer flushes at the end of the pass amortize over
+%% the whole train. These tests pin its contract: only datagram
+%% messages are taken, in order, up to the cap, and never once a close
+%% has been initiated.
+-module(quic_recv_drain_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ADDR, {{127, 0, 0, 1}, 4433}).
+
+%% An undecryptable short-header packet: parsed and discarded by the
+%% receive path without touching the (absent) keys.
+garbage(I) ->
+    <<1:1, 0:1, 0:6, I:8, 0:(40 * 8)>>.
+
+server_state() ->
+    quic_connection:test_state_for_server(?ADDR, undefined, <<>>).
+
+client_state() ->
+    quic_connection:test_state_for_client(?ADDR).
+
+flush_mailbox() ->
+    receive
+        _ -> flush_mailbox()
+    after 0 -> ok
+    end.
+
+mailbox() ->
+    {messages, Msgs} = process_info(self(), messages),
+    Msgs.
+
+drains_queued_server_datagrams_test() ->
+    flush_mailbox(),
+    self() ! {quic_packet, garbage(1), ?ADDR},
+    self() ! {quic_packets, [garbage(2), garbage(3)], ?ADDR},
+    self() ! {other, event},
+    self() ! {quic_packet, garbage(4), ?ADDR},
+    _ = quic_connection:drain_recv_msgs(server_state(), 64),
+    ?assertEqual([{other, event}], mailbox()).
+
+drains_queued_client_datagrams_test() ->
+    flush_mailbox(),
+    %% The drain matches on the state's socket, and the client path
+    %% re-arms {active, N} on it after each datagram.
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    S = quic_connection:test_state_with_socket(client_state(), Sock),
+    self() ! {udp, Sock, {127, 0, 0, 1}, 4433, garbage(1)},
+    self() ! {udp_batch, Sock, {127, 0, 0, 1}, 4433, [garbage(2), garbage(3)]},
+    self() ! {timeout, ref, idle},
+    _ = quic_connection:drain_recv_msgs(S, 64),
+    gen_udp:close(Sock),
+    ?assertEqual([{timeout, ref, idle}], mailbox()).
+
+stops_at_the_cap_test() ->
+    flush_mailbox(),
+    [self() ! {quic_packet, garbage(I), ?ADDR} || I <- lists:seq(1, 10)],
+    _ = quic_connection:drain_recv_msgs(server_state(), 4),
+    Left = mailbox(),
+    ?assertEqual(6, length(Left)),
+    %% Oldest first: the cap leaves the tail of the queue.
+    ?assertEqual({quic_packet, garbage(5), ?ADDR}, hd(Left)).
+
+zero_cap_takes_nothing_test() ->
+    flush_mailbox(),
+    self() ! {quic_packet, garbage(1), ?ADDR},
+    _ = quic_connection:drain_recv_msgs(server_state(), 0),
+    ?assertEqual(1, length(mailbox())).
+
+leaves_the_mailbox_alone_once_closing_test() ->
+    flush_mailbox(),
+    self() ! {quic_packet, garbage(1), ?ADDR},
+    S0 = server_state(),
+    S = quic_connection:test_state_closing(S0, {application, 0, <<"bye">>}),
+    ?assertEqual(S, quic_connection:drain_recv_msgs(S, 64)),
+    ?assertEqual(1, length(mailbox())).

--- a/test/quic_recv_pass_ack_tests.erl
+++ b/test/quic_recv_pass_ack_tests.erl
@@ -1,0 +1,52 @@
+%% Inside a connected-state receive pass, count-based ACK decimation
+%% only counts; finish_recv_pass/1 then emits one ACK for the whole
+%% train. Without this a 64-packet drain pass emitted an ACK every
+%% ack_packet_tolerance packets, and the ACK machinery on both ends
+%% ate a large share of the CPU on bulk flows.
+-module(quic_recv_pass_ack_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+in_pass(S) -> quic_connection:test_state_in_recv_pass(S).
+
+steps(S, 0) ->
+    S;
+steps(S, N) ->
+    {S1, _} = quic_connection:test_decimate_step(S),
+    steps(S1, N - 1).
+
+no_flush_inside_a_pass_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    %% Well past the tolerance (2): still counting, timer armed.
+    {_S, Info} = quic_connection:test_decimate_step(steps(S0, 7)),
+    ?assertMatch(#{ack_elicited_count := 8, ack_timer_armed := true}, Info).
+
+one_ack_at_pass_end_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    S1 = steps(S0, 8),
+    {_S2, Info} = quic_connection:test_finish_recv_pass(S1),
+    ?assertMatch(
+        #{ack_elicited_count := 0, ack_timer_armed := false, recv_pass := false}, Info
+    ).
+
+below_tolerance_keeps_the_timer_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    S1 = steps(S0, 1),
+    {_S2, Info} = quic_connection:test_finish_recv_pass(S1),
+    ?assertMatch(
+        #{ack_elicited_count := 1, ack_timer_armed := true, recv_pass := false}, Info
+    ).
+
+no_ack_when_the_pass_started_a_close_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    S1 = quic_connection:test_state_closing(steps(S0, 4), {application, 0, <<>>}),
+    {_S2, Info} = quic_connection:test_finish_recv_pass(S1),
+    ?assertMatch(#{ack_elicited_count := 4, recv_pass := false}, Info).
+
+decimation_resumes_after_the_pass_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    {S1, _} = quic_connection:test_finish_recv_pass(steps(S0, 3)),
+    %% Outside a pass the tolerance applies again: two packets flush.
+    {S2, _} = quic_connection:test_decimate_step(S1),
+    {_S3, Info} = quic_connection:test_decimate_step(S2),
+    ?assertMatch(#{ack_elicited_count := 0, ack_timer_armed := false}, Info).

--- a/test/quic_recv_queue_bound_tests.erl
+++ b/test/quic_recv_queue_bound_tests.erl
@@ -1,0 +1,81 @@
+%% The socket-backend receive paths (listener and client receiver)
+%% emulate a bounded kernel receive buffer: a train is forwarded in
+%% chunks so the mailbox bound caps queued packets, not just messages,
+%% and once the connection's mailbox is over the bound the train is
+%% tail-dropped. The listener keeps the head packet so the peer still
+%% gets a timely (dup-)ACK carrying the loss signal.
+-module(quic_recv_queue_bound_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(ADDR, {{127, 0, 0, 1}, 4433}).
+
+packets(N) ->
+    [<<I:16, 0:(1000 * 8)>> || I <- lists:seq(1, N)].
+
+%% A process that never reads its mailbox, optionally pre-filled.
+sink(Backlog) ->
+    Pid = spawn_link(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    [Pid ! {noise, I} || I <- lists:seq(1, Backlog)],
+    Pid.
+
+drain(Pid, Tag) ->
+    {messages, Msgs} = process_info(Pid, messages),
+    [M || M <- Msgs, element(1, M) =:= Tag].
+
+listener_forwards_single_packet_as_is_test() ->
+    Pid = sink(0),
+    [P] = packets(1),
+    ok = quic_listener:send_packets_to_connection(Pid, [P], ?ADDR),
+    ?assertEqual([{quic_packet, P, ?ADDR}], drain(Pid, quic_packet)),
+    ?assertEqual([], drain(Pid, quic_packets)).
+
+listener_chunks_a_train_test() ->
+    Pid = sink(0),
+    Ps = packets(2 * ?MAX_PACKETS_PER_CONN_MSG + 3),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    Msgs = drain(Pid, quic_packets),
+    Sizes = [length(Chunk) || {quic_packets, Chunk, _} <- Msgs],
+    ?assertEqual([?MAX_PACKETS_PER_CONN_MSG, ?MAX_PACKETS_PER_CONN_MSG, 3], Sizes),
+    %% Order and content survive the split.
+    ?assertEqual(Ps, lists:append([Chunk || {quic_packets, Chunk, _} <- Msgs])).
+
+listener_tail_drops_over_the_bound_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    Ps = packets(5),
+    Before = quic_listener:recv_drops(),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ?assertEqual([{quic_packet, hd(Ps), ?ADDR}], drain(Pid, quic_packet)),
+    ?assertEqual([], drain(Pid, quic_packets)),
+    ?assertEqual(Before + 4, quic_listener:recv_drops()).
+
+listener_at_the_bound_still_forwards_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS),
+    Ps = packets(3),
+    Before = quic_listener:recv_drops(),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ?assertEqual([{quic_packets, Ps, ?ADDR}], drain(Pid, quic_packets)),
+    ?assertEqual(Before, quic_listener:recv_drops()).
+
+client_forwards_a_train_as_one_message_test() ->
+    Pid = sink(0),
+    Ps = packets(4),
+    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, Ps),
+    ?assertEqual([{udp_batch, sock, {127, 0, 0, 1}, 4433, Ps}], drain(Pid, udp_batch)),
+    [P] = packets(1),
+    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, [P]),
+    ?assertEqual([{udp, sock, {127, 0, 0, 1}, 4433, P}], drain(Pid, udp)).
+
+client_tail_drops_over_the_bound_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    Ps = packets(6),
+    Before = quic_socket:client_recv_drops(),
+    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, Ps),
+    ?assertEqual([], drain(Pid, udp_batch)),
+    ?assertEqual([], drain(Pid, udp)),
+    ?assertEqual(Before + 6, quic_socket:client_recv_drops()).

--- a/test/quic_stream_recv_fast_path_tests.erl
+++ b/test/quic_stream_recv_fast_path_tests.erl
@@ -1,0 +1,156 @@
+%% The receive side has lean paths for the dominant bulk shape; each
+%% must be observably identical to the general path it shortcuts.
+-module(quic_stream_recv_fast_path_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(SID, 4).
+-define(WIN, ?DEFAULT_MAX_RECEIVE_WINDOW).
+
+%%--------------------------------------------------------------------
+%% Stream data: lean clause vs the general path
+%%--------------------------------------------------------------------
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+messages() ->
+    {messages, Msgs} = process_info(self(), messages),
+    Msgs.
+
+%% Run both paths on the same input and return {State, Messages} each.
+both(S, Offset, Data, Fin) ->
+    flush(),
+    Lean = quic_connection:do_process_stream_data_buffered(?SID, Offset, Data, Fin, S),
+    LeanMsgs = messages(),
+    flush(),
+    Slow = quic_connection:do_process_stream_data_slow(?SID, Offset, Data, Fin, S),
+    SlowMsgs = messages(),
+    flush(),
+    {{Lean, LeanMsgs}, {Slow, SlowMsgs}}.
+
+in_order_bulk_frame_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    Data = binary:copy(<<"d">>, 1200),
+    {L, R} = both(S, 5000, Data, false),
+    ?assertEqual(R, L),
+    {_, Msgs} = L,
+    ?assertEqual([{quic, self(), {stream_data, ?SID, Data, false}}], Msgs).
+
+%% A run of in-order frames threads identically through both paths.
+in_order_run_test() ->
+    S0 = quic_connection:test_recv_stream_state(?SID, 0, ?WIN, 2 * ?WIN),
+    Data = binary:copy(<<"r">>, 1000),
+    {Lean, Slow} = lists:foldl(
+        fun(I, {L, R}) ->
+            flush(),
+            L1 = quic_connection:do_process_stream_data_buffered(?SID, I * 1000, Data, false, L),
+            R1 = quic_connection:do_process_stream_data_slow(?SID, I * 1000, Data, false, R),
+            {L1, R1}
+        end,
+        {S0, S0},
+        lists:seq(0, 50)
+    ),
+    flush(),
+    ?assertEqual(Slow, Lean).
+
+%% Shapes the lean clause must hand to the general path: a gap, a
+%% duplicate, a FIN, an empty frame, an unknown stream. All wide-window,
+%% so the general path emits no flow-control frame either way.
+out_of_order_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 6200, binary:copy(<<"o">>, 1200), false),
+    ?assertEqual(R, L).
+
+duplicate_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 4000, binary:copy(<<"u">>, 1000), false),
+    ?assertEqual(R, L).
+
+fin_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 5000, binary:copy(<<"f">>, 100), true),
+    ?assertEqual(R, L).
+
+empty_frame_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 5000, <<>>, false),
+    ?assertEqual(R, L).
+
+%%--------------------------------------------------------------------
+%% PN space: sequential packets skip the ACK-range cap scan
+%%--------------------------------------------------------------------
+
+%% The pre-optimisation update: always run the cap.
+reference_pn_space_recv(PN, PNSpace, Now) ->
+    #pn_space{largest_recv = LargestRecv, ack_ranges = Ranges} = PNSpace,
+    NewLargest =
+        case LargestRecv of
+            undefined -> PN;
+            L when PN > L -> PN;
+            L -> L
+        end,
+    PNSpace#pn_space{
+        largest_recv = NewLargest,
+        recv_time = Now,
+        ack_ranges = quic_connection:cap_ack_ranges(quic_connection:add_to_ack_ranges(PN, Ranges))
+    }.
+
+empty_pn_space() ->
+    #pn_space{
+        next_pn = 0,
+        largest_acked = undefined,
+        largest_recv = undefined,
+        recv_time = undefined,
+        ack_ranges = [],
+        ack_eliciting_in_flight = 0,
+        loss_time = undefined,
+        sent_packets = #{}
+    }.
+
+pn_space_matches_reference_test_() ->
+    [
+        {"seed " ++ integer_to_list(Seed), fun() -> pn_space_run(Seed) end}
+     || Seed <- lists:seq(1, 10)
+    ].
+
+pn_space_run(Seed) ->
+    rand:seed(exsplus, {Seed, Seed * 11 + 3, Seed * 17 + 5}),
+    lists:foldl(
+        fun(I, {New, Ref}) ->
+            %% Enough gaps to overflow ?MAX_ACK_RANGES, so the cap
+            %% actually bites on the reordered packets.
+            PN =
+                case rand:uniform(3) of
+                    1 -> I * 2;
+                    _ -> I * 2 + 1
+                end,
+            New1 = quic_connection:update_pn_space_recv(PN, New, I),
+            Ref1 = reference_pn_space_recv(PN, Ref, I),
+            ?assertEqual(Ref1, New1),
+            {New1, Ref1}
+        end,
+        {empty_pn_space(), empty_pn_space()},
+        lists:seq(0, 400)
+    ).
+
+%%--------------------------------------------------------------------
+%% Delayed ACK: a leading stream frame never qualifies
+%%--------------------------------------------------------------------
+
+stream_frame_first_is_never_delayed_test() ->
+    Stream = {stream, ?SID, 0, <<"x">>, false},
+    ?assertNot(quic_connection:should_delay_ack([Stream])),
+    ?assertNot(quic_connection:should_delay_ack([Stream, {datagram, <<"d">>}])).
+
+datagram_only_is_delayed_test() ->
+    ?assert(quic_connection:should_delay_ack([{datagram, <<"d">>}])),
+    ?assert(quic_connection:should_delay_ack([padding, {datagram, <<"d">>}])),
+    %% A stream frame after a datagram: the general clause finds it.
+    ?assertNot(
+        quic_connection:should_delay_ack([{datagram, <<"d">>}, {stream, ?SID, 0, <<"x">>, false}])
+    ).


### PR DESCRIPTION
Second of the performance topics, on top of #274. One commit.

## What changes

With `delivery_coalescing => true`, consecutive same-stream `stream_data` deliveries within one receive pass merge into a single owner message, flushed at the end of the pass, as soon as a different stream delivers, or before a `stream_reset` notification for any stream. Only adjacent chunks of one stream merge, so the owner observes messages in exact arrival order; a first cut that coalesced per stream across the whole pass reordered control-vs-data stream delivery and broke a consumer's handshake. Owners otherwise wake once per packet on bulk flows, and that wakeup was a large share of receiver cost.

It is opt-in. QUIC makes no message-boundary guarantee, but owners that decode each delivery as one complete term rather than length-framing the byte stream break when two messages arrive in one pass; we saw that as a missing message in a production consumer under load. The default keeps the one-message-per-packet behaviour.

## Numbers

Measured on the production rig together with the run sender it was developed with (loopback, 200 MiB single stream): socket backend 59-66 to 76-81 MiB/s, gen_udp 40 to 45. Our transport runs with it on.

## Tests

`quic_delivery_coalescing_tests`: merging, FIN in the run, cross-stream flush order, a gap filled mid-pass, the default and the outside-a-pass behaviour, flushing when the pass initiated a close, and a RESET_STREAM that must not overtake data delivered before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhR5A9CgDvjXPLsqiewjCZ
