### PR TITLE
chore: release 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.8.2] - 2026-09-05
 
 ### Added
 - `versions` lists the QUIC versions a connection will also accept, for
@@ -224,7 +224,6 @@ All notable changes to this project will be documented in this file.
   millisecond resolution, so the fixed bucket capped throughput at 12
   packets per wakeup whenever the sender outran the ACK clock,
   regardless of the configured rate. Contributed by jbevemyr (#219).
-### Changed
 - A server with no explicit `groups` option now offers every classical
   group the crypto layer supports (x25519, secp256r1, secp384r1) instead
   of x25519 alone. A preference list holding only x25519 sent a

--- a/docs/QLOG_GUIDE.md
+++ b/docs/QLOG_GUIDE.md
@@ -132,6 +132,19 @@ Example: a1b2c3d4e5f6_client_1712345678901.qlog
 2. Go to Analyze > Follow > QUIC Stream
 3. Import QLOG for correlation with packet captures
 
+To let Wireshark decrypt the capture, set `SSLKEYLOGFILE` before starting the
+node. Every connection appends its TLS secrets to that file in the NSS key log
+format Wireshark reads:
+
+```bash
+export SSLKEYLOGFILE=/tmp/quic-keys.log
+erl -pa _build/default/lib/*/ebin
+```
+
+Then point Wireshark at it under Preferences > Protocols > TLS > (Pre)-Master-Secret
+log filename. The file holds the keys to every connection the node made, so treat
+it as a secret and use it on test traffic only.
+
 ### Command Line Analysis
 
 ```bash

--- a/docs/features.md
+++ b/docs/features.md
@@ -277,6 +277,13 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `recbuf` - UDP receive buffer size in bytes (default: 7MB)
 - `sndbuf` - UDP send buffer size in bytes (default: 7MB)
 - `server_send_batching` - Per-connection send batching on the server (default: true). On Linux + `socket_backend => socket` with UDP_SEGMENT, outgoing packets are coalesced into GSO super-datagrams via `sendmsg` cmsg; neutral on macOS / gen_udp. Set to `false` to fall back to direct `gen_udp:send/4`
+- `hibernate_after` - Hibernate an idle connection process after this many milliseconds, running a fullsweep so handshake garbage is not pinned to a heap that never collects (default: 5000; `infinity` opts out)
+- `versions` - QUIC versions this connection also accepts, for RFC 9368 compatible version negotiation (default: the negotiated `version` alone)
+- `ciphers` - TLS 1.3 cipher suites to offer, in preference order (default: `[aes_128_gcm, aes_256_gcm, chacha20_poly1305]`)
+- `max_burst_packets` - Packets allowed to leave per send drain, so a large queued write cannot monopolise the scheduler (default: 64)
+- `ack_packet_tolerance` - Ack-eliciting packets received before a 1-RTT ACK is sent, the RFC 9000 section 13.2.1 decimation threshold (default: 2)
+- `disconnect_timeout` - Milliseconds without a response from the peer before the connection is given up on, checked on its own timer (default: 16000)
+- `pmtu_raise_interval` - Milliseconds between PMTU raise probes (default: 600000)
 
 ### PMTU Discovery
 - `quic:get_mtu/1` - Get current effective MTU for a connection

--- a/src/quic.app.src
+++ b/src/quic.app.src
@@ -1,6 +1,6 @@
 {application, quic, [
     {description, "Pure Erlang QUIC implementation (RFC 9000)"},
-    {vsn, "1.8.1"},
+    {vsn, "1.8.2"},
     {registered, [
         quic_sup,
         quic_server_registry,


### PR DESCRIPTION
Cuts 1.8.2 from everything merged since 1.8.1: the send-queue requeue ordering fix, the distribution auth single-owner fix, the simultaneous-connect deadlock, the TLS alert reaching the wire, and the large body of protocol fixes contributed by jbevemyr (loss detection, ACK spaces, GSO/GRO, 0-RTT, version negotiation, session tickets).

Patch rather than minor: the release adds options but does not change any existing signature or return.

The `[Unreleased]` heading becomes `[1.8.2] - 2026-09-05`, `vsn` in `src/quic.app.src` goes to `1.8.2`, and the duplicate `### Changed` heading in the section is merged into one.

Also documents the options this cycle introduced, which had landed undocumented:

```erlang
quic:connect(Host, Port, #{
    hibernate_after => 5000,          %% or infinity
    versions => [16#00000001, 16#6b3343cf],
    ciphers => [aes_128_gcm, chacha20_poly1305],
    max_burst_packets => 64,
    ack_packet_tolerance => 2,
    disconnect_timeout => 16000,
    pmtu_raise_interval => 600000
}, 5000).
```

and `SSLKEYLOGFILE`, in the qlog guide's Wireshark section, since that is where you reach for it.
