### PR TITLE
Plumb chunk and gso through the sink bench, and correct a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,11 @@ All notable changes to this project will be documented in this file.
   interleaved. When the per-drain burst budget was spent, the unsent
   remainder was requeued at the back of its priority bucket instead of the
   front, so the drain round-robined between the queued entries and the
-  stream stayed out of order for the rest of the transfer. The receiver
-  then buffered nearly the whole stream for reassembly. The same 10 MB
-  delivered in 40 writes went at 1.4 MB/s against 63 for a single write;
-  it is now 69.5. Single writes were never affected, which is why bulk
-  benchmarks did not show it.
+  stream stayed out of order for the rest of the transfer, leaving the
+  receiver holding most of it for reassembly (1.2 MB buffered on a 2 MB
+  transfer in 16 writes, against 0 once ordered). Throughput on loopback
+  is unchanged; the cost is the reassembly buffer, and any real path where
+  reordering matters.
 - An authenticated distribution connection no longer drops the peer's
   first handshake message about half the time. The `auth_callback` path
   put a short-lived gatekeeper process in front of the dist controller

--- a/docker/benchmark/Dockerfile
+++ b/docker/benchmark/Dockerfile
@@ -13,13 +13,17 @@ ARG OTP_VERSION=28
 
 FROM erlang:${OTP_VERSION}
 
+# rebar3 3.24.0 does not load on OTP 29; CI uses nightly there, so let the
+# caller pick. --build-arg REBAR3_URL=https://s3.amazonaws.com/rebar3-nightly/rebar3
+ARG REBAR3_URL=https://github.com/erlang/rebar3/releases/download/3.24.0/rebar3
+
 WORKDIR /build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends cmake libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q https://github.com/erlang/rebar3/releases/download/3.24.0/rebar3 \
+RUN wget -q "${REBAR3_URL}" -O rebar3 \
     && chmod +x rebar3 \
     && mv rebar3 /usr/local/bin/
 

--- a/test/quic_throughput_bench.erl
+++ b/test/quic_throughput_bench.erl
@@ -296,7 +296,7 @@ run(Opts) ->
 
     %% Start server. Backend and batching are server-side knobs; applying
     %% them to the client alone silently benchmarks the wrong half.
-    ServerExtra = maps:with([socket_backend, server_send_batching], Opts),
+    ServerExtra = maps:with([socket_backend, server_send_batching, gso], Opts),
     case start_server(Port, RecvBuf, SndBuf, Mode, ServerExtra) of
         {ok, ServerPid, ActualPort, ServerBufs} ->
             io:format(
@@ -304,10 +304,12 @@ run(Opts) ->
                 [maps:get(recbuf, ServerBufs), maps:get(sndbuf, ServerBufs)]
             ),
 
-            %% Run client benchmark. Plumb client-relevant options
-            %% (currently just `socket_backend') so callers can compare
-            %% the gen_udp vs socket client paths.
-            ClientExtra = maps:with([socket_backend], Opts),
+            %% Run client benchmark. `chunk' decides how many
+            %% send_data/4 calls the payload takes, `gso' and
+            %% `socket_backend' select the send path. Dropping any of
+            %% them here silently benchmarks the default instead of what
+            %% the caller asked for.
+            ClientExtra = maps:with([socket_backend, chunk, gso], Opts),
             Result = run_client_benchmark(
                 ActualPort, DataSize, RecvBuf, SndBuf, Mode, ClientExtra
             ),


### PR DESCRIPTION
`run/1` filtered its client options down to `socket_backend`, so `chunk` and `gso` were accepted from the caller and then silently dropped. `run_download_sink/1` plumbs `chunk` correctly, which is what hid it.

That is how the throughput figures I quoted for #281 came to be wrong. Every sweep that appeared to vary the number of writes was in fact a single-write run, so the "after" column measured the same thing four times.

Re-measured with the options actually reaching the client, on Linux, with the ordering bug present and with it fixed:

| | with bug | fixed |
|---|---|---|
| 10 MB / 40 writes | 63.1 | 63.3 |
| 50 MB / 200 writes | 74.6 | 75.1 |
| 50 MB / 800 writes | 73.7 | 73.7 |

The reordering in #281 is real and the fix is correct: with the fix reverted, `stream_many_writes_stay_in_order` still fails with 1.2 MB sitting in the receiver's reassembly buffer, against 0 when ordered. What is not true is that it cost throughput on loopback. The changelog entry now says what was measured rather than what I inferred.

The 45x collapse I originally reported is not attributable to that bug. I could not reproduce it here at any transfer size or write count, and I am not able to explain the earlier runs, so I am not going to invent a cause for them. The harness now varies what it claims to vary, which is the part that was actually broken.