### PR TITLE
interop: declare the robustness cases, multiconnect per file, full cert chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,14 @@ All notable changes to this project will be documented in this file.
 - A server handshake flight lost on the wire is retransmitted on the client-Initial backoff schedule until the client's Finished arrives. Initial/Handshake packets are not loss-tracked, so a lost flight previously wedged the handshake permanently: the client's Initial retransmits only elicited ACKs once the server TLS state had advanced. (#263)
 
 ### Changed
+- The interop runner declares the passive robustness cases (longrtt,
+  blackhole, amplificationlimit, handshakeloss, transferloss,
+  handshakecorruption, transfercorruption, rebind-port, rebind-addr),
+  runs the multiconnect case as one connection per file so the runner's
+  handshake count matches, disables `disconnect_timeout` in both
+  endpoints so the blackhole case can outlast its outage, waits 60 s per
+  download, and the server loads the full certificate chain from
+  cert.pem.
 - Header protection reuses a cipher context instead of re-running the key
   schedule on every packet. Measured on an 8 MB transfer, the `crypto:*`
   share of connection-process time drops from 10.95% to 8.30%; header

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -39,7 +39,18 @@
     "resumption",
     "zerortt",
     "connectionmigration",
-    "http3"
+    "http3",
+    %% Passive robustness cases: the simulator induces the loss,
+    %% corruption, latency or rebinding; the endpoint just transfers.
+    "longrtt",
+    "blackhole",
+    "amplificationlimit",
+    "handshakeloss",
+    "transferloss",
+    "handshakecorruption",
+    "transfercorruption",
+    "rebind-port",
+    "rebind-addr"
 ]).
 
 %% Include for session_ticket record
@@ -88,6 +99,23 @@ run_test("zerortt", RequestsStr, DownloadsDir) ->
 run_test("connectionmigration", RequestsStr, DownloadsDir) ->
     %% Connection migration: simulate path change during transfer
     run_migration_test(RequestsStr, DownloadsDir);
+run_test("multiconnect", RequestsStr, DownloadsDir) ->
+    %% One connection per file, sequentially: the runner maps the
+    %% handshakeloss and handshakecorruption cases to this testcase
+    %% name and counts one handshake per requested file.
+    Requests = string:tokens(RequestsStr, " "),
+    Results = lists:append([
+        download_all("multiconnect", [R], DownloadsDir)
+     || R <- Requests
+    ]),
+    case lists:all(fun(R) -> R =:= ok end, Results) of
+        true ->
+            io:format("All downloads successful~n"),
+            halt(?EXIT_SUCCESS);
+        false ->
+            io:format("Some downloads failed~n"),
+            halt(?EXIT_FAILURE)
+    end;
 run_test(TestCase, RequestsStr, DownloadsDir) ->
     %% Standard test case
     Requests = string:tokens(RequestsStr, " "),
@@ -178,7 +206,7 @@ wait_connected(Conn, TestCase) ->
         {quic, Conn, {transport_error, Code, Msg}} ->
             io:format("Transport error: ~p ~p~n", [Code, Msg]),
             error
-    after 30000 ->
+    after 60000 ->
         io:format("Connection timeout~n"),
         error
     end.
@@ -228,10 +256,13 @@ build_opts("v2") ->
         versions => [16#6b3343cf, 16#00000001]
     };
 build_opts(_) ->
-    %% Default options
+    %% Default options. disconnect_timeout is off: the blackhole case
+    %% blacks the network out on purpose and expects the transfer to
+    %% outlast it.
     #{
         verify => false,
-        alpn => [<<"hq-interop">>, <<"h3">>]
+        alpn => [<<"hq-interop">>, <<"h3">>],
+        disconnect_timeout => infinity
     }.
 
 %% Keep as many streams in flight as the peer's stream credit allows and

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -39,7 +39,18 @@
     "resumption",
     "zerortt",
     "connectionmigration",
-    "http3"
+    "http3",
+    %% Passive robustness cases: the simulator induces the loss,
+    %% corruption, latency or rebinding; the endpoint just transfers.
+    "longrtt",
+    "blackhole",
+    "amplificationlimit",
+    "handshakeloss",
+    "transferloss",
+    "handshakecorruption",
+    "transfercorruption",
+    "rebind-port",
+    "rebind-addr"
 ]).
 
 main(_Args) ->
@@ -158,6 +169,9 @@ build_server_opts(TestCase, Cert, Key, WwwDir) ->
         cert => Cert,
         key => Key,
         alpn => [<<"hq-interop">>, <<"h3">>],
+        %% The blackhole case blacks the network out on purpose and
+        %% expects the connection to outlast it.
+        disconnect_timeout => infinity,
         connection_handler => fun(ConnPid, Conn) ->
             spawn_handler(ConnPid, Conn, WwwDir, TestCase)
         end

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -90,15 +90,20 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
 
     case {file:read_file(CertFile), file:read_file(KeyFile)} of
         {{ok, CertPem}, {ok, KeyPem}} ->
-            %% Decode PEM to DER
-            [{_, CertDer, _}] = public_key:pem_decode(CertPem),
+            %% Decode PEM to DER. The amplificationlimit case hands the
+            %% server a 9-deep chain in cert.pem; leaf first, then the
+            %% intermediates in order.
+            [CertDer | CertChain] = [
+                D
+             || {'Certificate', D, not_encrypted} <- public_key:pem_decode(CertPem)
+            ],
             PrivateKey = decode_private_key(KeyPem),
 
             case TestCase of
                 "http3" ->
-                    run_h3_server(Port, CertDer, PrivateKey, WwwDir);
+                    run_h3_server(Port, {CertDer, CertChain}, PrivateKey, WwwDir);
                 _ ->
-                    run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir)
+                    run_hq_server(TestCase, Port, {CertDer, CertChain}, PrivateKey, WwwDir)
             end;
         _ ->
             io:format("Failed to read certificates~n"),
@@ -107,13 +112,14 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
 
 %% The http3 case serves real HTTP/3 (RFC 9114) through quic_h3; every
 %% other case speaks hq-interop over a bare listener.
-run_h3_server(Port, CertDer, PrivateKey, WwwDir) ->
+run_h3_server(Port, {CertDer, CertChain}, PrivateKey, WwwDir) ->
     Handler = fun(Conn, StreamId, _Method, Path, _Headers) ->
         serve_h3_request(Conn, StreamId, Path, WwwDir)
     end,
     case
         quic_h3:start_server(interop_h3, Port, #{
             cert => CertDer,
+            cert_chain => CertChain,
             key => PrivateKey,
             handler => Handler
         })
@@ -164,9 +170,10 @@ run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir) ->
             halt(?EXIT_FAILURE)
     end.
 
-build_server_opts(TestCase, Cert, Key, WwwDir) ->
+build_server_opts(TestCase, {Cert, CertChain}, Key, WwwDir) ->
     BaseOpts = #{
         cert => Cert,
+        cert_chain => CertChain,
         key => Key,
         alpn => [<<"hq-interop">>, <<"h3">>],
         %% The blackhole case blacks the network out on purpose and


### PR DESCRIPTION
The interop-runner changes from our robustness campaign that had not been submitted; #245 (merged via #273) carried the http3 and resumption work, these two commits are the rest of the client and server side.

- Declare the passive robustness cases: longrtt, blackhole, amplificationlimit, handshakeloss, transferloss, handshakecorruption, transfercorruption, rebind-port, rebind-addr. The simulator induces the loss, corruption, latency or rebinding; the endpoint just transfers.
- Run `multiconnect` as one connection per file, sequentially and without retries: the runner maps handshakeloss and handshakecorruption to that testcase name and counts one handshake per requested file, so patience has to live in the handshake retransmission, not in reconnects.
- Disable `disconnect_timeout` in both endpoints: the blackhole case blacks the network out on purpose and expects the transfer to outlast it. Wait 60 s per download for the same reason.
- The server loads the full certificate chain from cert.pem, so a runner-provided chain is presented whole.

With these, our runner matrix against aioquic, quic-go and picoquic passed the declared cases; the Interop Tests job here is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhR5A9CgDvjXPLsqiewjCZ
