### PR TITLE
Performance series: interop cases, receive pass, delivery coalescing, send side, fused crypto NIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,55 @@ jobs:
           QUIC_DISABLE_CRYPTO_NIF: "1"
         run: rebar3 eunit
 
+  crypto-nif-fuzz:
+    name: Crypto NIF Fuzz (ASan)
+    needs: unit-tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24.0'
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake libssl-dev
+
+      # Compile first: the rebar pre_hook builds the NIF, and the ASan
+      # build below has to be the one left in priv/.
+      - name: Compile
+        run: rebar3 as test compile
+
+      - name: Rebuild the NIF with AddressSanitizer
+        run: |
+          rm -rf c_src/build priv/quic_crypto_nif.so
+          cmake -S c_src -B c_src/build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" \
+            -DCMAKE_MODULE_LINKER_FLAGS="-fsanitize=address"
+          cmake --build c_src/build
+          test -f priv/quic_crypto_nif.so || { echo "NIF was not built"; exit 1; }
+
+      # open_run parses frames in C from plaintext the peer controls, so
+      # this is the one place attacker input reaches a hand-written
+      # parser. ASan aborts the emulator on a finding, which fails the
+      # step. Leak detection is off: the BEAM is not leak-clean and its
+      # allocations are not what is under test.
+      - name: Fuzz the in-NIF frame parser
+        env:
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
+        run: |
+          erlc -o _build/test/lib/quic/test test/quic_nif_fuzz.erl
+          LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
+            erl -noshell -pa _build/test/lib/quic/ebin -pa _build/test/lib/quic/test -eval '
+              application:ensure_all_started(quic),
+              case quic_crypto_nif:is_loaded() of
+                false -> io:format("NIF not loaded, nothing fuzzed~n"), halt(1);
+                true -> quic_nif_fuzz:run(200000), halt(0)
+              end.'
+
   dist:
     name: Distribution Tests
     needs: unit-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,25 +58,85 @@ jobs:
       - name: Run property tests
         run: rebar3 proper
 
-  # unit-tests-freebsd:
-  #   name: Unit Tests on FreeBSD
-  #   runs-on: ubuntu-latest
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #
-  #     - name: Test on FreeBSD
-  #       uses: vmactions/freebsd-vm@v1
-  #       with:
-  #         release: '14.2'
-  #         usesh: true
-  #         prepare: |
-  #           pkg install -y erlang rebar3 git
-  #         run: |
-  #           erl -eval 'io:format("OTP ~s~n", [erlang:system_info(otp_release)]), halt().' -noshell
-  #           rebar3 compile
-  #           rebar3 eunit
-  #           rebar3 proper || true
+  macos:
+    name: macOS
+    needs: unit-tests
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # brew ships the current OTP; the point of this job is the
+      # platform, not the OTP matrix, which the Linux jobs cover.
+      - name: Set up Erlang
+        run: brew install erlang rebar3
+
+      - name: Compile
+        run: rebar3 compile
+
+      # CMake has to find the libcrypto brew's OTP is linked against and
+      # emit the Mach-O bundle flags. A silent skip here would leave the
+      # macOS build untested, so fail instead.
+      - name: Assert the NIF built and loaded
+        run: |
+          test -f priv/quic_crypto_nif.so || { echo "NIF was not built"; exit 1; }
+          rebar3 as test compile
+          erl -noshell -pa _build/test/lib/quic/ebin -eval '
+            application:ensure_all_started(quic),
+            case quic_crypto_nif:is_loaded() of
+              true -> halt(0);
+              false -> io:format("NIF built but not loaded~n"), halt(1)
+            end.'
+
+      - name: Run tests with the NIF
+        run: rebar3 eunit
+
+      - name: Run tests with the NIF disabled
+        env:
+          QUIC_DISABLE_CRYPTO_NIF: "1"
+        run: rebar3 eunit
+
+  freebsd:
+    name: FreeBSD
+    needs: unit-tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "14.2"
+          usesh: true
+          # The stock erlang pkg lags behind; the versioned runtime
+          # package tracks a supported OTP. cmake builds the NIF.
+          prepare: |
+            pkg install -y erlang-runtime28 cmake
+          run: |
+            # erlang-runtime28 installs outside the default PATH.
+            ERL_BIN="$(dirname "$(pkg info -l erlang-runtime28 | tr -d '[:blank:]' | grep -E '/bin/erl$' | grep -v 'erts-' | head -1)")"
+            export PATH="$ERL_BIN:/usr/local/bin:$PATH"
+            erl -noshell -eval 'io:format("OTP ~s~n", [erlang:system_info(otp_release)]), halt().'
+
+            fetch -q https://github.com/erlang/rebar3/releases/download/3.25.0/rebar3 -o rebar3
+            chmod +x rebar3
+
+            ./rebar3 compile
+
+            # bmake runs c_src/Makefile, which delegates to CMake; a
+            # skipped build would silently drop the NIF coverage.
+            test -f priv/quic_crypto_nif.so || { echo "NIF was not built"; exit 1; }
+            ./rebar3 as test compile
+            erl -noshell -pa _build/test/lib/quic/ebin -eval '
+              application:ensure_all_started(quic),
+              case quic_crypto_nif:is_loaded() of
+                true -> halt(0);
+                false -> io:format("NIF built but not loaded~n"), halt(1)
+              end.'
+
+            ./rebar3 eunit
+            QUIC_DISABLE_CRYPTO_NIF=1 ./rebar3 eunit
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,47 @@ jobs:
           QUIC_ENABLE_GSO_TEST: "1"
         run: rebar3 ct --suite=quic_server_batching_SUITE
 
+  crypto-nif:
+    name: Crypto NIF
+    needs: unit-tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24.0'
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake libssl-dev
+
+      - name: Compile
+        run: rebar3 compile
+
+      # The NIF tests skip themselves when it is not loaded, so a green
+      # run proves nothing unless the build is known to have produced
+      # it. Fail loudly here instead.
+      - name: Assert the NIF is loaded
+        run: |
+          test -f priv/quic_crypto_nif.so || { echo "NIF was not built"; exit 1; }
+          rebar3 as test compile
+          erl -noshell -pa _build/test/lib/quic/ebin -eval '
+            application:ensure_all_started(quic),
+            case quic_crypto_nif:is_loaded() of
+              true -> halt(0);
+              false -> io:format("NIF built but not loaded~n"), halt(1)
+            end.'
+
+      - name: Run tests with the NIF
+        run: rebar3 eunit
+
+      - name: Run tests with the NIF disabled
+        env:
+          QUIC_DISABLE_CRYPTO_NIF: "1"
+        run: rebar3 eunit
+
   dist:
     name: Distribution Tests
     needs: unit-tests

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ certs/*.key
 doc/
 rebar3.crashdump
 /priv/quic_crypto_nif.so
+/c_src/build/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ certs/*.pem
 certs/*.key
 doc/
 rebar3.crashdump
+/priv/quic_crypto_nif.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ All notable changes to this project will be documented in this file.
   endpoints so the blackhole case can outlast its outage, waits 60 s per
   download, and the server loads the full certificate chain from
   cert.pem.
+- The connected-state receive pass drains the datagram messages already
+  queued in the connection's mailbox (up to 64) before flushing ACKs,
+  socket batches and timers, so those flushes amortize over a train
+  instead of running once per datagram. On the socket backend the
+  listener and the client receiver now emulate a bounded kernel receive
+  buffer: trains are forwarded in chunks of at most 8 packets and
+  tail-dropped once the connection's mailbox holds more than 32
+  messages, keeping the head packet so the peer still gets a timely
+  ACK. An unbounded mailbox turned receiver overload into queueing
+  delay instead of loss, which inflated the peer's RTT samples and
+  destabilized its loss detector.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ All notable changes to this project will be documented in this file.
   for new connections.
 
 ### Fixed
+- A client Initial flight spanning more than one datagram reaches the
+  connection in full. The listener's receive sweep groups the packets
+  of one flight together, and the group that starts a new connection
+  handed only its first packet over, dropping the rest; the handshake
+  then stalled until the client retransmitted. A chunked
+  `x25519mlkem768` ClientHello makes a multi-datagram flight the normal
+  case, and the sweep put this on the default `gen_udp` path.
 - Pacing no longer freezes on sub-millisecond links. RTT samples are
   whole milliseconds, so such a link reports a smoothed RTT of 0 and
   `update_pacing_rate` treated that as "no RTT yet" and skipped the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,14 @@ All notable changes to this project will be documented in this file.
   gets a timely ACK. An unbounded mailbox turned receiver overload into queueing
   delay instead of loss, which inflated the peer's RTT samples and
   destabilized its loss detector.
+- With the crypto NIF loaded, a bulk chunk run is sealed in one call:
+  `protect_run` builds each short header, derives the nonce, AEAD-seals
+  the payload and applies header protection for the whole run in C,
+  instead of two crypto NIF calls plus header, nonce and mask glue per
+  packet. AES only (the header-protection context is ECB); ChaCha and
+  NIF-less builds seal per packet as before. Send-side crypto drops
+  from about 9% of connection CPU to about 2% on bulk flows. The output
+  is checked byte for byte against the per-packet path.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@ All notable changes to this project will be documented in this file.
   NIF-less builds seal per packet as before. Send-side crypto drops
   from about 9% of connection CPU to about 2% on bulk flows. The output
   is checked byte for byte against the per-packet path.
+- With the crypto NIF loaded, a received 1-RTT packet is opened in one
+  call: `open_packet` does header unprotection, packet-number
+  reconstruction (RFC 9000 Appendix A) and AEAD open together, replacing
+  two crypto NIF calls plus mask, packet-number and AAD glue per
+  packet. It runs only while no key update is in flight and checks the
+  key-phase bit before decrypting, handing a phase change to the
+  two-stage path so RFC 9001 §6 bookkeeping stays where it was. ChaCha
+  and NIF-less builds are unchanged.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ All notable changes to this project will be documented in this file.
   their batched receive path engages even for sparse traffic. ACK
   processing re-arms the PTO once at the end of the receive pass
   instead of once per ACK frame.
+  processing re-arms the PTO once at the end of the receive pass
+  instead of once per ACK frame.
+- Server connections on the socket backend hand their finished send
+  batches to one shared sender process per listener, which performs
+  the `sendmsg` calls serially. Concurrent `sendmsg` on one socket
+  handle from many connection processes burns about 20x the CPU in
+  NIF-level contention (98.6 vs 4.7 us per send with 50 concurrent
+  senders); in a 50-connection fan-out model server CPU went from 24.3
+  to 11.0 s for the same window. Connections keep their own batch
+  buffers, GSO grouping and counters; a connection whose sender has
+  died sends directly from then on, and the listener starts a new one
+  for new connections.
 
 ### Fixed
 - Pacing no longer freezes on sub-millisecond links. RTT samples are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ All notable changes to this project will be documented in this file.
   one complete application message break when deliveries merge, so it
   is opt-in.
 
+### Fixed
+- Pacing no longer freezes on sub-millisecond links. RTT samples are
+  whole milliseconds, so such a link reports a smoothed RTT of 0 and
+  `update_pacing_rate` treated that as "no RTT yet" and skipped the
+  update: the rate stayed at its handshake-time value while cwnd kept
+  growing, clocking the connection at that stale rate forever. The RTT
+  is floored at 1 ms for the rate computation instead.
+- Burst continuations are sent to the connection directly rather than
+  through `erlang:send_after(0, ...)`. The timer wheel's ~1 ms service
+  tick turned every 64-packet burst continuation into a 64 packets per
+  millisecond clock, capping bulk streams at roughly 85 MB/s regardless
+  of the paced rate. Together with the previous fix, a verified
+  single-stream loopback bulk transfer went from 83 to 194 MiB/s.
+
 ### Changed
 - The interop runner declares the passive robustness cases (longrtt,
   blackhole, amplificationlimit, handshakeloss, transferloss,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ All notable changes to this project will be documented in this file.
   ACK. An unbounded mailbox turned receiver overload into queueing
   delay instead of loss, which inflated the peer's RTT samples and
   destabilized its loss detector.
+- Count-based ACK decimation defers its flush while a receive pass is
+  active, so one ACK covers the whole drained train instead of one per
+  `ack_packet_tolerance` packets. A 64-packet pass previously emitted
+  about 32 ACKs, each costing a packet build, an AEAD seal and a send
+  on the receiver and a decrypt plus ACK-frame pass on the sender; it
+  also released the sender's window in 2-3 packet quanta, which kept
+  GSO batches near size 1. The max_ack_delay timer still bounds ACK
+  latency for below-tolerance remainders and the reordering
+  immediate-ACK path is unchanged.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,14 @@ All notable changes to this project will be documented in this file.
   key-phase bit before decrypting, handing a phase change to the
   two-stage path so RFC 9001 §6 bookkeeping stays where it was. ChaCha
   and NIF-less builds are unchanged.
+- A train of short-header datagrams (a GRO train at the server, the
+  drained mailbox at the client) is opened in one NIF call: `open_run`
+  carries the largest received packet number forward across the run in
+  C, matching sequential `open_packet` calls exactly, and stops at the
+  first packet that needs the generic path (key-phase transition,
+  authentication failure, undersized datagram), which the caller then
+  handles per packet. The client drain now collects queued same-source
+  datagrams into one batch before processing.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,19 @@ All notable changes to this project will be documented in this file.
   the burst budget allow are approved up front (consuming pacing
   tokens exactly as one-at-a-time sends would), sealed and handed to
   the socket in one loop, and loss, congestion, packet-number and
-  counter bookkeeping is updated once for the run. The per-packet
-  connection-state rebuild was the largest own-time item on the
-  bulk-send profile; a 64-packet run replaces 64 copies with one.
+  counter bookkeeping is updated once for the run:
+  `quic_cc:send_check_run/4` approves the run against cwnd and pacing
+  in one step (never more permissive than the sequential checks),
+  `quic_cc:on_packets_sent/2` and `quic_loss:on_packets_sent_run/3`
+  fold it into one record update each (native for NewReno, a fold for
+  other algorithms). The per-packet connection-state rebuild was the
+  largest own-time item on the bulk-send profile; a 64-packet run
+  replaces 64 copies with one. The socket-backend receive queue bound
+  is the connection's flow-control window in full-size packets (never
+  below 512 messages): a run sender inside the window it was given is
+  never tail-dropped, and the bound only catches a peer outside it. A
+  fixed 512-message bound sat below a 16 MB window and turned
+  flow-control-permitted data into loss on loopback.
 
 ### Fixed
 - Pacing no longer freezes on sub-millisecond links. RTT samples are
@@ -46,17 +56,6 @@ All notable changes to this project will be documented in this file.
   endpoints so the blackhole case can outlast its outage, waits 60 s per
   download, and the server loads the full certificate chain from
   cert.pem.
-- The connected-state receive pass drains the datagram messages already
-  queued in the connection's mailbox (up to 64) before flushing ACKs,
-  socket batches and timers, so those flushes amortize over a train
-  instead of running once per datagram. On the socket backend the
-  listener and the client receiver now emulate a bounded kernel receive
-  buffer: trains are forwarded in chunks of at most 8 packets and
-  tail-dropped once the connection's mailbox holds more than 32
-  messages, keeping the head packet so the peer still gets a timely
-  ACK. An unbounded mailbox turned receiver overload into queueing
-  delay instead of loss, which inflated the peer's RTT samples and
-  destabilized its loss detector.
 - Count-based ACK decimation defers its flush while a receive pass is
   active, so one ACK covers the whole drained train instead of one per
   `ack_packet_tolerance` packets. A 64-packet pass previously emitted
@@ -86,6 +85,17 @@ All notable changes to this project will be documented in this file.
   without the range-cap scan; a packet led by a stream frame skips the
   datagram-only delayed-ACK check. The per-frame `max_stream_data_check`
   debug log is gone, it cost a logger allow-check per frame.
+- The connected-state receive pass drains the datagram messages already
+  queued in the connection's mailbox (up to 64) before flushing ACKs,
+  socket batches and timers, so those flushes amortize over a train
+  instead of running once per datagram. On the socket backend the
+  listener and the client receiver now emulate a bounded kernel receive
+  buffer: trains are forwarded in chunks of at most 8 packets and
+  tail-dropped once the connection's mailbox exceeds its bound (see
+  the send-side entry), keeping the head packet so the peer still
+  gets a timely ACK. An unbounded mailbox turned receiver overload into queueing
+  delay instead of loss, which inflated the peer's RTT samples and
+  destabilized its loss detector.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ All notable changes to this project will be documented in this file.
   millisecond clock, capping bulk streams at roughly 85 MB/s regardless
   of the paced rate. Together with the previous fix, a verified
   single-stream loopback bulk transfer went from 83 to 194 MiB/s.
+- The frames a connection sends on entering `connected` (data queued
+  before the handshake finished, the server's NEW_TOKEN, the first PMTU
+  probe) leave with that transition. They went through the send batch
+  and the state-enter handler returned without flushing it, so they
+  waited for the next event on the connection: on a quiet connection the
+  peer's delayed ACK or a PTO. `get_stats` now reports
+  `send_batch_pending`, the packets built but not yet handed to the
+  socket, which is what caught this.
 
 ### Changed
 - The interop runner declares the passive robustness cases (longrtt,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to this project will be documented in this file.
   The map version rebuilt the whole buffer on every miss; with a
   multi-megabyte hole under loss recovery that walk dominated receiver
   CPU.
+- The per-packet receive bookkeeping on the 1-RTT path (PN space, spin
+  bit, activity stamp) is one state update instead of three; the three
+  separate helpers each rebuilt the full connection state and together
+  cost about a tenth of receive CPU on bulk flows.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ All notable changes to this project will be documented in this file.
   never tail-dropped, and the bound only catches a peer outside it. A
   fixed 512-message bound sat below a 16 MB window and turned
   flow-control-permitted data into loss on loopback.
+- The listener drains the datagram messages already queued in its
+  mailbox into one receive sweep (up to 256 packets), groups them per
+  source address and dispatches each group as one batch. Distinct
+  flows never GRO-coalesce, so at a server with many sparse
+  connections every datagram used to be its own listener message and
+  its own connection wakeup; connections now wake once per sweep and
+  their batched receive path engages even for sparse traffic. ACK
+  processing re-arms the PTO once at the end of the receive pass
+  instead of once per ACK frame.
 
 ### Fixed
 - Pacing no longer freezes on sub-millisecond links. RTT samples are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- The interop runner declares the passive robustness cases (longrtt,
+  blackhole, amplificationlimit, handshakeloss, transferloss,
+  handshakecorruption, transfercorruption, rebind-port, rebind-addr),
+  runs the multiconnect case as one connection per file so the runner's
+  handshake count matches, disables `disconnect_timeout` in both
+  endpoints so the blackhole case can outlast its outage, waits 60 s per
+  download, and the server loads the full certificate chain from
+  cert.pem.
+
 ## [1.8.2] - 2026-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,17 @@ All notable changes to this project will be documented in this file.
   authentication failure, undersized datagram), which the caller then
   handles per packet. The client drain now collects queued same-source
   datagrams into one batch before processing.
+- After the batched decrypt, `open_run` also parses each packet's
+  frames in C and returns a frame list term-identical to what
+  `quic_frame:decode/1` produces (PING, ACK with ECN, CRYPTO, STREAM,
+  MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS, HANDSHAKE_DONE, with stream
+  and crypto payloads as zero-copy sub-binaries). A packet with any
+  other frame type comes back raw and goes through the Erlang decoder,
+  which keeps every error semantic (unknown type, truncation, empty
+  packet). The parser is differential-tested against the decoder and
+  fuzzed with random and mutated frame sequences. In a 50-connection
+  server model this cut steady-state reductions by 8%; on a verified
+  bulk transfer, 190 to 222 MiB/s.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ All notable changes to this project will be documented in this file.
   for new connections.
 
 ### Fixed
+- The NIF's AEAD context cache is bounded and no longer raises. Each
+  key update derives fresh keys, and the per-process cache kept a live
+  EVP context for every one of them, so a long-lived bulk connection
+  accumulated them until it exited; only the current and previous key
+  phase are ever live (RFC 9001 section 6), so the oldest are now
+  evicted. A context the NIF cannot build also falls back to the OTP
+  crypto path instead of failing a `{ok, Ctx}` match, which is what the
+  optional NIF is supposed to guarantee.
 - A client Initial flight spanning more than one datagram reaches the
   connection in full. The listener's receive sweep groups the packets
   of one flight together, and the group that starts a new connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,17 @@ All notable changes to this project will be documented in this file.
   fuzzed with random and mutated frame sequences. In a 50-connection
   server model this cut steady-state reductions by 8%; on a verified
   bulk transfer, 190 to 222 MiB/s.
+- A batch-opened run whose packets continue the receive sequence is
+  folded with one receive-bookkeeping update (largest, ACK range, spin
+  bit, activity) and one ACK-decimation increment instead of one of
+  each per packet; and when such a run carries one stream frame per
+  packet, all for the same stream, offsets contiguous, no FIN, the
+  stream bookkeeping runs once for the train: one flow-control check
+  with the train's totals, one stream-record update, one delivery.
+  Every deviation (mixed frames, gaps, duplicates, FIN, tight windows,
+  qlog enabled) takes the per-packet path unchanged and the delivery
+  contract holds in both modes. Verified bulk with delivery coalescing
+  on: 339 to 405 MiB/s (+19%).
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented in this file.
   message-boundary guarantee, but owners that decode each delivery as
   one complete application message break when deliveries merge, so it
   is opt-in.
+- Bulk stream sends go out as runs: once the first full-size chunk is
+  approved, as many further chunks as congestion control, pacing and
+  the burst budget allow are approved up front (consuming pacing
+  tokens exactly as one-at-a-time sends would), sealed and handed to
+  the socket in one loop, and loss, congestion, packet-number and
+  counter bookkeeping is updated once for the run. The per-packet
+  connection-state rebuild was the largest own-time item on the
+  bulk-send profile; a 64-packet run replaces 64 copies with one.
 
 ### Fixed
 - Pacing no longer freezes on sub-millisecond links. RTT samples are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `delivery_coalescing` (default `false`) merges consecutive
+  same-stream `stream_data` deliveries of one receive pass into a
+  single owner message, flushed at the end of the pass or as soon as
+  another stream delivers, so arrival order across streams is kept and
+  a `stream_reset` never overtakes data delivered before it. Owners
+  otherwise wake once per packet on bulk flows. QUIC gives no
+  message-boundary guarantee, but owners that decode each delivery as
+  one complete application message break when deliveries merge, so it
+  is opt-in.
+
 ### Changed
 - The interop runner declares the passive robustness cases (longrtt,
   blackhole, amplificationlimit, handshakeloss, transferloss,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ All notable changes to this project will be documented in this file.
   bit, activity stamp) is one state update instead of three; the three
   separate helpers each rebuilt the full connection state and together
   cost about a tenth of receive CPU on bulk flows.
+- Receive-side fast paths for the dominant bulk shape: an in-order
+  stream frame on an existing stream with an empty reassembly buffer
+  and both flow-control windows comfortably open is one stream-record
+  update and one map put, falling back to the general path for every
+  other shape; a sequential packet number extends the head ACK range
+  without the range-cap scan; a packet led by a stream frame skips the
+  datagram-only delayed-ACK check. The per-frame `max_stream_data_check`
+  debug log is gone, it cost a logger allow-check per frame.
 
 ## [1.8.2] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ All notable changes to this project will be documented in this file.
   GSO batches near size 1. The max_ack_delay timer still bounds ACK
   latency for below-tolerance remainders and the reordering
   immediate-ACK path is unchanged.
+- The out-of-order reassembly buffers (stream data and CRYPTO) are
+  ordered trees instead of maps. A miss at the delivery point, which
+  happens once per received packet while a hole is outstanding, is now
+  answered with one smallest-key lookup, and the trim walk for
+  repacketized overlaps visits only chunks below the delivery point.
+  The map version rebuilt the whole buffer on every miss; with a
+  multi-megabyte hole under loss recovery that walk dominated receiver
+  CPU.
 
 ## [1.8.2] - 2026-09-05
 

--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -1,0 +1,124 @@
+# Builds the optional AEAD-context NIF.
+#
+# Best effort by design: the NIF is a pure accelerator with a
+# pure-Erlang fallback (see quic_aead_ctx.erl), so a missing toolchain,
+# a missing CMake or missing OpenSSL headers must never fail the build
+# of a project that embeds this library. The callers in rebar.config
+# and in the Makefile shim swallow a failure and print a note.
+#
+# The NIF links against the SAME libcrypto that OTP's own crypto NIF
+# uses, resolved from crypto.so with the platform's shared-library
+# lister, so loading it never pins an incompatible OpenSSL into the VM
+# before crypto.so loads. When that lookup fails we fall back to
+# find_package(OpenSSL), and then to a bare -lcrypto.
+
+cmake_minimum_required(VERSION 3.16)
+project(quic_crypto_nif C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+find_program(ERL_EXECUTABLE erl)
+if(NOT ERL_EXECUTABLE)
+  message(FATAL_ERROR "erl not found; skipping the NIF")
+endif()
+
+# Ask the running OTP where its headers and its crypto NIF live.
+function(erl_eval OUTVAR EXPR)
+  execute_process(
+    COMMAND ${ERL_EXECUTABLE} -noshell -boot no_dot_erlang -eval "${EXPR}"
+    OUTPUT_VARIABLE _out
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(${OUTVAR} "${_out}" PARENT_SCOPE)
+endfunction()
+
+erl_eval(ERTS_INCLUDE_DIR
+  "io:format(\"~ts/erts-~ts/include\", [code:root_dir(), erlang:system_info(version)]), halt().")
+erl_eval(OTP_CRYPTO_SO
+  "io:format(\"~ts\", [filename:join([code:lib_dir(crypto), \"priv\", \"lib\", \"crypto.so\"])]), halt().")
+
+if(NOT EXISTS "${ERTS_INCLUDE_DIR}/erl_nif.h")
+  message(FATAL_ERROR "erl_nif.h not found under ${ERTS_INCLUDE_DIR}; skipping the NIF")
+endif()
+
+# Resolve the libcrypto OTP's crypto.so is already linked against.
+# ldd on Linux and FreeBSD, otool -L on macOS: both print the absolute
+# path of each dependency, so one regex covers them.
+set(OTP_LIBCRYPTO "")
+if(EXISTS "${OTP_CRYPTO_SO}")
+  if(APPLE)
+    find_program(LIB_LISTER otool)
+    set(LIB_LISTER_ARGS -L)
+  else()
+    find_program(LIB_LISTER ldd)
+    set(LIB_LISTER_ARGS "")
+  endif()
+  if(LIB_LISTER)
+    execute_process(
+      COMMAND ${LIB_LISTER} ${LIB_LISTER_ARGS} "${OTP_CRYPTO_SO}"
+      OUTPUT_VARIABLE _deps ERROR_QUIET)
+    # Absolute path ending in libcrypto{.so,.dylib}{.version}
+    string(REGEX MATCH "(/[^ \t\n]*libcrypto[^ \t\n]*\\.(so|dylib)[^ \t\n]*)" _m "${_deps}")
+    if(_m)
+      set(OTP_LIBCRYPTO "${CMAKE_MATCH_1}")
+    endif()
+  endif()
+endif()
+
+if(OTP_LIBCRYPTO AND EXISTS "${OTP_LIBCRYPTO}")
+  get_filename_component(OTP_LIBCRYPTO_DIR "${OTP_LIBCRYPTO}" DIRECTORY)
+  get_filename_component(OPENSSL_PREFIX "${OTP_LIBCRYPTO_DIR}" DIRECTORY)
+  set(OPENSSL_LIBRARIES "${OTP_LIBCRYPTO}")
+  find_path(OPENSSL_INCLUDE_DIR openssl/evp.h
+    HINTS "${OPENSSL_PREFIX}/include" NO_DEFAULT_PATH)
+  if(NOT OPENSSL_INCLUDE_DIR)
+    find_path(OPENSSL_INCLUDE_DIR openssl/evp.h)
+  endif()
+  message(STATUS "quic_crypto_nif: using OTP's libcrypto ${OTP_LIBCRYPTO}")
+else()
+  find_package(OpenSSL)
+  if(OPENSSL_FOUND)
+    message(STATUS "quic_crypto_nif: using find_package(OpenSSL) ${OPENSSL_VERSION}")
+  else()
+    set(OPENSSL_LIBRARIES crypto)
+    message(STATUS "quic_crypto_nif: falling back to -lcrypto")
+  endif()
+endif()
+
+if(NOT OPENSSL_INCLUDE_DIR OR NOT EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/evp.h")
+  message(FATAL_ERROR "openssl/evp.h not found; skipping the NIF")
+endif()
+
+# MODULE, not SHARED: a NIF is dlopen'd, never linked against, and on
+# macOS MODULE gives a bundle rather than a dylib. erlang:load_nif/2
+# appends ".so" on every platform, macOS included, so pin the suffix.
+add_library(quic_crypto_nif MODULE quic_crypto_nif.c)
+set_target_properties(quic_crypto_nif PROPERTIES
+  PREFIX ""
+  SUFFIX ".so"
+  POSITION_INDEPENDENT_CODE ON
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../priv")
+
+target_include_directories(quic_crypto_nif PRIVATE
+  "${ERTS_INCLUDE_DIR}" "${OPENSSL_INCLUDE_DIR}")
+target_link_libraries(quic_crypto_nif PRIVATE ${OPENSSL_LIBRARIES})
+target_compile_options(quic_crypto_nif PRIVATE -Wall -Wextra)
+
+# The enif_* symbols are resolved by the emulator at load time, so the
+# link must tolerate them being undefined. ELF does by default; Mach-O
+# needs telling.
+if(APPLE)
+  target_link_options(quic_crypto_nif PRIVATE -undefined dynamic_lookup)
+endif()
+
+# Keep the resolved libcrypto findable at load time without leaning on
+# the system search path.
+if(OTP_LIBCRYPTO_DIR)
+  set_target_properties(quic_crypto_nif PROPERTIES
+    BUILD_RPATH "${OTP_LIBCRYPTO_DIR}"
+    INSTALL_RPATH "${OTP_LIBCRYPTO_DIR}")
+endif()

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -3,6 +3,12 @@
 # loading this NIF never pins an incompatible OpenSSL into the VM
 # before crypto.so loads. Falls back to plain -lcrypto when the
 # lookup fails.
+#
+# Best effort by design: the NIF is a pure accelerator with a
+# pure-Erlang fallback, so a missing toolchain or missing OpenSSL
+# headers must not fail the build of a project that embeds this
+# library (erlang.mk runs this Makefile unconditionally when it
+# exists). A failed compile prints a warning and succeeds.
 
 ERTS_INCLUDE := $(shell erl -noshell -eval 'io:format("~ts/erts-~ts/include", [code:root_dir(), erlang:system_info(version)]), halt().')
 CRYPTO_SO := $(shell erl -noshell -eval 'io:format("~ts", [filename:join([code:lib_dir(crypto), "priv", "lib", "crypto.so"])]), halt().')
@@ -18,11 +24,18 @@ LDFLAGS += -L$(OPENSSL_LIBDIR) -Wl,-rpath,$(OPENSSL_LIBDIR)
 CFLAGS += -I$(OPENSSL_LIBDIR)../include
 endif
 
+all: $(PRIV)/quic_crypto_nif.so
+
 $(PRIV)/quic_crypto_nif.so: quic_crypto_nif.c
-	mkdir -p $(PRIV)
-	$(CC) $(CFLAGS) -fPIC -shared -o $@ $< -I"$(ERTS_INCLUDE)" $(LDFLAGS) $(LDLIBS)
+	@mkdir -p $(PRIV)
+	@if $(CC) $(CFLAGS) -fPIC -shared -o $@ $< -I"$(ERTS_INCLUDE)" $(LDFLAGS) $(LDLIBS); then \
+	    echo "quic_crypto_nif: built $@"; \
+	else \
+	    echo "quic_crypto_nif: build failed (missing toolchain or OpenSSL headers?);" \
+	         "the pure-Erlang crypto path will be used" >&2; \
+	fi
 
 clean:
 	rm -f $(PRIV)/quic_crypto_nif.so
 
-.PHONY: clean
+.PHONY: all clean

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,0 +1,28 @@
+# Builds the optional AEAD-context NIF. Links against the SAME
+# libcrypto that OTP's own crypto NIF uses (resolved via ldd), so
+# loading this NIF never pins an incompatible OpenSSL into the VM
+# before crypto.so loads. Falls back to plain -lcrypto when the
+# lookup fails.
+
+ERTS_INCLUDE := $(shell erl -noshell -eval 'io:format("~ts/erts-~ts/include", [code:root_dir(), erlang:system_info(version)]), halt().')
+CRYPTO_SO := $(shell erl -noshell -eval 'io:format("~ts", [filename:join([code:lib_dir(crypto), "priv", "lib", "crypto.so"])]), halt().')
+OPENSSL_LIB := $(shell ldd "$(CRYPTO_SO)" 2>/dev/null | awk '/libcrypto/ && $$3 != "" {print $$3}')
+OPENSSL_LIBDIR := $(dir $(OPENSSL_LIB))
+
+CFLAGS ?= -O2 -Wall -Wextra
+LDLIBS := -lcrypto
+PRIV := ../priv
+
+ifneq ($(strip $(OPENSSL_LIBDIR)),)
+LDFLAGS += -L$(OPENSSL_LIBDIR) -Wl,-rpath,$(OPENSSL_LIBDIR)
+CFLAGS += -I$(OPENSSL_LIBDIR)../include
+endif
+
+$(PRIV)/quic_crypto_nif.so: quic_crypto_nif.c
+	mkdir -p $(PRIV)
+	$(CC) $(CFLAGS) -fPIC -shared -o $@ $< -I"$(ERTS_INCLUDE)" $(LDFLAGS) $(LDLIBS)
+
+clean:
+	rm -f $(PRIV)/quic_crypto_nif.so
+
+.PHONY: clean

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,41 +1,20 @@
-# Builds the optional AEAD-context NIF. Links against the SAME
-# libcrypto that OTP's own crypto NIF uses (resolved via ldd), so
-# loading this NIF never pins an incompatible OpenSSL into the VM
-# before crypto.so loads. Falls back to plain -lcrypto when the
-# lookup fails.
+# Shim so erlang.mk, which runs c_src/Makefile unconditionally when it
+# exists, builds the NIF the same way rebar3 does. The real build is
+# CMakeLists.txt in this directory.
 #
-# Best effort by design: the NIF is a pure accelerator with a
-# pure-Erlang fallback, so a missing toolchain or missing OpenSSL
-# headers must not fail the build of a project that embeds this
-# library (erlang.mk runs this Makefile unconditionally when it
-# exists). A failed compile prints a warning and succeeds.
+# POSIX make only (no GNU extensions): FreeBSD and NetBSD run this with
+# bmake. Best effort, like every other entry point to this build: the
+# NIF is an accelerator with a pure-Erlang fallback, so a missing CMake
+# or toolchain prints a note and succeeds.
 
-ERTS_INCLUDE := $(shell erl -noshell -eval 'io:format("~ts/erts-~ts/include", [code:root_dir(), erlang:system_info(version)]), halt().')
-CRYPTO_SO := $(shell erl -noshell -eval 'io:format("~ts", [filename:join([code:lib_dir(crypto), "priv", "lib", "crypto.so"])]), halt().')
-OPENSSL_LIB := $(shell ldd "$(CRYPTO_SO)" 2>/dev/null | awk '/libcrypto/ && $$3 != "" {print $$3}')
-OPENSSL_LIBDIR := $(dir $(OPENSSL_LIB))
+BUILD = build
 
-CFLAGS ?= -O2 -Wall -Wextra
-LDLIBS := -lcrypto
-PRIV := ../priv
-
-ifneq ($(strip $(OPENSSL_LIBDIR)),)
-LDFLAGS += -L$(OPENSSL_LIBDIR) -Wl,-rpath,$(OPENSSL_LIBDIR)
-CFLAGS += -I$(OPENSSL_LIBDIR)../include
-endif
-
-all: $(PRIV)/quic_crypto_nif.so
-
-$(PRIV)/quic_crypto_nif.so: quic_crypto_nif.c
-	@mkdir -p $(PRIV)
-	@if $(CC) $(CFLAGS) -fPIC -shared -o $@ $< -I"$(ERTS_INCLUDE)" $(LDFLAGS) $(LDLIBS); then \
-	    echo "quic_crypto_nif: built $@"; \
-	else \
-	    echo "quic_crypto_nif: build failed (missing toolchain or OpenSSL headers?);" \
-	         "the pure-Erlang crypto path will be used" >&2; \
-	fi
+all:
+	@cmake -S . -B $(BUILD) >/dev/null 2>&1 && cmake --build $(BUILD) >/dev/null 2>&1 \
+	  && echo "quic_crypto_nif: built ../priv/quic_crypto_nif.so" \
+	  || echo "quic_crypto_nif: build skipped (no cmake, toolchain or OpenSSL headers?); using the pure-Erlang crypto path"
 
 clean:
-	rm -f $(PRIV)/quic_crypto_nif.so
+	@rm -rf $(BUILD) ../priv/quic_crypto_nif.so
 
 .PHONY: all clean

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -429,6 +429,100 @@ open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         env, enif_make_uint64(env, pn), enif_make_uint(env, fb), plain_term);
 }
 
+/* open_run(AeadCtx, HpCtx, IV12, LargestRecv, ExpectedPhase, DcidLen,
+ *          Datagrams) -> {ok, [{PN, FirstByte, Plain}]} | {error, badarg}
+ *
+ * Batched open_packet over a train of short-header datagrams. Each
+ * datagram is FirstByte + DCID(DcidLen) + PN bytes + ciphertext + tag;
+ * the largest received PN is carried forward across the run for
+ * packet-number reconstruction, matching sequential per-packet calls.
+ * Stops at the first datagram that cannot be opened on this fast path
+ * (size, key-phase mismatch, auth failure): the result list is the
+ * consumed prefix and the caller reruns the rest generically. */
+#define OPEN_RUN_MAX 256
+static ERL_NIF_TERM
+open_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    qc_ctx *aead, *hp;
+    ErlNifBinary iv, dgram;
+    ErlNifSInt64 largest;
+    unsigned int expphase, dcidlen;
+    ERL_NIF_TERM list, head, tail, results[OPEN_RUN_MAX];
+    unsigned k = 0;
+
+    (void)argc;
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&aead) == 0 || aead->enc != 0 ||
+        enif_get_resource(env, argv[1], qc_ctx_type, (void **)&hp) == 0 ||
+        enif_inspect_binary(env, argv[2], &iv) == 0 || iv.size != NONCE_LEN ||
+        enif_get_int64(env, argv[3], &largest) == 0 ||
+        enif_get_uint(env, argv[4], &expphase) == 0 || expphase > 1 ||
+        enif_get_uint(env, argv[5], &dcidlen) == 0 || dcidlen > 20 ||
+        enif_is_list(env, argv[6]) == 0)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    list = argv[6];
+    while (k < OPEN_RUN_MAX && enif_get_list_cell(env, list, &head, &tail)) {
+        unsigned char mask[16], aad[1 + 20 + 4], nonce[NONCE_LEN], fb;
+        unsigned pnlen, phase, i, aadlen, ctlen, hdrlen = 1 + dcidlen;
+        ErlNifUInt64 trunc_pn = 0, pn;
+        ERL_NIF_TERM plain_term;
+        unsigned char *out, *payload;
+        unsigned payload_size;
+        int len = 0, len2 = 0, mlen = 0;
+
+        if (enif_inspect_binary(env, head, &dgram) == 0 ||
+            dgram.size < hdrlen + 4 + 16)
+            break;
+        payload = dgram.data + hdrlen;
+        payload_size = (unsigned)dgram.size - hdrlen;
+
+        if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, payload + 4, 16) != 1 || mlen != 16)
+            break;
+        fb = dgram.data[0] ^ (mask[0] & 0x1f);
+        pnlen = (fb & 0x03) + 1;
+        phase = (fb >> 2) & 1;
+        if (phase != expphase)
+            break;
+        if (payload_size < pnlen + TAG_LEN)
+            break;
+
+        aad[0] = fb;
+        memcpy(aad + 1, dgram.data + 1, dcidlen);
+        for (i = 0; i < pnlen; i++) {
+            unsigned char b = payload[i] ^ mask[1 + i];
+            aad[hdrlen + i] = b;
+            trunc_pn = (trunc_pn << 8) | b;
+        }
+        aadlen = hdrlen + pnlen;
+        pn = reconstruct_pn(largest, trunc_pn, pnlen);
+
+        memcpy(nonce, iv.data, NONCE_LEN);
+        for (i = 0; i < 8; i++)
+            nonce[NONCE_LEN - 1 - i] ^= (unsigned char)(pn >> (8 * i));
+
+        ctlen = payload_size - pnlen - TAG_LEN;
+        out = enif_make_new_binary(env, ctlen, &plain_term);
+
+        if (EVP_DecryptInit_ex(aead->ctx, NULL, NULL, NULL, nonce) != 1 ||
+            EVP_DecryptUpdate(aead->ctx, NULL, &len, aad, (int)aadlen) != 1 ||
+            (ctlen > 0 &&
+             EVP_DecryptUpdate(aead->ctx, out, &len, payload + pnlen, (int)ctlen) != 1) ||
+            EVP_CIPHER_CTX_ctrl(aead->ctx, EVP_CTRL_AEAD_SET_TAG, TAG_LEN,
+                                (void *)(payload + payload_size - TAG_LEN)) != 1)
+            break;
+        if (EVP_DecryptFinal_ex(aead->ctx, out + len, &len2) != 1)
+            break;
+
+        results[k++] = enif_make_tuple3(
+            env, enif_make_uint64(env, pn), enif_make_uint(env, fb), plain_term);
+        if ((ErlNifSInt64)pn > largest)
+            largest = (ErlNifSInt64)pn;
+        list = tail;
+    }
+
+    return enif_make_tuple2(env, am_ok, enif_make_list_from_array(env, results, k));
+}
+
 static ERL_NIF_TERM
 is_loaded(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -465,6 +559,7 @@ static ErlNifFunc nif_funcs[] = {
     {"hp_block", 2, hp_block, 0},
     {"protect_run", 7, protect_run, 0},
     {"open_packet", 7, open_packet, 0},
+    {"open_run", 7, open_run, 0},
 };
 
 ERL_NIF_INIT(quic_crypto_nif, nif_funcs, load, NULL, NULL, NULL)

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -13,7 +13,7 @@
  * whose NIF calls are sequential.
  *
  * The pure-Erlang code path remains the fallback when this NIF is not
- * built or fails to load; see quic_crypto.erl.
+ * built or fails to load; see quic_aead_ctx.erl.
  */
 
 #include <erl_nif.h>
@@ -162,8 +162,8 @@ seal(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     (void)argc;
     if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 || c->enc != 1 ||
         enif_inspect_binary(env, argv[1], &nonce) == 0 || nonce.size != NONCE_LEN ||
-        enif_inspect_binary(env, argv[2], &aad) == 0 ||
-        enif_inspect_binary(env, argv[3], &plain) == 0)
+        enif_inspect_iolist_as_binary(env, argv[2], &aad) == 0 ||
+        enif_inspect_iolist_as_binary(env, argv[3], &plain) == 0)
         return enif_make_tuple2(env, am_error, am_badarg);
 
     out = enif_make_new_binary(env, plain.size + TAG_LEN, &out_term);
@@ -196,8 +196,8 @@ open_(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     (void)argc;
     if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 || c->enc != 0 ||
         enif_inspect_binary(env, argv[1], &nonce) == 0 || nonce.size != NONCE_LEN ||
-        enif_inspect_binary(env, argv[2], &aad) == 0 ||
-        enif_inspect_binary(env, argv[3], &ct) == 0 ||
+        enif_inspect_iolist_as_binary(env, argv[2], &aad) == 0 ||
+        enif_inspect_iolist_as_binary(env, argv[3], &ct) == 0 ||
         enif_inspect_binary(env, argv[4], &tag) == 0 || tag.size != TAG_LEN)
         return enif_make_tuple2(env, am_error, am_badarg);
 

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -239,6 +239,98 @@ hp_block(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     return out_term;
 }
 
+/* protect_run(AeadCtx, HpCtx, IV12, PN0, FirstByteBase, DCID, Payloads)
+ *   -> [WirePacket] | {error, badarg}
+ *
+ * Seals a run of short-header packets with consecutive packet numbers
+ * in one call. For I = 0..K-1 with PN = PN0 + I:
+ *   PNLen   = 1..4 (smallest big-endian encoding of PN)
+ *   header  = (FirstByteBase | (PNLen-1)) ++ DCID ++ PN[PNLen]
+ *   nonce   = IV with PN xored into the low 64 bits
+ *   body    = AEAD_seal(aead, nonce, header, Payload) ++ tag
+ *   mask    = ECB(hp, body[4-PNLen .. +16])
+ *   header protection: first byte ^= mask[0] & 0x1f (short header),
+ *   PN bytes ^= mask[1..PNLen]
+ * FirstByteBase must have the PN-length bits (0-1) clear. AES only -
+ * the HP context is an ECB context; ChaCha callers use the per-packet
+ * path.
+ */
+#define MAX_RUN 256
+
+static ERL_NIF_TERM
+protect_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    qc_ctx *aead, *hp;
+    ErlNifBinary iv, dcid, plain;
+    ErlNifUInt64 pn0;
+    unsigned int fbase;
+    ERL_NIF_TERM list, head, tail;
+    ERL_NIF_TERM packets[MAX_RUN];
+    unsigned k = 0, i;
+
+    (void)argc;
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&aead) == 0 || aead->enc != 1 ||
+        enif_get_resource(env, argv[1], qc_ctx_type, (void **)&hp) == 0 ||
+        enif_inspect_binary(env, argv[2], &iv) == 0 || iv.size != NONCE_LEN ||
+        enif_get_uint64(env, argv[3], &pn0) == 0 || enif_get_uint(env, argv[4], &fbase) == 0 ||
+        fbase > 255 || enif_inspect_iolist_as_binary(env, argv[5], &dcid) == 0 ||
+        dcid.size > 20)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    list = argv[6];
+    while (enif_get_list_cell(env, list, &head, &tail)) {
+        ErlNifUInt64 pn = pn0 + k;
+        unsigned char header[1 + 20 + 4];
+        unsigned char nonce[NONCE_LEN];
+        unsigned char mask[16], sample_off;
+        unsigned pnlen, hlen;
+        unsigned char *out, *body;
+        ERL_NIF_TERM pkt;
+        int len = 0, len2 = 0, mlen = 0;
+
+        if (k >= MAX_RUN || enif_inspect_iolist_as_binary(env, head, &plain) == 0 ||
+            plain.size < 4)
+            return enif_make_tuple2(env, am_error, am_badarg);
+
+        pnlen = (pn < 0x100) ? 1 : (pn < 0x10000) ? 2 : (pn < 0x1000000) ? 3 : 4;
+        header[0] = (unsigned char)(fbase | (pnlen - 1));
+        memcpy(header + 1, dcid.data, dcid.size);
+        for (i = 0; i < pnlen; i++)
+            header[1 + dcid.size + i] = (unsigned char)(pn >> (8 * (pnlen - 1 - i)));
+        hlen = 1 + (unsigned)dcid.size + pnlen;
+
+        memcpy(nonce, iv.data, NONCE_LEN);
+        for (i = 0; i < 8; i++)
+            nonce[NONCE_LEN - 1 - i] ^= (unsigned char)(pn >> (8 * i));
+
+        out = enif_make_new_binary(env, hlen + plain.size + TAG_LEN, &pkt);
+        memcpy(out, header, hlen);
+        body = out + hlen;
+
+        if (EVP_EncryptInit_ex(aead->ctx, NULL, NULL, NULL, nonce) != 1 ||
+            EVP_EncryptUpdate(aead->ctx, NULL, &len, header, (int)hlen) != 1 ||
+            EVP_EncryptUpdate(aead->ctx, body, &len, plain.data, (int)plain.size) != 1 ||
+            EVP_EncryptFinal_ex(aead->ctx, body + len, &len2) != 1 ||
+            EVP_CIPHER_CTX_ctrl(aead->ctx, EVP_CTRL_AEAD_GET_TAG, TAG_LEN,
+                                body + plain.size) != 1)
+            return enif_make_tuple2(env, am_error, am_badarg);
+
+        sample_off = (unsigned char)(4 - pnlen);
+        if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, body + sample_off, 16) != 1 || mlen != 16)
+            return enif_make_tuple2(env, am_error, am_badarg);
+        out[0] ^= mask[0] & 0x1f;
+        for (i = 0; i < pnlen; i++)
+            out[1 + dcid.size + i] ^= mask[1 + i];
+
+        packets[k++] = pkt;
+        list = tail;
+    }
+    if (!enif_is_empty_list(env, list))
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    return enif_make_list_from_array(env, packets, k);
+}
+
 static ERL_NIF_TERM
 is_loaded(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -272,6 +364,7 @@ static ErlNifFunc nif_funcs[] = {
     {"seal", 4, seal, 0},
     {"open", 5, open_, 0},
     {"hp_block", 2, hp_block, 0},
+    {"protect_run", 7, protect_run, 0},
 };
 
 ERL_NIF_INIT(quic_crypto_nif, nif_funcs, load, NULL, NULL, NULL)

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -429,6 +429,191 @@ open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         env, enif_make_uint64(env, pn), enif_make_uint(env, fb), plain_term);
 }
 
+
+/* ---- In-NIF QUIC frame parsing for the batched receive path ----
+ * Produces term-identical output to quic_frame:decode/1 for the frame
+ * types that dominate the hot path; anything else makes the whole
+ * packet fall back to {raw, Plain} and the generic Erlang decoder,
+ * which also owns all error semantics (unknown type, truncation,
+ * empty packet). */
+
+#define PF_MAX_FRAMES 64
+
+static ERL_NIF_TERM am_padding_f, am_ping_f, am_ack_f, am_crypto_f,
+    am_stream_f, am_max_data_f, am_max_stream_data_f, am_max_streams_f,
+    am_bidi_f, am_uni_f, am_handshake_done_f, am_raw_f, am_undefined_f;
+
+static int
+rd_varint(const unsigned char *p, unsigned rem, ErlNifUInt64 *v, unsigned *used)
+{
+    unsigned len;
+    if (rem < 1)
+        return 0;
+    len = 1u << (p[0] >> 6);
+    if (rem < len)
+        return 0;
+    *v = p[0] & 0x3f;
+    for (unsigned i = 1; i < len; i++)
+        *v = (*v << 8) | p[i];
+    *used = len;
+    return 1;
+}
+
+/* Returns 1 and sets *out to the frames list (in wire order) on
+ * success; 0 to request the raw fallback. */
+static int
+parse_quic_frames(ErlNifEnv *env, ERL_NIF_TERM plain, const unsigned char *d,
+                  unsigned n, ERL_NIF_TERM *out)
+{
+    ERL_NIF_TERM frames[PF_MAX_FRAMES];
+    unsigned nf = 0, off = 0;
+
+    while (off < n) {
+        unsigned char t = d[off];
+        if (t == 0x00) { /* PADDING run: skip, no term (probing only) */
+            off++;
+            continue;
+        }
+        if (nf >= PF_MAX_FRAMES)
+            return 0;
+        if (t == 0x01) { /* PING */
+            frames[nf++] = am_ping_f;
+            off++;
+            continue;
+        }
+        if (t == 0x02 || t == 0x03) { /* ACK [+ECN] */
+            ErlNifUInt64 la, delay, cnt, fr;
+            unsigned u;
+            ERL_NIF_TERM ranges, ecn;
+            unsigned i;
+            off++;
+            if (!rd_varint(d + off, n - off, &la, &u)) return 0;
+            off += u;
+            if (!rd_varint(d + off, n - off, &delay, &u)) return 0;
+            off += u;
+            if (!rd_varint(d + off, n - off, &cnt, &u)) return 0;
+            off += u;
+            if (!rd_varint(d + off, n - off, &fr, &u)) return 0;
+            off += u;
+            if (cnt > 1024) return 0;
+            {
+                ERL_NIF_TERM pairs[64];
+                ERL_NIF_TERM tailride = enif_make_list(env, 0);
+                if (cnt > 64) return 0;
+                for (i = 0; i < cnt; i++) {
+                    ErlNifUInt64 gap, rng;
+                    if (!rd_varint(d + off, n - off, &gap, &u)) return 0;
+                    off += u;
+                    if (!rd_varint(d + off, n - off, &rng, &u)) return 0;
+                    off += u;
+                    pairs[i] = enif_make_tuple2(env,
+                        enif_make_uint64(env, gap), enif_make_uint64(env, rng));
+                }
+                for (i = cnt; i > 0; i--)
+                    tailride = enif_make_list_cell(env, pairs[i - 1], tailride);
+                ranges = enif_make_list_cell(env,
+                    enif_make_tuple2(env, enif_make_uint64(env, la),
+                        enif_make_uint64(env, fr)),
+                    tailride);
+            }
+            if (t == 0x03) {
+                ErlNifUInt64 e0, e1, ce;
+                if (!rd_varint(d + off, n - off, &e0, &u)) return 0;
+                off += u;
+                if (!rd_varint(d + off, n - off, &e1, &u)) return 0;
+                off += u;
+                if (!rd_varint(d + off, n - off, &ce, &u)) return 0;
+                off += u;
+                ecn = enif_make_tuple3(env, enif_make_uint64(env, e0),
+                    enif_make_uint64(env, e1), enif_make_uint64(env, ce));
+            } else {
+                ecn = am_undefined_f;
+            }
+            frames[nf++] = enif_make_tuple4(env, am_ack_f, ranges,
+                enif_make_uint64(env, delay), ecn);
+            continue;
+        }
+        if (t == 0x06) { /* CRYPTO */
+            ErlNifUInt64 o, len;
+            unsigned u;
+            off++;
+            if (!rd_varint(d + off, n - off, &o, &u)) return 0;
+            off += u;
+            if (!rd_varint(d + off, n - off, &len, &u)) return 0;
+            off += u;
+            if (len > n - off) return 0;
+            frames[nf++] = enif_make_tuple3(env, am_crypto_f,
+                enif_make_uint64(env, o),
+                enif_make_sub_binary(env, plain, off, (size_t)len));
+            off += (unsigned)len;
+            continue;
+        }
+        if (t >= 0x08 && t <= 0x0f) { /* STREAM */
+            ErlNifUInt64 sid, o = 0, len;
+            unsigned u;
+            ERL_NIF_TERM data, fin;
+            off++;
+            if (!rd_varint(d + off, n - off, &sid, &u)) return 0;
+            off += u;
+            if (t & 0x04) {
+                if (!rd_varint(d + off, n - off, &o, &u)) return 0;
+                off += u;
+            }
+            fin = (t & 0x01) ? am_true : am_false;
+            if (t & 0x02) {
+                if (!rd_varint(d + off, n - off, &len, &u)) return 0;
+                off += u;
+                if (len > n - off) return 0;
+                data = enif_make_sub_binary(env, plain, off, (size_t)len);
+                off += (unsigned)len;
+            } else {
+                data = enif_make_sub_binary(env, plain, off, n - off);
+                off = n;
+            }
+            frames[nf++] = enif_make_tuple5(env, am_stream_f,
+                enif_make_uint64(env, sid), enif_make_uint64(env, o), data, fin);
+            continue;
+        }
+        if (t == 0x10 || t == 0x11) { /* MAX_DATA / MAX_STREAM_DATA */
+            ErlNifUInt64 a, b;
+            unsigned u;
+            off++;
+            if (!rd_varint(d + off, n - off, &a, &u)) return 0;
+            off += u;
+            if (t == 0x10) {
+                frames[nf++] = enif_make_tuple2(env, am_max_data_f,
+                    enif_make_uint64(env, a));
+            } else {
+                if (!rd_varint(d + off, n - off, &b, &u)) return 0;
+                off += u;
+                frames[nf++] = enif_make_tuple3(env, am_max_stream_data_f,
+                    enif_make_uint64(env, a), enif_make_uint64(env, b));
+            }
+            continue;
+        }
+        if (t == 0x12 || t == 0x13) { /* MAX_STREAMS bidi/uni */
+            ErlNifUInt64 a;
+            unsigned u;
+            off++;
+            if (!rd_varint(d + off, n - off, &a, &u)) return 0;
+            off += u;
+            frames[nf++] = enif_make_tuple3(env, am_max_streams_f,
+                (t == 0x12) ? am_bidi_f : am_uni_f, enif_make_uint64(env, a));
+            continue;
+        }
+        if (t == 0x1e) { /* HANDSHAKE_DONE */
+            frames[nf++] = am_handshake_done_f;
+            off++;
+            continue;
+        }
+        return 0; /* anything else: raw fallback */
+    }
+    if (nf == 0)
+        return 0; /* padding-only packet: Erlang owns the violation */
+    *out = enif_make_list_from_array(env, frames, nf);
+    return 1;
+}
+
 /* open_run(AeadCtx, HpCtx, IV12, LargestRecv, ExpectedPhase, DcidLen,
  *          Datagrams) -> {ok, [{PN, FirstByte, Plain}]} | {error, badarg}
  *
@@ -513,8 +698,16 @@ open_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         if (EVP_DecryptFinal_ex(aead->ctx, out + len, &len2) != 1)
             break;
 
-        results[k++] = enif_make_tuple3(
-            env, enif_make_uint64(env, pn), enif_make_uint(env, fb), plain_term);
+        {
+            ERL_NIF_TERM frames;
+            ERL_NIF_TERM third;
+            if (parse_quic_frames(env, plain_term, out, (unsigned)(len + len2), &frames))
+                third = frames;
+            else
+                third = enif_make_tuple2(env, am_raw_f, plain_term);
+            results[k++] = enif_make_tuple3(
+                env, enif_make_uint64(env, pn), enif_make_uint(env, fb), third);
+        }
         if ((ErlNifSInt64)pn > largest)
             largest = (ErlNifSInt64)pn;
         list = tail;
@@ -547,6 +740,19 @@ load(ErlNifEnv *env, void **priv, ERL_NIF_TERM info)
     am_not_loaded = enif_make_atom(env, "not_loaded");
     am_badarg = enif_make_atom(env, "badarg");
     am_key_phase = enif_make_atom(env, "key_phase");
+    am_padding_f = enif_make_atom(env, "padding");
+    am_ping_f = enif_make_atom(env, "ping");
+    am_ack_f = enif_make_atom(env, "ack");
+    am_crypto_f = enif_make_atom(env, "crypto");
+    am_stream_f = enif_make_atom(env, "stream");
+    am_max_data_f = enif_make_atom(env, "max_data");
+    am_max_stream_data_f = enif_make_atom(env, "max_stream_data");
+    am_max_streams_f = enif_make_atom(env, "max_streams");
+    am_bidi_f = enif_make_atom(env, "bidi");
+    am_uni_f = enif_make_atom(env, "uni");
+    am_handshake_done_f = enif_make_atom(env, "handshake_done");
+    am_raw_f = enif_make_atom(env, "raw");
+    am_undefined_f = enif_make_atom(env, "undefined");
     return 0;
 }
 

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -36,6 +36,7 @@ static ERL_NIF_TERM am_true;
 static ERL_NIF_TERM am_false;
 static ERL_NIF_TERM am_not_loaded;
 static ERL_NIF_TERM am_badarg;
+static ERL_NIF_TERM am_key_phase;
 
 static void
 qc_ctx_dtor(ErlNifEnv *env, void *obj)
@@ -331,6 +332,103 @@ protect_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     return enif_make_list_from_array(env, packets, k);
 }
 
+/* RFC 9000 Appendix A packet number decoding. largest < 0 means no
+ * packet received yet (use the truncated PN directly). */
+static ErlNifUInt64
+reconstruct_pn(ErlNifSInt64 largest, ErlNifUInt64 trunc_pn, unsigned pnlen)
+{
+    ErlNifUInt64 win, hwin, expected, candidate;
+
+    if (largest < 0)
+        return trunc_pn;
+    win = (ErlNifUInt64)1 << (pnlen * 8);
+    hwin = win >> 1;
+    expected = (ErlNifUInt64)largest + 1;
+    candidate = (expected & ~(win - 1)) | trunc_pn;
+    if (candidate + hwin <= expected && candidate < (((ErlNifUInt64)1 << 62) - win))
+        return candidate + win;
+    if (candidate > expected + hwin && candidate >= win)
+        return candidate - win;
+    return candidate;
+}
+
+/* open_packet(AeadCtx, HpCtx, IV12, LargestRecv, ExpectedPhase,
+ *             Header, EncPayload)
+ *   -> {PN, FirstByte, Plain} | error | key_phase | {error, badarg}
+ *
+ * Fused short-header receive path: header unprotection, packet-number
+ * reconstruction and AEAD open in one call. Header is the protected
+ * first byte + DCID; EncPayload is PN bytes + ciphertext + tag.
+ * Returns `key_phase' without decrypting when the unprotected key
+ * phase bit differs from ExpectedPhase (caller reruns the generic
+ * path with key selection); `error' on authentication failure. */
+static ERL_NIF_TERM
+open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    qc_ctx *aead, *hp;
+    ErlNifBinary iv, header, payload;
+    ErlNifSInt64 largest;
+    unsigned int expphase;
+    unsigned char mask[16], aad[1 + 20 + 4], nonce[NONCE_LEN], fb;
+    unsigned pnlen, phase, i, aadlen, ctlen;
+    ErlNifUInt64 trunc_pn = 0, pn;
+    ERL_NIF_TERM plain_term;
+    unsigned char *out;
+    int len = 0, len2 = 0, mlen = 0;
+
+    (void)argc;
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&aead) == 0 || aead->enc != 0 ||
+        enif_get_resource(env, argv[1], qc_ctx_type, (void **)&hp) == 0 ||
+        enif_inspect_binary(env, argv[2], &iv) == 0 || iv.size != NONCE_LEN ||
+        enif_get_int64(env, argv[3], &largest) == 0 ||
+        enif_get_uint(env, argv[4], &expphase) == 0 || expphase > 1 ||
+        enif_inspect_binary(env, argv[5], &header) == 0 || header.size < 1 ||
+        header.size > 21 || enif_inspect_binary(env, argv[6], &payload) == 0 ||
+        payload.size < 4 + 16)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    /* Sample sits 4 bytes past the PN start; payload begins at the PN. */
+    if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, payload.data + 4, 16) != 1 || mlen != 16)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    fb = header.data[0] ^ (mask[0] & 0x1f);
+    pnlen = (fb & 0x03) + 1;
+    phase = (fb >> 2) & 1;
+    if (phase != expphase)
+        return am_key_phase;
+    if (payload.size < pnlen + TAG_LEN)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    aad[0] = fb;
+    memcpy(aad + 1, header.data + 1, header.size - 1);
+    for (i = 0; i < pnlen; i++) {
+        unsigned char b = payload.data[i] ^ mask[1 + i];
+        aad[header.size + i] = b;
+        trunc_pn = (trunc_pn << 8) | b;
+    }
+    aadlen = (unsigned)header.size + pnlen;
+    pn = reconstruct_pn(largest, trunc_pn, pnlen);
+
+    memcpy(nonce, iv.data, NONCE_LEN);
+    for (i = 0; i < 8; i++)
+        nonce[NONCE_LEN - 1 - i] ^= (unsigned char)(pn >> (8 * i));
+
+    ctlen = (unsigned)payload.size - pnlen - TAG_LEN;
+    out = enif_make_new_binary(env, ctlen, &plain_term);
+
+    if (EVP_DecryptInit_ex(aead->ctx, NULL, NULL, NULL, nonce) != 1 ||
+        EVP_DecryptUpdate(aead->ctx, NULL, &len, aad, (int)aadlen) != 1 ||
+        (ctlen > 0 &&
+         EVP_DecryptUpdate(aead->ctx, out, &len, payload.data + pnlen, (int)ctlen) != 1) ||
+        EVP_CIPHER_CTX_ctrl(aead->ctx, EVP_CTRL_AEAD_SET_TAG, TAG_LEN,
+                            (void *)(payload.data + payload.size - TAG_LEN)) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (EVP_DecryptFinal_ex(aead->ctx, out + len, &len2) != 1)
+        return am_error;
+
+    return enif_make_tuple3(
+        env, enif_make_uint64(env, pn), enif_make_uint(env, fb), plain_term);
+}
+
 static ERL_NIF_TERM
 is_loaded(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -354,6 +452,7 @@ load(ErlNifEnv *env, void **priv, ERL_NIF_TERM info)
     am_false = enif_make_atom(env, "false");
     am_not_loaded = enif_make_atom(env, "not_loaded");
     am_badarg = enif_make_atom(env, "badarg");
+    am_key_phase = enif_make_atom(env, "key_phase");
     return 0;
 }
 
@@ -365,6 +464,7 @@ static ErlNifFunc nif_funcs[] = {
     {"open", 5, open_, 0},
     {"hp_block", 2, hp_block, 0},
     {"protect_run", 7, protect_run, 0},
+    {"open_packet", 7, open_packet, 0},
 };
 
 ERL_NIF_INIT(quic_crypto_nif, nif_funcs, load, NULL, NULL, NULL)

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -1,0 +1,277 @@
+/*
+ * Batch/context AEAD NIF for erlang_quic.
+ *
+ * QUIC encrypts every ~1300-byte packet as its own AEAD unit. OTP's
+ * crypto:crypto_one_time_aead/7 re-runs the key schedule on every
+ * call, which dominates per-packet crypto cost on bulk transfers.
+ * This NIF keeps an EVP_CIPHER_CTX per key as a NIF resource: the key
+ * schedule runs once at context creation and each packet only resets
+ * the nonce.
+ *
+ * Contexts are NOT thread-safe; a context must only be used from the
+ * process that created it (one connection process in erlang_quic),
+ * whose NIF calls are sequential.
+ *
+ * The pure-Erlang code path remains the fallback when this NIF is not
+ * built or fails to load; see quic_crypto.erl.
+ */
+
+#include <erl_nif.h>
+#include <openssl/evp.h>
+#include <string.h>
+
+#define TAG_LEN 16
+#define NONCE_LEN 12
+
+typedef struct {
+    EVP_CIPHER_CTX *ctx;
+    int enc; /* 1 = seal, 0 = open */
+} qc_ctx;
+
+static ErlNifResourceType *qc_ctx_type;
+
+static ERL_NIF_TERM am_ok;
+static ERL_NIF_TERM am_error;
+static ERL_NIF_TERM am_true;
+static ERL_NIF_TERM am_false;
+static ERL_NIF_TERM am_not_loaded;
+static ERL_NIF_TERM am_badarg;
+
+static void
+qc_ctx_dtor(ErlNifEnv *env, void *obj)
+{
+    qc_ctx *c = (qc_ctx *)obj;
+    (void)env;
+    if (c->ctx != NULL) {
+        EVP_CIPHER_CTX_free(c->ctx);
+        c->ctx = NULL;
+    }
+}
+
+static const EVP_CIPHER *
+cipher_from_atom(ErlNifEnv *env, ERL_NIF_TERM atom)
+{
+    char name[32];
+    if (enif_get_atom(env, atom, name, sizeof(name), ERL_NIF_LATIN1) == 0)
+        return NULL;
+    if (strcmp(name, "aes_128_gcm") == 0)
+        return EVP_aes_128_gcm();
+    if (strcmp(name, "aes_256_gcm") == 0)
+        return EVP_aes_256_gcm();
+    if (strcmp(name, "chacha20_poly1305") == 0)
+        return EVP_chacha20_poly1305();
+    if (strcmp(name, "aes_128_ecb") == 0)
+        return EVP_aes_128_ecb();
+    if (strcmp(name, "aes_256_ecb") == 0)
+        return EVP_aes_256_ecb();
+    return NULL;
+}
+
+/* new_aead_ctx(Cipher, Key, Enc) -> {ok, Ctx} | {error, Reason} */
+static ERL_NIF_TERM
+new_aead_ctx(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    const EVP_CIPHER *cipher;
+    ErlNifBinary key;
+    qc_ctx *c;
+    ERL_NIF_TERM res;
+    int enc;
+
+    (void)argc;
+    cipher = cipher_from_atom(env, argv[0]);
+    if (cipher == NULL || enif_inspect_binary(env, argv[1], &key) == 0)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (enif_is_identical(argv[2], am_true))
+        enc = 1;
+    else if (enif_is_identical(argv[2], am_false))
+        enc = 0;
+    else
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    c = enif_alloc_resource(qc_ctx_type, sizeof(qc_ctx));
+    c->ctx = EVP_CIPHER_CTX_new();
+    c->enc = enc;
+    if (c->ctx == NULL)
+        goto fail;
+    /* Set cipher + key once; nonce comes per packet. */
+    if (EVP_CipherInit_ex(c->ctx, cipher, NULL, NULL, NULL, enc) != 1)
+        goto fail;
+    if (EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_AEAD_SET_IVLEN, NONCE_LEN, NULL) != 1)
+        goto fail;
+    if ((size_t)EVP_CIPHER_CTX_key_length(c->ctx) != key.size)
+        goto fail;
+    if (EVP_CipherInit_ex(c->ctx, NULL, NULL, key.data, NULL, enc) != 1)
+        goto fail;
+
+    res = enif_make_resource(env, c);
+    enif_release_resource(c);
+    return enif_make_tuple2(env, am_ok, res);
+
+fail:
+    enif_release_resource(c);
+    return enif_make_tuple2(env, am_error, am_badarg);
+}
+
+/* new_hp_ctx(Cipher, Key) -> {ok, Ctx} | {error, Reason}
+ * ECB context for AES header-protection mask generation. */
+static ERL_NIF_TERM
+new_hp_ctx(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    const EVP_CIPHER *cipher;
+    ErlNifBinary key;
+    qc_ctx *c;
+    ERL_NIF_TERM res;
+
+    (void)argc;
+    cipher = cipher_from_atom(env, argv[0]);
+    if (cipher == NULL || enif_inspect_binary(env, argv[1], &key) == 0)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    c = enif_alloc_resource(qc_ctx_type, sizeof(qc_ctx));
+    c->ctx = EVP_CIPHER_CTX_new();
+    c->enc = 1;
+    if (c->ctx == NULL)
+        goto fail;
+    if (EVP_EncryptInit_ex(c->ctx, cipher, NULL, NULL, NULL) != 1)
+        goto fail;
+    if ((size_t)EVP_CIPHER_CTX_key_length(c->ctx) != key.size)
+        goto fail;
+    if (EVP_EncryptInit_ex(c->ctx, NULL, NULL, key.data, NULL) != 1)
+        goto fail;
+    EVP_CIPHER_CTX_set_padding(c->ctx, 0);
+
+    res = enif_make_resource(env, c);
+    enif_release_resource(c);
+    return enif_make_tuple2(env, am_ok, res);
+
+fail:
+    enif_release_resource(c);
+    return enif_make_tuple2(env, am_error, am_badarg);
+}
+
+/* seal(Ctx, Nonce, AAD, Plain) -> CipherWithTag :: binary() | {error, _} */
+static ERL_NIF_TERM
+seal(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    qc_ctx *c;
+    ErlNifBinary nonce, aad, plain;
+    ERL_NIF_TERM out_term;
+    unsigned char *out;
+    int len = 0, len2 = 0;
+
+    (void)argc;
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 || c->enc != 1 ||
+        enif_inspect_binary(env, argv[1], &nonce) == 0 || nonce.size != NONCE_LEN ||
+        enif_inspect_binary(env, argv[2], &aad) == 0 ||
+        enif_inspect_binary(env, argv[3], &plain) == 0)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    out = enif_make_new_binary(env, plain.size + TAG_LEN, &out_term);
+
+    if (EVP_EncryptInit_ex(c->ctx, NULL, NULL, NULL, nonce.data) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (aad.size > 0 && EVP_EncryptUpdate(c->ctx, NULL, &len, aad.data, (int)aad.size) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (plain.size > 0 &&
+        EVP_EncryptUpdate(c->ctx, out, &len, plain.data, (int)plain.size) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (EVP_EncryptFinal_ex(c->ctx, out + len, &len2) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_AEAD_GET_TAG, TAG_LEN, out + plain.size) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    return out_term;
+}
+
+/* open(Ctx, Nonce, AAD, CipherText, Tag) -> Plain :: binary() | error */
+static ERL_NIF_TERM
+open_(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    qc_ctx *c;
+    ErlNifBinary nonce, aad, ct, tag;
+    ERL_NIF_TERM out_term;
+    unsigned char *out;
+    int len = 0, len2 = 0;
+
+    (void)argc;
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 || c->enc != 0 ||
+        enif_inspect_binary(env, argv[1], &nonce) == 0 || nonce.size != NONCE_LEN ||
+        enif_inspect_binary(env, argv[2], &aad) == 0 ||
+        enif_inspect_binary(env, argv[3], &ct) == 0 ||
+        enif_inspect_binary(env, argv[4], &tag) == 0 || tag.size != TAG_LEN)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    out = enif_make_new_binary(env, ct.size, &out_term);
+
+    if (EVP_DecryptInit_ex(c->ctx, NULL, NULL, NULL, nonce.data) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (aad.size > 0 && EVP_DecryptUpdate(c->ctx, NULL, &len, aad.data, (int)aad.size) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (ct.size > 0 && EVP_DecryptUpdate(c->ctx, out, &len, ct.data, (int)ct.size) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_AEAD_SET_TAG, TAG_LEN, tag.data) != 1)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    if (EVP_DecryptFinal_ex(c->ctx, out + len, &len2) != 1)
+        return am_error; /* authentication failure */
+
+    return out_term;
+}
+
+/* hp_block(Ctx, Sample16) -> Block16 :: binary() | {error, _}
+ * One ECB block for AES header protection. */
+static ERL_NIF_TERM
+hp_block(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    qc_ctx *c;
+    ErlNifBinary sample;
+    ERL_NIF_TERM out_term;
+    unsigned char *out;
+    int len = 0;
+
+    (void)argc;
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 ||
+        enif_inspect_binary(env, argv[1], &sample) == 0 || sample.size != 16)
+        return enif_make_tuple2(env, am_error, am_badarg);
+
+    out = enif_make_new_binary(env, 16, &out_term);
+    if (EVP_EncryptUpdate(c->ctx, out, &len, sample.data, 16) != 1 || len != 16)
+        return enif_make_tuple2(env, am_error, am_badarg);
+    return out_term;
+}
+
+static ERL_NIF_TERM
+is_loaded(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    (void)argc;
+    (void)argv;
+    return enif_make_atom(env, "true");
+}
+
+static int
+load(ErlNifEnv *env, void **priv, ERL_NIF_TERM info)
+{
+    (void)priv;
+    (void)info;
+    qc_ctx_type = enif_open_resource_type(
+        env, NULL, "quic_crypto_ctx", qc_ctx_dtor, ERL_NIF_RT_CREATE, NULL);
+    if (qc_ctx_type == NULL)
+        return -1;
+    am_ok = enif_make_atom(env, "ok");
+    am_error = enif_make_atom(env, "error");
+    am_true = enif_make_atom(env, "true");
+    am_false = enif_make_atom(env, "false");
+    am_not_loaded = enif_make_atom(env, "not_loaded");
+    am_badarg = enif_make_atom(env, "badarg");
+    return 0;
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"is_loaded", 0, is_loaded, 0},
+    {"new_aead_ctx", 3, new_aead_ctx, 0},
+    {"new_hp_ctx", 2, new_hp_ctx, 0},
+    {"seal", 4, seal, 0},
+    {"open", 5, open_, 0},
+    {"hp_block", 2, hp_block, 0},
+};
+
+ERL_NIF_INIT(quic_crypto_nif, nif_funcs, load, NULL, NULL, NULL)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -67,6 +67,48 @@ receive side. In no particular order:
 The full list, one commit per bullet, is in `CHANGELOG.md` under
 the 1.2.0 entry.
 
+## The crypto NIF is optional
+
+`c_src/quic_crypto_nif.c` is an accelerator, not a dependency. QUIC
+seals every packet as its own AEAD unit and OTP's
+`crypto:crypto_one_time_aead/7` re-runs the key schedule on each call;
+the NIF keeps an `EVP_CIPHER_CTX` per key so the schedule runs once,
+and fuses header protection, nonce derivation, packet-number
+reconstruction and (on receive) frame parsing into one call per run.
+
+You never have to build it. When it is missing the library uses the
+OTP crypto path with identical semantics, so the only difference is
+throughput.
+
+Build it with a C toolchain, CMake and OpenSSL headers present:
+
+```sh
+rebar3 compile          # the pre_hook builds it when it can
+```
+
+CMake resolves the ERTS headers and the same libcrypto OTP's own
+crypto NIF is linked against, so loading it never pins a second
+OpenSSL into the VM. Verified on Linux, macOS (arm64, OpenSSL from
+MacPorts or Homebrew) and FreeBSD 14.3 (arm64, base OpenSSL). A
+missing toolchain prints a note and the build succeeds:
+
+```
+quic_crypto_nif: build skipped (no cmake, toolchain or OpenSSL headers?), using pure-Erlang crypto path
+```
+
+Turn it off at runtime without rebuilding:
+
+```sh
+QUIC_DISABLE_CRYPTO_NIF=1    # this NIF only
+QUIC_DISABLE_NIFS=1          # every optional NIF
+```
+
+Two limits worth knowing. ChaCha20-Poly1305 connections keep only the
+per-packet acceleration, since the fused paths assume AES-ECB header
+protection. And `erlang:load_nif/2` looks under `code:priv_dir(quic)`,
+so a packaging layout where that does not resolve falls back to the
+OTP crypto path rather than failing.
+
 ## The socket backend is opt in, for now
 
 Version 1.2.0 adds a `socket_backend => socket` option on

--- a/docs/features.md
+++ b/docs/features.md
@@ -284,6 +284,7 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `ack_packet_tolerance` - Ack-eliciting packets received before a 1-RTT ACK is sent, the RFC 9000 section 13.2.1 decimation threshold (default: 2)
 - `disconnect_timeout` - Milliseconds without a response from the peer before the connection is given up on, checked on its own timer (default: 16000)
 - `pmtu_raise_interval` - Milliseconds between PMTU raise probes (default: 600000)
+- `delivery_coalescing` - Merge consecutive same-stream `stream_data` deliveries of one receive pass into a single owner message (default: `false`). Arrival order across streams is preserved and a `stream_reset` never overtakes data delivered before it, but an owner that counts messages rather than bytes sees fewer of them
 
 ### PMTU Discovery
 - `quic:get_mtu/1` - Get current effective MTU for a connection

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -410,14 +410,16 @@
 %% Default GSO segment size (QUIC packet size for batching)
 -define(DEFAULT_GSO_SEGMENT_SIZE, 1200).
 
-%% Max messages allowed in a connection process mailbox before the
-%% socket-backend receive path tail-drops incoming datagrams, emulating
-%% a bounded kernel receive buffer. Without a bound a fast sender turns
-%% receiver overload into unbounded queueing delay instead of loss;
-%% inflated RTT samples and spurious loss detection then destabilize
-%% the peer's congestion controller. Early tail drop gives it a clean
-%% loss signal at a bounded queue depth, like gen_udp + kernel rcvbuf.
--define(MAX_CONN_RECV_QUEUE_MSGS, 32).
+%% Floor on the messages a connection process mailbox may hold before
+%% the socket-backend receive path tail-drops incoming datagrams. The
+%% working bound is quic_socket:recv_queue_max/1: the connection's
+%% flow-control window in full-size packets, so a peer inside the
+%% window it was given is never dropped and the bound only catches one
+%% outside it. A bound below the window turned flow-control-permitted
+%% data into loss.
+-define(MAX_CONN_RECV_QUEUE_MSGS, 512).
+%% Nominal packet size used to turn a byte window into that bound.
+-define(RECV_QUEUE_PACKET_BYTES, 1200).
 
 %% Max packets per {quic_packets, ...} message forwarded to a
 %% connection. GRO can aggregate trains of ~44 packets; forwarded

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -409,6 +409,23 @@
 -define(DEFAULT_MAX_BATCH_PACKETS, 64).
 %% Default GSO segment size (QUIC packet size for batching)
 -define(DEFAULT_GSO_SEGMENT_SIZE, 1200).
+
+%% Max messages allowed in a connection process mailbox before the
+%% socket-backend receive path tail-drops incoming datagrams, emulating
+%% a bounded kernel receive buffer. Without a bound a fast sender turns
+%% receiver overload into unbounded queueing delay instead of loss;
+%% inflated RTT samples and spurious loss detection then destabilize
+%% the peer's congestion controller. Early tail drop gives it a clean
+%% loss signal at a bounded queue depth, like gen_udp + kernel rcvbuf.
+-define(MAX_CONN_RECV_QUEUE_MSGS, 32).
+
+%% Max packets per {quic_packets, ...} message forwarded to a
+%% connection. GRO can aggregate trains of ~44 packets; forwarded
+%% whole, the mailbox bound above cannot cap queueing DELAY (a message
+%% may be 1 or 44 packets). Splitting trains keeps the worst-case
+%% queued backlog, and thus the RTT inflation seen by the peer's loss
+%% detector, small and predictable.
+-define(MAX_PACKETS_PER_CONN_MSG, 8).
 %% Kernel limits on a single UDP_SEGMENT write: UDP_MAX_SEGMENTS segments,
 %% and a payload that still fits a 16-bit UDP length. A run larger than
 %% either is split across writes.

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -591,8 +591,11 @@
     recv_offset :: non_neg_integer(),
     recv_max_data :: non_neg_integer(),
     recv_fin :: boolean(),
-    %% #{Offset => Data} for out-of-order reassembly
-    recv_buffer :: map(),
+    %% Offset => Data, ordered, for out-of-order reassembly. Ordering
+    %% keeps the per-packet gap check O(log n) and lets the trim walk
+    %% stop at the delivered point instead of visiting every buffered
+    %% chunk, which matters once loss recovery has megabytes buffered.
+    recv_buffer :: gb_trees:tree(non_neg_integer(), binary()),
     %% Our recv side is terminal: FIN read (buffer empty) or peer RESET_STREAM.
     recv_done = false :: boolean(),
 

--- a/rebar.config
+++ b/rebar.config
@@ -13,6 +13,18 @@
 
 {deps, []}.
 
+%% Optional AEAD-context NIF (c_src/quic_crypto_nif.c). Best effort:
+%% when no C toolchain or OpenSSL headers are available the build is
+%% skipped and the library runs on the pure OTP crypto path.
+{pre_hooks, [
+    {compile,
+        "sh -c 'make -C c_src >/dev/null 2>&1 || "
+        "echo \"quic_crypto_nif: build skipped (no toolchain?), using pure-Erlang crypto path\"'"}
+]}.
+{post_hooks, [
+    {clean, "sh -c 'make -C c_src clean >/dev/null 2>&1 || true'"}
+]}.
+
 {profiles, [
     {test, [
         {deps, [

--- a/rebar.config
+++ b/rebar.config
@@ -18,11 +18,13 @@
 %% skipped and the library runs on the pure OTP crypto path.
 {pre_hooks, [
     {compile,
-        "sh -c 'make -C c_src >/dev/null 2>&1 || "
-        "echo \"quic_crypto_nif: build skipped (no toolchain?), using pure-Erlang crypto path\"'"}
+        "sh -c 'cmake -S c_src -B c_src/build >/dev/null 2>&1 && "
+        "cmake --build c_src/build >/dev/null 2>&1 || "
+        "echo \"quic_crypto_nif: build skipped (no cmake, toolchain or OpenSSL headers?), "
+        "using pure-Erlang crypto path\"'"}
 ]}.
 {post_hooks, [
-    {clean, "sh -c 'make -C c_src clean >/dev/null 2>&1 || true'"}
+    {clean, "sh -c 'rm -rf c_src/build priv/quic_crypto_nif.so || true'"}
 ]}.
 
 {profiles, [

--- a/src/interop/quic_interop_client.erl
+++ b/src/interop/quic_interop_client.erl
@@ -39,7 +39,18 @@
     "resumption",
     "zerortt",
     "connectionmigration",
-    "http3"
+    "http3",
+    %% Passive robustness cases: the simulator induces the loss,
+    %% corruption, latency or rebinding; the endpoint just transfers.
+    "longrtt",
+    "blackhole",
+    "amplificationlimit",
+    "handshakeloss",
+    "transferloss",
+    "handshakecorruption",
+    "transfercorruption",
+    "rebind-port",
+    "rebind-addr"
 ]).
 
 %% Include for session_ticket record
@@ -88,6 +99,23 @@ run_test("zerortt", RequestsStr, DownloadsDir) ->
 run_test("connectionmigration", RequestsStr, DownloadsDir) ->
     %% Connection migration: simulate path change during transfer
     run_migration_test(RequestsStr, DownloadsDir);
+run_test("multiconnect", RequestsStr, DownloadsDir) ->
+    %% One connection per file, sequentially: the runner maps the
+    %% handshakeloss and handshakecorruption cases to this testcase
+    %% name and counts one handshake per requested file.
+    Requests = string:tokens(RequestsStr, " "),
+    Results = lists:append([
+        download_all("multiconnect", [R], DownloadsDir)
+     || R <- Requests
+    ]),
+    case lists:all(fun(R) -> R =:= ok end, Results) of
+        true ->
+            io:format("All downloads successful~n"),
+            halt(?EXIT_SUCCESS);
+        false ->
+            io:format("Some downloads failed~n"),
+            halt(?EXIT_FAILURE)
+    end;
 run_test(TestCase, RequestsStr, DownloadsDir) ->
     %% Standard test case
     Requests = string:tokens(RequestsStr, " "),
@@ -178,7 +206,7 @@ wait_connected(Conn, TestCase) ->
         {quic, Conn, {transport_error, Code, Msg}} ->
             io:format("Transport error: ~p ~p~n", [Code, Msg]),
             error
-    after 30000 ->
+    after 60000 ->
         io:format("Connection timeout~n"),
         error
     end.
@@ -228,10 +256,13 @@ build_opts("v2") ->
         versions => [16#6b3343cf, 16#00000001]
     };
 build_opts(_) ->
-    %% Default options
+    %% Default options. disconnect_timeout is off: the blackhole case
+    %% blacks the network out on purpose and expects the transfer to
+    %% outlast it.
     #{
         verify => false,
-        alpn => [<<"hq-interop">>, <<"h3">>]
+        alpn => [<<"hq-interop">>, <<"h3">>],
+        disconnect_timeout => infinity
     }.
 
 %% Keep as many streams in flight as the peer's stream credit allows and

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -39,7 +39,18 @@
     "resumption",
     "zerortt",
     "connectionmigration",
-    "http3"
+    "http3",
+    %% Passive robustness cases: the simulator induces the loss,
+    %% corruption, latency or rebinding; the endpoint just transfers.
+    "longrtt",
+    "blackhole",
+    "amplificationlimit",
+    "handshakeloss",
+    "transferloss",
+    "handshakecorruption",
+    "transfercorruption",
+    "rebind-port",
+    "rebind-addr"
 ]).
 
 main(_Args) ->
@@ -158,6 +169,9 @@ build_server_opts(TestCase, Cert, Key, WwwDir) ->
         cert => Cert,
         key => Key,
         alpn => [<<"hq-interop">>, <<"h3">>],
+        %% The blackhole case blacks the network out on purpose and
+        %% expects the connection to outlast it.
+        disconnect_timeout => infinity,
         connection_handler => fun(ConnPid, Conn) ->
             spawn_handler(ConnPid, Conn, WwwDir, TestCase)
         end

--- a/src/interop/quic_interop_server.erl
+++ b/src/interop/quic_interop_server.erl
@@ -90,15 +90,20 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
 
     case {file:read_file(CertFile), file:read_file(KeyFile)} of
         {{ok, CertPem}, {ok, KeyPem}} ->
-            %% Decode PEM to DER
-            [{_, CertDer, _}] = public_key:pem_decode(CertPem),
+            %% Decode PEM to DER. The amplificationlimit case hands the
+            %% server a 9-deep chain in cert.pem; leaf first, then the
+            %% intermediates in order.
+            [CertDer | CertChain] = [
+                D
+             || {'Certificate', D, not_encrypted} <- public_key:pem_decode(CertPem)
+            ],
             PrivateKey = decode_private_key(KeyPem),
 
             case TestCase of
                 "http3" ->
-                    run_h3_server(Port, CertDer, PrivateKey, WwwDir);
+                    run_h3_server(Port, {CertDer, CertChain}, PrivateKey, WwwDir);
                 _ ->
-                    run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir)
+                    run_hq_server(TestCase, Port, {CertDer, CertChain}, PrivateKey, WwwDir)
             end;
         _ ->
             io:format("Failed to read certificates~n"),
@@ -107,13 +112,14 @@ run_server(TestCase, Port, CertsDir, WwwDir) ->
 
 %% The http3 case serves real HTTP/3 (RFC 9114) through quic_h3; every
 %% other case speaks hq-interop over a bare listener.
-run_h3_server(Port, CertDer, PrivateKey, WwwDir) ->
+run_h3_server(Port, {CertDer, CertChain}, PrivateKey, WwwDir) ->
     Handler = fun(Conn, StreamId, _Method, Path, _Headers) ->
         serve_h3_request(Conn, StreamId, Path, WwwDir)
     end,
     case
         quic_h3:start_server(interop_h3, Port, #{
             cert => CertDer,
+            cert_chain => CertChain,
             key => PrivateKey,
             handler => Handler
         })
@@ -164,9 +170,10 @@ run_hq_server(TestCase, Port, CertDer, PrivateKey, WwwDir) ->
             halt(?EXIT_FAILURE)
     end.
 
-build_server_opts(TestCase, Cert, Key, WwwDir) ->
+build_server_opts(TestCase, {Cert, CertChain}, Key, WwwDir) ->
     BaseOpts = #{
         cert => Cert,
+        cert_chain => CertChain,
         key => Key,
         alpn => [<<"hq-interop">>, <<"h3">>],
         %% The blackhole case blacks the network out on purpose and

--- a/src/quic_aead.erl
+++ b/src/quic_aead.erl
@@ -29,6 +29,7 @@
 -dialyzer([no_match]).
 
 -export([
+    ecb_mask/3,
     encrypt/5,
     encrypt/6,
     decrypt/5,
@@ -89,10 +90,7 @@ encrypt(Key, IV, PN, AAD, Plaintext) ->
     binary().
 encrypt(Key, IV, PN, AAD, Plaintext, Cipher) ->
     Nonce = compute_nonce(IV, PN),
-    {Ciphertext, Tag} = crypto:crypto_one_time_aead(
-        Cipher, Key, Nonce, Plaintext, AAD, ?TAG_LEN, true
-    ),
-    <<Ciphertext/binary, Tag/binary>>.
+    quic_aead_ctx:aead_encrypt(Cipher, Key, Nonce, Plaintext, AAD).
 
 %% @doc Decrypt a QUIC packet payload using AEAD.
 %%
@@ -111,11 +109,7 @@ decrypt(Key, IV, PN, AAD, CiphertextWithTag, Cipher) ->
     Nonce = compute_nonce(IV, PN),
     CipherLen = byte_size(CiphertextWithTag) - ?TAG_LEN,
     <<Ciphertext:CipherLen/binary, Tag:?TAG_LEN/binary>> = CiphertextWithTag,
-    case
-        crypto:crypto_one_time_aead(
-            Cipher, Key, Nonce, Ciphertext, AAD, Tag, false
-        )
-    of
+    case quic_aead_ctx:aead_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag) of
         Plaintext when is_binary(Plaintext) ->
             {ok, Plaintext};
         error ->
@@ -253,11 +247,10 @@ cipher_for_key(Key) when byte_size(Key) =:= 32 -> aes_256_gcm.
 %% Compute header protection mask
 compute_hp_mask(aes_128_gcm, HP, Sample) ->
     %% AES-ECB encryption of sample
-    ecb_mask(aes_128_ecb, HP, Sample);
+    quic_aead_ctx:hp_block(aes_128_ecb, HP, Sample);
 compute_hp_mask(aes_256_gcm, HP, Sample) ->
-    %% AES-ECB encryption of sample (use first 16 bytes of 32-byte key)
-    %% Actually, HP for AES-256 is 32 bytes, use aes_256_ecb
-    ecb_mask(aes_256_ecb, HP, Sample);
+    %% HP for AES-256 is 32 bytes, use aes_256_ecb
+    quic_aead_ctx:hp_block(aes_256_ecb, HP, Sample);
 compute_hp_mask(chacha20_poly1305, HP, Sample) ->
     %% ChaCha20 with counter=0 and the sample as nonce
     %% Sample is 16 bytes: first 4 = counter, last 12 = nonce
@@ -279,6 +272,8 @@ compute_hp_mask(chacha20_poly1305, HP, Sample) ->
 %% single-entry cache makes them evict each other and re-runs the key
 %% schedule anyway. Both are kept, and a key update (a third key) drops
 %% the pair rather than letting the cache grow.
+%% Header-protection block on a cached ECB context (the pure-Erlang
+%% path; quic_aead_ctx:hp_block/3 falls back to this without the NIF).
 ecb_mask(Cipher, Key, Sample) ->
     crypto:crypto_update(ecb_ctx(Cipher, Key), Sample).
 
@@ -399,10 +394,7 @@ protect_long_packet(Cipher, Key, IV, HP, PN, HeaderPrefix, Plaintext) ->
 protect_packet_common(Cipher, Key, IV, HP, PN, HeaderPrefix, PNBin, Plaintext) ->
     AAD = <<HeaderPrefix/binary, PNBin/binary>>,
     Nonce = compute_nonce(IV, PN),
-    {Ciphertext, Tag} = crypto:crypto_one_time_aead(
-        Cipher, Key, Nonce, Plaintext, AAD, ?TAG_LEN, true
-    ),
-    EncryptedPayload = <<Ciphertext/binary, Tag/binary>>,
+    EncryptedPayload = quic_aead_ctx:aead_encrypt(Cipher, Key, Nonce, Plaintext, AAD),
     PNOffset = byte_size(HeaderPrefix),
     ProtectedHeader = protect_header(Cipher, HP, AAD, EncryptedPayload, PNOffset),
     <<ProtectedHeader/binary, EncryptedPayload/binary>>.
@@ -480,11 +472,7 @@ unprotect_packet_common(Cipher, Key, IV, HP, Header, EncryptedPayload, LargestRe
             Nonce = compute_nonce(IV, PN),
             CipherLen = byte_size(Ciphertext) - ?TAG_LEN,
             <<CiphertextOnly:CipherLen/binary, Tag:?TAG_LEN/binary>> = Ciphertext,
-            case
-                crypto:crypto_one_time_aead(
-                    Cipher, Key, Nonce, CiphertextOnly, AAD, Tag, false
-                )
-            of
+            case quic_aead_ctx:aead_decrypt(Cipher, Key, Nonce, CiphertextOnly, AAD, Tag) of
                 Plaintext when is_binary(Plaintext) ->
                     {ok, PN, UnprotectedHeader, Plaintext};
                 error ->
@@ -578,7 +566,7 @@ decrypt_short_payload(
     Nonce = compute_nonce(IV, PN),
     CipherLen = byte_size(Ciphertext) - ?TAG_LEN,
     <<CiphertextOnly:CipherLen/binary, Tag:?TAG_LEN/binary>> = Ciphertext,
-    case crypto:crypto_one_time_aead(Cipher, Key, Nonce, CiphertextOnly, AAD, Tag, false) of
+    case quic_aead_ctx:aead_decrypt(Cipher, Key, Nonce, CiphertextOnly, AAD, Tag) of
         Plaintext when is_binary(Plaintext) ->
             {ok, PN, Plaintext};
         error ->

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -151,7 +151,7 @@ open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload)
     0 | 1,
     non_neg_integer(),
     [binary()]
-) -> {ok, [{non_neg_integer(), byte(), binary()}]} | fallback.
+) -> {ok, [{non_neg_integer(), byte(), [term()] | {raw, binary()}}]} | fallback.
 open_run(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _DcidLen, _Datagrams) ->
     fallback;
 open_run(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, DcidLen, Datagrams) ->

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -17,7 +17,8 @@
     aead_encrypt/5,
     aead_decrypt/6,
     hp_block/3,
-    protect_run/8
+    protect_run/8,
+    open_packet/8
 ]).
 
 -define(TAG_LEN, 16).
@@ -102,6 +103,48 @@ protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
 
 hp_ecb_cipher(aes_128_gcm) -> aes_128_ecb;
 hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
+
+%% @doc Fused short-header receive: header unprotection, PN
+%% reconstruction and AEAD open in one NIF call. Returns
+%% `{ok, PN, UnprotectedFirstByte, Plaintext}', `error' on
+%% authentication failure, or `fallback' (NIF missing, ChaCha, or the
+%% packet's key phase differs from ExpectedPhase - the caller then
+%% runs the generic path with key selection).
+-spec open_packet(
+    atom(),
+    binary(),
+    binary(),
+    binary(),
+    non_neg_integer() | undefined,
+    0 | 1,
+    binary(),
+    binary()
+) -> {ok, non_neg_integer(), byte(), binary()} | error | fallback.
+open_packet(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _Header, _Payload) ->
+    fallback;
+open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload) ->
+    case nif_enabled() of
+        true ->
+            DecCtx = ctx(qc_dec, Cipher, Key),
+            HpCtx = hp_ctx(hp_ecb_cipher(Cipher), HP),
+            Largest =
+                case LargestRecv of
+                    undefined -> -1;
+                    _ -> LargestRecv
+                end,
+            case
+                quic_crypto_nif:open_packet(
+                    DecCtx, HpCtx, IV, Largest, ExpectedPhase, Header, EncPayload
+                )
+            of
+                {PN, FirstByte, Plain} -> {ok, PN, FirstByte, Plain};
+                error -> error;
+                key_phase -> fallback;
+                {error, _} -> fallback
+            end;
+        false ->
+            fallback
+    end.
 
 %%====================================================================
 %% Internal

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -18,7 +18,8 @@
     aead_decrypt/6,
     hp_block/3,
     protect_run/8,
-    open_packet/8
+    open_packet/8,
+    open_run/8
 ]).
 
 -define(TAG_LEN, 16).
@@ -123,25 +124,60 @@ hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
 open_packet(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _Header, _Payload) ->
     fallback;
 open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload) ->
+    with_open_ctx(Cipher, Key, HP, LargestRecv, fun(DecCtx, HpCtx, Largest) ->
+        case
+            quic_crypto_nif:open_packet(
+                DecCtx, HpCtx, IV, Largest, ExpectedPhase, Header, EncPayload
+            )
+        of
+            {PN, FirstByte, Plain} -> {ok, PN, FirstByte, Plain};
+            error -> error;
+            key_phase -> fallback;
+            {error, _} -> fallback
+        end
+    end).
+
+%% @doc Batched open_packet over a train of short-header datagrams
+%% (FirstByte + DCID + PN + ciphertext + tag each). Returns the opened
+%% prefix; a shorter list than Datagrams means the remainder must be
+%% run through the generic per-packet path. `fallback' when the NIF is
+%% unavailable or the cipher is ChaCha.
+-spec open_run(
+    atom(),
+    binary(),
+    binary(),
+    binary(),
+    non_neg_integer() | undefined,
+    0 | 1,
+    non_neg_integer(),
+    [binary()]
+) -> {ok, [{non_neg_integer(), byte(), binary()}]} | fallback.
+open_run(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _DcidLen, _Datagrams) ->
+    fallback;
+open_run(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, DcidLen, Datagrams) ->
+    with_open_ctx(Cipher, Key, HP, LargestRecv, fun(DecCtx, HpCtx, Largest) ->
+        case
+            quic_crypto_nif:open_run(
+                DecCtx, HpCtx, IV, Largest, ExpectedPhase, DcidLen, Datagrams
+            )
+        of
+            {ok, _Results} = Ok -> Ok;
+            {error, _} -> fallback
+        end
+    end).
+
+%% Run Fun with the decrypt and header-protection contexts and the
+%% largest-received PN in NIF form (-1 for none); `fallback' without
+%% the NIF.
+with_open_ctx(Cipher, Key, HP, LargestRecv, Fun) ->
     case nif_enabled() of
         true ->
-            DecCtx = ctx(qc_dec, Cipher, Key),
-            HpCtx = hp_ctx(hp_ecb_cipher(Cipher), HP),
             Largest =
                 case LargestRecv of
                     undefined -> -1;
                     _ -> LargestRecv
                 end,
-            case
-                quic_crypto_nif:open_packet(
-                    DecCtx, HpCtx, IV, Largest, ExpectedPhase, Header, EncPayload
-                )
-            of
-                {PN, FirstByte, Plain} -> {ok, PN, FirstByte, Plain};
-                error -> error;
-                key_phase -> fallback;
-                {error, _} -> fallback
-            end;
+            Fun(ctx(qc_dec, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP), Largest);
         false ->
             fallback
     end.

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -1,0 +1,116 @@
+%%% -*- erlang -*-
+%%%
+%%% AEAD dispatch: NIF-accelerated contexts with OTP crypto fallback.
+%%%
+%%% QUIC seals/opens every packet as its own AEAD unit, and the OTP
+%%% one-shot API re-runs the key schedule on each call. When the
+%%% optional quic_crypto_nif is loaded, this module keeps an
+%%% EVP context per {direction, cipher, key} in the calling process's
+%%% dictionary (contexts are single-process; connection processes are
+%%% the only callers) so the key schedule runs once per key. Without
+%%% the NIF every function degrades to crypto:crypto_one_time_aead /
+%%% crypto:crypto_one_time with identical semantics.
+
+-module(quic_aead_ctx).
+
+-export([
+    aead_encrypt/5,
+    aead_decrypt/6,
+    hp_block/3
+]).
+
+-define(TAG_LEN, 16).
+
+%% @doc Seal: returns Ciphertext||Tag.
+-spec aead_encrypt(atom(), binary(), binary(), binary(), binary()) -> binary().
+aead_encrypt(Cipher, Key, Nonce, Plaintext, AAD) ->
+    case nif_enabled() of
+        true ->
+            Ctx = ctx(qc_enc, Cipher, Key),
+            case quic_crypto_nif:seal(Ctx, Nonce, AAD, Plaintext) of
+                Out when is_binary(Out) -> Out;
+                {error, _} -> fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD)
+            end;
+        false ->
+            fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD)
+    end.
+
+%% @doc Open: Ciphertext WITHOUT tag + Tag; returns Plaintext | error.
+-spec aead_decrypt(atom(), binary(), binary(), binary(), binary(), binary()) ->
+    binary() | error.
+aead_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag) ->
+    case nif_enabled() of
+        true ->
+            Ctx = ctx(qc_dec, Cipher, Key),
+            case quic_crypto_nif:open(Ctx, Nonce, AAD, Ciphertext, Tag) of
+                Out when is_binary(Out) -> Out;
+                error -> error;
+                {error, _} -> fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag)
+            end;
+        false ->
+            fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag)
+    end.
+
+%% @doc One ECB block for AES header protection (mask source).
+-spec hp_block(aes_128_ecb | aes_256_ecb, binary(), binary()) -> binary().
+hp_block(Cipher, Key, Sample) ->
+    case nif_enabled() of
+        true ->
+            Ctx = hp_ctx(Cipher, Key),
+            case quic_crypto_nif:hp_block(Ctx, Sample) of
+                Out when is_binary(Out) -> Out;
+                {error, _} -> quic_aead:ecb_mask(Cipher, Key, Sample)
+            end;
+        false ->
+            quic_aead:ecb_mask(Cipher, Key, Sample)
+    end.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD) ->
+    {Ciphertext, Tag} = crypto:crypto_one_time_aead(
+        Cipher, Key, Nonce, Plaintext, AAD, ?TAG_LEN, true
+    ),
+    <<Ciphertext/binary, Tag/binary>>.
+
+fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag) ->
+    crypto:crypto_one_time_aead(Cipher, Key, Nonce, Ciphertext, AAD, Tag, false).
+
+%% Cache the NIF-availability flag per process: checked on every
+%% packet, and a process dictionary read beats a NIF call.
+nif_enabled() ->
+    case erlang:get(qc_nif) of
+        undefined ->
+            V = quic_crypto_nif:is_loaded(),
+            erlang:put(qc_nif, V),
+            V;
+        V ->
+            V
+    end.
+
+%% Per-process context cache. A connection holds a handful of live
+%% keys (current + previous key phase per direction); stale entries
+%% from key updates are few and die with the process.
+ctx(Kind, Cipher, Key) ->
+    PdKey = {Kind, Cipher, Key},
+    case erlang:get(PdKey) of
+        undefined ->
+            {ok, Ctx} = quic_crypto_nif:new_aead_ctx(Cipher, Key, Kind =:= qc_enc),
+            erlang:put(PdKey, Ctx),
+            Ctx;
+        Ctx ->
+            Ctx
+    end.
+
+hp_ctx(Cipher, Key) ->
+    PdKey = {qc_hp, Cipher, Key},
+    case erlang:get(PdKey) of
+        undefined ->
+            {ok, Ctx} = quic_crypto_nif:new_hp_ctx(Cipher, Key),
+            erlang:put(PdKey, Ctx),
+            Ctx;
+        Ctx ->
+            Ctx
+    end.

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -16,7 +16,8 @@
 -export([
     aead_encrypt/5,
     aead_decrypt/6,
-    hp_block/3
+    hp_block/3,
+    protect_run/8
 ]).
 
 -define(TAG_LEN, 16).
@@ -64,6 +65,43 @@ hp_block(Cipher, Key, Sample) ->
         false ->
             quic_aead:ecb_mask(Cipher, Key, Sample)
     end.
+
+%% @doc Seal a run of short-header packets with consecutive PNs in one
+%% NIF call (header build + nonce + AEAD + header protection fused).
+%% Returns `{ok, [WirePacket]}' or `fallback' when the NIF is not
+%% loaded, the cipher is ChaCha (its HP is not ECB) or the NIF rejects
+%% the input - callers then take the per-packet path.
+-spec protect_run(
+    atom(),
+    binary(),
+    binary(),
+    binary(),
+    non_neg_integer(),
+    byte(),
+    binary(),
+    [iodata()]
+) -> {ok, [binary()]} | fallback.
+protect_run(chacha20_poly1305, _Key, _IV, _HP, _PN0, _FirstByteBase, _DCID, _Payloads) ->
+    fallback;
+protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
+    case nif_enabled() of
+        true ->
+            AeadCtx = ctx(qc_enc, Cipher, Key),
+            HpCtx = hp_ctx(hp_ecb_cipher(Cipher), HP),
+            case
+                quic_crypto_nif:protect_run(
+                    AeadCtx, HpCtx, IV, PN0, FirstByteBase, DCID, Payloads
+                )
+            of
+                Packets when is_list(Packets) -> {ok, Packets};
+                {error, _} -> fallback
+            end;
+        false ->
+            fallback
+    end.
+
+hp_ecb_cipher(aes_128_gcm) -> aes_128_ecb;
+hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
 
 %%====================================================================
 %% Internal

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -23,16 +23,23 @@
 ]).
 
 -define(TAG_LEN, 16).
+%% Current and previous key phase, encrypt and decrypt, plus the two
+%% header-protection contexts, which do not rotate on a key update.
+-define(MAX_CACHED_CTX, 6).
 
 %% @doc Seal: returns Ciphertext||Tag.
 -spec aead_encrypt(atom(), binary(), binary(), binary(), binary()) -> binary().
 aead_encrypt(Cipher, Key, Nonce, Plaintext, AAD) ->
     case nif_enabled() of
         true ->
-            Ctx = ctx(qc_enc, Cipher, Key),
-            case quic_crypto_nif:seal(Ctx, Nonce, AAD, Plaintext) of
-                Out when is_binary(Out) -> Out;
-                {error, _} -> fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD)
+            case ctx(qc_enc, Cipher, Key) of
+                {ok, Ctx} ->
+                    case quic_crypto_nif:seal(Ctx, Nonce, AAD, Plaintext) of
+                        Out when is_binary(Out) -> Out;
+                        {error, _} -> fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD)
+                    end;
+                error ->
+                    fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD)
             end;
         false ->
             fallback_encrypt(Cipher, Key, Nonce, Plaintext, AAD)
@@ -44,11 +51,15 @@ aead_encrypt(Cipher, Key, Nonce, Plaintext, AAD) ->
 aead_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag) ->
     case nif_enabled() of
         true ->
-            Ctx = ctx(qc_dec, Cipher, Key),
-            case quic_crypto_nif:open(Ctx, Nonce, AAD, Ciphertext, Tag) of
-                Out when is_binary(Out) -> Out;
-                error -> error;
-                {error, _} -> fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag)
+            case ctx(qc_dec, Cipher, Key) of
+                {ok, Ctx} ->
+                    case quic_crypto_nif:open(Ctx, Nonce, AAD, Ciphertext, Tag) of
+                        Out when is_binary(Out) -> Out;
+                        error -> error;
+                        {error, _} -> fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag)
+                    end;
+                error ->
+                    fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag)
             end;
         false ->
             fallback_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag)
@@ -59,10 +70,14 @@ aead_decrypt(Cipher, Key, Nonce, Ciphertext, AAD, Tag) ->
 hp_block(Cipher, Key, Sample) ->
     case nif_enabled() of
         true ->
-            Ctx = hp_ctx(Cipher, Key),
-            case quic_crypto_nif:hp_block(Ctx, Sample) of
-                Out when is_binary(Out) -> Out;
-                {error, _} -> quic_aead:ecb_mask(Cipher, Key, Sample)
+            case hp_ctx(Cipher, Key) of
+                {ok, Ctx} ->
+                    case quic_crypto_nif:hp_block(Ctx, Sample) of
+                        Out when is_binary(Out) -> Out;
+                        {error, _} -> quic_aead:ecb_mask(Cipher, Key, Sample)
+                    end;
+                error ->
+                    quic_aead:ecb_mask(Cipher, Key, Sample)
             end;
         false ->
             quic_aead:ecb_mask(Cipher, Key, Sample)
@@ -88,15 +103,18 @@ protect_run(chacha20_poly1305, _Key, _IV, _HP, _PN0, _FirstByteBase, _DCID, _Pay
 protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
     case nif_enabled() of
         true ->
-            AeadCtx = ctx(qc_enc, Cipher, Key),
-            HpCtx = hp_ctx(hp_ecb_cipher(Cipher), HP),
-            case
-                quic_crypto_nif:protect_run(
-                    AeadCtx, HpCtx, IV, PN0, FirstByteBase, DCID, Payloads
-                )
-            of
-                Packets when is_list(Packets) -> {ok, Packets};
-                {error, _} -> fallback
+            case {ctx(qc_enc, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP)} of
+                {{ok, AeadCtx}, {ok, HpCtx}} ->
+                    case
+                        quic_crypto_nif:protect_run(
+                            AeadCtx, HpCtx, IV, PN0, FirstByteBase, DCID, Payloads
+                        )
+                    of
+                        Packets when is_list(Packets) -> {ok, Packets};
+                        {error, _} -> fallback
+                    end;
+                _ ->
+                    fallback
             end;
         false ->
             fallback
@@ -177,7 +195,10 @@ with_open_ctx(Cipher, Key, HP, LargestRecv, Fun) ->
                     undefined -> -1;
                     _ -> LargestRecv
                 end,
-            Fun(ctx(qc_dec, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP), Largest);
+            case {ctx(qc_dec, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP)} of
+                {{ok, DecCtx}, {ok, HpCtx}} -> Fun(DecCtx, HpCtx, Largest);
+                _ -> fallback
+            end;
         false ->
             fallback
     end.
@@ -211,23 +232,49 @@ nif_enabled() ->
 %% keys (current + previous key phase per direction); stale entries
 %% from key updates are few and die with the process.
 ctx(Kind, Cipher, Key) ->
-    PdKey = {Kind, Cipher, Key},
-    case erlang:get(PdKey) of
-        undefined ->
-            {ok, Ctx} = quic_crypto_nif:new_aead_ctx(Cipher, Key, Kind =:= qc_enc),
-            erlang:put(PdKey, Ctx),
-            Ctx;
-        Ctx ->
-            Ctx
-    end.
+    cached({Kind, Cipher, Key}, fun() ->
+        quic_crypto_nif:new_aead_ctx(Cipher, Key, Kind =:= qc_enc)
+    end).
 
 hp_ctx(Cipher, Key) ->
-    PdKey = {qc_hp, Cipher, Key},
+    cached({qc_hp, Cipher, Key}, fun() -> quic_crypto_nif:new_hp_ctx(Cipher, Key) end).
+
+%% Look the context up, creating it on a miss. A creation failure
+%% returns `error' rather than raising: every caller then takes the OTP
+%% crypto path, which is the point of the NIF being optional.
+cached(PdKey, New) ->
     case erlang:get(PdKey) of
         undefined ->
-            {ok, Ctx} = quic_crypto_nif:new_hp_ctx(Cipher, Key),
-            erlang:put(PdKey, Ctx),
-            Ctx;
+            case New() of
+                {ok, Ctx} ->
+                    erlang:put(PdKey, Ctx),
+                    retain(PdKey),
+                    {ok, Ctx};
+                {error, _} ->
+                    error
+            end;
         Ctx ->
-            Ctx
+            {ok, Ctx}
+    end.
+
+%% Bound the cache. RFC 9001 section 6 keeps at most the current and
+%% previous key phase live, but a key update fires every
+%% ?AEAD_CONFIDENTIALITY_LIMIT packets and derives fresh keys each
+%% time, so without eviction a long-lived bulk connection accumulates
+%% one live EVP context per update. Evicting the oldest only costs
+%% recreating it if it is asked for again.
+retain(PdKey) ->
+    Prev =
+        case erlang:get(qc_ctx_live) of
+            undefined -> [];
+            L -> L
+        end,
+    Live = [PdKey | lists:delete(PdKey, Prev)],
+    case length(Live) > ?MAX_CACHED_CTX of
+        true ->
+            {Keep, [Evict]} = lists:split(?MAX_CACHED_CTX, Live),
+            erlang:erase(Evict),
+            erlang:put(qc_ctx_live, Keep);
+        false ->
+            erlang:put(qc_ctx_live, Live)
     end.

--- a/src/quic_cc.erl
+++ b/src/quic_cc.erl
@@ -66,6 +66,8 @@
     get_pacing_tokens/2,
     pacing_delay/2,
     send_check/3,
+    send_check_run/4,
+    on_packets_sent/2,
     max_datagram_size/1,
     min_recovery_duration/1,
     ecn_ce_counter/1
@@ -332,6 +334,35 @@ send_check(#cc_wrapper{algorithm = Mod, state = State} = W, Size, Urgency) ->
         {ok, NewState} -> {ok, W#cc_wrapper{state = NewState}};
         Other -> Other
     end.
+
+%% @doc Batched send_check: approve up to MaxK packets of Size in one
+%% pass. Native for newreno; other algorithms fold send_check/3 with
+%% identical results.
+-spec send_check_run(cc_state(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
+    {non_neg_integer(), cc_state()}.
+send_check_run(
+    #cc_wrapper{algorithm = quic_cc_newreno, state = State} = W, Size, MaxK, Urgency
+) ->
+    {K, NewState} = quic_cc_newreno:send_check_run(State, Size, MaxK, Urgency),
+    {K, W#cc_wrapper{state = NewState}};
+send_check_run(W, Size, MaxK, Urgency) ->
+    send_check_run_iter(W, Size, MaxK, Urgency, 0).
+
+send_check_run_iter(W, _Size, MaxK, _Urgency, K) when K >= MaxK ->
+    {K, W};
+send_check_run_iter(W, Size, MaxK, Urgency, K) ->
+    case send_check(W, Size, Urgency) of
+        {ok, W1} -> send_check_run_iter(W1, Size, MaxK, Urgency, K + 1);
+        _ -> {K, W}
+    end.
+
+%% @doc Batched on_packet_sent for a run: one update for newreno, a
+%% fold for other algorithms.
+-spec on_packets_sent(cc_state(), [non_neg_integer()]) -> cc_state().
+on_packets_sent(#cc_wrapper{algorithm = quic_cc_newreno, state = State} = W, Sizes) ->
+    W#cc_wrapper{state = quic_cc_newreno:on_packets_sent(State, Sizes)};
+on_packets_sent(W, Sizes) ->
+    lists:foldl(fun(Size, Acc) -> on_packet_sent(Acc, Size) end, W, Sizes).
 
 %% @doc Get the current max datagram size.
 -spec max_datagram_size(cc_state()) -> pos_integer().

--- a/src/quic_cc_newreno.erl
+++ b/src/quic_cc_newreno.erl
@@ -57,6 +57,8 @@
     get_pacing_tokens/2,
     pacing_delay/2,
     send_check/3,
+    send_check_run/4,
+    on_packets_sent/2,
     max_datagram_size/1,
     min_recovery_duration/1,
     ecn_ce_counter/1
@@ -237,6 +239,21 @@ on_packet_sent(
     };
 on_packet_sent(#cc_state{bytes_in_flight = InFlight} = State, Size) ->
     State#cc_state{bytes_in_flight = InFlight + Size}.
+
+%% @doc Batched on_packet_sent for a run of packets: one state update
+%% for the whole list of sizes.
+-spec on_packets_sent(cc_state(), [non_neg_integer()]) -> cc_state().
+on_packets_sent(State, []) ->
+    State;
+on_packets_sent(#cc_state{bytes_in_flight = InFlight} = State, Sizes) ->
+    Total = lists:sum(Sizes),
+    case State#cc_state.first_sent_time of
+        undefined ->
+            Now = erlang:monotonic_time(millisecond),
+            State#cc_state{bytes_in_flight = InFlight + Total, first_sent_time = Now};
+        _ ->
+            State#cc_state{bytes_in_flight = InFlight + Total}
+    end.
 
 %% @doc Process acknowledged packets.
 %% AckedBytes is the total size of acknowledged packets.
@@ -1044,6 +1061,59 @@ send_check(
                     Deficit = Size - Refreshed,
                     DelayMs = max(1, (Deficit + Rate - 1) div Rate),
                     {blocked_pacing, DelayMs}
+            end
+    end.
+
+%% @doc Batched send_check: approve up to MaxK packets of Size in one
+%% pass, consuming pacing tokens exactly as MaxK sequential send_check
+%% calls would, minus the sub-millisecond token refill between
+%% iterations, so the batch is never more permissive. Returns how many
+%% packets were approved and the updated state.
+-spec send_check_run(cc_state(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
+    {non_neg_integer(), cc_state()}.
+send_check_run(
+    #cc_state{
+        cwnd = Cwnd,
+        bytes_in_flight = InFlight,
+        control_allowance = Allowance,
+        pacing_rate = Rate
+    } = State,
+    Size,
+    MaxK,
+    Urgency
+) ->
+    CwndLimit =
+        case Urgency of
+            0 -> Cwnd + Allowance;
+            _ -> Cwnd
+        end,
+    Room = CwndLimit - InFlight,
+    KC =
+        case Room >= Size of
+            true -> min(MaxK, Room div Size);
+            false -> 0
+        end,
+    case {KC, Rate} of
+        {0, _} ->
+            {0, State};
+        {_, 0} ->
+            {KC, State};
+        _ ->
+            #cc_state{
+                pacing_tokens = Tokens,
+                pacing_max_burst = MaxBurst,
+                last_pacing_update = LastUpdate
+            } = State,
+            Now = erlang:monotonic_time(microsecond),
+            Refreshed = refill_tokens_at(Tokens, MaxBurst, Rate, LastUpdate, Now),
+            case min(KC, Refreshed div Size) of
+                KP when KP =< 0 ->
+                    {0, State};
+                KP ->
+                    {KP, State#cc_state{
+                        pacing_tokens = Refreshed - KP * Size,
+                        last_pacing_update = Now
+                    }}
             end
     end.
 

--- a/src/quic_cc_newreno.erl
+++ b/src/quic_cc_newreno.erl
@@ -885,7 +885,13 @@ on_persistent_congestion(#cc_state{cwnd = Cwnd, minimum_window = MinimumWindow} 
 %% RFC 9002: pacing_rate = cwnd / smoothed_rtt
 %% Called when RTT estimate is updated.
 -spec update_pacing_rate(cc_state(), non_neg_integer()) -> cc_state().
-update_pacing_rate(#cc_state{cwnd = Cwnd} = State, SmoothedRTT) when SmoothedRTT > 0 ->
+update_pacing_rate(#cc_state{cwnd = Cwnd} = State, SmoothedRTT0) ->
+    %% RTT samples are whole milliseconds, so a sub-millisecond link
+    %% reports 0. Skipping the update then freezes the rate at its
+    %% handshake-time value while cwnd keeps growing, clocking the
+    %% connection at that stale rate forever. Floor at 1 ms so the
+    %% rate keeps tracking cwnd and the congestion controller governs.
+    SmoothedRTT = max(1, SmoothedRTT0),
     %% pacing_rate stored as milli-bytes per microsecond for precision with us timestamps
     %% Formula: (cwnd * 1.25 * 1000) / (RTT_ms * 1000) = (cwnd * 1250) / (RTT_ms * 1000)
     %% Simplified: (cwnd * 5 * 250) / (RTT_ms * 1000) = (cwnd * 1250) / (RTT_ms * 1000)
@@ -914,10 +920,7 @@ update_pacing_rate(#cc_state{cwnd = Cwnd} = State, SmoothedRTT) when SmoothedRTT
     %% the rate.
     MaxBurst = max(12 * State1#cc_state.max_datagram_size, 2 * PacingRate),
 
-    State1#cc_state{pacing_rate = PacingRate, pacing_max_burst = MaxBurst};
-update_pacing_rate(State, _SmoothedRTT) ->
-    %% No valid RTT yet, keep current state
-    State.
+    State1#cc_state{pacing_rate = PacingRate, pacing_max_burst = MaxBurst}.
 
 %% @doc Check if pacing allows sending Size bytes.
 %% Returns true if enough tokens are available (including burst allowance).

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -199,6 +199,7 @@
     test_state_for_server/3,
     %% Mailbox drain of the connected-state receive pass
     drain_recv_msgs/2,
+    collect_client_udp/5,
     test_state_closing/2,
     test_state_with_socket/2,
     test_state_in_recv_pass/1,
@@ -4327,9 +4328,102 @@ handle_packets_batch(Packets, State) ->
 %% This is more efficient than receiving multiple messages
 do_handle_packets_batch([], State) ->
     State;
+do_handle_packets_batch([<<0:1, 1:1, _:6, _/binary>> | _] = Packets, State) ->
+    %% Leading run of short-header (1-RTT) datagrams: open the whole
+    %% run in one NIF call when the fused fast path applies.
+    case fused_run_keys(State) of
+        {ok, Keys} ->
+            handle_short_run(Packets, Keys, State);
+        no ->
+            [Packet | Rest] = Packets,
+            do_handle_packets_batch(Rest, handle_packet_loop(Packet, State))
+    end;
 do_handle_packets_batch([Packet | Rest], State) ->
     NewState = handle_packet_loop(Packet, State),
     do_handle_packets_batch(Rest, NewState).
+
+%% Peer-direction keys for the batched fused open, under the same
+%% no-key-update-in-flight condition as fused_decrypt_keys/2.
+fused_run_keys(#state{app_keys = undefined}) ->
+    no;
+fused_run_keys(#state{app_keys = {ClientKeys, ServerKeys}, role = Role} = State) ->
+    Current =
+        case Role of
+            client -> ServerKeys;
+            server -> ClientKeys
+        end,
+    fused_decrypt_keys(Current, State).
+
+handle_short_run(Packets, Keys, State) ->
+    {Run, Tail} = take_short_run(Packets, []),
+    #crypto_keys{key = Key, iv = IV, hp = HP, cipher = Cipher} = Keys,
+    case
+        quic_aead_ctx:open_run(
+            Cipher,
+            Key,
+            IV,
+            HP,
+            get_largest_recv(app, State),
+            get_current_key_phase(State),
+            byte_size(State#state.scid),
+            Run
+        )
+    of
+        {ok, Results} ->
+            State1 = fold_opened(Results, State),
+            case lists:nthtail(length(Results), Run) of
+                [] ->
+                    do_handle_packets_batch(Tail, State1);
+                [Unopened | RunRest] ->
+                    %% First datagram the NIF could not open takes the
+                    %% generic path (slow decrypt, key-phase transition,
+                    %% stateless-reset check), then keep batching.
+                    State2 = handle_packet_loop(Unopened, State1),
+                    do_handle_packets_batch(RunRest ++ Tail, State2)
+            end;
+        fallback ->
+            [Packet | Rest] = Packets,
+            do_handle_packets_batch(Rest, handle_packet_loop(Packet, State))
+    end.
+
+take_short_run([<<0:1, 1:1, _:6, _/binary>> = P | Rest], Acc) ->
+    take_short_run(Rest, [P | Acc]);
+take_short_run(Rest, Acc) ->
+    {lists:reverse(Acc), Rest}.
+
+%% Post-decrypt processing for a batch-opened run: the same per-packet
+%% effects as the fused branch of decrypt_app_packet/4 followed by the
+%% `processed' branch of handle_packet_loop/2.
+fold_opened([], State) ->
+    State;
+fold_opened([{PN, FirstByte, Plaintext} | Rest], State) ->
+    Now = erlang:monotonic_time(millisecond),
+    StateF = record_app_recv(FirstByte, PN, State, Now),
+    case decode_and_process_streaming(app, Plaintext, StateF) of
+        {ok, NewState, Frames} ->
+            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
+                packet_type => app,
+                frames => Frames
+            }),
+            NewState1 = NewState#state{
+                packets_received = NewState#state.packets_received + 1
+            },
+            ?QLOG_EMIT_FRAMES_PROCESSED(NewState1#state.qlog_ctx, Frames),
+            fold_opened(Rest, maybe_send_ack(app, Frames, NewState1));
+        {error, Reason} ->
+            %% Same recovery as handle_packet_loop/2: log, drop the
+            %% datagram, continue with the pre-packet state.
+            ?LOG_WARNING(
+                #{
+                    what => packet_decode_decrypt_failed,
+                    role => State#state.role,
+                    reason => Reason,
+                    source => State#state.current_packet_source
+                },
+                ?QUIC_LOG_META
+            ),
+            fold_opened(Rest, State)
+    end.
 
 %% One server receive pass: process the packets of a listener message
 %% (source tracking, frame classification, RFC 9000 §9.1 migration
@@ -4359,8 +4453,11 @@ drain_recv_msgs(State, 0) ->
 drain_recv_msgs(#state{role = client, socket = Socket} = State, N) ->
     receive
         {udp, Socket, IP, Port, Data} ->
+            %% Collect the rest of the queued same-source datagrams so a
+            %% train is opened as one batch instead of per message.
             State1 = State#state{current_packet_source = {IP, Port}},
-            drain_recv_msgs(handle_packet(Data, State1), N - 1);
+            {Datagrams, Left} = collect_client_udp(Socket, IP, Port, N - 1, [Data]),
+            drain_recv_msgs(handle_packets_batch(Datagrams, State1), Left);
         {udp_batch, Socket, IP, Port, Packets} ->
             State1 = State#state{current_packet_source = {IP, Port}},
             drain_recv_msgs(handle_packets_batch(Packets, State1), N - 1)
@@ -4375,6 +4472,21 @@ drain_recv_msgs(#state{role = server} = State, N) ->
             drain_recv_msgs(server_recv_pass(Packets, RemoteAddr, State), N - 1)
     after 0 ->
         State
+    end.
+
+collect_client_udp(_Socket, _IP, _Port, 0, Acc) ->
+    {lists:reverse(Acc), 0};
+collect_client_udp(Socket, IP, Port, N, Acc) ->
+    %% Both message shapes in one receive: taking only the single-datagram
+    %% shape would pull those past earlier queued trains and reorder
+    %% the connection's view of the wire.
+    receive
+        {udp, Socket, IP, Port, Data} ->
+            collect_client_udp(Socket, IP, Port, N - 1, [Data | Acc]);
+        {udp_batch, Socket, IP, Port, Packets} ->
+            collect_client_udp(Socket, IP, Port, N - 1, lists:reverse(Packets, Acc))
+    after 0 ->
+        {lists:reverse(Acc), N}
     end.
 
 handle_packet_loop(<<>>, #state{role = client, active_n = N} = State) ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5267,8 +5267,9 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
                             FinSids -> lists:foldl(fun settle_fin_ack/2, State4, FinSids)
                         end,
 
-                    %% Reset PTO timer after ACK processing
-                    State5 = set_pto_timer(State4a),
+                    %% Re-arm the PTO once at the end of the pass
+                    %% (flush_dirty_timers) instead of once per ACK frame.
+                    State5 = State4a#state{pto_dirty = true},
 
                     %% Try to send queued data now that cwnd may have freed up.
                     %% This also drains retransmit_stream entries deferred by CC.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1687,7 +1687,13 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
     ClientReceiver =
         case ClientSocketBackend of
             socket when SocketState =/= undefined ->
-                {ok, RPid} = quic_socket:start_client_receiver(SocketState, self()),
+                {ok, RPid} = quic_socket:start_client_receiver(
+                    SocketState,
+                    self(),
+                    quic_socket:recv_queue_max(
+                        maps:get(max_data, Opts, ?DEFAULT_INITIAL_MAX_DATA)
+                    )
+                ),
                 RPid;
             _ ->
                 undefined
@@ -11807,13 +11813,18 @@ rebind_client_socket_otp(
     #state{
         remote_addr = {RemoteIP, _},
         socket_state = OldSocketState,
-        client_receiver = OldReceiver
+        client_receiver = OldReceiver,
+        max_data_local = MaxData
     } = State
 ) ->
     OpenOpts = #{backend => socket},
     case quic_socket:open_for_send(RemoteIP, OpenOpts) of
         {ok, NewSocketState} ->
-            case quic_socket:start_client_receiver(NewSocketState, self()) of
+            case
+                quic_socket:start_client_receiver(
+                    NewSocketState, self(), quic_socket:recv_queue_max(MaxData)
+                )
+            of
                 {ok, NewReceiver} ->
                     ok = quic_socket:stop_client_receiver(OldReceiver),
                     close_socket_state_quietly(OldSocketState),

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -190,6 +190,8 @@
     drain_recv_msgs/2,
     test_state_closing/2,
     test_state_with_socket/2,
+    test_state_in_recv_pass/1,
+    test_finish_recv_pass/1,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
     test_coalesce_small_stream/1,
     %% Regression helper for zero-byte FIN entries stranded in the send queue
@@ -771,6 +773,13 @@
     %% (GSO bursts especially) before any loss signal is seen.
     burst_budget = ?DEFAULT_MAX_BURST_PACKETS :: pos_integer(),
     burst_sent = 0 :: non_neg_integer(),
+    %% True while a connected-state receive pass (first datagram plus
+    %% drained mailbox train) is being processed. Count-based ACK
+    %% decimation defers its flush to the end of the pass, so one ACK
+    %% covers the whole train instead of one per ack_packet_tolerance
+    %% packets. The max_ack_delay timer still bounds latency; the
+    %% reordering immediate-ACK path bypasses this.
+    recv_pass = false :: boolean(),
     ack_elicited_count = 0 :: non_neg_integer(),
     %% How many ack-eliciting 1-RTT packets to accumulate before
     %% flushing an ACK. 2 is the RFC 9000 §13.2.1 recommendation;
@@ -2371,11 +2380,11 @@ connected({call, From}, {migrate, _Opts}, #state{remote_addr = RemoteAddr} = Sta
     end;
 connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) ->
     %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
-    State1 = State#state{current_packet_source = {IP, Port}},
+    State1 = State#state{current_packet_source = {IP, Port}, recv_pass = true},
     NewState = handle_packet(Data, State1),
     %% Drain any further datagrams already in the mailbox into this
     %% pass, then flush ACKs / batches / timers once for the lot.
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
@@ -2383,16 +2392,16 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
 %% message; processing it in one pass amortizes the per-event flushes
 %% over the train.
 connected(info, {udp_batch, Socket, IP, Port, Packets}, #state{socket = Socket} = State) ->
-    State1 = State#state{current_packet_source = {IP, Port}},
+    State1 = State#state{current_packet_source = {IP, Port}, recv_pass = true},
     NewState = handle_packets_batch(Packets, State1),
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
 %% Server receives packets from listener
 connected(info, {quic_packet, Data, RemoteAddr}, #state{role = server} = State) ->
-    NewState = server_recv_pass([Data], RemoteAddr, State),
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    NewState = server_recv_pass([Data], RemoteAddr, State#state{recv_pass = true}),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
@@ -2400,8 +2409,8 @@ connected(info, {quic_packet, Data, RemoteAddr}, #state{role = server} = State) 
     check_state_transition(connected, FinalState);
 %% Server receives batched packets from listener (GRO optimization)
 connected(info, {quic_packets, Packets, RemoteAddr}, #state{role = server} = State) ->
-    NewState = server_recv_pass(Packets, RemoteAddr, State),
-    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    NewState = server_recv_pass(Packets, RemoteAddr, State#state{recv_pass = true}),
+    DrainedState = finish_recv_pass(drain_recv_msgs(NewState, ?RECV_DRAIN_MAX)),
     FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
@@ -7634,6 +7643,10 @@ maybe_send_ack(_, _, State) ->
 %% When `?ACK_PACKET_TOLERANCE' ack-eliciting packets have been seen
 %% since the last emitted ACK, flush immediately. Otherwise increment
 %% the counter and arm a max_ack_delay timer (if not already armed).
+maybe_decimate_app_ack(#state{recv_pass = true} = State) ->
+    %% Inside a receive pass: only count; finish_recv_pass/1 flushes
+    %% one ACK for the whole train.
+    arm_ack_timer(State#state{ack_elicited_count = State#state.ack_elicited_count + 1});
 maybe_decimate_app_ack(State) ->
     NewCount = State#state.ack_elicited_count + 1,
     case NewCount >= State#state.ack_packet_tolerance of
@@ -7642,6 +7655,19 @@ maybe_decimate_app_ack(State) ->
         false ->
             arm_ack_timer(State#state{ack_elicited_count = NewCount})
     end.
+
+%% End of a connected-state receive pass: emit the deferred ACK (one
+%% per train) if enough ack-eliciting packets accumulated, then clear
+%% the pass flag. Below-tolerance remainders keep their ack_timer.
+finish_recv_pass(
+    #state{ack_elicited_count = Count, ack_packet_tolerance = Tol, close_reason = undefined} =
+        State
+) when
+    Count >= Tol
+->
+    send_app_ack(State#state{recv_pass = false});
+finish_recv_pass(State) ->
+    State#state{recv_pass = false}.
 
 %% Arm the max_ack_delay timer if not already armed.
 arm_ack_timer(#state{ack_timer = Ref} = State) when Ref =/= undefined ->
@@ -13079,6 +13105,27 @@ test_decimate_step(State) ->
     {NewState, #{
         ack_elicited_count => NewState#state.ack_elicited_count,
         ack_timer_armed => NewState#state.ack_timer =/= undefined
+    }}.
+
+%% Mark the state as inside a connected-state receive pass, as the
+%% datagram handlers do before processing a train.
+-spec test_state_in_recv_pass(#state{}) -> #state{}.
+test_state_in_recv_pass(State) ->
+    State#state{recv_pass = true}.
+
+%% Run finish_recv_pass/1 and return the observable decimation fields.
+-spec test_finish_recv_pass(#state{}) ->
+    {#state{}, #{
+        ack_elicited_count := non_neg_integer(),
+        ack_timer_armed := boolean(),
+        recv_pass := boolean()
+    }}.
+test_finish_recv_pass(State) ->
+    NewState = finish_recv_pass(State),
+    {NewState, #{
+        ack_elicited_count => NewState#state.ack_elicited_count,
+        ack_timer_armed => NewState#state.ack_timer =/= undefined,
+        recv_pass => NewState#state.recv_pass
     }}.
 
 %% Simulate the delayed-ack timer firing by routing through

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -311,23 +311,6 @@
 -define(AEAD_CONFIDENTIALITY_LIMIT, 16#800000).
 
 %% Connection state record
-%% Per-run constants for the bulk chunk-run sender (see
-%% send_stream_chunk_run/8): everything that would otherwise be
-%% re-extracted from #state{} on every packet of the run.
--record(chunk_run, {
-    stream_id :: non_neg_integer(),
-    max_chunk :: pos_integer(),
-    header_prefix :: binary(),
-    length_varint :: binary(),
-    key_phase :: 0 | 1,
-    cipher :: quic_aead:cipher(),
-    key :: binary(),
-    iv :: binary(),
-    hp :: binary(),
-    dcid :: binary(),
-    now :: integer()
-}).
-
 -record(state, {
     %% Connection identity
     scid :: binary(),
@@ -9355,21 +9338,37 @@ send_stream_chunk_run(StreamId, Offset, Data, Fin, State0, BytesSentSoFar, Ctx, 
         end,
     #crypto_keys{key = Key, iv = IV, hp = HP, cipher = Cipher} = EncryptKeys,
     Now = erlang:monotonic_time(millisecond),
-    Run = #chunk_run{
-        stream_id = StreamId,
-        max_chunk = MaxChunkSize,
-        header_prefix = HeaderPrefix,
-        length_varint = LengthVarint,
-        key_phase = get_current_key_phase(State),
-        cipher = Cipher,
-        key = Key,
-        iv = IV,
-        hp = HP,
-        dcid = DCID,
-        now = Now
-    },
-    {SS1, TrackedRev, Offset1, Rest} =
-        chunk_run_loop(K, Offset, Data, State, Run, SocketState, [], 0),
+    PN0 = PNSpace#pn_space.next_pn,
+    KeyPhase = get_current_key_phase(State),
+    %% Build the run's frames and QUIC-frame payloads, then seal all K
+    %% packets: one fused NIF call when available (header, nonce, AEAD
+    %% and header protection in C), per-packet Erlang sealing otherwise.
+    {Frames, Payloads, Offset1, Rest} =
+        build_run_payloads(K, StreamId, Offset, Data, HeaderPrefix, LengthVarint, MaxChunkSize),
+    FirstByteBase = short_header_first_byte(KeyPhase, 1, State),
+    Packets =
+        case quic_aead_ctx:protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) of
+            {ok, Ps} ->
+                Ps;
+            fallback ->
+                {Ps, _} = lists:mapfoldl(
+                    fun(Payload, PN) ->
+                        FirstByte = short_header_first_byte(
+                            KeyPhase, quic_packet:pn_length(PN), State
+                        ),
+                        {
+                            quic_aead:protect_short_packet(
+                                Cipher, Key, IV, HP, PN, FirstByte, DCID, Payload
+                            ),
+                            PN + 1
+                        }
+                    end,
+                    PN0,
+                    Payloads
+                ),
+                Ps
+        end,
+    {SS1, TrackedRev} = send_run_packets(Packets, Frames, PN0, State, SocketState, []),
     %% One loss-tracker and one CC update for the run's successful sends.
     {Loss1, CC1} =
         case TrackedRev of
@@ -9382,7 +9381,6 @@ send_stream_chunk_run(StreamId, Offset, Data, Fin, State0, BytesSentSoFar, Ctx, 
                     quic_cc:on_packets_sent(CCState, [Sz || {_, Sz, _} <- Tracked])
                 }
         end,
-    PN0 = PNSpace#pn_space.next_pn,
     %% RFC 9000 §10.1: the idle timer restarts on the first ack-eliciting
     %% send since the last receive (see send_app_packet_now/3).
     RestartIdle = not State#state.ack_eliciting_since_recv,
@@ -9406,34 +9404,41 @@ send_stream_chunk_run(StreamId, Offset, Data, Fin, State0, BytesSentSoFar, Ctx, 
         StreamId, Offset1, Rest, Fin, State2, BytesSentSoFar + K * MaxChunkSize, Ctx
     ).
 
-%% Per-chunk inner loop: seal and send only; the socket state is
-%% threaded explicitly so no #state{} copy happens per packet, and the
-%% successful sends are collected as [{PN, Size, Frame}] (reversed)
-%% for one batched loss/CC update afterwards. Chunk I takes packet
-%% number next_pn + I; the caller advances next_pn by K. A failed send
-%% skips that packet's tracking exactly as send_app_packet_now/3 does
-%% (PTO owns retransmission).
-chunk_run_loop(0, Offset, Data, _State, _Run, SS, Tracked, _I) ->
-    {SS, Tracked, Offset, Data};
-chunk_run_loop(K, Offset, Data, State, Run, SS, Tracked, I) ->
-    #chunk_run{
-        stream_id = StreamId,
-        max_chunk = MaxChunkSize,
-        header_prefix = HeaderPrefix,
-        length_varint = LengthVarint,
-        key_phase = KeyPhase,
-        cipher = Cipher,
-        key = Key,
-        iv = IV,
-        hp = HP,
-        dcid = DCID
-    } = Run,
-    <<Chunk:MaxChunkSize/binary, Rest/binary>> = Data,
-    Frame = {stream, StreamId, Offset, Chunk, false},
+%% Split the run's data into K full chunks, building the stream frame
+%% and QUIC-frame payload for each. Returns the leftover data and its
+%% starting offset for the caller to continue with.
+build_run_payloads(K, StreamId, Offset, Data, HeaderPrefix, LengthVarint, MaxChunkSize) ->
+    build_run_payloads(
+        K, StreamId, Offset, Data, HeaderPrefix, LengthVarint, MaxChunkSize, [], []
+    ).
+
+build_run_payloads(0, _Sid, Offset, Data, _HP, _LV, _MCS, FrAcc, PlAcc) ->
+    {lists:reverse(FrAcc), lists:reverse(PlAcc), Offset, Data};
+build_run_payloads(K, Sid, Offset, Data, HeaderPrefix, LengthVarint, MCS, FrAcc, PlAcc) ->
+    <<Chunk:MCS/binary, Rest/binary>> = Data,
+    Frame = {stream, Sid, Offset, Chunk, false},
     Payload = build_chunk_iodata(HeaderPrefix, Offset, LengthVarint, Chunk, Frame),
-    PN = (State#state.pn_app)#pn_space.next_pn + I,
-    FirstByte = short_header_first_byte(KeyPhase, quic_packet:pn_length(PN), State),
-    Packet = quic_aead:protect_short_packet(Cipher, Key, IV, HP, PN, FirstByte, DCID, Payload),
+    build_run_payloads(
+        K - 1,
+        Sid,
+        Offset + MCS,
+        Rest,
+        HeaderPrefix,
+        LengthVarint,
+        MCS,
+        [Frame | FrAcc],
+        [Payload | PlAcc]
+    ).
+
+%% Hand the run's sealed packets to the socket; the socket state is
+%% threaded explicitly so no #state{} copy happens per packet, and the
+%% successful sends are collected as [{PN, Size, Frame}] (reversed) for
+%% one batched loss/CC update afterwards. Packet I carries PN0 + I. A
+%% failed send skips that packet's tracking exactly as
+%% send_app_packet_now/3 does (PTO owns retransmission).
+send_run_packets([], [], _PN, _State, SS, Tracked) ->
+    {SS, Tracked};
+send_run_packets([Packet | Pkts], [Frame | Frs], PN, State, SS, Tracked) ->
     PacketSize = byte_size(Packet),
     #state{remote_addr = {IP, Port}} = State,
     SendResult =
@@ -9459,22 +9464,19 @@ chunk_run_loop(K, Offset, Data, State, Run, SS, Tracked, I) ->
                     undefined -> SS;
                     _ -> SS1
                 end,
-            Tracked1 = [{PN, PacketSize, Frame} | Tracked],
-            chunk_run_loop(K - 1, Offset + MaxChunkSize, Rest, State, Run, SS2, Tracked1, I + 1);
+            send_run_packets(Pkts, Frs, PN + 1, State, SS2, [{PN, PacketSize, Frame} | Tracked]);
         {error, Reason, SSCleared} ->
             ?LOG_WARNING(
                 #{what => udp_send_failed, reason => Reason, pn => PN, size => PacketSize},
                 ?QUIC_LOG_META
             ),
-            chunk_run_loop(
-                K - 1, Offset + MaxChunkSize, Rest, State, Run, SSCleared, Tracked, I + 1
-            );
+            send_run_packets(Pkts, Frs, PN + 1, State, SSCleared, Tracked);
         {error, Reason} ->
             ?LOG_WARNING(
                 #{what => udp_send_failed, reason => Reason, pn => PN, size => PacketSize},
                 ?QUIC_LOG_META
             ),
-            chunk_run_loop(K - 1, Offset + MaxChunkSize, Rest, State, Run, SS, Tracked, I + 1)
+            send_run_packets(Pkts, Frs, PN + 1, State, SS, Tracked)
     end.
 
 %% Build the iodata payload `[Header, Chunk]' for a chunked stream

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -311,6 +311,23 @@
 -define(AEAD_CONFIDENTIALITY_LIMIT, 16#800000).
 
 %% Connection state record
+%% Per-run constants for the bulk chunk-run sender (see
+%% send_stream_chunk_run/8): everything that would otherwise be
+%% re-extracted from #state{} on every packet of the run.
+-record(chunk_run, {
+    stream_id :: non_neg_integer(),
+    max_chunk :: pos_integer(),
+    header_prefix :: binary(),
+    length_varint :: binary(),
+    key_phase :: 0 | 1,
+    cipher :: quic_aead:cipher(),
+    key :: binary(),
+    iv :: binary(),
+    hp :: binary(),
+    dcid :: binary(),
+    now :: integer()
+}).
+
 -record(state, {
     %% Connection identity
     scid :: binary(),
@@ -9276,6 +9293,175 @@ send_stream_single_packet(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Wh
             end
     end.
 
+%% Approve up to KMax-1 additional same-size sends against CC/pacing,
+%% consuming pacing tokens exactly as the one-at-a-time path would.
+approve_more_chunks(CC, _Size, _Urgency, _Pacing, KMax, K) when K >= KMax ->
+    {K, CC};
+approve_more_chunks(CC, Size, Urgency, true, KMax, K) ->
+    %% One batched CC/pacing check for the rest of the run instead of
+    %% a send_check per chunk.
+    {KExtra, CC1} = quic_cc:send_check_run(CC, Size, KMax - K, Urgency),
+    {K + KExtra, CC1};
+approve_more_chunks(CC, Size, Urgency, false, KMax, K) ->
+    %% Pacing off: count how many more chunks fit in the window,
+    %% accounting each on a scratch copy so the checks see the chunks
+    %% already approved. The real CC state is updated once for the run.
+    {cwnd_room_chunks(CC, Size, Urgency, KMax, K), CC}.
+
+cwnd_room_chunks(_CC, _Size, _Urgency, KMax, K) when K >= KMax ->
+    K;
+cwnd_room_chunks(CC, Size, Urgency, KMax, K) ->
+    case cwnd_only_check(CC, Size, Urgency) of
+        {ok, _} -> cwnd_room_chunks(quic_cc:on_packet_sent(CC, Size), Size, Urgency, KMax, K + 1);
+        _ -> K
+    end.
+
+%% Send K CC-approved full-size chunks as one run: seal and hand each
+%% wire packet to the socket, then update loss/CC/PN/counters and
+%% rebuild #state{} ONCE for the whole run instead of once per packet.
+send_stream_chunk_run(StreamId, Offset, Data, Fin, State0, BytesSentSoFar, Ctx, K) ->
+    {chunked_ctx, MaxChunkSize, _Urgency, _PacketSize, HeaderPrefix, LengthVarint, _Where} = Ctx,
+    %% A packet still pending from send coalescing goes out first so
+    %% the wire order matches the send order.
+    State = flush_pending_packet(State0),
+    #state{
+        dcid = DCID,
+        app_keys = {ClientKeys, ServerKeys},
+        role = Role,
+        pn_app = PNSpace,
+        loss_state = LossState,
+        cc_state = CCState,
+        socket_state = SocketState
+    } = State,
+    EncryptKeys =
+        case Role of
+            client -> ClientKeys;
+            server -> ServerKeys
+        end,
+    #crypto_keys{key = Key, iv = IV, hp = HP, cipher = Cipher} = EncryptKeys,
+    Now = erlang:monotonic_time(millisecond),
+    Run = #chunk_run{
+        stream_id = StreamId,
+        max_chunk = MaxChunkSize,
+        header_prefix = HeaderPrefix,
+        length_varint = LengthVarint,
+        key_phase = get_current_key_phase(State),
+        cipher = Cipher,
+        key = Key,
+        iv = IV,
+        hp = HP,
+        dcid = DCID,
+        now = Now
+    },
+    {SS1, TrackedRev, Offset1, Rest} =
+        chunk_run_loop(K, Offset, Data, State, Run, SocketState, [], 0),
+    %% One loss-tracker and one CC update for the run's successful sends.
+    {Loss1, CC1} =
+        case TrackedRev of
+            [] ->
+                {LossState, CCState};
+            _ ->
+                Tracked = lists:reverse(TrackedRev),
+                {
+                    quic_loss:on_packets_sent_run(LossState, Tracked, Now),
+                    quic_cc:on_packets_sent(CCState, [Sz || {_, Sz, _} <- Tracked])
+                }
+        end,
+    PN0 = PNSpace#pn_space.next_pn,
+    %% RFC 9000 §10.1: the idle timer restarts on the first ack-eliciting
+    %% send since the last receive (see send_app_packet_now/3).
+    RestartIdle = not State#state.ack_eliciting_since_recv,
+    State1 = State#state{
+        pn_app = PNSpace#pn_space{next_pn = PN0 + K},
+        loss_state = Loss1,
+        cc_state = CC1,
+        socket_state = SS1,
+        packets_sent = State#state.packets_sent + K,
+        burst_sent = State#state.burst_sent + K,
+        last_activity =
+            case RestartIdle of
+                true -> Now;
+                false -> State#state.last_activity
+            end,
+        ack_eliciting_since_recv = true,
+        pto_dirty = true
+    },
+    State2 = maybe_force_key_update(State1, K),
+    send_stream_chunked_loop(
+        StreamId, Offset1, Rest, Fin, State2, BytesSentSoFar + K * MaxChunkSize, Ctx
+    ).
+
+%% Per-chunk inner loop: seal and send only; the socket state is
+%% threaded explicitly so no #state{} copy happens per packet, and the
+%% successful sends are collected as [{PN, Size, Frame}] (reversed)
+%% for one batched loss/CC update afterwards. Chunk I takes packet
+%% number next_pn + I; the caller advances next_pn by K. A failed send
+%% skips that packet's tracking exactly as send_app_packet_now/3 does
+%% (PTO owns retransmission).
+chunk_run_loop(0, Offset, Data, _State, _Run, SS, Tracked, _I) ->
+    {SS, Tracked, Offset, Data};
+chunk_run_loop(K, Offset, Data, State, Run, SS, Tracked, I) ->
+    #chunk_run{
+        stream_id = StreamId,
+        max_chunk = MaxChunkSize,
+        header_prefix = HeaderPrefix,
+        length_varint = LengthVarint,
+        key_phase = KeyPhase,
+        cipher = Cipher,
+        key = Key,
+        iv = IV,
+        hp = HP,
+        dcid = DCID
+    } = Run,
+    <<Chunk:MaxChunkSize/binary, Rest/binary>> = Data,
+    Frame = {stream, StreamId, Offset, Chunk, false},
+    Payload = build_chunk_iodata(HeaderPrefix, Offset, LengthVarint, Chunk, Frame),
+    PN = (State#state.pn_app)#pn_space.next_pn + I,
+    FirstByte = short_header_first_byte(KeyPhase, quic_packet:pn_length(PN), State),
+    Packet = quic_aead:protect_short_packet(Cipher, Key, IV, HP, PN, FirstByte, DCID, Payload),
+    PacketSize = byte_size(Packet),
+    #state{remote_addr = {IP, Port}} = State,
+    SendResult =
+        case SS of
+            undefined ->
+                case gen_udp:send(State#state.socket, IP, Port, Packet) of
+                    ok -> {ok, undefined};
+                    {error, _} = E -> E
+                end;
+            _ ->
+                quic_socket:send(SS, IP, Port, Packet)
+        end,
+    case SendResult of
+        {ok, SS1} ->
+            ?QLOG_EMIT_PACKET_SENT(State#state.qlog_ctx, #{
+                packet_type => one_rtt,
+                packet_number => PN,
+                length => PacketSize,
+                frames => [Frame]
+            }),
+            SS2 =
+                case SS1 of
+                    undefined -> SS;
+                    _ -> SS1
+                end,
+            Tracked1 = [{PN, PacketSize, Frame} | Tracked],
+            chunk_run_loop(K - 1, Offset + MaxChunkSize, Rest, State, Run, SS2, Tracked1, I + 1);
+        {error, Reason, SSCleared} ->
+            ?LOG_WARNING(
+                #{what => udp_send_failed, reason => Reason, pn => PN, size => PacketSize},
+                ?QUIC_LOG_META
+            ),
+            chunk_run_loop(
+                K - 1, Offset + MaxChunkSize, Rest, State, Run, SSCleared, Tracked, I + 1
+            );
+        {error, Reason} ->
+            ?LOG_WARNING(
+                #{what => udp_send_failed, reason => Reason, pn => PN, size => PacketSize},
+                ?QUIC_LOG_META
+            ),
+            chunk_run_loop(K - 1, Offset + MaxChunkSize, Rest, State, Run, SS, Tracked, I + 1)
+    end.
+
 %% Build the iodata payload `[Header, Chunk]' for a chunked stream
 %% send, reusing the pre-computed header pieces when `Offset > 0'.
 %% On the `Offset =:= 0' first-chunk path the wire format needs a
@@ -9357,7 +9543,7 @@ send_stream_chunked_step(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx
     end.
 
 send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSentSoFar, Ctx) ->
-    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, HeaderPrefix, LengthVarint, Where} = Ctx,
+    {chunked_ctx, MaxChunkSize, Urgency, PacketSize, _HeaderPrefix, _LengthVarint, Where} = Ctx,
     #state{cc_state = CCState, pacing_enabled = PacingEnabled} = State,
     Check =
         case PacingEnabled of
@@ -9366,20 +9552,19 @@ send_stream_chunked_step_unbudgeted(StreamId, Offset, Data, Fin, State, BytesSen
         end,
     case Check of
         {ok, NewCCState} ->
-            State0 = State#state{cc_state = NewCCState},
-            <<Chunk:MaxChunkSize/binary, Rest/binary>> = Data,
-            Frame = {stream, StreamId, Offset, Chunk, false},
-            Payload = build_chunk_iodata(HeaderPrefix, Offset, LengthVarint, Chunk, Frame),
-            State1 = send_app_packet_internal(Payload, [Frame], State0),
-            send_stream_chunked_loop(
-                StreamId,
-                Offset + MaxChunkSize,
-                Rest,
-                Fin,
-                State1,
-                BytesSentSoFar + MaxChunkSize,
-                Ctx
-            );
+            %% First chunk approved. Approve as many further full
+            %% chunks as CC/pacing and the burst budget allow, then
+            %% send the whole run with one bookkeeping pass: the
+            %% per-packet #state{} rebuild in send_app_packet_now is
+            %% the largest own-time item on the bulk-send profile.
+            FullChunks = byte_size(Data) div MaxChunkSize,
+            BudgetLeft = max(1, State#state.burst_budget - State#state.burst_sent),
+            KMax = min(FullChunks, BudgetLeft),
+            {K, CCStateK} = approve_more_chunks(
+                NewCCState, PacketSize, Urgency, PacingEnabled, KMax, 1
+            ),
+            State0 = State#state{cc_state = CCStateK},
+            send_stream_chunk_run(StreamId, Offset, Data, Fin, State0, BytesSentSoFar, Ctx, K);
         {blocked_pacing, Delay} ->
             ?LOG_DEBUG(
                 #{
@@ -11167,10 +11352,14 @@ normalize_alpn_list(_) ->
 %% and force a key update before it is reached (RFC 9001 §6.6). Only the
 %% first over-limit packet in an idle phase triggers the update; the
 %% counter resets when the new phase begins.
-maybe_force_key_update(#state{key_state = undefined} = State) ->
+maybe_force_key_update(State) ->
+    maybe_force_key_update(State, 1).
+
+%% N packets at once, for the chunk-run sender.
+maybe_force_key_update(#state{key_state = undefined} = State, _N) ->
     State;
-maybe_force_key_update(#state{key_state = KeyState} = State) ->
-    NewCount = KeyState#key_update_state.send_count + 1,
+maybe_force_key_update(#state{key_state = KeyState} = State, N) ->
+    NewCount = KeyState#key_update_state.send_count + N,
     State1 = State#state{key_state = KeyState#key_update_state{send_count = NewCount}},
     case
         NewCount >= ?AEAD_CONFIDENTIALITY_LIMIT andalso

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1505,7 +1505,9 @@ build_server_socket_state(Socket, Opts) ->
     SenderOpts = #{
         backend => maps:get(listener_socket_backend, Opts, gen_udp),
         gso_supported => maps:get(listener_gso_supported, Opts, false),
-        batching => BatchOpts
+        batching => BatchOpts,
+        sender_pid => maps:get(send_sender, Opts, undefined),
+        gso_counter => maps:get(send_gso_counter, Opts, undefined)
     },
     case quic_socket:new_sender(Socket, SenderOpts) of
         {ok, S} -> S;

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4914,6 +4914,62 @@ decode_short_header_packet(Data, State) ->
 %% Decrypt an application (1-RTT) packet with key phase handling
 %% Uses 2-stage API: unprotect header to get key_phase, then decrypt with selected keys
 decrypt_app_packet(Header, EncryptedPayload, CurrentKeys, State) ->
+    %% Fast path: fused unprotect + PN reconstruction + AEAD open in
+    %% one NIF call, valid only when no key update is in flight (the
+    %% NIF bails to the generic path when the packet's phase bit
+    %% differs from the current phase, and the generic path owns the
+    %% RFC 9001 §6 phase-transition bookkeeping).
+    Fused =
+        case fused_decrypt_keys(CurrentKeys, State) of
+            {ok, #crypto_keys{key = FKey, iv = FIV, hp = FHP, cipher = FCipher}} ->
+                quic_aead_ctx:open_packet(
+                    FCipher,
+                    FKey,
+                    FIV,
+                    FHP,
+                    get_largest_recv(app, State),
+                    get_current_key_phase(State),
+                    Header,
+                    EncryptedPayload
+                );
+            no ->
+                fallback
+        end,
+    case Fused of
+        {ok, PN0, FirstByte0, Plaintext0} ->
+            Now0 = erlang:monotonic_time(millisecond),
+            StateF = record_app_recv(FirstByte0, PN0, State, Now0),
+            case decode_and_process_streaming(app, Plaintext0, StateF) of
+                {ok, NewState0, Frames0} ->
+                    {ok, app, Frames0, <<>>, NewState0, processed};
+                {error, Reason0} ->
+                    {error, Reason0}
+            end;
+        error ->
+            {error, decryption_failed};
+        fallback ->
+            decrypt_app_packet_slow(Header, EncryptedPayload, CurrentKeys, State)
+    end.
+
+%% The peer-direction keys for the fused path: only when no key update
+%% is in flight, so a same-phase packet cannot carry phase-transition
+%% side effects (select_decrypt_keys/2 handles those on the slow path).
+fused_decrypt_keys(CurrentKeys, #state{key_state = undefined}) ->
+    {ok, CurrentKeys};
+fused_decrypt_keys(_CurrentKeys, #state{
+    key_state = #key_update_state{update_state = idle, current_keys = {CK, SK}},
+    role = Role
+}) ->
+    case Role of
+        server -> {ok, CK};
+        client -> {ok, SK}
+    end;
+fused_decrypt_keys(_CurrentKeys, _State) ->
+    no.
+
+%% The two-stage path: unprotect the header to learn the key phase,
+%% select keys, then decrypt.
+decrypt_app_packet_slow(Header, EncryptedPayload, CurrentKeys, State) ->
     %% The cipher must come from the negotiated keys: inferring it from
     %% the HP key length mistakes ChaCha20-Poly1305 for AES-256-GCM and
     %% drops every received 1-RTT packet on such connections.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4462,82 +4462,59 @@ seq_run_last(_, _) ->
 fold_opened_seq([], State, N, Elicited) ->
     fold_opened_finish(State, N, Elicited);
 fold_opened_seq([{_PN, _FB, Opened} | Rest], State, N, Elicited) ->
-    case opened_frames(Opened, State) of
-        {ok, NewState, Frames} ->
-            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
-                packet_type => app,
-                frames => Frames
-            }),
-            ?QLOG_EMIT_FRAMES_PROCESSED(NewState#state.qlog_ctx, Frames),
-            {State2, Elicited2} =
-                case contains_ack_eliciting_frames(Frames) of
-                    false ->
-                        {NewState, Elicited};
-                    true ->
-                        case should_delay_ack(Frames) of
-                            true -> {schedule_delayed_ack(app, NewState), Elicited};
-                            false -> {NewState, Elicited + 1}
-                        end
-                end,
-            fold_opened_seq(Rest, State2, N + 1, Elicited2);
-        {error, Reason} ->
-            log_opened_decode_failure(Reason, State),
-            fold_opened_seq(Rest, State, N, Elicited)
-    end.
+    {ok, NewState, Frames} = opened_frames(Opened, State),
+    ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
+        packet_type => app,
+        frames => Frames
+    }),
+    ?QLOG_EMIT_FRAMES_PROCESSED(NewState#state.qlog_ctx, Frames),
+    {State2, Elicited2} =
+        case contains_ack_eliciting_frames(Frames) of
+            false ->
+                {NewState, Elicited};
+            true ->
+                case should_delay_ack(Frames) of
+                    true -> {schedule_delayed_ack(app, NewState), Elicited};
+                    false -> {NewState, Elicited + 1}
+                end
+        end,
+    fold_opened_seq(Rest, State2, N + 1, Elicited2).
 
 %% Per-packet loop for a run that is not one contiguous sequence.
 fold_opened([], State, _Now, N, Elicited) ->
     fold_opened_finish(State, N, Elicited);
 fold_opened([{PN, FirstByte, Opened} | Rest], State, Now, N, Elicited) ->
     StateF = record_app_recv(FirstByte, PN, State, Now),
-    case opened_frames(Opened, StateF) of
-        {ok, NewState, Frames} ->
-            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
-                packet_type => app,
-                frames => Frames
-            }),
-            ?QLOG_EMIT_FRAMES_PROCESSED(NewState#state.qlog_ctx, Frames),
-            %% Per-packet ACK policy identical to maybe_send_ack(app, ...),
-            %% except the count-based decimation increment is accumulated
-            %% across the run and applied once at the end.
-            {State2, Elicited2} =
-                case contains_ack_eliciting_frames(Frames) of
-                    false ->
-                        {NewState, Elicited};
+    {ok, NewState, Frames} = opened_frames(Opened, StateF),
+    ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
+        packet_type => app,
+        frames => Frames
+    }),
+    ?QLOG_EMIT_FRAMES_PROCESSED(NewState#state.qlog_ctx, Frames),
+    %% Per-packet ACK policy identical to maybe_send_ack(app, ...),
+    %% except the count-based decimation increment is accumulated
+    %% across the run and applied once at the end.
+    {State2, Elicited2} =
+        case contains_ack_eliciting_frames(Frames) of
+            false ->
+                {NewState, Elicited};
+            true ->
+                case should_delay_ack(Frames) of
                     true ->
-                        case should_delay_ack(Frames) of
-                            true ->
-                                {schedule_delayed_ack(app, NewState), Elicited};
-                            false ->
-                                case NewState#state.last_recv_trigger of
-                                    reordered ->
-                                        %% send_app_ack acks everything seen so
-                                        %% far and clears the count, so pending
-                                        %% increments are dropped with it.
-                                        {send_app_ack(NewState), 0};
-                                    sequential ->
-                                        {NewState, Elicited + 1}
-                                end
+                        {schedule_delayed_ack(app, NewState), Elicited};
+                    false ->
+                        case NewState#state.last_recv_trigger of
+                            reordered ->
+                                %% send_app_ack acks everything seen so
+                                %% far and clears the count, so pending
+                                %% increments are dropped with it.
+                                {send_app_ack(NewState), 0};
+                            sequential ->
+                                {NewState, Elicited + 1}
                         end
-                end,
-            fold_opened(Rest, State2, Now, N + 1, Elicited2);
-        {error, Reason} ->
-            log_opened_decode_failure(Reason, State),
-            fold_opened(Rest, State, Now, N, Elicited)
-    end.
-
-%% Same recovery as handle_packet_loop/2: log and drop the datagram,
-%% continue with the pre-packet state.
-log_opened_decode_failure(Reason, State) ->
-    ?LOG_WARNING(
-        #{
-            what => packet_decode_decrypt_failed,
-            role => State#state.role,
-            reason => Reason,
-            source => State#state.current_packet_source
-        },
-        ?QUIC_LOG_META
-    ).
+                end
+        end,
+    fold_opened(Rest, State2, Now, N + 1, Elicited2).
 
 %% Apply the run's packet count and its accumulated ack-eliciting
 %% count. Inside a receive pass decimation only counts (the pass end

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -200,6 +200,10 @@
     %% Mailbox drain of the connected-state receive pass
     drain_recv_msgs/2,
     collect_client_udp/5,
+    %% Batch-opened run processing
+    fold_opened/2,
+    test_state_with_pn_app/2,
+    test_recv_summary/2,
     test_state_closing/2,
     test_state_with_socket/2,
     test_state_in_recv_pass/1,
@@ -4386,6 +4390,175 @@ handle_short_run(Packets, Keys, State) ->
             do_handle_packets_batch(Rest, handle_packet_loop(Packet, State))
     end.
 
+take_short_run([<<0:1, 1:1, _:6, _/binary>> = P | Rest], Acc) ->
+    take_short_run(Rest, [P | Acc]);
+take_short_run(Rest, Acc) ->
+    {lists:reverse(Acc), Rest}.
+
+%% Post-decrypt processing for a batch-opened run: the same per-packet
+%% effects as the fused branch of decrypt_app_packet/4 followed by the
+%% `processed' branch of handle_packet_loop/2, with the per-packet
+%% bookkeeping collapsed where the run's shape allows it.
+%%
+%% One monotonic_time sample serves the whole run (runs are opened
+%% well under a millisecond, and nothing reads the counter mid-fold).
+fold_opened(Results, State) ->
+    Now = erlang:monotonic_time(millisecond),
+    %% Contiguous-run fast path: when the whole opened run continues the
+    %% receive sequence exactly (PNs consecutive from largest_recv + 1,
+    %% which also means the head ACK range extends in place), the
+    %% per-packet receive bookkeeping collapses into one state update:
+    %% largest/ranges/spin from the last packet, every packet classified
+    %% sequential. Any other shape takes the per-packet path unchanged.
+    case State#state.pn_app of
+        #pn_space{largest_recv = L, ack_ranges = [{RangeStart, L} | RestRanges]} = PNSpace when
+            is_integer(L)
+        ->
+            case seq_run_last(Results, L + 1) of
+                {LastPN, LastFB} ->
+                    SpinRecv = (LastFB bsr 5) band 1,
+                    SpinOut =
+                        case State#state.spin_bit_enabled of
+                            false -> State#state.spin_outgoing;
+                            true when State#state.role =:= client -> SpinRecv;
+                            true -> 1 - SpinRecv
+                        end,
+                    State1 = State#state{
+                        pn_app = PNSpace#pn_space{
+                            largest_recv = LastPN,
+                            recv_time = Now,
+                            ack_ranges = [{RangeStart, LastPN} | RestRanges]
+                        },
+                        last_recv_trigger = sequential,
+                        spin_recv = SpinRecv,
+                        spin_recv_largest_pn = LastPN,
+                        spin_outgoing = SpinOut,
+                        last_activity = Now,
+                        ack_eliciting_since_recv = false
+                    },
+                    case stream_train(Results, State1) of
+                        {ok, StreamId, FirstOff, RevChunks, Total, N} ->
+                            apply_stream_train(StreamId, FirstOff, RevChunks, Total, N, State1);
+                        no ->
+                            fold_opened_seq(Results, State1, 0, 0)
+                    end;
+                no ->
+                    fold_opened(Results, State, Now, 0, 0)
+            end;
+        _ ->
+            fold_opened(Results, State, Now, 0, 0)
+    end.
+
+%% Last {PN, FirstByte} of a run iff PNs are consecutive from Expected.
+seq_run_last([{PN, FB, _}], PN) ->
+    {PN, FB};
+seq_run_last([{PN, _, _} | [{PN2, _, _} | _] = Rest], PN) when PN2 =:= PN + 1 ->
+    seq_run_last(Rest, PN2);
+seq_run_last(_, _) ->
+    no.
+
+%% Per-packet loop for a contiguous run: receive bookkeeping already
+%% applied for the whole train, every packet known sequential.
+fold_opened_seq([], State, N, Elicited) ->
+    fold_opened_finish(State, N, Elicited);
+fold_opened_seq([{_PN, _FB, Opened} | Rest], State, N, Elicited) ->
+    case opened_frames(Opened, State) of
+        {ok, NewState, Frames} ->
+            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
+                packet_type => app,
+                frames => Frames
+            }),
+            ?QLOG_EMIT_FRAMES_PROCESSED(NewState#state.qlog_ctx, Frames),
+            {State2, Elicited2} =
+                case contains_ack_eliciting_frames(Frames) of
+                    false ->
+                        {NewState, Elicited};
+                    true ->
+                        case should_delay_ack(Frames) of
+                            true -> {schedule_delayed_ack(app, NewState), Elicited};
+                            false -> {NewState, Elicited + 1}
+                        end
+                end,
+            fold_opened_seq(Rest, State2, N + 1, Elicited2);
+        {error, Reason} ->
+            log_opened_decode_failure(Reason, State),
+            fold_opened_seq(Rest, State, N, Elicited)
+    end.
+
+%% Per-packet loop for a run that is not one contiguous sequence.
+fold_opened([], State, _Now, N, Elicited) ->
+    fold_opened_finish(State, N, Elicited);
+fold_opened([{PN, FirstByte, Opened} | Rest], State, Now, N, Elicited) ->
+    StateF = record_app_recv(FirstByte, PN, State, Now),
+    case opened_frames(Opened, StateF) of
+        {ok, NewState, Frames} ->
+            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
+                packet_type => app,
+                frames => Frames
+            }),
+            ?QLOG_EMIT_FRAMES_PROCESSED(NewState#state.qlog_ctx, Frames),
+            %% Per-packet ACK policy identical to maybe_send_ack(app, ...),
+            %% except the count-based decimation increment is accumulated
+            %% across the run and applied once at the end.
+            {State2, Elicited2} =
+                case contains_ack_eliciting_frames(Frames) of
+                    false ->
+                        {NewState, Elicited};
+                    true ->
+                        case should_delay_ack(Frames) of
+                            true ->
+                                {schedule_delayed_ack(app, NewState), Elicited};
+                            false ->
+                                case NewState#state.last_recv_trigger of
+                                    reordered ->
+                                        %% send_app_ack acks everything seen so
+                                        %% far and clears the count, so pending
+                                        %% increments are dropped with it.
+                                        {send_app_ack(NewState), 0};
+                                    sequential ->
+                                        {NewState, Elicited + 1}
+                                end
+                        end
+                end,
+            fold_opened(Rest, State2, Now, N + 1, Elicited2);
+        {error, Reason} ->
+            log_opened_decode_failure(Reason, State),
+            fold_opened(Rest, State, Now, N, Elicited)
+    end.
+
+%% Same recovery as handle_packet_loop/2: log and drop the datagram,
+%% continue with the pre-packet state.
+log_opened_decode_failure(Reason, State) ->
+    ?LOG_WARNING(
+        #{
+            what => packet_decode_decrypt_failed,
+            role => State#state.role,
+            reason => Reason,
+            source => State#state.current_packet_source
+        },
+        ?QUIC_LOG_META
+    ).
+
+%% Apply the run's packet count and its accumulated ack-eliciting
+%% count. Inside a receive pass decimation only counts (the pass end
+%% flushes), so one increment and one arm_ack_timer serve the run;
+%% outside a pass each increment gets the threshold check it would
+%% have had per packet.
+fold_opened_finish(State, N, Elicited) ->
+    State1 = State#state{packets_received = State#state.packets_received + N},
+    case {Elicited, State1#state.recv_pass} of
+        {0, _} ->
+            State1;
+        {_, true} ->
+            arm_ack_timer(State1#state{
+                ack_elicited_count = State1#state.ack_elicited_count + Elicited
+            });
+        {_, false} ->
+            lists:foldl(
+                fun(_, S) -> maybe_decimate_app_ack(S) end, State1, lists:seq(1, Elicited)
+            )
+    end.
+
 %% Consume an open_run result: the NIF returns either a pre-parsed
 %% frame list (term-identical to quic_frame:decode/1 output) or
 %% {raw, Plain} for packets with frame types outside the fast path,
@@ -4401,44 +4574,117 @@ opened_frames(Frames, State) when is_list(Frames) ->
         ),
         Frames}.
 
-take_short_run([<<0:1, 1:1, _:6, _/binary>> = P | Rest], Acc) ->
-    take_short_run(Rest, [P | Acc]);
-take_short_run(Rest, Acc) ->
-    {lists:reverse(Acc), Rest}.
-
-%% Post-decrypt processing for a batch-opened run: the same per-packet
-%% effects as the fused branch of decrypt_app_packet/4 followed by the
-%% `processed' branch of handle_packet_loop/2.
-fold_opened([], State) ->
-    State;
-fold_opened([{PN, FirstByte, Opened} | Rest], State) ->
-    Now = erlang:monotonic_time(millisecond),
-    StateF = record_app_recv(FirstByte, PN, State, Now),
-    case opened_frames(Opened, StateF) of
-        {ok, NewState, Frames} ->
-            ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
-                packet_type => app,
-                frames => Frames
-            }),
-            NewState1 = NewState#state{
-                packets_received = NewState#state.packets_received + 1
-            },
-            ?QLOG_EMIT_FRAMES_PROCESSED(NewState1#state.qlog_ctx, Frames),
-            fold_opened(Rest, maybe_send_ack(app, Frames, NewState1));
-        {error, Reason} ->
-            %% Same recovery as handle_packet_loop/2: log, drop the
-            %% datagram, continue with the pre-packet state.
-            ?LOG_WARNING(
-                #{
-                    what => packet_decode_decrypt_failed,
-                    role => State#state.role,
-                    reason => Reason,
-                    source => State#state.current_packet_source
-                },
-                ?QUIC_LOG_META
-            ),
-            fold_opened(Rest, State)
+%% Textbook bulk train: every packet in the run carries exactly one
+%% stream frame, all for the same stream, offsets contiguous, no FIN,
+%% and qlog is off (its per-packet events would be skipped). Returns
+%% the chunks in reverse order.
+stream_train(Results, State) ->
+    case ?QLOG_ENABLED(State#state.qlog_ctx) of
+        true -> no;
+        false -> stream_train(Results, undefined, undefined, [], 0, 0)
     end.
+
+stream_train([], Sid, _NextOff, RevChunks, Total, N) when Sid =/= undefined ->
+    {Off, _} = lists:last(RevChunks),
+    {ok, Sid, Off, RevChunks, Total, N};
+stream_train(
+    [{_PN, _FB, [{stream, Sid, Off, Data, false}]} | Rest], undefined, undefined, [], 0, 0
+) ->
+    stream_train(Rest, Sid, Off + byte_size(Data), [{Off, Data}], byte_size(Data), 1);
+stream_train(
+    [{_PN, _FB, [{stream, Sid, Off, Data, false}]} | Rest], Sid, Off, RevChunks, Total, N
+) ->
+    stream_train(
+        Rest,
+        Sid,
+        Off + byte_size(Data),
+        [{Off, Data} | RevChunks],
+        Total + byte_size(Data),
+        N + 1
+    );
+stream_train(_, _, _, _, _, _) ->
+    no.
+
+%% One bookkeeping pass for a whole contiguous stream train: the same
+%% conditions as the lean clause of do_process_stream_data_buffered/5,
+%% checked once with the train's totals; any deviation replays the
+%% train through the per-packet path.
+apply_stream_train(StreamId, FirstOff, RevChunks, Total, N, State) ->
+    case State#state.streams of
+        #{
+            StreamId := #stream_state{
+                recv_offset = FirstOff,
+                recv_max_data = RecvMaxData,
+                final_size = undefined,
+                recv_reset_at = undefined,
+                recv_buffer = RB
+            } = Stream
+        } ->
+            EndOffset = FirstOff + Total,
+            NewDataReceived = State#state.data_received + Total,
+            HalfWindow = State#state.fc_max_receive_window div 2,
+            case
+                Total > 0 andalso
+                    gb_trees:is_empty(RB) andalso
+                    RecvMaxData - EndOffset >= HalfWindow andalso
+                    State#state.max_data_local - NewDataReceived >= HalfWindow andalso
+                    State#state.recv_buffer_bytes + Total =< ?MAX_RECV_BUFFER_BYTES
+            of
+                true ->
+                    PendDeliver = deliver_stream_train(StreamId, RevChunks, State),
+                    State1 = State#state{
+                        streams = maps:put(
+                            StreamId,
+                            Stream#stream_state{recv_offset = EndOffset},
+                            State#state.streams
+                        ),
+                        data_received = NewDataReceived,
+                        pend_deliver = PendDeliver,
+                        has_non_probing_frame = true
+                    },
+                    fold_opened_finish(State1, N, N);
+                false ->
+                    stream_train_fallback(StreamId, RevChunks, State)
+            end;
+        _ ->
+            stream_train_fallback(StreamId, RevChunks, State)
+    end.
+
+%% Deviating train: replay it through the ordinary per-packet path.
+stream_train_fallback(StreamId, RevChunks, State) ->
+    {StateN, N} = lists:foldr(
+        fun({Off, Data}, {Acc, Cnt}) ->
+            {process_stream_data(StreamId, Off, Data, false, Acc), Cnt + 1}
+        end,
+        {State, 0},
+        RevChunks
+    ),
+    fold_opened_finish(StateN#state{has_non_probing_frame = true}, N, N).
+
+%% Deliver a whole train with the delivery contract of
+%% deliver_stream_data/4: merged into the pending run under coalescing
+%% (the chunks are adjacent and in order by construction), one message
+%% per chunk in stream order otherwise. Returns the new pend_deliver.
+deliver_stream_train(
+    StreamId, RevChunks, #state{recv_pass = true, delivery_coalescing = true} = State
+) ->
+    RevData = [Data || {_Off, Data} <- RevChunks],
+    case State#state.pend_deliver of
+        {StreamId, Acc, F} ->
+            {StreamId, RevData ++ Acc, F};
+        none ->
+            {StreamId, RevData, false};
+        {OtherId, Acc, F} ->
+            State#state.owner ! {quic, self(), {stream_data, OtherId, run_binary(Acc), F}},
+            {StreamId, RevData, false}
+    end;
+deliver_stream_train(StreamId, RevChunks, State) ->
+    Owner = State#state.owner,
+    lists:foreach(
+        fun({_Off, Data}) -> Owner ! {quic, self(), {stream_data, StreamId, Data, false}} end,
+        lists:reverse(RevChunks)
+    ),
+    State#state.pend_deliver.
 
 %% One server receive pass: process the packets of a listener message
 %% (source tracking, frame classification, RFC 9000 §9.1 migration
@@ -13481,6 +13727,38 @@ test_add_recv_stream(#state{streams = Streams} = State, StreamId, StreamCredit) 
         final_size = undefined
     },
     State#state{streams = Streams#{StreamId => Stream}}.
+
+%% Give a test state a 1-RTT PN space that has received 0..Largest.
+-spec test_state_with_pn_app(#state{}, non_neg_integer()) -> #state{}.
+test_state_with_pn_app(State, Largest) ->
+    State#state{
+        pn_app = #pn_space{
+            next_pn = 0,
+            largest_acked = undefined,
+            largest_recv = Largest,
+            recv_time = 0,
+            ack_ranges = [{0, Largest}],
+            ack_eliciting_in_flight = 0,
+            loss_time = undefined,
+            sent_packets = #{}
+        },
+        transport_params = #{max_ack_delay => 25}
+    }.
+
+%% The receive-side fields a batch-opened run is expected to move.
+-spec test_recv_summary(#state{}, non_neg_integer()) -> map().
+test_recv_summary(#state{pn_app = PN, streams = Streams} = State, StreamId) ->
+    #{
+        largest_recv => PN#pn_space.largest_recv,
+        ack_ranges => PN#pn_space.ack_ranges,
+        recv_offset => (maps:get(StreamId, Streams))#stream_state.recv_offset,
+        data_received => State#state.data_received,
+        packets_received => State#state.packets_received,
+        ack_elicited_count => State#state.ack_elicited_count,
+        pend_deliver => State#state.pend_deliver,
+        spin_recv_largest_pn => State#state.spin_recv_largest_pn,
+        has_non_probing_frame => State#state.has_non_probing_frame
+    }.
 
 %% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
 %% tests that run record_app_recv/4 against its unfused parts.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -2173,7 +2173,10 @@ connected(
     State4 = set_keep_alive_timer(update_last_activity(State3b)),
     %% RFC 8899: Initialize PMTU discovery after handshake
     State5 = init_pmtu_probing(TransportParams, State4),
-    {keep_state, State5};
+    %% Everything queued above (pending data, NEW_TOKEN, the first PMTU
+    %% probe) sits in the send batch; without a flush here it would
+    %% only leave with the next event on this connection.
+    {keep_state, flush_dirty_timers(flush_socket_batch(State5))};
 connected({call, From}, get_ref, #state{conn_ref = Ref} = State) ->
     {keep_state, State, [{reply, From, Ref}]};
 connected({call, From}, get_state, State) ->
@@ -2370,7 +2373,7 @@ connected(
     %% Return packet counts for liveness detection (net_kernel uses
     %% recv count to verify peer is alive) plus send-path batching
     %% counters for benchmarks and tests.
-    {Flushes, Coalesced, GSOFlushes} = send_batch_counters(SocketState),
+    {Flushes, Coalesced, GSOFlushes, Pending} = send_batch_counters(SocketState),
     Stats = #{
         packets_received => PacketsRecv,
         packets_sent => PacketsSent,
@@ -2380,7 +2383,10 @@ connected(
         retransmits => Retransmits,
         batch_flushes => Flushes,
         packets_coalesced => Coalesced,
-        gso_flushes => GSOFlushes
+        gso_flushes => GSOFlushes,
+        %% Packets built but not yet handed to the socket. Non-zero
+        %% between events means a handler forgot to flush.
+        send_batch_pending => Pending
     },
     {keep_state, State, [{reply, From, {ok, Stats}}]};
 connected({call, From}, get_peer_transport_params, #state{transport_params = TP} = State) ->
@@ -11323,13 +11329,14 @@ send_gso_supported(SocketState) ->
     maps:get(gso_supported, quic_socket:info(SocketState)).
 
 send_batch_counters(undefined) ->
-    {0, 0, 0};
+    {0, 0, 0, 0};
 send_batch_counters(SocketState) ->
     Info = quic_socket:info(SocketState),
     {
         maps:get(batch_flushes, Info),
         maps:get(packets_coalesced, Info),
-        maps:get(gso_flushes, Info)
+        maps:get(gso_flushes, Info),
+        maps:get(batch_pending, Info)
     }.
 
 %% Normalize ALPN list - handles binary, list of binaries, list of strings

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -167,6 +167,7 @@
     do_process_stream_data_buffered/5,
     do_process_stream_data_slow/5,
     test_recv_stream_state/4,
+    test_add_recv_stream/3,
     update_pn_space_recv/3,
     should_delay_ack/1,
     short_header_first_byte/3,
@@ -201,6 +202,8 @@
     test_state_closing/2,
     test_state_with_socket/2,
     test_state_in_recv_pass/1,
+    test_state_coalescing/2,
+    test_pending_delivery/1,
     test_finish_recv_pass/1,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
     test_coalesce_small_stream/1,
@@ -792,6 +795,19 @@
     %% packets. The max_ack_delay timer still bounds latency; the
     %% reordering immediate-ACK path bypasses this.
     recv_pass = false :: boolean(),
+    %% Opt-in (delivery_coalescing option): merge consecutive
+    %% same-stream stream_data deliveries of one receive pass into a
+    %% single owner message. QUIC gives no message-boundary guarantee,
+    %% but owners that decode each delivery as one complete
+    %% application message (rather than length-framing the byte
+    %% stream) break when deliveries merge, so the default keeps the
+    %% one-message-per-packet behaviour.
+    delivery_coalescing = false :: boolean(),
+    %% Pending run for the above: stream id, reversed chunk list, fin.
+    %% A delivery for a DIFFERENT stream flushes the pending one
+    %% first, so the owner observes stream_data messages in exact
+    %% arrival order; only adjacent chunks of one stream merge.
+    pend_deliver = none :: none | {non_neg_integer(), [binary()], boolean()},
     ack_elicited_count = 0 :: non_neg_integer(),
     %% How many ack-eliciting 1-RTT packets to accumulate before
     %% flushing an ACK. 2 is the RFC 9000 §13.2.1 recommendation;
@@ -1317,6 +1333,7 @@ init({server, Opts}) ->
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
         ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
         burst_budget = maps:get(max_burst_packets, Opts, ?DEFAULT_MAX_BURST_PACKETS),
+        delivery_coalescing = bool_opt(delivery_coalescing, Opts),
         % Server-initiated bidi: 1, 5, 9, ...
         next_stream_id_bidi = 1,
         % Server-initiated uni: 3, 7, 11, ...
@@ -1716,6 +1733,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         fc_max_receive_window = maps:get(max_receive_window, Opts, ?DEFAULT_MAX_RECEIVE_WINDOW),
         ack_packet_tolerance = maps:get(ack_packet_tolerance, Opts, ?ACK_PACKET_TOLERANCE),
         burst_budget = maps:get(max_burst_packets, Opts, ?DEFAULT_MAX_BURST_PACKETS),
+        delivery_coalescing = bool_opt(delivery_coalescing, Opts),
         % Client-initiated bidi: 0, 4, 8, ...
         next_stream_id_bidi = 0,
         % Client-initiated uni: 2, 6, 10, ...
@@ -5426,8 +5444,11 @@ process_frame(
                 },
                 Streams
             ),
+            %% Data delivered earlier in this receive pass reaches the
+            %% owner before the reset notification.
+            StateFl = flush_pending_delivery(State),
             Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
-            maybe_reclaim_stream(StreamId, State#state{streams = NewStreams});
+            maybe_reclaim_stream(StreamId, StateFl#state{streams = NewStreams});
         error ->
             case is_reclaimed_frame(StreamId, State) of
                 true ->
@@ -5449,8 +5470,9 @@ process_frame(
                                 },
                                 Streams
                             ),
+                            StateFl = flush_pending_delivery(State),
                             Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
-                            State#state{streams = NewStreams}
+                            StateFl#state{streams = NewStreams}
                     end
             end
     end;
@@ -5507,8 +5529,9 @@ process_frame(
                         Streams
                     ),
                     %% Notify owner - same message as RESET_STREAM
+                    StateFl = flush_pending_delivery(State),
                     Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
-                    maybe_reclaim_stream(StreamId, State#state{streams = NewStreams});
+                    maybe_reclaim_stream(StreamId, StateFl#state{streams = NewStreams});
                 error ->
                     case is_reclaimed_frame(StreamId, State) of
                         true ->
@@ -5535,9 +5558,10 @@ process_frame(
                                         },
                                         Streams
                                     ),
+                                    StateFl = flush_pending_delivery(State),
                                     Owner ! {quic, self(), {stream_reset, StreamId, ErrorCode}},
                                     maybe_reclaim_stream(
-                                        StreamId, State#state{streams = NewStreams}
+                                        StreamId, StateFl#state{streams = NewStreams}
                                     )
                             end
                     end
@@ -7092,14 +7116,15 @@ do_process_stream_data_buffered(StreamId, Offset, Data, false = Fin, State) ->
                     State#state.recv_buffer_bytes + DataSize =< ?MAX_RECV_BUFFER_BYTES
             of
                 true ->
-                    State#state.owner ! {quic, self(), {stream_data, StreamId, Data, false}},
+                    PendDeliver = deliver_stream_data(StreamId, Data, false, State),
                     State#state{
                         streams = maps:put(
                             StreamId,
                             Stream#stream_state{recv_offset = EndOffset},
                             State#state.streams
                         ),
-                        data_received = NewDataReceived
+                        data_received = NewDataReceived,
+                        pend_deliver = PendDeliver
                     };
                 false ->
                     do_process_stream_data_slow(StreamId, Offset, Data, Fin, State)
@@ -7278,16 +7303,14 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
 
                     %% Deliver contiguous data to owner
                     %% RFC 9000: Also deliver FIN-only notification when no data but FIN received
-                    case {DeliverData, DeliverFin, Fin} of
-                        {<<>>, false, _} ->
-                            %% No contiguous data to deliver yet
-                            ok;
-                        {<<>>, true, _} ->
-                            %% FIN-only delivery (all data already delivered)
-                            Owner ! {quic, self(), {stream_data, StreamId, <<>>, true}};
-                        {_, _, _} ->
-                            Owner ! {quic, self(), {stream_data, StreamId, DeliverData, DeliverFin}}
-                    end,
+                    PendDeliver1 =
+                        case {DeliverData, DeliverFin} of
+                            {<<>>, false} ->
+                                %% No contiguous data to deliver yet
+                                State#state.pend_deliver;
+                            _ ->
+                                deliver_stream_data(StreamId, DeliverData, DeliverFin, State)
+                        end,
 
                     NewStream = Stream#stream_state{
                         recv_offset = NewRecvOffset,
@@ -7323,7 +7346,8 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
                     State1 = State#state{
                         streams = maps:put(StreamId, NewStream, Streams),
                         data_received = NewDataReceivedVal,
-                        recv_buffer_bytes = NewRecvBufferBytes
+                        recv_buffer_bytes = NewRecvBufferBytes,
+                        pend_deliver = PendDeliver1
                     },
                     %% The stream is reclaimed at the end of this clause (after the
                     %% MAX_STREAM_DATA / MAX_DATA updates, which re-put the stream),
@@ -7712,18 +7736,62 @@ maybe_decimate_app_ack(State) ->
             arm_ack_timer(State#state{ack_elicited_count = NewCount})
     end.
 
-%% End of a connected-state receive pass: emit the deferred ACK (one
-%% per train) if enough ack-eliciting packets accumulated, then clear
-%% the pass flag. Below-tolerance remainders keep their ack_timer.
-finish_recv_pass(
-    #state{ack_elicited_count = Count, ack_packet_tolerance = Tol, close_reason = undefined} =
-        State
-) when
-    Count >= Tol
-->
-    send_app_ack(State#state{recv_pass = false});
-finish_recv_pass(State) ->
-    State#state{recv_pass = false}.
+%% End of a connected-state receive pass: flush the accumulated stream
+%% delivery, emit the deferred ACK (one per train) if enough
+%% ack-eliciting packets accumulated, then clear the pass flag.
+%% Below-tolerance remainders keep their ack_timer. The delivery
+%% flushes even when the pass initiated a close: the data arrived
+%% before it.
+finish_recv_pass(State0) ->
+    State = flush_pending_delivery(State0),
+    case State of
+        #state{
+            ack_elicited_count = Count, ack_packet_tolerance = Tol, close_reason = undefined
+        } when
+            Count >= Tol
+        ->
+            send_app_ack(State#state{recv_pass = false});
+        _ ->
+            State#state{recv_pass = false}
+    end.
+
+%% A boolean option: true only when set to exactly `true'.
+bool_opt(Key, Opts) ->
+    case maps:get(Key, Opts, false) of
+        true -> true;
+        _ -> false
+    end.
+
+%% Hand stream data to the owner. With delivery coalescing on and a
+%% receive pass active, consecutive deliveries for the same stream
+%% merge into one pending message, flushed at the end of the pass or
+%% as soon as another stream delivers (exact arrival order is kept:
+%% only adjacent chunks of one stream merge). Otherwise one message
+%% per delivery, as before. Returns the new pend_deliver.
+deliver_stream_data(
+    StreamId, Data, Fin, #state{recv_pass = true, delivery_coalescing = true} = State
+) ->
+    case State#state.pend_deliver of
+        {StreamId, Acc, F} ->
+            {StreamId, [Data | Acc], F orelse Fin};
+        none ->
+            {StreamId, [Data], Fin};
+        {OtherId, Acc, F} ->
+            State#state.owner ! {quic, self(), {stream_data, OtherId, run_binary(Acc), F}},
+            {StreamId, [Data], Fin}
+    end;
+deliver_stream_data(StreamId, Data, Fin, State) ->
+    State#state.owner ! {quic, self(), {stream_data, StreamId, Data, Fin}},
+    State#state.pend_deliver.
+
+run_binary([Single]) -> Single;
+run_binary(RevChunks) -> iolist_to_binary(lists:reverse(RevChunks)).
+
+flush_pending_delivery(#state{pend_deliver = none} = State) ->
+    State;
+flush_pending_delivery(#state{pend_deliver = {StreamId, Acc, Fin}, owner = Owner} = State) ->
+    Owner ! {quic, self(), {stream_data, StreamId, run_binary(Acc), Fin}},
+    State#state{pend_deliver = none}.
 
 %% Arm the max_ack_delay timer if not already armed.
 arm_ack_timer(#state{ack_timer = Ref} = State) when Ref =/= undefined ->
@@ -12996,6 +13064,24 @@ test_recv_stream_state(StreamId, RecvOffset, StreamCredit, ConnCredit) ->
         recv_buffer_bytes = 0
     }.
 
+%% Add another peer-initiated stream at offset 0 to a test state.
+-spec test_add_recv_stream(#state{}, non_neg_integer(), non_neg_integer()) -> #state{}.
+test_add_recv_stream(#state{streams = Streams} = State, StreamId, StreamCredit) ->
+    Stream = #stream_state{
+        id = StreamId,
+        state = open,
+        send_offset = 0,
+        send_max_data = 0,
+        send_fin = false,
+        send_buffer = [],
+        recv_offset = 0,
+        recv_max_data = StreamCredit,
+        recv_fin = false,
+        recv_buffer = gb_trees:empty(),
+        final_size = undefined
+    },
+    State#state{streams = Streams#{StreamId => Stream}}.
+
 %% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
 %% tests that run record_app_recv/4 against its unfused parts.
 -spec test_app_recv_state(client | server, boolean()) -> #state{}.
@@ -13253,6 +13339,13 @@ test_decimate_step(State) ->
 -spec test_state_in_recv_pass(#state{}) -> #state{}.
 test_state_in_recv_pass(State) ->
     State#state{recv_pass = true}.
+
+-spec test_state_coalescing(#state{}, boolean()) -> #state{}.
+test_state_coalescing(State, On) ->
+    State#state{delivery_coalescing = On}.
+
+-spec test_pending_delivery(#state{}) -> none | {non_neg_integer(), [binary()], boolean()}.
+test_pending_delivery(#state{pend_deliver = P}) -> P.
 
 %% Run finish_recv_pass/1 and return the observable decimation fields.
 -spec test_finish_recv_pass(#state{}) ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -442,7 +442,9 @@
     negotiated_scheme :: atom() | undefined,
 
     %% CRYPTO frame buffer (per level: initial, handshake, app)
-    crypto_buffer = #{initial => #{}, handshake => #{}, app => #{}} :: map(),
+    crypto_buffer = #{
+        initial => gb_trees:empty(), handshake => gb_trees:empty(), app => gb_trees:empty()
+    } :: map(),
     crypto_offset = #{initial => 0, handshake => 0, app => 0} :: map(),
     %% Incomplete TLS message buffer (data that couldn't be parsed yet)
     tls_buffer = #{initial => <<>>, handshake => <<>>, app => <<>>} :: map(),
@@ -5739,16 +5741,16 @@ buffer_crypto_data(Level, Offset, Data, State) ->
         end,
 
     %% Get current buffer
-    Buffer = maps:get(LevelAtom, State#state.crypto_buffer, #{}),
+    Buffer = maps:get(LevelAtom, State#state.crypto_buffer, gb_trees:empty()),
 
     %% Bound out-of-order CRYPTO reassembly so a peer cannot grow memory
     %% before the handshake completes (RFC 9000 §7.5). Offsets beyond the
     %% cap can never become contiguous, so reject them too.
-    BufferedBytes = maps:fold(fun(_, V, Acc) -> Acc + byte_size(V) end, 0, Buffer),
+    BufferedBytes = reassembly_buffer_bytes(Buffer),
     Overflow =
         (Offset > ?MAX_CRYPTO_BUFFER_BYTES) orelse
             ((BufferedBytes + byte_size(Data)) > ?MAX_CRYPTO_BUFFER_BYTES) orelse
-            (maps:size(Buffer) >= ?MAX_CRYPTO_BUFFER_ENTRIES),
+            (gb_trees:size(Buffer) >= ?MAX_CRYPTO_BUFFER_ENTRIES),
     case Overflow of
         true ->
             ?LOG_WARNING(
@@ -5756,7 +5758,7 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                     what => crypto_buffer_exceeded,
                     level => LevelAtom,
                     buffered_bytes => BufferedBytes,
-                    entries => maps:size(Buffer)
+                    entries => gb_trees:size(Buffer)
                 },
                 ?QUIC_LOG_META
             ),
@@ -5795,17 +5797,17 @@ buffer_crypto_data(Level, Offset, Data, State) ->
 
 %% Process contiguous CRYPTO data
 process_crypto_buffer(Level, State) ->
-    Buffer = maps:get(Level, State#state.crypto_buffer, #{}),
+    Buffer = maps:get(Level, State#state.crypto_buffer, gb_trees:empty()),
     ExpectedOffset = maps:get(Level, State#state.crypto_offset, 0),
 
-    case maps:find(ExpectedOffset, Buffer) of
-        {ok, Data} ->
+    case gb_trees:lookup(ExpectedOffset, Buffer) of
+        {value, Data} ->
             %% Process this data
             State1 = process_tls_data(Level, Data, State),
 
             %% Update offset and remove from buffer
             NewOffset = ExpectedOffset + byte_size(Data),
-            NewBuffer = maps:remove(ExpectedOffset, Buffer),
+            NewBuffer = gb_trees:delete(ExpectedOffset, Buffer),
             NewCryptoBuffer = maps:put(Level, NewBuffer, State1#state.crypto_buffer),
             NewCryptoOffset = maps:put(Level, NewOffset, State1#state.crypto_offset),
 
@@ -5816,7 +5818,7 @@ process_crypto_buffer(Level, State) ->
 
             %% Try to process more
             process_crypto_buffer(Level, State2);
-        error ->
+        none ->
             %% Nothing keyed exactly at ExpectedOffset, which does not mean a
             %% gap: a peer may re-frame CRYPTO data it retransmits (RFC 9000
             %% §13.3), so the bytes we need can sit inside a chunk that starts
@@ -5828,7 +5830,7 @@ process_crypto_buffer(Level, State) ->
             State1 = State#state{
                 crypto_buffer = maps:put(Level, Trimmed, State#state.crypto_buffer)
             },
-            case maps:is_key(ExpectedOffset, Trimmed) of
+            case gb_trees:is_defined(ExpectedOffset, Trimmed) of
                 true -> process_crypto_buffer(Level, State1);
                 false -> State1
             end
@@ -7097,7 +7099,7 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                     recv_offset = 0,
                     recv_max_data = InitRecvMaxData,
                     recv_fin = false,
-                    recv_buffer = #{},
+                    recv_buffer = gb_trees:empty(),
                     final_size = undefined
                 }
         end,
@@ -7109,11 +7111,11 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
     %% Check if this would exceed our receive buffer limit (malicious peer protection)
     RecvBuffer =
         case Stream#stream_state.recv_buffer of
-            B when is_map(B) -> B;
-            _ -> #{}
+            undefined -> gb_trees:empty();
+            B -> B
         end,
     CurrentOffset = Stream#stream_state.recv_offset,
-    IsDuplicate = Offset < CurrentOffset orelse maps:is_key(Offset, RecvBuffer),
+    IsDuplicate = Offset < CurrentOffset orelse gb_trees:is_defined(Offset, RecvBuffer),
 
     %% Only check buffer limit for new (non-duplicate) data
     BufferOverflow =
@@ -7206,9 +7208,9 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                         end,
 
                     %% Fast path: in-order delivery with empty buffer
-                    %% Avoids maps:put and extract_contiguous_data for common case
+                    %% Avoids the buffer insert and extract_contiguous_data for common case
                     {DeliverData, NewRecvOffset, NewBuffer, DeliverFin} =
-                        case Offset =:= CurrentOffset andalso map_size(RecvBuffer) =:= 0 of
+                        case Offset =:= CurrentOffset andalso gb_trees:is_empty(RecvBuffer) of
                             true ->
                                 %% In-order with empty buffer: deliver directly
                                 {Data, EndOffset, RecvBuffer, Fin};
@@ -7241,7 +7243,7 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                         recv_buffer = NewBuffer,
                         final_size = FinalSize,
                         recv_done =
-                            (DeliverFin andalso map_size(NewBuffer) =:= 0) orelse
+                            (DeliverFin andalso gb_trees:is_empty(NewBuffer)) orelse
                                 recv_reset_at_met(Stream, NewRecvOffset) orelse
                                 Stream#stream_state.recv_done
                     },
@@ -7424,7 +7426,7 @@ extract_contiguous_data(Buffer, Offset) ->
     extract_contiguous_data(Buffer, Offset, <<>>).
 
 extract_contiguous_data(Buffer, Offset, Acc) ->
-    case maps:take(Offset, Buffer) of
+    case gb_trees:take_any(Offset, Buffer) of
         {Data, NewBuffer} ->
             %% Found data at this offset, continue looking for next chunk
             %% Binary append is O(1) amortized due to Erlang's pre-allocation
@@ -7435,44 +7437,58 @@ extract_contiguous_data(Buffer, Offset, Acc) ->
             %% a peer may split or coalesce retransmitted data differently
             %% (RFC 9000 §2.2, §13.3), so the bytes we want can sit inside
             %% a chunk that starts earlier. Drop what is already delivered,
-            %% re-key what straddles Offset, then retry once.
-            Trimmed = trim_reassembly_buffer(Buffer, Offset),
-            case maps:is_key(Offset, Trimmed) of
-                true -> extract_contiguous_data(Trimmed, Offset, Acc);
-                false -> {Acc, Offset, Trimmed}
+            %% re-key what straddles Offset, then retry once. When every
+            %% buffered chunk starts above Offset (the normal shape while
+            %% waiting on a hole, and this runs once per received packet
+            %% until the hole fills) the ordered tree answers that with one
+            %% smallest-key lookup and no walk.
+            case gb_trees:is_empty(Buffer) orelse element(1, gb_trees:smallest(Buffer)) > Offset of
+                true ->
+                    {Acc, Offset, Buffer};
+                false ->
+                    Trimmed = trim_reassembly_buffer(Buffer, Offset),
+                    case gb_trees:is_defined(Offset, Trimmed) of
+                        true -> extract_contiguous_data(Trimmed, Offset, Acc);
+                        false -> {Acc, Offset, Trimmed}
+                    end
             end
     end.
 
 %% Drop buffered chunks that end at or before Offset and trim those that
 %% straddle it, re-keying them to Offset. Keeps the longest chunk at each
 %% offset, so overlapping retransmissions collapse instead of accumulating.
+%% Only chunks keyed below Offset can qualify, so the ordered walk stops
+%% there; everything above is left untouched.
 trim_reassembly_buffer(Buffer, Offset) ->
-    maps:fold(
-        fun(Off, Data, Acc) ->
-            End = Off + byte_size(Data),
-            if
-                End =< Offset ->
-                    Acc;
-                Off >= Offset ->
-                    keep_longest_chunk(Off, Data, Acc);
-                true ->
-                    Kept = binary:part(Data, Offset - Off, End - Offset),
-                    keep_longest_chunk(Offset, Kept, Acc)
-            end
-        end,
-        #{},
-        Buffer
-    ).
+    trim_reassembly_buffer(gb_trees:iterator(Buffer), Buffer, Offset).
 
-keep_longest_chunk(Off, Data, Acc) ->
-    case Acc of
-        #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Acc;
-        _ -> Acc#{Off => Data}
+trim_reassembly_buffer(Iter0, Buffer, Offset) ->
+    case gb_trees:next(Iter0) of
+        {Off, Data, Iter} when Off < Offset ->
+            End = Off + byte_size(Data),
+            Buffer1 = gb_trees:delete(Off, Buffer),
+            Buffer2 =
+                case End > Offset of
+                    true ->
+                        Kept = binary:part(Data, Offset - Off, End - Offset),
+                        keep_longest_chunk(Offset, Kept, Buffer1);
+                    false ->
+                        Buffer1
+                end,
+            trim_reassembly_buffer(Iter, Buffer2, Offset);
+        _ ->
+            Buffer
+    end.
+
+keep_longest_chunk(Off, Data, Buffer) ->
+    case gb_trees:lookup(Off, Buffer) of
+        {value, Existing} when byte_size(Existing) >= byte_size(Data) -> Buffer;
+        _ -> gb_trees:enter(Off, Data, Buffer)
     end.
 
 %% Total bytes held in a reassembly buffer.
 reassembly_buffer_bytes(Buffer) ->
-    maps:fold(fun(_, Data, Acc) -> Acc + byte_size(Data) end, 0, Buffer).
+    lists:foldl(fun(Data, Acc) -> Acc + byte_size(Data) end, 0, gb_trees:values(Buffer)).
 
 %% Get the maximum stream receive window across all streams.
 %% Used to ensure connection window >= 1.5x largest stream window.
@@ -8353,7 +8369,7 @@ do_open_stream(
                 recv_offset = 0,
                 recv_max_data = RecvMaxData,
                 recv_fin = false,
-                recv_buffer = #{},
+                recv_buffer = gb_trees:empty(),
                 final_size = undefined
             },
             NewState = State#state{
@@ -8404,7 +8420,7 @@ do_open_unidirectional_stream(
                 recv_max_data = 0,
                 % No incoming data expected
                 recv_fin = true,
-                recv_buffer = #{},
+                recv_buffer = gb_trees:empty(),
                 final_size = undefined
             },
             NewState = State#state{

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -163,6 +163,12 @@
     record_received_pn/4,
     update_last_activity/2,
     test_app_recv_state/2,
+    %% Stream-data receive paths (lean vs general)
+    do_process_stream_data_buffered/5,
+    do_process_stream_data_slow/5,
+    test_recv_stream_state/4,
+    update_pn_space_recv/3,
+    should_delay_ack/1,
     short_header_first_byte/3,
     test_spin_state/1,
     test_spin_state_for/2,
@@ -7057,7 +7063,54 @@ clamp_recv_reset_at(StreamId, Offset, Data, Fin, State) ->
 recv_reset_at_met(#stream_state{recv_reset_at = R}, Off) ->
     R =/= undefined andalso Off >= R.
 
+%% Lean path for the dominant bulk shape: existing stream, exactly
+%% in-order, empty reassembly buffer, no FIN in sight, no pending reset,
+%% both flow-control windows comfortably open (so neither
+%% MAX_STREAM_DATA nor MAX_DATA fires). One stream-record update and one
+%% map put. Every other shape takes the general path below with
+%% identical semantics; on bulk flows 97+ percent of frames land here.
+do_process_stream_data_buffered(StreamId, Offset, Data, false = Fin, State) ->
+    case State#state.streams of
+        #{
+            StreamId := #stream_state{
+                recv_offset = Offset,
+                recv_max_data = RecvMaxData,
+                final_size = undefined,
+                recv_reset_at = undefined,
+                recv_buffer = RB
+            } = Stream
+        } ->
+            DataSize = byte_size(Data),
+            EndOffset = Offset + DataSize,
+            NewDataReceived = State#state.data_received + DataSize,
+            HalfWindow = State#state.fc_max_receive_window div 2,
+            case
+                DataSize > 0 andalso
+                    gb_trees:is_empty(RB) andalso
+                    RecvMaxData - EndOffset >= HalfWindow andalso
+                    State#state.max_data_local - NewDataReceived >= HalfWindow andalso
+                    State#state.recv_buffer_bytes + DataSize =< ?MAX_RECV_BUFFER_BYTES
+            of
+                true ->
+                    State#state.owner ! {quic, self(), {stream_data, StreamId, Data, false}},
+                    State#state{
+                        streams = maps:put(
+                            StreamId,
+                            Stream#stream_state{recv_offset = EndOffset},
+                            State#state.streams
+                        ),
+                        data_received = NewDataReceived
+                    };
+                false ->
+                    do_process_stream_data_slow(StreamId, Offset, Data, Fin, State)
+            end;
+        _ ->
+            do_process_stream_data_slow(StreamId, Offset, Data, Fin, State)
+    end;
 do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
+    do_process_stream_data_slow(StreamId, Offset, Data, Fin, State).
+
+do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
     #state{
         owner = Owner,
         streams = Streams,
@@ -7291,18 +7344,6 @@ do_process_stream_data_buffered(StreamId, Offset, Data, Fin, State) ->
                     WillSendMaxStreamData =
                         Headroom < (MaxWindowForStream div 2) andalso
                             NewStream#stream_state.final_size =:= undefined,
-                    Threshold = RecvMaxData - (MaxWindowForStream div 2),
-                    ?LOG_DEBUG(
-                        #{
-                            what => max_stream_data_check,
-                            stream_id => StreamId,
-                            recv_offset => NewRecvOffset,
-                            recv_max_data => RecvMaxData,
-                            threshold => Threshold,
-                            will_send => WillSendMaxStreamData
-                        },
-                        ?QUIC_LOG_META
-                    ),
                     State2 =
                         case WillSendMaxStreamData of
                             true ->
@@ -7695,6 +7736,10 @@ arm_ack_timer(#state{ack_timer = undefined} = State) ->
 
 %% Per RFC 9221 Section 5.2: Delay ACKs for packets containing only
 %% non-retransmittable ack-eliciting frames (like DATAGRAM).
+should_delay_ack([{stream, _, _, _, _} | _]) ->
+    %% Hot path: a stream frame is ack-eliciting and retransmittable,
+    %% so the packet never qualifies for the datagram-only delay.
+    false;
 should_delay_ack(Frames) ->
     AckEliciting = [F || F <- Frames, is_ack_eliciting_frame(F)],
     Retransmittable = quic_loss:retransmittable_frames(AckEliciting),
@@ -8109,8 +8154,14 @@ update_pn_space_recv(PN, PNSpace, Now) ->
             L when PN > L -> PN;
             L -> L
         end,
-    %% Add to ack_ranges maintaining descending order and merging adjacent ranges
-    NewRanges = cap_ack_ranges(add_to_ack_ranges(PN, Ranges)),
+    %% Add to ack_ranges maintaining descending order and merging adjacent
+    %% ranges. A sequential PN extends the head range in place, so the
+    %% range count cannot grow and the cap scan is skipped.
+    NewRanges =
+        case LargestRecv =/= undefined andalso PN =:= LargestRecv + 1 of
+            true -> add_to_ack_ranges(PN, Ranges);
+            false -> cap_ack_ranges(add_to_ack_ranges(PN, Ranges))
+        end,
     PNSpace#pn_space{
         largest_recv = NewLargest,
         recv_time = Now,
@@ -12913,6 +12964,37 @@ test_spin_state(#state{
 -spec test_spin_state_for(client | server, boolean()) -> #state{}.
 test_spin_state_for(Role, Enabled) ->
     #state{role = Role, spin_bit_enabled = Enabled}.
+
+%% #state{} holding one peer-initiated stream at RecvOffset with the
+%% given stream and connection receive credit, the caller as owner.
+%% For the tests that run the lean stream-data path against the
+%% general one.
+-spec test_recv_stream_state(
+    non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()
+) -> #state{}.
+test_recv_stream_state(StreamId, RecvOffset, StreamCredit, ConnCredit) ->
+    Stream = #stream_state{
+        id = StreamId,
+        state = open,
+        send_offset = 0,
+        send_max_data = 0,
+        send_fin = false,
+        send_buffer = [],
+        recv_offset = RecvOffset,
+        recv_max_data = RecvOffset + StreamCredit,
+        recv_fin = false,
+        recv_buffer = gb_trees:empty(),
+        final_size = undefined
+    },
+    #state{
+        role = server,
+        owner = self(),
+        streams = #{StreamId => Stream},
+        data_received = RecvOffset,
+        max_data_local = RecvOffset + ConnCredit,
+        fc_max_receive_window = ?DEFAULT_MAX_RECEIVE_WINDOW,
+        recv_buffer_bytes = 0
+    }.
 
 %% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
 %% tests that run record_app_recv/4 against its unfused parts.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -159,6 +159,10 @@
     test_complete_migration/3,
     %% Spin bit (RFC 9000 §17.4)
     update_spin_from_recv/3,
+    record_app_recv/4,
+    record_received_pn/4,
+    update_last_activity/2,
+    test_app_recv_state/2,
     short_header_first_byte/3,
     test_spin_state/1,
     test_spin_state_for/2,
@@ -4912,12 +4916,7 @@ decrypt_app_packet(Header, EncryptedPayload, CurrentKeys, State) ->
                     %% recv_time and last_activity to save one BIF
                     %% call per received packet on the hot path.
                     Now = erlang:monotonic_time(millisecond),
-                    State2 = update_spin_from_recv(
-                        UnprotectedFirstByte,
-                        PN,
-                        record_received_pn(app, PN, State1, Now)
-                    ),
-                    State3 = update_last_activity(State2, Now),
+                    State3 = record_app_recv(UnprotectedFirstByte, PN, State1, Now),
                     %% Use streaming decode for efficiency
                     case decode_and_process_streaming(app, Plaintext, State3) of
                         {ok, NewState, Frames} ->
@@ -8890,10 +8889,46 @@ short_header_first_byte(KeyPhase, PNLen, #state{
 short_header_first_byte(KeyPhase, PNLen, #state{spin_bit_enabled = false}) ->
     16#40 bor (KeyPhase bsl 2) bor (PNLen - 1).
 
+%% Per-packet receive bookkeeping for the 1-RTT hot path: PN-space
+%% update, spin-bit tracking and the activity stamp in one #state{}
+%% rebuild. As three separate helpers (record_received_pn +
+%% update_spin_from_recv + update_last_activity) each rebuilt the full
+%% state record, together ~10% of receive CPU on bulk flows. Same
+%% logic as those helpers; the spin part mirrors update_spin_from_recv.
+record_app_recv(FirstByte, PN, #state{pn_app = PNSpace} = State, Now) ->
+    Trigger = classify_recv_trigger(PN, PNSpace),
+    NewPNSpace = update_pn_space_recv(PN, PNSpace, Now),
+    {SpinRecv, SpinLargest, SpinOut} =
+        case PN > State#state.spin_recv_largest_pn of
+            true ->
+                R = (FirstByte bsr 5) band 1,
+                Out =
+                    case State#state.spin_bit_enabled of
+                        false -> State#state.spin_outgoing;
+                        true when State#state.role =:= client -> R;
+                        true -> 1 - R
+                    end,
+                {R, PN, Out};
+            false ->
+                {State#state.spin_recv, State#state.spin_recv_largest_pn, State#state.spin_outgoing}
+        end,
+    State#state{
+        pn_app = NewPNSpace,
+        last_recv_trigger = Trigger,
+        spin_recv = SpinRecv,
+        spin_recv_largest_pn = SpinLargest,
+        spin_outgoing = SpinOut,
+        last_activity = Now,
+        ack_eliciting_since_recv = false
+    }.
+
 %% Update the spin-bit tracking state from a received 1-RTT packet.
 %% RFC 9000 §17.4 only updates on packets whose PN is greater than any
 %% previously received on this path so that reorderings don't flip the
 %% edge. Client mirrors the received bit; server inverts it.
+%% Kept for the spin-bit unit tests and as the reference the fused
+%% record_app_recv/4 is checked against.
+-ifdef(TEST).
 update_spin_from_recv(
     FirstByte, PN, #state{spin_recv_largest_pn = Largest, role = Role} = State
 ) when PN > Largest ->
@@ -8911,6 +8946,7 @@ update_spin_from_recv(
     };
 update_spin_from_recv(_FirstByte, _PN, State) ->
     State.
+-endif.
 
 %% Short-header packet overhead for a DATAGRAM frame on the 1-RTT level:
 %%   1 byte flags
@@ -12877,6 +12913,13 @@ test_spin_state(#state{
 -spec test_spin_state_for(client | server, boolean()) -> #state{}.
 test_spin_state_for(Role, Enabled) ->
     #state{role = Role, spin_bit_enabled = Enabled}.
+
+%% Minimal #state{} with a 1-RTT PN space, for the receive-bookkeeping
+%% tests that run record_app_recv/4 against its unfused parts.
+-spec test_app_recv_state(client | server, boolean()) -> #state{}.
+test_app_recv_state(Role, SpinEnabled) ->
+    S = test_decimate_initial_state(),
+    S#state{role = Role, spin_bit_enabled = SpinEnabled}.
 
 %% Minimal #state{} for stateless-reset tests.
 -spec test_state_with_secret(binary() | undefined) -> #state{}.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -186,6 +186,10 @@
     decode_and_process_streaming/3,
     maybe_validate_initial_token/2,
     test_state_for_server/3,
+    %% Mailbox drain of the connected-state receive pass
+    drain_recv_msgs/2,
+    test_state_closing/2,
+    test_state_with_socket/2,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
     test_coalesce_small_stream/1,
     %% Regression helper for zero-byte FIN entries stranded in the send queue
@@ -260,6 +264,10 @@
 %% from parking the flight past the idle timeout.
 -define(HS_FLIGHT_MIN_INTERVAL, 100).
 -define(HS_FLIGHT_MAX_INTERVAL, 3000).
+
+%% Max additional datagram messages drained from the mailbox in one
+%% connected-state receive pass (see drain_recv_msgs/2).
+-define(RECV_DRAIN_MAX, 64).
 
 %% Max ACK ranges retained per PN space (RFC 9000 §13.2.4 allows the
 %% receiver to limit these). Under burst loss an unbounded list
@@ -2365,8 +2373,10 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
     %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
     State1 = State#state{current_packet_source = {IP, Port}},
     NewState = handle_packet(Data, State1),
-    %% Clear packet source and flush
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    %% Drain any further datagrams already in the mailbox into this
+    %% pass, then flush ACKs / batches / timers once for the lot.
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
 %% Client receives a whole GRO train from the receiver process as one
@@ -2375,46 +2385,24 @@ connected(info, {udp, Socket, IP, Port, Data}, #state{socket = Socket} = State) 
 connected(info, {udp_batch, Socket, IP, Port, Packets}, #state{socket = Socket} = State) ->
     State1 = State#state{current_packet_source = {IP, Port}},
     NewState = handle_packets_batch(Packets, State1),
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState)),
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{current_packet_source = undefined},
     check_state_transition(connected, FinalState);
 %% Server receives packets from listener
 connected(info, {quic_packet, Data, RemoteAddr}, #state{role = server} = State) ->
-    %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
-    %% Clear has_non_probing_frame before processing - will be set by process_frame_track_probing
-    State1 = State#state{current_packet_source = RemoteAddr, has_non_probing_frame = false},
-    %% Process packet FIRST to classify frames
-    NewState = handle_packet(Data, State1),
-    %% RFC 9000 Section 9.1: Only trigger migration if packet contains non-probing frames
-    NewState2 =
-        case NewState#state.has_non_probing_frame of
-            true -> maybe_handle_address_change(RemoteAddr, byte_size(Data), NewState);
-            false -> NewState
-        end,
-    %% Clear transient fields and flush
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState2)),
+    NewState = server_recv_pass([Data], RemoteAddr, State),
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
     },
     check_state_transition(connected, FinalState);
 %% Server receives batched packets from listener (GRO optimization)
 connected(info, {quic_packets, Packets, RemoteAddr}, #state{role = server} = State) ->
-    %% Track packet source for PATH_RESPONSE routing (RFC 9000 Section 8.2.2)
-    %% Clear has_non_probing_frame before processing - will be set by process_frame_track_probing
-    State1 = State#state{current_packet_source = RemoteAddr, has_non_probing_frame = false},
-    %% Process packets FIRST to classify frames
-    NewState = handle_packets_batch(Packets, State1),
-    %% RFC 9000 Section 9.1: Only trigger migration if any packet contains non-probing frames
-    NewState2 =
-        case NewState#state.has_non_probing_frame of
-            true ->
-                TotalSize = lists:sum([byte_size(P) || P <- Packets]),
-                maybe_handle_address_change(RemoteAddr, TotalSize, NewState);
-            false ->
-                NewState
-        end,
-    %% Clear transient fields and flush
-    FlushedState = flush_dirty_timers(flush_socket_batch(NewState2)),
+    NewState = server_recv_pass(Packets, RemoteAddr, State),
+    DrainedState = drain_recv_msgs(NewState, ?RECV_DRAIN_MAX),
+    FlushedState = flush_dirty_timers(flush_socket_batch(DrainedState)),
     FinalState = FlushedState#state{
         current_packet_source = undefined, has_non_probing_frame = false
     },
@@ -4287,6 +4275,52 @@ do_handle_packets_batch([], State) ->
 do_handle_packets_batch([Packet | Rest], State) ->
     NewState = handle_packet_loop(Packet, State),
     do_handle_packets_batch(Rest, NewState).
+
+%% One server receive pass: process the packets of a listener message
+%% (source tracking, frame classification, RFC 9000 §9.1 migration
+%% check) without the per-message flushes - the caller flushes once
+%% per drain.
+server_recv_pass(Packets, RemoteAddr, State) ->
+    State1 = State#state{current_packet_source = RemoteAddr, has_non_probing_frame = false},
+    NewState = handle_packets_batch(Packets, State1),
+    case NewState#state.has_non_probing_frame of
+        true ->
+            TotalSize = lists:sum([byte_size(P) || P <- Packets]),
+            maybe_handle_address_change(RemoteAddr, TotalSize, NewState);
+        false ->
+            NewState
+    end.
+
+%% Drain datagram messages already queued in the mailbox into the
+%% current receive pass, so ACK emission, socket-batch flushing and
+%% timer resets amortize over the whole train instead of running per
+%% datagram. Stops as soon as a close is initiated (the remaining
+%% messages are handled as ordinary events by the next state) or the
+%% cap is hit (bounds time away from the event loop).
+drain_recv_msgs(#state{close_reason = CR} = State, _N) when CR =/= undefined ->
+    State;
+drain_recv_msgs(State, 0) ->
+    State;
+drain_recv_msgs(#state{role = client, socket = Socket} = State, N) ->
+    receive
+        {udp, Socket, IP, Port, Data} ->
+            State1 = State#state{current_packet_source = {IP, Port}},
+            drain_recv_msgs(handle_packet(Data, State1), N - 1);
+        {udp_batch, Socket, IP, Port, Packets} ->
+            State1 = State#state{current_packet_source = {IP, Port}},
+            drain_recv_msgs(handle_packets_batch(Packets, State1), N - 1)
+    after 0 ->
+        State
+    end;
+drain_recv_msgs(#state{role = server} = State, N) ->
+    receive
+        {quic_packet, Data, RemoteAddr} ->
+            drain_recv_msgs(server_recv_pass([Data], RemoteAddr, State), N - 1);
+        {quic_packets, Packets, RemoteAddr} ->
+            drain_recv_msgs(server_recv_pass(Packets, RemoteAddr, State), N - 1)
+    after 0 ->
+        State
+    end.
 
 handle_packet_loop(<<>>, #state{role = client, active_n = N} = State) ->
     %% No more data to process - re-enable socket for client connections
@@ -12859,6 +12893,12 @@ test_state_for_server(RemoteAddr, Secret, ODCID) ->
 
 -spec test_close_reason(#state{}) -> term().
 test_close_reason(#state{close_reason = R}) -> R.
+
+-spec test_state_closing(#state{}, term()) -> #state{}.
+test_state_closing(State, Reason) -> State#state{close_reason = Reason}.
+
+-spec test_state_with_socket(#state{}, gen_udp:socket()) -> #state{}.
+test_state_with_socket(State, Socket) -> State#state{socket = Socket}.
 
 %% Minimal #state{} carrying a caller-supplied loss tracker, for tests
 %% that need to observe what an incoming frame does to it.

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -203,6 +203,8 @@
     test_state_with_socket/2,
     test_state_in_recv_pass/1,
     test_state_coalescing/2,
+    arm_burst_continuation/1,
+    test_pacing_timer/1,
     test_pending_delivery/1,
     test_finish_recv_pass/1,
     %% Regression helper for send_queue_bytes accounting during ACK coalesce
@@ -11068,13 +11070,16 @@ burst_exhausted(#state{burst_sent = Sent, burst_budget = Budget}) ->
 
 %% Arm a zero-delay pacing continuation so the queued remainder is
 %% drained in the next event-loop pass, after any pending ACK / loss
-%% feedback in the mailbox. Reuses the pacing timer and message so the
-%% drain and stale-reference handling are shared with real pacing.
+%% feedback in the mailbox. Reuses the pacing message so the drain and
+%% stale-reference handling are shared with real pacing, but sends it
+%% directly: send_after(0) goes through the timer wheel, whose ~1 ms
+%% service tick would clock every burst continuation (64 packets/ms
+%% caps bulk streams at ~85 MB/s regardless of rate).
 arm_burst_continuation(#state{pacing_timer = Ref} = State) when Ref =/= undefined ->
     State;
 arm_burst_continuation(State) ->
     Ref = make_ref(),
-    erlang:send_after(0, self(), {pacing_timeout, Ref}),
+    self() ! {pacing_timeout, Ref},
     State#state{pacing_timer = Ref}.
 
 %% Convert state to map for debugging
@@ -13339,6 +13344,9 @@ test_decimate_step(State) ->
 -spec test_state_in_recv_pass(#state{}) -> #state{}.
 test_state_in_recv_pass(State) ->
     State#state{recv_pass = true}.
+
+-spec test_pacing_timer(#state{}) -> undefined | reference().
+test_pacing_timer(#state{pacing_timer = Ref}) -> Ref.
 
 -spec test_state_coalescing(#state{}, boolean()) -> #state{}.
 test_state_coalescing(State, On) ->

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -4386,6 +4386,21 @@ handle_short_run(Packets, Keys, State) ->
             do_handle_packets_batch(Rest, handle_packet_loop(Packet, State))
     end.
 
+%% Consume an open_run result: the NIF returns either a pre-parsed
+%% frame list (term-identical to quic_frame:decode/1 output) or
+%% {raw, Plain} for packets with frame types outside the fast path,
+%% which keep the generic decoder and its error semantics. Parsed
+%% frames go through the same per-frame processing as the decoder
+%% loop.
+opened_frames({raw, Plain}, State) ->
+    decode_and_process_streaming(app, Plain, State);
+opened_frames(Frames, State) when is_list(Frames) ->
+    {ok,
+        lists:foldl(
+            fun(F, S) -> process_frame_track_probing(app, F, S) end, State, Frames
+        ),
+        Frames}.
+
 take_short_run([<<0:1, 1:1, _:6, _/binary>> = P | Rest], Acc) ->
     take_short_run(Rest, [P | Acc]);
 take_short_run(Rest, Acc) ->
@@ -4396,10 +4411,10 @@ take_short_run(Rest, Acc) ->
 %% `processed' branch of handle_packet_loop/2.
 fold_opened([], State) ->
     State;
-fold_opened([{PN, FirstByte, Plaintext} | Rest], State) ->
+fold_opened([{PN, FirstByte, Opened} | Rest], State) ->
     Now = erlang:monotonic_time(millisecond),
     StateF = record_app_recv(FirstByte, PN, State, Now),
-    case decode_and_process_streaming(app, Plaintext, StateF) of
+    case opened_frames(Opened, StateF) of
         {ok, NewState, Frames} ->
             ?QLOG_EMIT_PACKET_RECEIVED(NewState#state.qlog_ctx, #{
                 packet_type => app,

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -35,8 +35,17 @@ load() ->
 -spec is_loaded() -> boolean().
 is_loaded() -> false.
 
-new_aead_ctx(_Cipher, _Key, _Enc) -> {error, not_loaded}.
-new_hp_ctx(_Cipher, _Key) -> {error, not_loaded}.
+%% The stubs raise (none() success typing) so dialyzer takes the specs
+%% below as the NIF return types. They are unreachable in practice:
+%% every caller gates on is_loaded/0 first.
+-spec new_aead_ctx(atom(), binary(), boolean()) -> {ok, reference()} | {error, atom()}.
+new_aead_ctx(_Cipher, _Key, _Enc) -> erlang:nif_error(not_loaded).
+-spec new_hp_ctx(atom(), binary()) -> {ok, reference()} | {error, atom()}.
+new_hp_ctx(_Cipher, _Key) -> erlang:nif_error(not_loaded).
+-spec seal(reference(), binary(), iodata(), iodata()) -> binary() | {error, atom()}.
 seal(_Ctx, _Nonce, _AAD, _Plain) -> erlang:nif_error(not_loaded).
+-spec open(reference(), binary(), iodata(), iodata(), binary()) ->
+    binary() | error | {error, atom()}.
 open(_Ctx, _Nonce, _AAD, _CipherText, _Tag) -> erlang:nif_error(not_loaded).
+-spec hp_block(reference(), binary()) -> binary() | {error, atom()}.
 hp_block(_Ctx, _Sample) -> erlang:nif_error(not_loaded).

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -17,7 +17,8 @@
     open/5,
     hp_block/2,
     protect_run/7,
-    open_packet/7
+    open_packet/7,
+    open_run/7
 ]).
 
 -nifs([
@@ -28,7 +29,8 @@
     open/5,
     hp_block/2,
     protect_run/7,
-    open_packet/7
+    open_packet/7,
+    open_run/7
 ]).
 -on_load(load/0).
 
@@ -82,4 +84,6 @@ hp_block(_Ctx, _Sample) -> erlang:nif_error(not_loaded).
 protect_run(_AeadCtx, _HpCtx, _IV, _PN0, _FirstByteBase, _DCID, _Payloads) ->
     {error, not_loaded}.
 open_packet(_AeadCtx, _HpCtx, _IV, _LargestRecv, _ExpectedPhase, _Header, _EncPayload) ->
+    {error, not_loaded}.
+open_run(_AeadCtx, _HpCtx, _IV, _LargestRecv, _ExpectedPhase, _DcidLen, _Datagrams) ->
     {error, not_loaded}.

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -1,0 +1,42 @@
+%%% -*- erlang -*-
+%%%
+%%% Loader/stubs for the optional AEAD context NIF (c_src/quic_crypto_nif.c).
+%%%
+%%% The NIF is a pure accelerator: when the shared object is missing
+%%% or fails to load, `is_loaded/0' stays `false' and quic_crypto
+%%% falls back to the OTP crypto one-shot API, so the library keeps
+%%% working without a C toolchain.
+
+-module(quic_crypto_nif).
+
+-export([
+    is_loaded/0,
+    new_aead_ctx/3,
+    new_hp_ctx/2,
+    seal/4,
+    open/5,
+    hp_block/2
+]).
+
+-nifs([is_loaded/0, new_aead_ctx/3, new_hp_ctx/2, seal/4, open/5, hp_block/2]).
+-on_load(load/0).
+
+load() ->
+    So = filename:join(code:priv_dir(quic), "quic_crypto_nif"),
+    case erlang:load_nif(So, 0) of
+        ok ->
+            ok;
+        {error, _Reason} ->
+            %% Fallback path: stubs below stay in place; is_loaded/0
+            %% returns false and quic_crypto uses OTP crypto.
+            ok
+    end.
+
+-spec is_loaded() -> boolean().
+is_loaded() -> false.
+
+new_aead_ctx(_Cipher, _Key, _Enc) -> {error, not_loaded}.
+new_hp_ctx(_Cipher, _Key) -> {error, not_loaded}.
+seal(_Ctx, _Nonce, _AAD, _Plain) -> erlang:nif_error(not_loaded).
+open(_Ctx, _Nonce, _AAD, _CipherText, _Tag) -> erlang:nif_error(not_loaded).
+hp_block(_Ctx, _Sample) -> erlang:nif_error(not_loaded).

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -16,7 +16,8 @@
     seal/4,
     open/5,
     hp_block/2,
-    protect_run/7
+    protect_run/7,
+    open_packet/7
 ]).
 
 -nifs([
@@ -26,7 +27,8 @@
     seal/4,
     open/5,
     hp_block/2,
-    protect_run/7
+    protect_run/7,
+    open_packet/7
 ]).
 -on_load(load/0).
 
@@ -78,4 +80,6 @@ open(_Ctx, _Nonce, _AAD, _CipherText, _Tag) -> erlang:nif_error(not_loaded).
 -spec hp_block(reference(), binary()) -> binary() | {error, atom()}.
 hp_block(_Ctx, _Sample) -> erlang:nif_error(not_loaded).
 protect_run(_AeadCtx, _HpCtx, _IV, _PN0, _FirstByteBase, _DCID, _Payloads) ->
+    {error, not_loaded}.
+open_packet(_AeadCtx, _HpCtx, _IV, _LargestRecv, _ExpectedPhase, _Header, _EncPayload) ->
     {error, not_loaded}.

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -81,9 +81,18 @@ seal(_Ctx, _Nonce, _AAD, _Plain) -> erlang:nif_error(not_loaded).
 open(_Ctx, _Nonce, _AAD, _CipherText, _Tag) -> erlang:nif_error(not_loaded).
 -spec hp_block(reference(), binary()) -> binary() | {error, atom()}.
 hp_block(_Ctx, _Sample) -> erlang:nif_error(not_loaded).
+-spec protect_run(
+    reference(), reference(), binary(), non_neg_integer(), byte(), iodata(), [iodata()]
+) -> [binary()] | {error, atom()}.
 protect_run(_AeadCtx, _HpCtx, _IV, _PN0, _FirstByteBase, _DCID, _Payloads) ->
-    {error, not_loaded}.
+    erlang:nif_error(not_loaded).
+-spec open_packet(
+    reference(), reference(), binary(), integer(), 0 | 1, binary(), binary()
+) -> {non_neg_integer(), byte(), binary()} | error | key_phase | {error, atom()}.
 open_packet(_AeadCtx, _HpCtx, _IV, _LargestRecv, _ExpectedPhase, _Header, _EncPayload) ->
-    {error, not_loaded}.
+    erlang:nif_error(not_loaded).
+-spec open_run(
+    reference(), reference(), binary(), integer(), 0 | 1, non_neg_integer(), [binary()]
+) -> {ok, [{non_neg_integer(), byte(), [term()] | {raw, binary()}}]} | {error, atom()}.
 open_run(_AeadCtx, _HpCtx, _IV, _LargestRecv, _ExpectedPhase, _DcidLen, _Datagrams) ->
-    {error, not_loaded}.
+    erlang:nif_error(not_loaded).

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -15,10 +15,19 @@
     new_hp_ctx/2,
     seal/4,
     open/5,
-    hp_block/2
+    hp_block/2,
+    protect_run/7
 ]).
 
--nifs([is_loaded/0, new_aead_ctx/3, new_hp_ctx/2, seal/4, open/5, hp_block/2]).
+-nifs([
+    is_loaded/0,
+    new_aead_ctx/3,
+    new_hp_ctx/2,
+    seal/4,
+    open/5,
+    hp_block/2,
+    protect_run/7
+]).
 -on_load(load/0).
 
 load() ->
@@ -68,3 +77,5 @@ seal(_Ctx, _Nonce, _AAD, _Plain) -> erlang:nif_error(not_loaded).
 open(_Ctx, _Nonce, _AAD, _CipherText, _Tag) -> erlang:nif_error(not_loaded).
 -spec hp_block(reference(), binary()) -> binary() | {error, atom()}.
 hp_block(_Ctx, _Sample) -> erlang:nif_error(not_loaded).
+protect_run(_AeadCtx, _HpCtx, _IV, _PN0, _FirstByteBase, _DCID, _Payloads) ->
+    {error, not_loaded}.

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -22,14 +22,33 @@
 -on_load(load/0).
 
 load() ->
-    So = filename:join(code:priv_dir(quic), "quic_crypto_nif"),
-    case erlang:load_nif(So, 0) of
-        ok ->
+    case nif_disabled() of
+        true ->
+            %% Opt-out: stubs below stay in place; is_loaded/0 returns
+            %% false and quic_crypto uses OTP crypto.
             ok;
-        {error, _Reason} ->
-            %% Fallback path: stubs below stay in place; is_loaded/0
-            %% returns false and quic_crypto uses OTP crypto.
-            ok
+        false ->
+            So = filename:join(code:priv_dir(quic), "quic_crypto_nif"),
+            case erlang:load_nif(So, 0) of
+                ok ->
+                    ok;
+                {error, _Reason} ->
+                    %% Fallback path: same as the opt-out.
+                    ok
+            end
+    end.
+
+%% Runtime opt-out for benchmarking and fault isolation, read once at
+%% module load: QUIC_DISABLE_CRYPTO_NIF=1 disables this NIF alone,
+%% QUIC_DISABLE_NIFS=1 disables every optional NIF.
+nif_disabled() ->
+    env_true("QUIC_DISABLE_CRYPTO_NIF") orelse env_true("QUIC_DISABLE_NIFS").
+
+env_true(Var) ->
+    case os:getenv(Var) of
+        "1" -> true;
+        "true" -> true;
+        _ -> false
     end.
 
 -spec is_loaded() -> boolean().

--- a/src/quic_crypto_nif.erl
+++ b/src/quic_crypto_nif.erl
@@ -34,6 +34,11 @@
 ]).
 -on_load(load/0).
 
+%% Never fails: an on_load that returns anything but ok makes the
+%% module unloadable, and every caller then dies with undef instead of
+%% taking the pure-Erlang path. code:priv_dir/1 answers {error, _} when
+%% the app is not resolvable (an escript bundle, a bare code path), so
+%% it has to be matched rather than passed to filename:join/2.
 load() ->
     case nif_disabled() of
         true ->
@@ -41,12 +46,11 @@ load() ->
             %% false and quic_crypto uses OTP crypto.
             ok;
         false ->
-            So = filename:join(code:priv_dir(quic), "quic_crypto_nif"),
-            case erlang:load_nif(So, 0) of
-                ok ->
+            case code:priv_dir(quic) of
+                {error, _} ->
                     ok;
-                {error, _Reason} ->
-                    %% Fallback path: same as the opt-out.
+                Dir ->
+                    _ = erlang:load_nif(filename:join(Dir, "quic_crypto_nif"), 0),
                     ok
             end
     end.

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -111,8 +111,15 @@
 ]).
 
 -ifdef(TEST).
--export([send_packet/6, compute_stateless_reset_token/2, build_stateless_reset/2]).
+-export([
+    send_packet/6,
+    compute_stateless_reset_token/2,
+    build_stateless_reset/2,
+    send_packets_to_connection/3
+]).
 -endif.
+
+-export([recv_drops/0]).
 
 -include("quic.hrl").
 -include_lib("kernel/include/logger.hrl").
@@ -600,13 +607,60 @@ group_packets_by_conn([Packet | Rest], DCIDLen, Conns, Acc) ->
             group_packets_by_conn(Rest, DCIDLen, Conns, Acc)
     end.
 
-%% Send batched packets to a connection
-send_packets_to_connection(ConnPid, [Packet], RemoteAddr) ->
-    %% Single packet - use existing message format
-    ConnPid ! {quic_packet, Packet, RemoteAddr};
+%% Send batched packets to a connection. Tail-drops when the
+%% connection's mailbox is over ?MAX_CONN_RECV_QUEUE_MSGS - see the
+%% define for rationale.
 send_packets_to_connection(ConnPid, Packets, RemoteAddr) ->
-    %% Multiple packets - use batched message
-    ConnPid ! {quic_packets, Packets, RemoteAddr}.
+    case erlang:process_info(ConnPid, message_queue_len) of
+        {message_queue_len, QLen} when QLen > ?MAX_CONN_RECV_QUEUE_MSGS ->
+            %% Over the bound: keep one packet of the train so the peer
+            %% still gets a timely (dup-)ACK carrying the loss signal,
+            %% drop the rest - per-packet-ish drops beat losing whole
+            %% GRO trains, which fragments ACK ranges and provokes
+            %% retransmit storms.
+            count_recv_drop(length(Packets) - 1),
+            ConnPid ! {quic_packet, hd(Packets), RemoteAddr},
+            ok;
+        _ ->
+            forward_packet_chunks(ConnPid, Packets, RemoteAddr)
+    end.
+
+%% Forward a train in =< ?MAX_PACKETS_PER_CONN_MSG chunks so the
+%% mailbox bound above translates to a bounded packet backlog.
+forward_packet_chunks(ConnPid, [Packet], RemoteAddr) ->
+    ConnPid ! {quic_packet, Packet, RemoteAddr},
+    ok;
+forward_packet_chunks(ConnPid, Packets, RemoteAddr) ->
+    case length(Packets) =< ?MAX_PACKETS_PER_CONN_MSG of
+        true ->
+            ConnPid ! {quic_packets, Packets, RemoteAddr},
+            ok;
+        false ->
+            {Chunk, Rest} = lists:split(?MAX_PACKETS_PER_CONN_MSG, Packets),
+            ConnPid ! {quic_packets, Chunk, RemoteAddr},
+            forward_packet_chunks(ConnPid, Rest, RemoteAddr)
+    end.
+
+%% Bench diagnostic: global tail-drop counter, readable via
+%% quic_listener:recv_drops/0.
+count_recv_drop(N) ->
+    Ref =
+        case persistent_term:get({?MODULE, recv_drops}, undefined) of
+            undefined ->
+                R = atomics:new(1, []),
+                persistent_term:put({?MODULE, recv_drops}, R),
+                R;
+            R ->
+                R
+        end,
+    atomics:add(Ref, 1, N).
+
+-spec recv_drops() -> non_neg_integer().
+recv_drops() ->
+    case persistent_term:get({?MODULE, recv_drops}, undefined) of
+        undefined -> 0;
+        Ref -> atomics:get(Ref, 1)
+    end.
 
 %% @doc false
 terminate(_Reason, #listener_state{

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -642,9 +642,22 @@ dispatch_batched_packets(
                     ConnPid, lists:reverse(PacketList), RemoteAddr, QueueMax
                 );
             ({new, DCID, Version}, PacketList) ->
-                %% Initial packets that need new connections
-                [FirstPacket | _] = lists:reverse(PacketList),
-                create_connection(FirstPacket, DCID, Version, RemoteAddr, State)
+                %% Initial packets that need new connections. A client
+                %% flight larger than one datagram (a hybrid
+                %% x25519mlkem768 ClientHello is chunked across
+                %% Initials) arrives as several packets for the same
+                %% unknown DCID: the first starts the connection, the
+                %% rest have to reach it too or the handshake stalls
+                %% until the client retransmits them.
+                [FirstPacket | Rest] = lists:reverse(PacketList),
+                case create_connection(FirstPacket, DCID, Version, RemoteAddr, State) of
+                    {ok, ConnPid} when Rest =/= [] ->
+                        send_packets_to_connection(ConnPid, Rest, RemoteAddr, QueueMax);
+                    _ ->
+                        %% Retry sent, limit reached or start failed:
+                        %% the client resends the whole flight.
+                        ok
+                end
         end,
         Groups
     ).

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -115,7 +115,7 @@
     send_packet/6,
     compute_stateless_reset_token/2,
     build_stateless_reset/2,
-    send_packets_to_connection/3
+    send_packets_to_connection/4
 ]).
 -endif.
 
@@ -128,6 +128,7 @@
 }).
 
 -record(listener_state, {
+    recv_queue_max = ?MAX_CONN_RECV_QUEUE_MSGS :: pos_integer(),
     socket :: gen_udp:socket() | socket:socket(),
     %% Socket state for quic_socket abstraction (for GRO support on Linux)
     socket_state :: quic_socket:socket_state() | undefined,
@@ -370,6 +371,9 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
         connection_handler = ConnHandler,
         cid_config = CIDConfig,
         dcid_len = DCIDLen,
+        recv_queue_max = quic_socket:recv_queue_max(
+            maps:get(max_data, Opts, ?DEFAULT_INITIAL_MAX_DATA)
+        ),
         opts = Opts
     },
     {noreply, State}.
@@ -546,7 +550,9 @@ handle_gro_packets(Packets, RemoteAddr, State) ->
 
 %% Group packets by connection ID and dispatch in batches
 dispatch_batched_packets(
-    Packets, RemoteAddr, #listener_state{dcid_len = DCIDLen, connections = Conns} = State
+    Packets,
+    RemoteAddr,
+    #listener_state{dcid_len = DCIDLen, connections = Conns, recv_queue_max = QueueMax} = State
 ) ->
     %% Build map of ConnPid -> [Packets] (preserving order)
     Groups = group_packets_by_conn(Packets, DCIDLen, Conns, #{}),
@@ -555,7 +561,9 @@ dispatch_batched_packets(
         fun
             ({conn, ConnPid}, PacketList) ->
                 %% Reverse to restore original order (we prepended)
-                send_packets_to_connection(ConnPid, lists:reverse(PacketList), RemoteAddr);
+                send_packets_to_connection(
+                    ConnPid, lists:reverse(PacketList), RemoteAddr, QueueMax
+                );
             ({new, DCID, Version}, PacketList) ->
                 %% Initial packets that need new connections
                 [FirstPacket | _] = lists:reverse(PacketList),
@@ -608,11 +616,11 @@ group_packets_by_conn([Packet | Rest], DCIDLen, Conns, Acc) ->
     end.
 
 %% Send batched packets to a connection. Tail-drops when the
-%% connection's mailbox is over ?MAX_CONN_RECV_QUEUE_MSGS - see the
-%% define for rationale.
-send_packets_to_connection(ConnPid, Packets, RemoteAddr) ->
+%% connection's mailbox is over QueueMax, see
+%% quic_socket:recv_queue_max/1.
+send_packets_to_connection(ConnPid, Packets, RemoteAddr, QueueMax) ->
     case erlang:process_info(ConnPid, message_queue_len) of
-        {message_queue_len, QLen} when QLen > ?MAX_CONN_RECV_QUEUE_MSGS ->
+        {message_queue_len, QLen} when QLen > QueueMax ->
             %% Over the bound: keep one packet of the train so the peer
             %% still gets a timely (dup-)ACK carrying the loss signal,
             %% drop the rest - per-packet-ish drops beat losing whole

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -115,7 +115,9 @@
     send_packet/6,
     compute_stateless_reset_token/2,
     build_stateless_reset/2,
-    send_packets_to_connection/4
+    send_packets_to_connection/4,
+    drain_recv_sweep/4,
+    group_recv_sweep/1
 ]).
 -endif.
 
@@ -126,6 +128,9 @@
 -define(QUIC_LOG_META, #{
     domain => [erlang_quic, listener], report_cb => fun quic_log:format_report/2
 }).
+
+%% Packets drained from the listener mailbox into one receive sweep.
+-define(RECV_SWEEP_MAX, 256).
 
 -record(listener_state, {
     recv_queue_max = ?MAX_CONN_RECV_QUEUE_MSGS :: pos_integer(),
@@ -487,7 +492,10 @@ handle_info(
         #{what => udp_received, src_ip => SrcIP, src_port => SrcPort, size => byte_size(Packet)},
         ?QUIC_LOG_META
     ),
-    handle_packet(Packet, {SrcIP, SrcPort}, State),
+    Items = drain_recv_sweep(
+        Socket, gen_udp, ?RECV_SWEEP_MAX - 1, [{{SrcIP, SrcPort}, [Packet]}]
+    ),
+    dispatch_recv_sweep(Items, State),
     {noreply, State};
 %% Handle GRO packets (socket backend with GRO)
 %% May receive multiple packets in single recv call
@@ -504,8 +512,10 @@ handle_info(
         },
         ?QUIC_LOG_META
     ),
-    RemoteAddr = {SrcIP, SrcPort},
-    handle_gro_packets(Packets, RemoteAddr, State),
+    Items = drain_recv_sweep(
+        undefined, socket, ?RECV_SWEEP_MAX - length(Packets), [{{SrcIP, SrcPort}, Packets}]
+    ),
+    dispatch_recv_sweep(Items, State),
     {noreply, State};
 %% Handle socket going passive (backpressure with {active, N}) - gen_udp only
 handle_info(
@@ -536,6 +546,49 @@ handle_info({udp, _OtherSocket, _SrcIP, _SrcPort, _Packet}, State) ->
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
+
+%% Drain the datagram messages already queued in the listener mailbox
+%% into one receive sweep, so packets for the same connection arriving
+%% as separate messages (distinct flows never GRO-coalesce) are
+%% dispatched as one batch: the connection wakes once per sweep instead
+%% of once per datagram, and its batched receive path engages even for
+%% sparse per-connection traffic. Bounded to keep the listener
+%% responsive under floods. Returns [{Addr, Packets}] in arrival order.
+drain_recv_sweep(_Socket, _Backend, Budget, Acc) when Budget =< 0 ->
+    lists:reverse(Acc);
+drain_recv_sweep(Socket, Backend, Budget, Acc) ->
+    receive
+        {udp, Socket, IP, Port, Packet} when Backend =:= gen_udp ->
+            drain_recv_sweep(Socket, Backend, Budget - 1, [{{IP, Port}, [Packet]} | Acc]);
+        {gro_packets, IP, Port, Packets} when Backend =:= socket ->
+            drain_recv_sweep(
+                Socket, Backend, Budget - length(Packets), [{{IP, Port}, Packets} | Acc]
+            )
+    after 0 ->
+        lists:reverse(Acc)
+    end.
+
+%% Merge the sweep per source address (per-flow packet order preserved,
+%% cross-flow order irrelevant) and route each group through the
+%% existing batched dispatch, which groups by connection and creates
+%% new connections.
+dispatch_recv_sweep([{Addr, Packets}], State) ->
+    handle_gro_packets(Packets, Addr, State);
+dispatch_recv_sweep(Items, State) ->
+    maps:foreach(
+        fun(Addr, Packets) -> handle_gro_packets(Packets, Addr, State) end,
+        group_recv_sweep(Items)
+    ).
+
+group_recv_sweep(Items) ->
+    Grouped = lists:foldl(
+        fun({Addr, Packets}, M) ->
+            maps:update_with(Addr, fun(L) -> [Packets | L] end, [Packets], M)
+        end,
+        #{},
+        Items
+    ),
+    maps:map(fun(_, Trains) -> lists:append(lists:reverse(Trains)) end, Grouped).
 
 %% Handle multiple packets received via GRO
 %% Groups packets by connection and sends batched messages

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -141,6 +141,10 @@
     socket_backend = gen_udp :: gen_udp | socket,
     %% GRO receiver process (when using socket backend)
     gro_receiver :: pid() | undefined,
+    %% Shared sender serializing server-connection sendmsg calls
+    %% (socket backend only; see quic_socket:start_shared_sender/1).
+    send_sender :: pid() | undefined,
+    send_gso_counter :: atomics:atomics_ref() | undefined,
     port :: inet:port_number(),
     %% Cert + private_key are optional; PSK-only listeners run with
     %% both `undefined' and rely on `psks' / `psk_callback'.
@@ -353,12 +357,15 @@ handle_continue(discover_manager, {Socket, SocketState, Backend, Opts}) ->
 
     %% Start GRO receiver if using socket backend
     GROReceiver = maybe_start_gro_receiver(Backend, SocketState),
+    {SendSender, SendGSOCounter} = maybe_start_shared_sender(Backend, SocketState),
 
     State = #listener_state{
         socket = Socket,
         socket_state = SocketState,
         socket_backend = Backend,
         gro_receiver = GROReceiver,
+        send_sender = SendSender,
+        send_gso_counter = SendGSOCounter,
         port = ActualPort,
         cert = Cert,
         cert_chain = CertChain,
@@ -432,6 +439,11 @@ maybe_start_gro_receiver(socket, SocketState) when SocketState =/= undefined ->
     spawn_link(fun() -> gro_receive_loop(SocketState, Listener) end);
 maybe_start_gro_receiver(_, _) ->
     undefined.
+
+maybe_start_shared_sender(socket, SocketState) when SocketState =/= undefined ->
+    quic_socket:start_shared_sender(SocketState);
+maybe_start_shared_sender(_, _) ->
+    {undefined, undefined}.
 
 %% GRO receiver loop - runs in separate process
 %% Does blocking recvmsg calls and forwards packets to listener
@@ -527,7 +539,9 @@ handle_info(
     {noreply, State};
 %% Handle connection process exit
 handle_info(
-    {'EXIT', Pid, _Reason}, #listener_state{connections = Conns, gro_receiver = GROReceiver} = State
+    {'EXIT', Pid, _Reason},
+    #listener_state{connections = Conns, gro_receiver = GROReceiver, send_sender = SendSender} =
+        State
 ) ->
     case Pid of
         GROReceiver ->
@@ -537,6 +551,16 @@ handle_info(
                 State#listener_state.socket_state
             ),
             {noreply, State#listener_state{gro_receiver = NewReceiver}};
+        SendSender when is_pid(SendSender) ->
+            %% Shared sender died: new connections get a fresh one,
+            %% existing connections fall back to sending directly.
+            {NewSender, NewCounter} = maybe_start_shared_sender(
+                State#listener_state.socket_backend,
+                State#listener_state.socket_state
+            ),
+            {noreply, State#listener_state{
+                send_sender = NewSender, send_gso_counter = NewCounter
+            }};
         _ ->
             cleanup_connection(Conns, Pid),
             {noreply, State}
@@ -1061,6 +1085,8 @@ create_connection_unconditional(
         connection_handler = ConnHandler,
         cid_config = CIDConfig,
         reset_secret = ResetSecret,
+        send_sender = SendSender,
+        send_gso_counter = SendGSOCounter,
         opts = Opts
     }
 ) ->
@@ -1091,6 +1117,8 @@ create_connection_unconditional(
         socket => Socket,
         listener_socket_backend => Backend,
         listener_gso_supported => ListenerGSO,
+        send_sender => SendSender,
+        send_gso_counter => SendGSOCounter,
         remote_addr => RemoteAddr,
         initial_dcid => DCID,
         %% original_destination_connection_id transport param: the client's

--- a/src/quic_loss.erl
+++ b/src/quic_loss.erl
@@ -38,6 +38,7 @@
     on_packet_sent/4,
     on_packet_sent/5,
     on_packet_sent/6,
+    on_packets_sent_run/3,
     on_ack_received/3,
 
     %% Retransmission
@@ -230,6 +231,39 @@ on_packet_sent(
     State#loss_state{
         sent_q = queue:in(SentPacket, Q),
         bytes_in_flight = NewInFlight,
+        outstanding_since = OutstandingSince
+    }.
+
+%% @doc Batched on_packet_sent for a run of ack-eliciting packets sent
+%% at the same instant: one queue fold and one record update. Tracked
+%% is [{PN, Size, Frame}] in ascending PN order.
+-spec on_packets_sent_run(
+    loss_state(), [{non_neg_integer(), non_neg_integer(), term()}], integer()
+) -> loss_state().
+on_packets_sent_run(#loss_state{sent_q = Q, bytes_in_flight = InFlight} = State, Tracked, Now) ->
+    {Q1, Total} = lists:foldl(
+        fun({PN, Size, Frame}, {QAcc, TAcc}) ->
+            SentPacket = #sent_packet{
+                pn = PN,
+                time_sent = Now,
+                ack_eliciting = true,
+                in_flight = true,
+                size = Size,
+                frames = [Frame]
+            },
+            {queue:in(SentPacket, QAcc), TAcc + Size}
+        end,
+        {Q, 0},
+        Tracked
+    ),
+    OutstandingSince =
+        case InFlight =:= 0 andalso Total > 0 of
+            true -> Now;
+            false -> State#loss_state.outstanding_since
+        end,
+    State#loss_state{
+        sent_q = Q1,
+        bytes_in_flight = InFlight + Total,
         outstanding_since = OutstandingSince
     }.
 

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -59,7 +59,8 @@
     info/1,
     start_client_receiver/2,
     stop_client_receiver/1,
-    set_socket/2
+    set_socket/2,
+    client_recv_drops/0
 ]).
 
 -include("quic.hrl").
@@ -135,7 +136,8 @@
 -export([
     extract_gro_segment_size/1,
     split_gro_packets/2,
-    split_uniform_runs/1
+    split_uniform_runs/1,
+    forward_to_owner/5
 ]).
 -endif.
 
@@ -688,11 +690,8 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
     %% trains, not packets, and the whole train is processed in one
     %% receive pass.
     case recv_gro(Socket, 100) of
-        {ok, {IP, Port}, [Single]} ->
-            Owner ! {udp, Socket, IP, Port, Single},
-            client_recv_loop(SocketState, Owner);
         {ok, {IP, Port}, Packets} ->
-            Owner ! {udp_batch, Socket, IP, Port, Packets},
+            forward_to_owner(Owner, Socket, IP, Port, Packets),
             client_recv_loop(SocketState, Owner);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner);
@@ -701,6 +700,40 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
         {error, Reason} ->
             ?LOG_WARNING(#{what => client_recv_loop_exit, reason => Reason}),
             ok
+    end.
+
+%% Bench diagnostic: client-receiver tail-drop counter.
+%% Tail-drop over ?MAX_CONN_RECV_QUEUE_MSGS, emulating a bounded
+%% kernel rcvbuf (see the define for rationale).
+forward_to_owner(Owner, Socket, IP, Port, Packets) ->
+    case erlang:process_info(Owner, message_queue_len) of
+        {message_queue_len, QLen} when QLen > ?MAX_CONN_RECV_QUEUE_MSGS ->
+            count_client_recv_drop(length(Packets));
+        _ ->
+            case Packets of
+                [Single] -> Owner ! {udp, Socket, IP, Port, Single};
+                _ -> Owner ! {udp_batch, Socket, IP, Port, Packets}
+            end,
+            ok
+    end.
+
+count_client_recv_drop(N) ->
+    Ref =
+        case persistent_term:get({?MODULE, recv_drops}, undefined) of
+            undefined ->
+                R = atomics:new(1, []),
+                persistent_term:put({?MODULE, recv_drops}, R),
+                R;
+            R ->
+                R
+        end,
+    atomics:add(Ref, 1, N).
+
+-spec client_recv_drops() -> non_neg_integer().
+client_recv_drops() ->
+    case persistent_term:get({?MODULE, recv_drops}, undefined) of
+        undefined -> 0;
+        Ref -> atomics:get(Ref, 1)
     end.
 
 %% @doc Detect platform capabilities for GSO/GRO. Context-free wrapper that

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -339,6 +339,7 @@ gso_supported(#socket_state{gso_supported = Supported}) ->
         gro_enabled := boolean(),
         batching_enabled := boolean(),
         max_batch_packets := pos_integer(),
+        batch_pending := non_neg_integer(),
         batch_flushes := non_neg_integer(),
         packets_coalesced := non_neg_integer(),
         gso_flushes := non_neg_integer()
@@ -352,10 +353,12 @@ info(#socket_state{
     max_batch_packets = MaxBatch,
     batch_flushes = Flushes,
     packets_coalesced = Coalesced,
-    gso_flushes = GSOFlushes
+    gso_flushes = GSOFlushes,
+    batch_count = Pending
 }) ->
     #{
         backend => Backend,
+        batch_pending => Pending,
         gso_supported => GSO,
         gso_size => GSOSize,
         gro_enabled => GRO,

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -57,7 +57,8 @@
     get_socket/1,
     gso_supported/1,
     info/1,
-    start_client_receiver/2,
+    recv_queue_max/1,
+    start_client_receiver/3,
     stop_client_receiver/1,
     set_socket/2,
     client_recv_drops/0
@@ -137,7 +138,7 @@
     extract_gro_segment_size/1,
     split_gro_packets/2,
     split_uniform_runs/1,
-    forward_to_owner/5
+    forward_to_owner/6
 ]).
 -endif.
 
@@ -651,18 +652,29 @@ get_fd(#socket_state{backend = adapter}) ->
 %%
 %% Returns the receiver pid, linked to the caller so it terminates
 %% when the connection process exits.
--spec start_client_receiver(socket_state(), pid()) -> {ok, pid()} | {error, term()}.
-start_client_receiver(#socket_state{backend = socket} = SocketState, Owner) when is_pid(Owner) ->
-    Pid = spawn_link(fun() -> client_recv_loop(SocketState, Owner) end),
+%% QueueMax is the owner's mailbox bound, see recv_queue_max/1.
+-spec start_client_receiver(socket_state(), pid(), pos_integer()) ->
+    {ok, pid()} | {error, term()}.
+start_client_receiver(#socket_state{backend = socket} = SocketState, Owner, QueueMax) when
+    is_pid(Owner)
+->
+    Pid = spawn_link(fun() -> client_recv_loop(SocketState, Owner, QueueMax) end),
     {ok, Pid};
-start_client_receiver(#socket_state{backend = gen_udp}, _Owner) ->
+start_client_receiver(#socket_state{backend = gen_udp}, _Owner, _QueueMax) ->
     {error, not_supported_on_gen_udp};
-start_client_receiver(#socket_state{backend = adapter}, _Owner) ->
+start_client_receiver(#socket_state{backend = adapter}, _Owner, _QueueMax) ->
     %% Adapter callers deliver `{udp, ...}' messages themselves.
     {error, not_supported_on_adapter}.
 
+%% Mailbox bound for a receiver that advertised MaxData bytes of
+%% connection flow-control window: the window in full-size packets,
+%% never below ?MAX_CONN_RECV_QUEUE_MSGS.
+-spec recv_queue_max(non_neg_integer()) -> pos_integer().
+recv_queue_max(MaxData) ->
+    max(?MAX_CONN_RECV_QUEUE_MSGS, MaxData div ?RECV_QUEUE_PACKET_BYTES).
+
 %% @doc Stop a client receiver process previously returned by
-%% `start_client_receiver/2'. Safe to call with `undefined'.
+%% `start_client_receiver/3'. Safe to call with `undefined'.
 -spec stop_client_receiver(pid() | undefined) -> ok.
 stop_client_receiver(undefined) ->
     ok;
@@ -682,7 +694,7 @@ stop_client_receiver(Pid) when is_pid(Pid) ->
 %% socket handle stored in `#state.socket'. Uses a 100ms timeout so
 %% exit signals from the linked owner are processed promptly rather
 %% than blocking forever in the NIF.
-client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
+client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner, QueueMax) ->
     %% recv_gro splits GRO-coalesced trains and sizes the read buffer
     %% for a maximal train; a plain recvfrom with the default 8 KiB
     %% buffer would silently truncate coalesced input. A multi-packet
@@ -691,10 +703,10 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
     %% receive pass.
     case recv_gro(Socket, 100) of
         {ok, {IP, Port}, Packets} ->
-            forward_to_owner(Owner, Socket, IP, Port, Packets),
-            client_recv_loop(SocketState, Owner);
+            forward_to_owner(Owner, Socket, IP, Port, Packets, QueueMax),
+            client_recv_loop(SocketState, Owner, QueueMax);
         {error, timeout} ->
-            client_recv_loop(SocketState, Owner);
+            client_recv_loop(SocketState, Owner, QueueMax);
         {error, closed} ->
             ok;
         {error, Reason} ->
@@ -703,11 +715,10 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner) ->
     end.
 
 %% Bench diagnostic: client-receiver tail-drop counter.
-%% Tail-drop over ?MAX_CONN_RECV_QUEUE_MSGS, emulating a bounded
-%% kernel rcvbuf (see the define for rationale).
-forward_to_owner(Owner, Socket, IP, Port, Packets) ->
+%% Tail-drop over QueueMax, see recv_queue_max/1.
+forward_to_owner(Owner, Socket, IP, Port, Packets, QueueMax) ->
     case erlang:process_info(Owner, message_queue_len) of
-        {message_queue_len, QLen} when QLen > ?MAX_CONN_RECV_QUEUE_MSGS ->
+        {message_queue_len, QLen} when QLen > QueueMax ->
             count_client_recv_drop(length(Packets));
         _ ->
             case Packets of

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -44,6 +44,7 @@
     open_adapter/1,
     wrap/2,
     new_sender/2,
+    start_shared_sender/1,
     close/1,
     send/4,
     send_immediate/4,
@@ -65,6 +66,9 @@
 ]).
 
 -include("quic.hrl").
+
+%% Idle tick of the shared sender loop; also keeps its receive bounded.
+-define(SHARED_SENDER_IDLE_MS, 30000).
 -include_lib("kernel/include/logger.hrl").
 
 %% GSO/GRO socket option constants for Linux
@@ -118,7 +122,19 @@
     batch_flushes = 0 :: non_neg_integer(),
     packets_coalesced = 0 :: non_neg_integer(),
     %% Batches the kernel segmented, as opposed to sent packet by packet.
-    gso_flushes = 0 :: non_neg_integer()
+    gso_flushes = 0 :: non_neg_integer(),
+    %% Shared sender process: when set, flush/1 hands the batch to this
+    %% process instead of calling sendmsg from the connection process.
+    %% Concurrent sendmsg on one socket handle burns ~20x the CPU in
+    %% NIF-level contention (measured 98.6 vs 4.7 us per send with 50
+    %% concurrent senders), so server connections serialize the actual
+    %% syscalls through the listener's sender while keeping their own
+    %% batch buffers and GSO grouping.
+    sender_pid = undefined :: undefined | pid(),
+    %% GSO flushes performed by the shared sender on behalf of every
+    %% connection of the listener, so a connection's gso_flushes stays
+    %% meaningful (listener-wide) once the syscall has moved out of it.
+    gso_counter = undefined :: undefined | atomics:atomics_ref()
 }).
 
 %% Packet can be:
@@ -138,8 +154,11 @@
     extract_gro_segment_size/1,
     split_gro_packets/2,
     split_uniform_runs/1,
-    forward_to_owner/6
+    forward_to_owner/6,
+    test_socket/1
 ]).
+
+test_socket(#socket_state{socket = S}) -> S.
 -endif.
 
 %%====================================================================
@@ -353,9 +372,18 @@ info(#socket_state{
     max_batch_packets = MaxBatch,
     batch_flushes = Flushes,
     packets_coalesced = Coalesced,
-    gso_flushes = GSOFlushes,
-    batch_count = Pending
+    gso_flushes = OwnGSOFlushes,
+    batch_count = Pending,
+    sender_pid = Sender,
+    gso_counter = Counter
 }) ->
+    %% With a shared sender the segmented flushes happen there; report
+    %% the listener-wide count in that case.
+    GSOFlushes =
+        case {Sender, Counter} of
+            {P, C} when is_pid(P), C =/= undefined -> atomics:get(C, 1);
+            _ -> OwnGSOFlushes
+        end,
     #{
         backend => Backend,
         batch_pending => Pending,
@@ -453,9 +481,67 @@ new_sender(Socket, Opts) ->
         gso_supported = GSOSupported andalso (Backend =:= socket),
         gro_enabled = false,
         batching_enabled = BatchingEnabled,
-        max_batch_packets = MaxBatch
+        max_batch_packets = MaxBatch,
+        sender_pid = maps:get(sender_pid, Opts, undefined),
+        gso_counter = maps:get(gso_counter, Opts, undefined)
     },
     {ok, State}.
+
+%% @doc Spawn the shared sender for a listener socket: a process that
+%% performs the actual sendmsg calls for every server connection's
+%% batches, serially. GSO state (including the partial-send disable)
+%% lives in the sender's own socket_state copy. Linked to the caller.
+%% Returns the sender and the counter connections read gso_flushes
+%% from; both go into new_sender/2 options (`sender_pid`,
+%% `gso_counter`).
+-spec start_shared_sender(socket_state()) -> {pid(), atomics:atomics_ref()}.
+start_shared_sender(#socket_state{} = SS) ->
+    Counter = atomics:new(1, []),
+    Template = SS#socket_state{
+        sender_pid = undefined,
+        gso_counter = Counter,
+        owns_socket = false,
+        batch_buffer = [],
+        batch_count = 0,
+        batch_addr = undefined
+    },
+    {spawn_link(fun() -> shared_sender_loop(Template) end), Counter}.
+
+shared_sender_loop(SS) ->
+    receive
+        {send_batch, Addr, Buffer, Count} ->
+            Loaded = SS#socket_state{
+                batch_buffer = Buffer,
+                batch_count = Count,
+                batch_addr = Addr
+            },
+            SS2 =
+                case flush(Loaded) of
+                    {ok, S} ->
+                        S;
+                    {error, Reason, S} ->
+                        ?LOG_WARNING(#{what => shared_sender_flush_failed, reason => Reason}),
+                        S
+                end,
+            %% Carry forward only the socket-global bits (a partial GSO
+            %% send disables GSO for the socket).
+            shared_sender_loop(SS#socket_state{
+                gso_supported = SS2#socket_state.gso_supported,
+                gso_size = SS2#socket_state.gso_size
+            });
+        stop ->
+            ok
+    after ?SHARED_SENDER_IDLE_MS ->
+        %% Nothing to send for a while: shed the heap the batches left.
+        erlang:garbage_collect(),
+        shared_sender_loop(SS)
+    end.
+
+bump_batch_counters(#socket_state{} = State, Count) ->
+    State#socket_state{
+        batch_flushes = State#socket_state.batch_flushes + 1,
+        packets_coalesced = State#socket_state.packets_coalesced + Count
+    }.
 
 %% @doc Close the socket and flush any pending packets.
 %% Only closes the socket if owns_socket is true (i.e., socket was created by us).
@@ -533,6 +619,25 @@ flush(#socket_state{batch_count = Count, batch_addr = undefined} = State) ->
     %% No address set but have data - shouldn't happen, but clear buffer
     ?LOG_WARNING(#{what => flush_no_addr, buffer_size => Count}),
     {ok, clear_batch(State)};
+flush(
+    #socket_state{
+        sender_pid = Sender,
+        batch_count = Count,
+        batch_addr = Addr,
+        batch_buffer = Buffer
+    } = State
+) when is_pid(Sender) ->
+    %% Hand the whole batch to the shared sender (see the sender_pid
+    %% field). Fire-and-forget: send errors are logged by the sender
+    %% and covered by loss recovery, the same contract as the direct
+    %% path. A dead sender means a direct path from here on.
+    case is_process_alive(Sender) of
+        true ->
+            Sender ! {send_batch, Addr, Buffer, Count},
+            {ok, bump_batch_counters(clear_batch(State), Count)};
+        false ->
+            flush(State#socket_state{sender_pid = undefined})
+    end;
 flush(#socket_state{gso_supported = true, batch_count = 1} = State) ->
     %% Single-packet batch has no segmentation work; direct send.
     flush_individual(State);
@@ -1299,6 +1404,10 @@ record_run_flush(State, Runs) ->
         [] ->
             State1;
         [Size | _] = Sizes ->
+            case State#socket_state.gso_counter of
+                undefined -> ok;
+                Counter -> atomics:add(Counter, 1, length(Sizes))
+            end,
             State1#socket_state{
                 gso_flushes = State#socket_state.gso_flushes + length(Sizes),
                 gso_size = Size

--- a/test/quic_aead_ctx_cache_tests.erl
+++ b/test/quic_aead_ctx_cache_tests.erl
@@ -1,0 +1,90 @@
+%% The NIF context cache lives in the connection process dictionary.
+%% Two properties matter beyond "it caches": it must not grow without
+%% bound as key updates derive fresh keys, and a context that cannot be
+%% created must fall back to the OTP crypto path rather than raise,
+%% since the NIF is meant to be optional.
+-module(quic_aead_ctx_cache_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(IV, <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>).
+
+with_nif(Fun) ->
+    case quic_crypto_nif:is_loaded() of
+        true -> Fun();
+        false -> ok
+    end.
+
+clear() ->
+    [erlang:erase(K) || {K, _} <- erlang:get()],
+    ok.
+
+cached_ctx_count() ->
+    length([K || {K, _} <- erlang:get(), is_tuple(K), element(1, K) =/= qc_ctx_live]).
+
+%% Every distinct key would otherwise leave a live EVP context behind.
+%% A key update derives fresh keys, so this is the shape of a
+%% long-lived bulk connection.
+cache_stays_bounded_across_key_updates_test() ->
+    with_nif(fun() ->
+        clear(),
+        lists:foreach(
+            fun(_) ->
+                Key = crypto:strong_rand_bytes(16),
+                _ = quic_aead_ctx:aead_encrypt(aes_128_gcm, Key, ?IV, <<"payload">>, <<>>),
+                _ = quic_aead_ctx:aead_decrypt(
+                    aes_128_gcm, Key, ?IV, <<"xxxxxxx">>, <<>>, <<0:128>>
+                )
+            end,
+            lists:seq(1, 200)
+        ),
+        Live = cached_ctx_count(),
+        ?assert(Live =< 6),
+        clear()
+    end).
+
+%% Reusing one key must still hit the cache: bounding it must not turn
+%% the accelerator into a per-packet context builder.
+repeated_key_is_cached_test() ->
+    with_nif(fun() ->
+        clear(),
+        Key = crypto:strong_rand_bytes(16),
+        lists:foreach(
+            fun(_) ->
+                _ = quic_aead_ctx:aead_encrypt(aes_128_gcm, Key, ?IV, <<"payload">>, <<>>)
+            end,
+            lists:seq(1, 50)
+        ),
+        ?assertEqual(1, cached_ctx_count()),
+        clear()
+    end).
+
+%% A key the NIF cannot build a context for (wrong length for the
+%% cipher) must produce the same answer as the pure-Erlang path, not a
+%% crash. crypto raises on the bad key too, so both sides agree by
+%% raising the same class rather than one dying on a badmatch inside
+%% the cache.
+unbuildable_context_does_not_badmatch_test() ->
+    with_nif(fun() ->
+        clear(),
+        Short = <<0:64>>,
+        Got = attempt(fun() ->
+            quic_aead_ctx:aead_encrypt(aes_128_gcm, Short, ?IV, <<"p">>, <<>>)
+        end),
+        Ref = attempt(fun() ->
+            crypto:crypto_one_time_aead(aes_128_gcm, Short, ?IV, <<"p">>, <<>>, 16, true)
+        end),
+        %% Same outcome as the pure path, and in particular never a
+        %% badmatch on {ok, Ctx} from inside the cache.
+        ?assertEqual(Ref, Got),
+        clear()
+    end).
+
+%% Reduce an outcome to something comparable across the two paths:
+%% either both return a value or both raise the same class and reason.
+attempt(Fun) ->
+    try
+        {ok, Fun()}
+    catch
+        Class:Reason -> {raised, Class, Reason}
+    end.

--- a/test/quic_bulk_run_send_SUITE.erl
+++ b/test/quic_bulk_run_send_SUITE.erl
@@ -1,0 +1,95 @@
+%%% -*- erlang -*-
+%%%
+%%% Bulk stream sends go out as chunk runs: many full-size packets
+%%% sealed and handed to the socket in one loop with one bookkeeping
+%%% pass. The wire must not notice: every byte arrives, in order, on
+%%% both socket backends, with pacing on and off.
+-module(quic_bulk_run_send_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    gen_udp_paced/1,
+    gen_udp_unpaced/1,
+    socket_paced/1,
+    socket_unpaced/1
+]).
+
+-define(SIZE, 3 * 1024 * 1024).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [gen_udp_paced, gen_udp_unpaced, socket_paced, socket_unpaced].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+gen_udp_paced(_) -> round_trip(gen_udp, true).
+gen_udp_unpaced(_) -> round_trip(gen_udp, false).
+socket_paced(_) -> round_trip(socket, true).
+socket_unpaced(_) -> round_trip(socket, false).
+
+%% One stream, one send of ?SIZE random bytes with FIN, echoed back.
+round_trip(Backend, Pacing) ->
+    {ok, Server} = quic_test_echo_server:start(#{
+        socket_backend => Backend,
+        max_data => 64 * 1024 * 1024
+    }),
+    Port = maps:get(port, Server),
+    try
+        {ok, Conn} = quic:connect(
+            <<"127.0.0.1">>,
+            Port,
+            #{
+                verify => false,
+                alpn => [<<"echo">>],
+                socket_backend => Backend,
+                pacing_enabled => Pacing,
+                max_data => 64 * 1024 * 1024,
+                max_stream_data_bidi_local => 8 * 1024 * 1024,
+                max_stream_data_bidi_remote => 8 * 1024 * 1024
+            },
+            self()
+        ),
+        receive
+            {quic, Conn, {connected, _}} -> ok
+        after 10000 -> ct:fail(connect_timeout)
+        end,
+        {ok, StreamId} = quic:open_stream(Conn),
+        Data = crypto:strong_rand_bytes(?SIZE),
+        T0 = erlang:monotonic_time(millisecond),
+        ok = quic:send_data(Conn, StreamId, Data, true),
+        Echo = collect(Conn, StreamId, <<>>),
+        T1 = erlang:monotonic_time(millisecond),
+        ct:pal("~p pacing=~p: ~p bytes round trip in ~p ms", [
+            Backend, Pacing, byte_size(Echo), T1 - T0
+        ]),
+        ?assertEqual(?SIZE, byte_size(Echo)),
+        ?assertEqual(Data, Echo),
+        ok = quic:close(Conn, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+collect(Conn, StreamId, Acc) ->
+    receive
+        {quic, Conn, {stream_data, StreamId, Chunk, Fin}} ->
+            Acc1 = <<Acc/binary, Chunk/binary>>,
+            case Fin orelse byte_size(Acc1) >= ?SIZE of
+                true -> Acc1;
+                false -> collect(Conn, StreamId, Acc1)
+            end;
+        {quic, Conn, {closed, Reason}} ->
+            ct:fail({closed_before_fin, Reason, byte_size(Acc)})
+    after 30000 ->
+        ct:fail({echo_timeout, byte_size(Acc)})
+    end.

--- a/test/quic_burst_continuation_tests.erl
+++ b/test/quic_burst_continuation_tests.erl
@@ -1,0 +1,34 @@
+%% A burst continuation must reach the connection's mailbox directly.
+%% erlang:send_after(0, ...) goes through the timer wheel, whose ~1 ms
+%% service tick clocked every 64-packet burst continuation and capped
+%% bulk streams at ~85 MB/s regardless of the paced rate.
+-module(quic_burst_continuation_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+continuation_is_in_the_mailbox_immediately_test() ->
+    S0 = quic_connection:test_decimate_initial_state(),
+    S1 = quic_connection:arm_burst_continuation(S0),
+    Ref = quic_connection:test_pacing_timer(S1),
+    ?assert(is_reference(Ref)),
+    receive
+        {pacing_timeout, Ref} -> ok
+    after 0 ->
+        ?assert(false)
+    end.
+
+armed_continuation_is_not_duplicated_test() ->
+    S0 = quic_connection:test_decimate_initial_state(),
+    S1 = quic_connection:arm_burst_continuation(S0),
+    S2 = quic_connection:arm_burst_continuation(S1),
+    ?assertEqual(quic_connection:test_pacing_timer(S1), quic_connection:test_pacing_timer(S2)),
+    receive
+        {pacing_timeout, _} -> ok
+    after 0 ->
+        ?assert(false)
+    end,
+    receive
+        {pacing_timeout, _} -> ?assert(false)
+    after 0 ->
+        ok
+    end.

--- a/test/quic_delivery_coalescing_tests.erl
+++ b/test/quic_delivery_coalescing_tests.erl
@@ -1,0 +1,120 @@
+%% With delivery_coalescing on, consecutive same-stream deliveries of
+%% one receive pass reach the owner as one message; everything else
+%% about delivery (order across streams, FIN, the default) is unchanged.
+-module(quic_delivery_coalescing_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(WIN, ?DEFAULT_MAX_RECEIVE_WINDOW).
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+messages() ->
+    {messages, Msgs} = process_info(self(), messages),
+    Msgs.
+
+%% Streams 4 and 8 at offset 0, wide windows, inside a receive pass.
+state(Coalescing) ->
+    flush(),
+    S0 = quic_connection:test_recv_stream_state(4, 0, ?WIN, 2 * ?WIN),
+    S1 = quic_connection:test_add_recv_stream(S0, 8, ?WIN),
+    quic_connection:test_state_coalescing(quic_connection:test_state_in_recv_pass(S1), Coalescing).
+
+deliver(S, StreamId, Offset, Data, Fin) ->
+    quic_connection:do_process_stream_data_buffered(StreamId, Offset, Data, Fin, S).
+
+finish(S) ->
+    {S1, _} = quic_connection:test_finish_recv_pass(S),
+    S1.
+
+data(StreamId, Msgs) ->
+    [{D, F} || {quic, _, {stream_data, Id, D, F}} <- Msgs, Id =:= StreamId].
+
+adjacent_chunks_merge_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = deliver(S1, 4, 3, <<"bbb">>, false),
+    S3 = deliver(S2, 4, 6, <<"ccc">>, false),
+    ?assertEqual([], messages()),
+    ?assertMatch(
+        {4, [<<"ccc">>, <<"bbb">>, <<"aaa">>], false}, quic_connection:test_pending_delivery(S3)
+    ),
+    S4 = finish(S3),
+    ?assertEqual([{<<"aaabbbccc">>, false}], data(4, messages())),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S4)).
+
+fin_merges_into_the_run_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = deliver(S1, 4, 3, <<"bbb">>, true),
+    _ = finish(S2),
+    ?assertEqual([{<<"aaabbb">>, true}], data(4, messages())).
+
+%% Only adjacent chunks of one stream merge: another stream's delivery
+%% flushes the pending run first, so arrival order is preserved.
+another_stream_flushes_first_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"a1">>, false),
+    S2 = deliver(S1, 8, 0, <<"b1">>, false),
+    S3 = deliver(S2, 4, 2, <<"a2">>, false),
+    _ = finish(S3),
+    Msgs = [M || {quic, _, M} <- messages(), element(1, M) =:= stream_data],
+    ?assertEqual(
+        [
+            {stream_data, 4, <<"a1">>, false},
+            {stream_data, 8, <<"b1">>, false},
+            {stream_data, 4, <<"a2">>, false}
+        ],
+        Msgs
+    ).
+
+%% Flushing a run that grew through the general path (a gap filled
+%% mid-pass) still yields the bytes in order.
+out_of_order_fill_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 3, <<"bbb">>, false),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S1)),
+    S2 = deliver(S1, 4, 0, <<"aaa">>, false),
+    S3 = deliver(S2, 4, 6, <<"ccc">>, false),
+    _ = finish(S3),
+    ?assertEqual([{<<"aaabbbccc">>, false}], data(4, messages())).
+
+off_by_default_delivers_per_frame_test() ->
+    S0 = state(false),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = deliver(S1, 4, 3, <<"bbb">>, false),
+    ?assertEqual([{<<"aaa">>, false}, {<<"bbb">>, false}], data(4, messages())),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S2)).
+
+outside_a_pass_delivers_per_frame_test() ->
+    flush(),
+    S0 = quic_connection:test_recv_stream_state(4, 0, ?WIN, 2 * ?WIN),
+    S = quic_connection:test_state_coalescing(S0, true),
+    S1 = deliver(S, 4, 0, <<"aaa">>, false),
+    _ = deliver(S1, 4, 3, <<"bbb">>, false),
+    ?assertEqual([{<<"aaa">>, false}, {<<"bbb">>, false}], data(4, messages())).
+
+%% The run flushes even when the pass initiated a close: the data
+%% arrived before the close did.
+flushes_when_the_pass_closes_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    S2 = quic_connection:test_state_closing(S1, {application, 0, <<>>}),
+    _ = finish(S2),
+    ?assertEqual([{<<"aaa">>, false}], data(4, messages())).
+
+%% A RESET_STREAM arriving mid-pass must not overtake data the stream
+%% delivered earlier in the same pass.
+reset_does_not_overtake_pending_data_test() ->
+    S0 = state(true),
+    S1 = deliver(S0, 4, 0, <<"aaa">>, false),
+    ?assertEqual([], messages()),
+    S2 = quic_connection:process_frame(app, {reset_stream, 4, 7, 3}, S1),
+    ?assertEqual(none, quic_connection:test_pending_delivery(S2)),
+    Msgs = [M || {quic, _, M} <- messages(), element(2, M) =:= 4],
+    ?assertEqual([{stream_data, 4, <<"aaa">>, false}, {stream_reset, 4, 7}], Msgs).

--- a/test/quic_dist_rpc_tests.erl
+++ b/test/quic_dist_rpc_tests.erl
@@ -253,26 +253,50 @@ test_rpc_cast({#{peer1 := Peer1, peer2 := Peer2, node2 := Node2}, _TmpDir}) ->
             after 5000 ->
                 put(cast_result, timeout)
             end,
-            %% Keep alive for a bit so we can check
-            timer:sleep(1000)
+            %% Stay alive past the polling below; the node is torn
+            %% down at the end of the case either way.
+            timer:sleep(30000)
         end
     ]),
 
     %% Cast from Node1 to Node2
     true = peer:call(Peer1, rpc, cast, [Node2, erlang, send, [ReceiverPid, {cast_test, TestRef}]]),
 
-    %% Wait a bit and check the result
-    timer:sleep(200),
-    Result = peer:call(Peer2, erlang, apply, [
-        fun(Pid) -> rpc:call(node(Pid), erlang, process_info, [Pid, dictionary]) end,
-        [ReceiverPid]
-    ]),
-    case Result of
+    %% A cast is asynchronous, so poll for the receiver to record it
+    %% rather than sleeping a fixed 200 ms and hoping that was enough:
+    %% a loaded runner loses that race. The budget stays under eunit's
+    %% 5 s per-test timeout so an exhausted poll fails as `timed_out'
+    %% instead of being cancelled, and a receiver that has vanished no
+    %% longer passes the case by falling through.
+    ?assertEqual({got_cast, TestRef}, await_cast_result(Peer2, ReceiverPid, 30)).
+
+await_cast_result(_Peer, _Pid, 0) ->
+    timed_out;
+await_cast_result(Peer, Pid, Tries) ->
+    %% The peer call itself can fail while the node is busy or the
+    %% receiver is gone; that is a retry, not a reason to abandon the
+    %% case with an exception.
+    Info =
+        try
+            peer:call(Peer, erlang, apply, [
+                fun(P) -> rpc:call(node(P), erlang, process_info, [P, dictionary]) end,
+                [Pid]
+            ])
+        catch
+            _:_ -> unavailable
+        end,
+    case Info of
         {dictionary, Dict} ->
-            ?assertEqual({got_cast, TestRef}, proplists:get_value(cast_result, Dict));
+            case proplists:get_value(cast_result, Dict) of
+                undefined ->
+                    timer:sleep(100),
+                    await_cast_result(Peer, Pid, Tries - 1);
+                Value ->
+                    Value
+            end;
         _ ->
-            %% Process might have exited, check differently
-            ok
+            timer:sleep(100),
+            await_cast_result(Peer, Pid, Tries - 1)
     end.
 
 %% Test RPC multicall

--- a/test/quic_listener_initial_flight_tests.erl
+++ b/test/quic_listener_initial_flight_tests.erl
@@ -1,0 +1,112 @@
+%% A client Initial flight larger than one datagram must reach the
+%% connection in full.
+%%
+%% The listener drains its mailbox into one receive sweep and groups
+%% the packets by destination. For a DCID it has never seen, the group
+%% starts a connection; every packet in that group after the first has
+%% to be forwarded to it as well. Dropping them costs a PTO before the
+%% client resends, and a chunked ClientHello (x25519mlkem768 splits one
+%% across Initials) makes a multi-datagram flight the normal case.
+%%
+%% Determinism: the listener is suspended while both datagrams are put
+%% on the wire, so they are both in its mailbox before it runs and the
+%% sweep is guaranteed to see them together. The connection is
+%% suspended the moment it is created, so its mailbox accumulates
+%% whatever the listener routed instead of draining it.
+-module(quic_listener_initial_flight_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DCID, <<9, 9, 9, 9, 9, 9, 9, 9>>).
+-define(SCID, <<1, 2, 3, 4>>).
+
+%% Long header, fixed bit, QUIC v1 Initial (type bits 00). Only the
+%% header is parsed for routing, so the body can be anything: the
+%% connection process is suspended before it looks at it.
+initial(Body) ->
+    <<
+        16#C0,
+        1:32,
+        (byte_size(?DCID)),
+        ?DCID/binary,
+        (byte_size(?SCID)),
+        ?SCID/binary,
+        Body/binary
+    >>.
+
+%% Capture and freeze the connection the listener creates. Returning
+%% {error, _} keeps the listener from calling set_owner_sync, which
+%% would deadlock against the suspend.
+handler(Test) ->
+    fun(ConnPid, _DCID) ->
+        sys:suspend(ConnPid),
+        Test ! {conn, ConnPid},
+        {error, frozen_by_test}
+    end.
+
+wait_for_queue(Pid, N, 0) ->
+    ?assertEqual(
+        {N, ok},
+        {element(2, process_info(Pid, message_queue_len)), timed_out_waiting_for_packets}
+    );
+wait_for_queue(Pid, N, Tries) ->
+    case process_info(Pid, message_queue_len) of
+        {message_queue_len, Len} when Len >= N -> ok;
+        _ ->
+            timer:sleep(20),
+            wait_for_queue(Pid, N, Tries - 1)
+    end.
+
+%% Both Initials of a two-datagram flight reach the new connection.
+whole_initial_flight_reaches_the_connection_test_() ->
+    {timeout, 30, fun() ->
+        %% A PSK satisfies the listener's auth check without needing
+        %% cert files; no handshake runs here, the connection is frozen
+        %% before it looks at a packet.
+        {ok, Listener} = quic_listener:start(0, #{
+            connection_handler => handler(self()),
+            psks => #{<<"id">> => <<"secret">>},
+            alpn => [<<"h3">>]
+        }),
+        Port = quic_listener:get_port(Listener),
+        {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+        try
+            P1 = initial(<<"first-chunk">>),
+            P2 = initial(<<"second-chunk">>),
+
+            %% Freeze the listener so both datagrams queue up and the
+            %% sweep sees them as one group.
+            sys:suspend(Listener),
+            ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, P1),
+            ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, P2),
+            wait_for_queue(Listener, 2, 100),
+            sys:resume(Listener),
+
+            ConnPid =
+                receive
+                    {conn, Pid} -> Pid
+                after 5000 -> exit(no_connection_created)
+                end,
+
+            %% One {quic_packet, P1, _} from connection creation and
+            %% one {quic_packets, [P2], _} for the remainder of the
+            %% flight. Without the forward, only the first ever
+            %% arrives and this times out.
+            wait_for_queue(ConnPid, 2, 100),
+            {messages, Msgs} = process_info(ConnPid, messages),
+            Delivered = lists:append([
+                case M of
+                    {quic_packet, P, _} -> [P];
+                    {quic_packets, Ps, _} -> Ps;
+                    _ -> []
+                end
+             || M <- Msgs
+            ]),
+            ?assertEqual([P1, P2], Delivered),
+
+            sys:resume(ConnPid)
+        after
+            gen_udp:close(Sock),
+            catch quic_listener:stop(Listener)
+        end
+    end}.

--- a/test/quic_listener_recv_sweep_tests.erl
+++ b/test/quic_listener_recv_sweep_tests.erl
@@ -1,0 +1,61 @@
+%% The listener drains the datagram messages already queued in its
+%% mailbox into one receive sweep and dispatches them per source
+%% address, so a connection wakes once per sweep instead of once per
+%% datagram. Per-flow order must survive the grouping.
+-module(quic_listener_recv_sweep_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(A, {{10, 0, 0, 1}, 1111}).
+-define(B, {{10, 0, 0, 2}, 2222}).
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+drains_gen_udp_messages_in_order_test() ->
+    flush(),
+    Sock = sock,
+    self() ! {udp, Sock, element(1, ?A), element(2, ?A), <<"a2">>},
+    self() ! {udp, Sock, element(1, ?B), element(2, ?B), <<"b1">>},
+    self() ! {udp_passive, Sock},
+    self() ! {udp, Sock, element(1, ?A), element(2, ?A), <<"a3">>},
+    Items = quic_listener:drain_recv_sweep(Sock, gen_udp, 255, [{?A, [<<"a1">>]}]),
+    ?assertEqual([{?A, [<<"a1">>]}, {?A, [<<"a2">>]}, {?B, [<<"b1">>]}, {?A, [<<"a3">>]}], Items),
+    %% Non-datagram messages stay where they are.
+    receive
+        {udp_passive, Sock} -> ok
+    after 0 -> ?assert(false)
+    end.
+
+drains_gro_trains_within_budget_test() ->
+    flush(),
+    self() ! {gro_packets, element(1, ?B), element(2, ?B), [<<"b1">>, <<"b2">>, <<"b3">>]},
+    self() ! {gro_packets, element(1, ?A), element(2, ?A), [<<"a4">>]},
+    %% Budget 3 admits the first train (which overshoots) and stops.
+    Items = quic_listener:drain_recv_sweep(undefined, socket, 3, [{?A, [<<"a1">>]}]),
+    ?assertEqual([{?A, [<<"a1">>]}, {?B, [<<"b1">>, <<"b2">>, <<"b3">>]}], Items),
+    receive
+        {gro_packets, _, _, [<<"a4">>]} -> ok
+    after 0 -> ?assert(false)
+    end.
+
+backend_mismatch_is_left_alone_test() ->
+    flush(),
+    self() ! {gro_packets, element(1, ?A), element(2, ?A), [<<"x">>]},
+    ?assertEqual([], quic_listener:drain_recv_sweep(sock, gen_udp, 10, [])),
+    receive
+        {gro_packets, _, _, _} -> ok
+    after 0 -> ?assert(false)
+    end.
+
+grouping_keeps_per_flow_order_test() ->
+    Items = [
+        {?A, [<<"a1">>]}, {?B, [<<"b1">>, <<"b2">>]}, {?A, [<<"a2">>, <<"a3">>]}, {?B, [<<"b3">>]}
+    ],
+    ?assertEqual(
+        #{?A => [<<"a1">>, <<"a2">>, <<"a3">>], ?B => [<<"b1">>, <<"b2">>, <<"b3">>]},
+        quic_listener:group_recv_sweep(Items)
+    ).

--- a/test/quic_nif_frame_parse_tests.erl
+++ b/test/quic_nif_frame_parse_tests.erl
@@ -1,0 +1,207 @@
+%%% Differential tests for the in-NIF frame parser (open_run/8) against
+%%% quic_frame:decode/1.
+%%%
+%%% The contract under test: the NIF may always decline a packet by
+%%% returning {raw, Plaintext} (the Erlang decoder then owns it,
+%%% including all error semantics), but whenever it does return a frame
+%%% list, that list must equal what quic_frame:decode/1 produces, minus
+%%% PADDING frames (which carry no semantics: neither ack-eliciting nor
+%%% non-probing).
+-module(quic_nif_frame_parse_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(KEY, <<0:128>>).
+-define(IV, <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>).
+-define(HP, <<16#aa:8, 0:120>>).
+-define(DCID, <<9, 8, 7, 6>>).
+-define(FB_BASE, 16#40).
+%% protect_run needs enough plaintext for header-protection sampling;
+%% pad with leading PADDING frames so no trailing length-less STREAM
+%% frame can swallow the padding.
+-define(PAD, 64).
+
+with_nif(Fun) ->
+    case quic_crypto_nif:is_loaded() of
+        true -> Fun();
+        false -> ok
+    end.
+
+pad(Plain) ->
+    <<0:(?PAD * 8), Plain/binary>>.
+
+%% Decode the way decode_and_process_streaming/4 does, but surfacing
+%% failures (including decoder crashes on truncated input) as errors.
+erl_decode(Data) ->
+    try
+        erl_decode(Data, [])
+    catch
+        _:_ -> error
+    end.
+
+erl_decode(<<>>, Acc) ->
+    lists:reverse(Acc);
+erl_decode(Data, Acc) ->
+    case quic_frame:decode(Data) of
+        {error, _} -> error;
+        {Frame, Rest} -> erl_decode(Rest, [Frame | Acc])
+    end.
+
+strip_padding(error) -> error;
+strip_padding(Frames) -> [F || F <- Frames, F =/= padding].
+
+%% Encrypt one packet carrying Plain and run it back through open_run.
+open_one(Plain) ->
+    {ok, [Packet]} = quic_aead_ctx:protect_run(
+        aes_128_gcm, ?KEY, ?IV, ?HP, 7, ?FB_BASE, ?DCID, [Plain]
+    ),
+    {ok, [{_PN, _FB, Third}]} = quic_aead_ctx:open_run(
+        aes_128_gcm, ?KEY, ?IV, ?HP, 6, 0, byte_size(?DCID), [Packet]
+    ),
+    Third.
+
+%% Core invariant: parsed output equals the Erlang decoder's, and the
+%% raw fallback preserves the plaintext exactly.
+check(Plain0) ->
+    Plain = pad(Plain0),
+    case open_one(Plain) of
+        {raw, Got} ->
+            ?assertEqual(Plain, Got),
+            raw;
+        Parsed ->
+            ?assertEqual(strip_padding(erl_decode(Plain)), Parsed),
+            parsed
+    end.
+
+%% Frames the NIF is expected to parse itself.
+fast_path_frames() ->
+    [
+        ping,
+        {ack, [{100, 3}], 42, undefined},
+        {ack, [{100, 3}, {2, 5}, {1, 1}], 7, undefined},
+        {ack, [{500, 10}], 1, {1, 2, 3}},
+        {crypto, 0, <<"hello crypto">>},
+        {crypto, 1000, binary:copy(<<$c>>, 300)},
+        {stream, 4, 0, <<"payload">>, false},
+        {stream, 8, 1234, <<"more">>, true},
+        {stream, 16383, 16384, binary:copy(<<$s>>, 500), false},
+        {max_data, 1048576},
+        {max_stream_data, 12, 65536},
+        {max_streams, bidi, 100},
+        {max_streams, uni, 3},
+        handshake_done
+    ].
+
+%% Frames outside the fast path: must take the raw fallback.
+fallback_frames() ->
+    [
+        {reset_stream, 4, 7, 100},
+        {stop_sending, 8, 2},
+        {new_token, <<"token">>},
+        {data_blocked, 500},
+        {stream_data_blocked, 4, 100},
+        {streams_blocked, bidi, 7},
+        {new_connection_id, 1, 0, <<1, 2, 3, 4, 5, 6, 7, 8>>, <<0:128>>},
+        {retire_connection_id, 3},
+        {path_challenge, <<1, 2, 3, 4, 5, 6, 7, 8>>},
+        {path_response, <<8, 7, 6, 5, 4, 3, 2, 1>>},
+        {connection_close, transport, 0, 0, <<"bye">>}
+    ].
+
+enc(Frames) ->
+    iolist_to_binary([quic_frame:encode(F) || F <- Frames]).
+
+each_fast_path_frame_is_parsed_test() ->
+    with_nif(fun() ->
+        lists:foreach(
+            fun(Frame) ->
+                ?assertEqual({Frame, parsed}, {Frame, check(enc([Frame]))})
+            end,
+            fast_path_frames()
+        )
+    end).
+
+mixed_fast_path_packet_is_parsed_test() ->
+    with_nif(fun() ->
+        ?assertEqual(parsed, check(enc(fast_path_frames())))
+    end).
+
+padding_between_frames_is_skipped_test() ->
+    with_nif(fun() ->
+        Frames = [{stream, 4, 0, <<"data">>, false}, ping],
+        Plain = <<
+            (quic_frame:encode(hd(Frames)))/binary,
+            0:(100 * 8),
+            (quic_frame:encode(lists:last(Frames)))/binary
+        >>,
+        ?assertEqual(parsed, check(Plain)),
+        ?assertEqual(Frames, open_one(pad(Plain)))
+    end).
+
+padding_only_packet_falls_back_test() ->
+    with_nif(fun() ->
+        %% No frames at all: the Erlang decoder owns the
+        %% PROTOCOL_VIOLATION for a frameless packet.
+        ?assertEqual(raw, check(<<0:(200 * 8)>>))
+    end).
+
+unknown_frame_types_fall_back_test() ->
+    with_nif(fun() ->
+        lists:foreach(
+            fun(Frame) ->
+                ?assertEqual({Frame, raw}, {Frame, check(enc([Frame]))})
+            end,
+            fallback_frames()
+        )
+    end).
+
+%% A fast-path frame followed by a fallback frame must not be split:
+%% the whole packet takes the raw path.
+partial_fast_path_falls_back_test() ->
+    with_nif(fun() ->
+        Plain = enc([{stream, 4, 0, <<"x">>, false}, {stop_sending, 8, 2}]),
+        ?assertEqual(raw, check(Plain))
+    end).
+
+%% Truncated input must never yield a frame list that disagrees with
+%% the Erlang decoder (check/1 asserts the invariant either way).
+truncated_frames_test() ->
+    with_nif(fun() ->
+        Full = enc([{crypto, 1000, binary:copy(<<$c>>, 300)}]),
+        lists:foreach(
+            fun(Len) ->
+                <<Prefix:Len/binary, _/binary>> = Full,
+                check(Prefix)
+            end,
+            [1, 2, 3, 5, 8, 40, byte_size(Full) - 1]
+        )
+    end).
+
+%% Randomised differential run over the fast-path forms.
+random_mixes_match_erlang_test() ->
+    with_nif(fun() ->
+        All = fast_path_frames(),
+        lists:foreach(
+            fun(Seed) ->
+                rand:seed(exsplus, {Seed, Seed * 7, Seed * 13}),
+                N = rand:uniform(6),
+                Frames = [lists:nth(rand:uniform(length(All)), All) || _ <- lists:seq(1, N)],
+                ?assertEqual({Seed, parsed}, {Seed, check(enc(Frames))})
+            end,
+            lists:seq(1, 200)
+        )
+    end).
+
+%% Random byte soup: the NIF must either decline or agree exactly.
+random_garbage_never_disagrees_test() ->
+    with_nif(fun() ->
+        lists:foreach(
+            fun(Seed) ->
+                rand:seed(exsplus, {Seed, Seed * 3, Seed * 11}),
+                Len = rand:uniform(120),
+                Plain = list_to_binary([rand:uniform(256) - 1 || _ <- lists:seq(1, Len)]),
+                check(Plain)
+            end,
+            lists:seq(1, 500)
+        )
+    end).

--- a/test/quic_nif_fuzz.erl
+++ b/test/quic_nif_fuzz.erl
@@ -1,0 +1,105 @@
+%%% Fuzz harness for the in-NIF frame parser. Not part of the normal
+%%% eunit run: intended to be driven under AddressSanitizer or valgrind,
+%%% where the point is to crash the NIF, not to assert on output.
+%%%
+%%%   erlc -o ebin test/quic_nif_fuzz.erl
+%%%   LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
+%%%     erl -noshell -pa ebin -eval 'quic_nif_fuzz:run(200000), halt().'
+-module(quic_nif_fuzz).
+
+-export([run/1, run/2]).
+
+-define(KEY, <<0:128>>).
+-define(IV, <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>).
+-define(HP, <<16#aa:8, 0:120>>).
+-define(DCID, <<9, 8, 7, 6>>).
+-define(FB_BASE, 16#40).
+
+run(N) ->
+    run(N, 1).
+
+run(N, Seed) ->
+    case quic_crypto_nif:is_loaded() of
+        false ->
+            io:format("NIF not loaded, nothing to fuzz~n");
+        true ->
+            rand:seed(exsplus, {Seed, Seed * 7 + 1, Seed * 13 + 3}),
+            {Parsed, Raw, Rejected} = loop(N, 0, 0, 0),
+            io:format(
+                "fuzzed ~b packets: parsed=~b raw=~b rejected=~b~n",
+                [N, Parsed, Raw, Rejected]
+            )
+    end.
+
+loop(0, P, R, X) ->
+    {P, R, X};
+loop(N, P, R, X) ->
+    Plain = payload(),
+    case protect(Plain) of
+        {ok, Packet} ->
+            case
+                catch quic_aead_ctx:open_run(
+                    aes_128_gcm, ?KEY, ?IV, ?HP, 0, 0, byte_size(?DCID), [Packet]
+                )
+            of
+                {ok, [{_PN, _FB, {raw, _}}]} -> loop(N - 1, P, R + 1, X);
+                {ok, [{_PN, _FB, L}]} when is_list(L) -> loop(N - 1, P + 1, R, X);
+                _ -> loop(N - 1, P, R, X + 1)
+            end;
+        skip ->
+            loop(N - 1, P, R, X + 1)
+    end.
+
+protect(Plain) ->
+    case
+        catch quic_aead_ctx:protect_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, 7, ?FB_BASE, ?DCID, [Plain]
+        )
+    of
+        {ok, [Packet]} -> {ok, Packet};
+        _ -> skip
+    end.
+
+%% A mix of shapes: pure noise, valid frames with corrupted tails,
+%% truncations, and deeply nested length fields.
+payload() ->
+    Base =
+        case rand:uniform(4) of
+            1 -> noise(rand:uniform(1200));
+            2 -> frames(rand:uniform(8));
+            3 -> truncate(frames(rand:uniform(6)));
+            4 -> corrupt(frames(rand:uniform(6)))
+        end,
+    %% keep protect_run happy (needs sampling room)
+    <<0:(64 * 8), Base/binary>>.
+
+noise(Len) ->
+    list_to_binary([rand:uniform(256) - 1 || _ <- lists:seq(1, Len)]).
+
+frames(N) ->
+    iolist_to_binary([quic_frame:encode(frame()) || _ <- lists:seq(1, N)]).
+
+frame() ->
+    case rand:uniform(9) of
+        1 -> ping;
+        2 -> {ack, [{rand:uniform(1000), rand:uniform(50)}], rand:uniform(100), undefined};
+        3 -> {ack, [{rand:uniform(1000), rand:uniform(50)}], 1, {1, 2, 3}};
+        4 -> {crypto, rand:uniform(100000), noise(rand:uniform(400))};
+        5 -> {stream, rand:uniform(64), rand:uniform(100000), noise(rand:uniform(400)), false};
+        6 -> {stream, rand:uniform(64), 0, noise(rand:uniform(200)), true};
+        7 -> {max_data, rand:uniform(1000000)};
+        8 -> {max_stream_data, rand:uniform(64), rand:uniform(1000000)};
+        9 -> handshake_done
+    end.
+
+truncate(Bin) when byte_size(Bin) > 1 ->
+    binary:part(Bin, 0, rand:uniform(byte_size(Bin)));
+truncate(Bin) ->
+    Bin.
+
+corrupt(Bin) when byte_size(Bin) > 2 ->
+    Pos = rand:uniform(byte_size(Bin)) - 1,
+    <<A:Pos/binary, B, Rest/binary>> = Bin,
+    <<A/binary, (B bxor (rand:uniform(255))), Rest/binary>>;
+corrupt(Bin) ->
+    Bin.

--- a/test/quic_nif_fuzz.erl
+++ b/test/quic_nif_fuzz.erl
@@ -64,11 +64,12 @@ protect(Plain) ->
 %% truncations, and deeply nested length fields.
 payload() ->
     Base =
-        case rand:uniform(4) of
+        case rand:uniform(5) of
             1 -> noise(rand:uniform(1200));
             2 -> frames(rand:uniform(8));
             3 -> truncate(frames(rand:uniform(6)));
-            4 -> corrupt(frames(rand:uniform(6)))
+            4 -> corrupt(frames(rand:uniform(6)));
+            5 -> many_frames(rand:uniform(96))
         end,
     %% keep protect_run happy (needs sampling room)
     <<0:(64 * 8), Base/binary>>.
@@ -78,6 +79,20 @@ noise(Len) ->
 
 frames(N) ->
     iolist_to_binary([quic_frame:encode(frame()) || _ <- lists:seq(1, N)]).
+
+%% Single-byte frames only, so the count crosses the parser's
+%% PF_MAX_FRAMES cap (64) without the packet growing out of proportion.
+%% The other shapes top out at 8 frames and never reach the array bound,
+%% which left the one fixed-size buffer in the parser unexercised.
+many_frames(N) ->
+    iolist_to_binary([quic_frame:encode(small_frame()) || _ <- lists:seq(1, N)]).
+
+small_frame() ->
+    case rand:uniform(3) of
+        1 -> ping;
+        2 -> handshake_done;
+        3 -> {max_data, rand:uniform(1000000)}
+    end.
 
 frame() ->
     case rand:uniform(9) of

--- a/test/quic_open_packet_tests.erl
+++ b/test/quic_open_packet_tests.erl
@@ -1,0 +1,111 @@
+%% open_packet/8 fuses header unprotection, packet-number reconstruction
+%% and AEAD open for one short-header packet. It must open what
+%% protect_run sealed, byte for byte, across packet-number length
+%% boundaries, hand a key-phase mismatch back to the generic path
+%% untouched, and reject a corrupted tag.
+-module(quic_open_packet_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DCID, <<9, 8, 7, 6>>).
+-define(BASE, 16#40).
+
+keys() ->
+    {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(16)}.
+
+%% Split a wire packet into the header the receiver has parsed (first
+%% byte + DCID) and the rest, as decrypt_app_packet sees it.
+split(Packet) ->
+    HLen = 1 + byte_size(?DCID),
+    <<Header:HLen/binary, Rest/binary>> = Packet,
+    {Header, Rest}.
+
+roundtrip(PN0, K) ->
+    {Key, IV, HP} = keys(),
+    Payloads = [crypto:strong_rand_bytes(60 + I) || I <- lists:seq(1, K)],
+    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, PN0, ?BASE, ?DCID, Payloads) of
+        fallback ->
+            ok;
+        {ok, Packets} ->
+            lists:foldl(
+                fun({Packet, Payload}, Largest) ->
+                    {Header, Rest} = split(Packet),
+                    {ok, PN, FirstByte, Plain} =
+                        quic_aead_ctx:open_packet(
+                            aes_128_gcm, Key, IV, HP, Largest, 0, Header, Rest
+                        ),
+                    ?assertEqual(Payload, Plain),
+                    %% Fixed bit set, key phase 0, PN length as encoded.
+                    ?assertEqual(?BASE bor (quic_packet:pn_length(PN) - 1), FirstByte),
+                    PN
+                end,
+                undefined,
+                lists:zip(Packets, Payloads)
+            ),
+            ok
+    end.
+
+roundtrip_test_() ->
+    [
+        {lists:flatten(io_lib:format("pn0=~p k=~p", [PN0, K])), fun() -> roundtrip(PN0, K) end}
+     || {PN0, K} <- [{0, 6}, {250, 10}, {65530, 10}, {16777210, 10}]
+    ].
+
+%% The receiver tracks largest_recv as packets arrive; a packet whose
+%% PN is reconstructed against a stale (lower) largest still decodes
+%% while within the window.
+reconstruction_with_stale_largest_test() ->
+    {Key, IV, HP} = keys(),
+    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, 300, ?BASE, ?DCID, [<<0:(80 * 8)>>]) of
+        fallback ->
+            ok;
+        {ok, [Packet]} ->
+            {Header, Rest} = split(Packet),
+            ?assertMatch(
+                {ok, 300, _, _},
+                quic_aead_ctx:open_packet(aes_128_gcm, Key, IV, HP, 250, 0, Header, Rest)
+            )
+    end.
+
+key_phase_mismatch_is_fallback_test() ->
+    {Key, IV, HP} = keys(),
+    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, 5, ?BASE, ?DCID, [<<1:(80 * 8)>>]) of
+        fallback ->
+            ok;
+        {ok, [Packet]} ->
+            {Header, Rest} = split(Packet),
+            %% Sealed with phase 0; the receiver expects phase 1.
+            ?assertEqual(
+                fallback, quic_aead_ctx:open_packet(aes_128_gcm, Key, IV, HP, 4, 1, Header, Rest)
+            )
+    end.
+
+corrupted_tag_is_an_error_test() ->
+    {Key, IV, HP} = keys(),
+    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, 5, ?BASE, ?DCID, [<<2:(80 * 8)>>]) of
+        fallback ->
+            ok;
+        {ok, [Packet]} ->
+            {Header, Rest0} = split(Packet),
+            Sz = byte_size(Rest0),
+            <<Keep:(Sz - 1)/binary, Last>> = Rest0,
+            Rest = <<Keep/binary, (Last bxor 16#ff)>>,
+            ?assertEqual(
+                error, quic_aead_ctx:open_packet(aes_128_gcm, Key, IV, HP, 4, 0, Header, Rest)
+            )
+    end.
+
+chacha_is_fallback_test() ->
+    ?assertEqual(
+        fallback,
+        quic_aead_ctx:open_packet(
+            chacha20_poly1305,
+            crypto:strong_rand_bytes(32),
+            crypto:strong_rand_bytes(12),
+            crypto:strong_rand_bytes(32),
+            undefined,
+            0,
+            <<16#40, 1, 2, 3, 4>>,
+            <<0:(64 * 8)>>
+        )
+    ).

--- a/test/quic_open_run_tests.erl
+++ b/test/quic_open_run_tests.erl
@@ -1,0 +1,143 @@
+%%% Differential tests for the batched fused receive path
+%%% (quic_aead_ctx:open_run/8) against the per-packet open_packet/8.
+-module(quic_open_run_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(KEY, <<0:128>>).
+-define(IV, <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>).
+-define(HP, <<16#aa:8, 0:120>>).
+-define(DCID, <<9, 8, 7, 6>>).
+
+%% FirstByteBase: short header, fixed bit, phase 0 (PN-length bits clear)
+-define(FB_BASE, 16#40).
+%% Same with key-phase bit (bit 2) set
+-define(FB_PHASE1, 16#44).
+
+with_nif(Fun) ->
+    case quic_crypto_nif:is_loaded() of
+        true -> Fun();
+        false -> ok
+    end.
+
+build_run(PN0, FirstByteBase, Payloads) ->
+    {ok, Packets} = quic_aead_ctx:protect_run(
+        aes_128_gcm, ?KEY, ?IV, ?HP, PN0, FirstByteBase, ?DCID, Payloads
+    ),
+    Packets.
+
+payloads(N) ->
+    [
+        <<I, "payload-", (integer_to_binary(I))/binary, 0:(200 * 8)>>
+     || <<I>> <= list_to_binary(lists:seq(1, N))
+    ].
+
+open_run_roundtrip_test() ->
+    with_nif(fun() ->
+        Payloads = payloads(8),
+        Packets = build_run(0, ?FB_BASE, Payloads),
+        {ok, Results} = quic_aead_ctx:open_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, undefined, 0, byte_size(?DCID), Packets
+        ),
+        ?assertEqual(8, length(Results)),
+        ?assertEqual(
+            lists:seq(0, 7),
+            [PN || {PN, _FB, _P} <- Results]
+        ),
+        ?assertEqual(Payloads, [P || {_PN, _FB, P} <- Results])
+    end).
+
+open_run_matches_sequential_test() ->
+    with_nif(fun() ->
+        Payloads = payloads(6),
+        Packets = build_run(100, ?FB_BASE, Payloads),
+        {ok, Batch} = quic_aead_ctx:open_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, 99, 0, byte_size(?DCID), Packets
+        ),
+        HdrLen = 1 + byte_size(?DCID),
+        {Seq, _} = lists:mapfoldl(
+            fun(Pkt, Largest) ->
+                <<Header:HdrLen/binary, Payload/binary>> = Pkt,
+                {ok, PN, FB, Plain} = quic_aead_ctx:open_packet(
+                    aes_128_gcm, ?KEY, ?IV, ?HP, Largest, 0, Header, Payload
+                ),
+                {{PN, FB, Plain}, max(Largest, PN)}
+            end,
+            99,
+            Packets
+        ),
+        ?assertEqual(Seq, Batch)
+    end).
+
+open_run_stops_at_bad_tag_test() ->
+    with_nif(fun() ->
+        Packets = build_run(0, ?FB_BASE, payloads(6)),
+        {Good, [Bad | Tail]} = lists:split(3, Packets),
+        Sz = byte_size(Bad),
+        <<Head:(Sz - 1)/binary, Last>> = Bad,
+        Corrupt = <<Head/binary, (Last bxor 16#ff)>>,
+        {ok, Results} = quic_aead_ctx:open_run(
+            aes_128_gcm,
+            ?KEY,
+            ?IV,
+            ?HP,
+            undefined,
+            0,
+            byte_size(?DCID),
+            Good ++ [Corrupt | Tail]
+        ),
+        ?assertEqual(3, length(Results)),
+        ?assertEqual([0, 1, 2], [PN || {PN, _, _} <- Results])
+    end).
+
+open_run_stops_at_phase_mismatch_test() ->
+    with_nif(fun() ->
+        [P0, P1] = build_run(0, ?FB_BASE, payloads(2)),
+        [Q0] = build_run(2, ?FB_PHASE1, payloads(1)),
+        {ok, Results} = quic_aead_ctx:open_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, undefined, 0, byte_size(?DCID), [P0, P1, Q0]
+        ),
+        ?assertEqual(2, length(Results))
+    end).
+
+open_run_short_datagram_test() ->
+    with_nif(fun() ->
+        [P0] = build_run(0, ?FB_BASE, payloads(1)),
+        {ok, Results} = quic_aead_ctx:open_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, undefined, 0, byte_size(?DCID), [<<1, 2, 3>>, P0]
+        ),
+        ?assertEqual([], Results)
+    end).
+
+open_run_empty_test() ->
+    with_nif(fun() ->
+        ?assertEqual(
+            {ok, []},
+            quic_aead_ctx:open_run(
+                aes_128_gcm, ?KEY, ?IV, ?HP, undefined, 0, byte_size(?DCID), []
+            )
+        )
+    end).
+
+%% A run with a hole in the packet-number sequence (a lost datagram in
+%% the middle of a GRO train) must still open every present packet with
+%% its own packet number, carrying the largest forward across the gap.
+open_run_with_pn_gap_test() ->
+    with_nif(fun() ->
+        [A, B] = build_run(10, ?FB_BASE, payloads(2)),
+        [C, D] = build_run(13, ?FB_BASE, payloads(2)),
+        {ok, Results} = quic_aead_ctx:open_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, 9, 0, byte_size(?DCID), [A, B, C, D]
+        ),
+        ?assertEqual([10, 11, 13, 14], [PN || {PN, _FB, _P} <- Results])
+    end).
+
+%% Reordered within a train: an older packet after newer ones.
+open_run_reordered_test() ->
+    with_nif(fun() ->
+        [A, B, C] = build_run(20, ?FB_BASE, payloads(3)),
+        {ok, Results} = quic_aead_ctx:open_run(
+            aes_128_gcm, ?KEY, ?IV, ?HP, 19, 0, byte_size(?DCID), [B, C, A]
+        ),
+        ?assertEqual([21, 22, 20], [PN || {PN, _FB, _P} <- Results])
+    end).

--- a/test/quic_open_run_tests.erl
+++ b/test/quic_open_run_tests.erl
@@ -27,8 +27,10 @@ build_run(PN0, FirstByteBase, Payloads) ->
     Packets.
 
 payloads(N) ->
+    %% 16#1f is not a QUIC frame type, so the in-NIF frame parser always
+    %% takes the {raw, Plain} fallback for these synthetic payloads.
     [
-        <<I, "payload-", (integer_to_binary(I))/binary, 0:(200 * 8)>>
+        <<16#1f, I, "payload-", (integer_to_binary(I))/binary, 0:(199 * 8)>>
      || <<I>> <= list_to_binary(lists:seq(1, N))
     ].
 
@@ -44,7 +46,9 @@ open_run_roundtrip_test() ->
             lists:seq(0, 7),
             [PN || {PN, _FB, _P} <- Results]
         ),
-        ?assertEqual(Payloads, [P || {_PN, _FB, P} <- Results])
+        %% Test payloads are not valid frame sequences, so the in-NIF
+        %% frame parser falls back to {raw, Plain} for every packet.
+        ?assertEqual(Payloads, [P || {_PN, _FB, {raw, P}} <- Results])
     end).
 
 open_run_matches_sequential_test() ->
@@ -61,7 +65,7 @@ open_run_matches_sequential_test() ->
                 {ok, PN, FB, Plain} = quic_aead_ctx:open_packet(
                     aes_128_gcm, ?KEY, ?IV, ?HP, Largest, 0, Header, Payload
                 ),
-                {{PN, FB, Plain}, max(Largest, PN)}
+                {{PN, FB, {raw, Plain}}, max(Largest, PN)}
             end,
             99,
             Packets

--- a/test/quic_pacing_burst_tests.erl
+++ b/test/quic_pacing_burst_tests.erl
@@ -130,8 +130,18 @@ update_mtu_keeps_the_floor_at_low_rates_test() ->
 %% Degenerate input
 %%====================================================================
 
-zero_rtt_leaves_pacing_untouched_test() ->
-    %% No RTT sample yet: update_pacing_rate is a no-op, so the state is
-    %% returned unchanged and sends stay unpaced.
-    State = quic_cc_newreno:new(#{max_datagram_size => ?MDS}),
-    ?assertEqual(State, quic_cc_newreno:update_pacing_rate(State, 0)).
+zero_rtt_paces_as_one_millisecond_test() ->
+    %% RTT samples are whole milliseconds, so a sub-millisecond link
+    %% reports 0. Treating that as "no RTT yet" froze the pacing rate at
+    %% its handshake-time value while cwnd kept growing. The rate is
+    %% computed as for a 1 ms RTT instead, so it keeps tracking cwnd.
+    Small = 12000,
+    Large = 4000000,
+    ?assertEqual(
+        max(12 * ?MDS, 2 * rate(Small, 1)),
+        burst_ceiling(paced(Small, 0))
+    ),
+    ?assertEqual(
+        max(12 * ?MDS, 2 * rate(Large, 1)),
+        burst_ceiling(paced(Large, 0))
+    ).

--- a/test/quic_post_handshake_flush_SUITE.erl
+++ b/test/quic_post_handshake_flush_SUITE.erl
@@ -1,0 +1,160 @@
+%%% -*- erlang -*-
+%%%
+%%% The frames a server sends on entering `connected' (queued data,
+%%% NEW_TOKEN, the first PMTU probe) must leave with that transition,
+%%% not with the next event on the connection.
+%%%
+%%% They go through the per-connection send batch, and the state-enter
+%%% handler returned without flushing it, so they sat there until
+%%% something else (an ACK, a timer) happened to flush. On a quiet
+%%% connection that is the peer's delayed ACK or a PTO later; any
+%%% consumer waiting for the token, and the MTU discovery, waited with
+%%% them. This suite is a guard on the fixed behaviour: it holds with
+%%% the fix, and the flake it was distilled from (the server-side
+%%% baseline in quic_server_batching_SUITE seeing two packets built but
+%%% not yet flushed) is what showed the bug.
+-module(quic_post_handshake_flush_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([nothing_pending_after_connected/1]).
+
+suite() ->
+    [{timetrap, {minutes, 1}}].
+
+all() ->
+    [nothing_pending_after_connected].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(crypto),
+    {ok, _} = application:ensure_all_started(quic),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% The client reaches the server through a bridge that can drop the
+%% client-to-server direction. Once the handshake is complete the
+%% bridge is blackholed, so nothing from the client can reach the
+%% server and flush a batch on its behalf; the server must have flushed
+%% everything it queued on entering `connected' by itself.
+nothing_pending_after_connected(_Config) ->
+    {ok, Server} = quic_test_echo_server:start(#{
+        %% A token secret makes the server issue NEW_TOKEN on connect.
+        reset_secret => crypto:strong_rand_bytes(32)
+    }),
+    Port = maps:get(port, Server),
+    try
+        {Conn, Bridge} = connect_through_bridge(Port),
+        Bridge ! blackhole,
+        SConn = server_connection(maps:get(name, Server)),
+        ok = wait_connected(SConn, 400),
+        {ok, Stats} = quic:get_stats(SConn),
+        ct:pal("server stats right after connected: ~p", [Stats]),
+        ?assertEqual(0, maps:get(send_batch_pending, Stats)),
+        ?assert(maps:get(packets_sent, Stats) > 0),
+        Bridge ! heal,
+        ok = quic:close(Conn, normal)
+    after
+        quic_test_echo_server:stop(Server)
+    end.
+
+server_connection(Name) ->
+    {ok, Pids} = quic:get_server_connections(Name),
+    [Pid | _] = lists:usort(Pids),
+    Pid.
+
+%% The server side becomes connected when the client's Finished is
+%% processed; that datagram left before the client learned it was
+%% connected, so it is through the bridge before the blackhole.
+wait_connected(_Pid, 0) ->
+    {error, server_never_connected};
+wait_connected(Pid, N) ->
+    case catch quic_connection:get_state(Pid) of
+        {connected, _} ->
+            ok;
+        _ ->
+            timer:sleep(5),
+            wait_connected(Pid, N - 1)
+    end.
+
+%%====================================================================
+%% Bridge harness (as in quic_stranded_window_recovery_SUITE)
+%%====================================================================
+
+connect_through_bridge(Port) ->
+    ServerIP = {127, 0, 0, 1},
+    SocketRef = make_ref(),
+    Bridge = spawn_link(fun() -> bridge_init(ServerIP, Port, SocketRef) end),
+    Adapter = #{
+        send_fun => fun(IP, P, Pkt) ->
+            Bridge ! {send, IP, P, Pkt},
+            ok
+        end,
+        close_fun => fun() ->
+            Bridge ! stop,
+            ok
+        end,
+        local => {{127, 0, 0, 1}, 0},
+        socket_ref => SocketRef
+    },
+    Opts = #{
+        verify => false,
+        alpn => [<<"echo">>],
+        socket_backend => adapter,
+        socket_adapter => Adapter,
+        %% No immediate ACKs from the client: the server's post-handshake
+        %% packets must not be flushed by an ACK racing the blackhole.
+        ack_packet_tolerance => 1000
+    },
+    {ok, Conn} = quic:connect(<<"127.0.0.1">>, Port, Opts, self()),
+    Bridge ! {set_conn, Conn},
+    receive
+        {quic, Conn, {connected, _}} -> {Conn, Bridge}
+    after 10000 -> ct:fail("connect timeout")
+    end.
+
+bridge_init(ServerIP, ServerPort, SocketRef) ->
+    {ok, Sock} = gen_udp:open(0, [binary, {active, true}]),
+    bridge_loop(#{
+        sock => Sock,
+        conn => undefined,
+        pending => [],
+        blackhole => false,
+        server => {ServerIP, ServerPort},
+        socket_ref => SocketRef
+    }).
+
+bridge_loop(#{sock := Sock, server := {ServerIP, ServerPort}} = Bridge) ->
+    receive
+        {set_conn, Conn} ->
+            [deliver(Bridge, Conn, D) || D <- lists:reverse(maps:get(pending, Bridge))],
+            bridge_loop(Bridge#{conn := Conn, pending := []});
+        blackhole ->
+            bridge_loop(Bridge#{blackhole := true});
+        heal ->
+            bridge_loop(Bridge#{blackhole := false});
+        {send, _IP, _Port, Pkt} ->
+            case maps:get(blackhole, Bridge) of
+                true -> ok;
+                false -> ok = gen_udp:send(Sock, ServerIP, ServerPort, Pkt)
+            end,
+            bridge_loop(Bridge);
+        {udp, Sock, _IP, _Port, Data} ->
+            case maps:get(conn, Bridge) of
+                undefined ->
+                    bridge_loop(Bridge#{pending := [Data | maps:get(pending, Bridge)]});
+                Conn ->
+                    deliver(Bridge, Conn, Data),
+                    bridge_loop(Bridge)
+            end;
+        stop ->
+            gen_udp:close(Sock);
+        _ ->
+            bridge_loop(Bridge)
+    end.
+
+deliver(#{server := {ServerIP, ServerPort}, socket_ref := SocketRef}, Conn, Data) ->
+    Conn ! {udp, SocketRef, ServerIP, ServerPort, Data}.

--- a/test/quic_protect_run_tests.erl
+++ b/test/quic_protect_run_tests.erl
@@ -1,0 +1,75 @@
+%% protect_run/8 seals a run of short-header packets in one NIF call.
+%% Its output must be byte-identical to sealing each packet with
+%% quic_aead:protect_short_packet/8, across ciphers and across the
+%% packet-number length boundaries inside a run; ChaCha and a missing
+%% NIF report `fallback' so the caller takes the per-packet path.
+-module(quic_protect_run_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DCID, <<1, 2, 3, 4, 5, 6, 7, 8>>).
+%% Short header base: fixed bit set, key phase 0, PN-length bits clear.
+-define(FIRST_BYTE_BASE, 16#40).
+
+keys(aes_128_gcm) ->
+    {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(16)};
+keys(aes_256_gcm) ->
+    {crypto:strong_rand_bytes(32), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(32)};
+keys(chacha20_poly1305) ->
+    {crypto:strong_rand_bytes(32), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(32)}.
+
+payloads(K) ->
+    [crypto:strong_rand_bytes(100 + I) || I <- lists:seq(1, K)].
+
+reference(Cipher, Key, IV, HP, PN0, Payloads) ->
+    {Ps, _} = lists:mapfoldl(
+        fun(Payload, PN) ->
+            FirstByte = ?FIRST_BYTE_BASE bor (quic_packet:pn_length(PN) - 1),
+            {
+                quic_aead:protect_short_packet(Cipher, Key, IV, HP, PN, FirstByte, ?DCID, Payload),
+                PN + 1
+            }
+        end,
+        PN0,
+        Payloads
+    ),
+    Ps.
+
+run_matches_reference(Cipher, PN0, K) ->
+    {Key, IV, HP} = keys(Cipher),
+    Payloads = payloads(K),
+    case quic_aead_ctx:protect_run(Cipher, Key, IV, HP, PN0, ?FIRST_BYTE_BASE, ?DCID, Payloads) of
+        {ok, Packets} ->
+            ?assertEqual(reference(Cipher, Key, IV, HP, PN0, Payloads), Packets);
+        fallback ->
+            %% No NIF on this host (or disabled): nothing to compare, the
+            %% caller seals per packet with the reference itself.
+            ok
+    end.
+
+aes_128_run_test_() ->
+    [
+        {lists:flatten(io_lib:format("aes128 pn0=~p k=~p", [PN0, K])), fun() ->
+            run_matches_reference(aes_128_gcm, PN0, K)
+        end}
+     || {PN0, K} <- [{0, 8}, {250, 12}, {65530, 12}, {16777210, 12}, {4294967290, 12}, {7, 1}]
+    ].
+
+aes_256_run_test() ->
+    run_matches_reference(aes_256_gcm, 65530, 16).
+
+chacha_is_fallback_test() ->
+    {Key, IV, HP} = keys(chacha20_poly1305),
+    ?assertEqual(
+        fallback,
+        quic_aead_ctx:protect_run(
+            chacha20_poly1305, Key, IV, HP, 0, ?FIRST_BYTE_BASE, ?DCID, payloads(3)
+        )
+    ).
+
+empty_run_test() ->
+    {Key, IV, HP} = keys(aes_128_gcm),
+    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, 0, ?FIRST_BYTE_BASE, ?DCID, []) of
+        {ok, []} -> ok;
+        fallback -> ok
+    end.

--- a/test/quic_reassembly_tests.erl
+++ b/test/quic_reassembly_tests.erl
@@ -14,11 +14,17 @@
 chunk(Start, Len) ->
     <<<<(B rem 256)>> || B <- lists:seq(Start, Start + Len - 1)>>.
 
+%% The buffer is an ordered tree; tests build and compare it as a map
+%% so the fixtures stay readable.
+tree(Map) ->
+    gb_trees:from_orddict(lists:sort(maps:to_list(Map))).
+
 extract(Buffer, Offset) ->
-    quic_connection:extract_contiguous_data(Buffer, Offset).
+    {Data, Off, Rest} = quic_connection:extract_contiguous_data(tree(Buffer), Offset),
+    {Data, Off, maps:from_list(gb_trees:to_list(Rest))}.
 
 trim(Buffer, Offset) ->
-    quic_connection:trim_reassembly_buffer(Buffer, Offset).
+    maps:from_list(gb_trees:to_list(quic_connection:trim_reassembly_buffer(tree(Buffer), Offset))).
 
 %%====================================================================
 %% Extraction
@@ -91,6 +97,21 @@ trim_is_idempotent_test() ->
 trim_leaves_future_chunks_untouched_test() ->
     Buffer = #{800 => chunk(800, 100), 900 => chunk(900, 100)},
     ?assertEqual(Buffer, trim(Buffer, 800)).
+
+%% The walk stops at the delivery point: with a large hole and many
+%% chunks buffered above it, a miss at the hole is answered without
+%% rebuilding the buffer (the returned tree is the input, unchanged).
+gap_below_a_large_buffer_is_answered_without_a_walk_test() ->
+    Above = tree(maps:from_list([{Off, chunk(Off, 100)} || Off <- lists:seq(1000, 100000, 100)])),
+    ?assertMatch({<<>>, 500, Above}, quic_connection:extract_contiguous_data(Above, 500)).
+
+%% With one straddling chunk below the point, only that chunk is
+%% touched; the chunks above come back as they were.
+trim_touches_only_chunks_below_the_point_test() ->
+    Above = [{Off, chunk(Off, 100)} || Off <- lists:seq(1000, 5000, 100)],
+    Buffer = maps:from_list([{300, chunk(300, 400)} | Above]),
+    Expected = maps:from_list([{500, chunk(500, 200)} | Above]),
+    ?assertEqual(Expected, trim(Buffer, 500)).
 
 %%====================================================================
 %% Randomised: any fragmentation of a known stream reassembles to it

--- a/test/quic_record_app_recv_tests.erl
+++ b/test/quic_record_app_recv_tests.erl
@@ -1,0 +1,47 @@
+%% record_app_recv/4 fuses the three per-packet receive updates of the
+%% 1-RTT hot path (PN space, spin bit, activity stamp) into one state
+%% rebuild. It must stay observably identical to running the three
+%% helpers in sequence, which these tests check over random packet
+%% sequences for every role and spin-bit setting.
+-module(quic_record_app_recv_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+reference(FirstByte, PN, State, Now) ->
+    S1 = quic_connection:record_received_pn(app, PN, State, Now),
+    S2 = quic_connection:update_spin_from_recv(FirstByte, PN, S1),
+    quic_connection:update_last_activity(S2, Now).
+
+%% Short-header first byte with the spin bit set or clear.
+first_byte(Spin) -> 16#40 bor (Spin bsl 5).
+
+run(Role, SpinEnabled, Seed) ->
+    rand:seed(exsplus, {Seed, Seed * 3 + 1, Seed * 5 + 2}),
+    S0 = quic_connection:test_app_recv_state(Role, SpinEnabled),
+    lists:foldl(
+        fun(I, {Fused, Ref}) ->
+            %% Mostly sequential with occasional reordering and duplicates.
+            PN =
+                case rand:uniform(10) of
+                    1 -> max(0, I - rand:uniform(4));
+                    2 -> I + rand:uniform(3);
+                    _ -> I
+                end,
+            FB = first_byte(rand:uniform(2) - 1),
+            Now = 1000 + I,
+            NewFused = quic_connection:record_app_recv(FB, PN, Fused, Now),
+            NewRef = reference(FB, PN, Ref, Now),
+            ?assertEqual(NewRef, NewFused),
+            {NewFused, NewRef}
+        end,
+        {S0, S0},
+        lists:seq(0, 200)
+    ).
+
+fused_matches_reference_test_() ->
+    [
+        {lists:flatten(io_lib:format("~p spin=~p seed=~p", [Role, Spin, Seed])), fun() ->
+            run(Role, Spin, Seed)
+        end}
+     || Role <- [client, server], Spin <- [true, false], Seed <- lists:seq(1, 5)
+    ].

--- a/test/quic_recv_drain_tests.erl
+++ b/test/quic_recv_drain_tests.erl
@@ -75,3 +75,21 @@ leaves_the_mailbox_alone_once_closing_test() ->
     S = quic_connection:test_state_closing(S0, {application, 0, <<"bye">>}),
     ?assertEqual(S, quic_connection:drain_recv_msgs(S, 64)),
     ?assertEqual(1, length(mailbox())).
+
+%% The same-source collection must keep mailbox order across both
+%% message shapes: a single datagram queued behind a GRO train belongs
+%% after it, not in front of it. Taking one shape at a time would
+%% reorder the wire.
+client_collect_keeps_mailbox_order_test() ->
+    flush_mailbox(),
+    Sock = sock,
+    self() ! {udp_batch, Sock, {127, 0, 0, 1}, 4433, [garbage(2), garbage(3)]},
+    self() ! {udp, Sock, {127, 0, 0, 1}, 4433, garbage(4)},
+    self() ! {udp_batch, Sock, {127, 0, 0, 1}, 4433, [garbage(5)]},
+    self() ! {other, event},
+    {Datagrams, Left} = quic_connection:collect_client_udp(Sock, {127, 0, 0, 1}, 4433, 64, [
+        garbage(1)
+    ]),
+    ?assertEqual([garbage(I) || I <- lists:seq(1, 5)], Datagrams),
+    ?assertEqual(61, Left),
+    ?assertEqual([{other, event}], mailbox()).

--- a/test/quic_recv_drain_tests.erl
+++ b/test/quic_recv_drain_tests.erl
@@ -1,0 +1,77 @@
+%% drain_recv_msgs/2 pulls datagram messages already queued in the
+%% connection's mailbox into the current receive pass, so the ACK,
+%% socket-batch and timer flushes at the end of the pass amortize over
+%% the whole train. These tests pin its contract: only datagram
+%% messages are taken, in order, up to the cap, and never once a close
+%% has been initiated.
+-module(quic_recv_drain_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ADDR, {{127, 0, 0, 1}, 4433}).
+
+%% An undecryptable short-header packet: parsed and discarded by the
+%% receive path without touching the (absent) keys.
+garbage(I) ->
+    <<1:1, 0:1, 0:6, I:8, 0:(40 * 8)>>.
+
+server_state() ->
+    quic_connection:test_state_for_server(?ADDR, undefined, <<>>).
+
+client_state() ->
+    quic_connection:test_state_for_client(?ADDR).
+
+flush_mailbox() ->
+    receive
+        _ -> flush_mailbox()
+    after 0 -> ok
+    end.
+
+mailbox() ->
+    {messages, Msgs} = process_info(self(), messages),
+    Msgs.
+
+drains_queued_server_datagrams_test() ->
+    flush_mailbox(),
+    self() ! {quic_packet, garbage(1), ?ADDR},
+    self() ! {quic_packets, [garbage(2), garbage(3)], ?ADDR},
+    self() ! {other, event},
+    self() ! {quic_packet, garbage(4), ?ADDR},
+    _ = quic_connection:drain_recv_msgs(server_state(), 64),
+    ?assertEqual([{other, event}], mailbox()).
+
+drains_queued_client_datagrams_test() ->
+    flush_mailbox(),
+    %% The drain matches on the state's socket, and the client path
+    %% re-arms {active, N} on it after each datagram.
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    S = quic_connection:test_state_with_socket(client_state(), Sock),
+    self() ! {udp, Sock, {127, 0, 0, 1}, 4433, garbage(1)},
+    self() ! {udp_batch, Sock, {127, 0, 0, 1}, 4433, [garbage(2), garbage(3)]},
+    self() ! {timeout, ref, idle},
+    _ = quic_connection:drain_recv_msgs(S, 64),
+    gen_udp:close(Sock),
+    ?assertEqual([{timeout, ref, idle}], mailbox()).
+
+stops_at_the_cap_test() ->
+    flush_mailbox(),
+    [self() ! {quic_packet, garbage(I), ?ADDR} || I <- lists:seq(1, 10)],
+    _ = quic_connection:drain_recv_msgs(server_state(), 4),
+    Left = mailbox(),
+    ?assertEqual(6, length(Left)),
+    %% Oldest first: the cap leaves the tail of the queue.
+    ?assertEqual({quic_packet, garbage(5), ?ADDR}, hd(Left)).
+
+zero_cap_takes_nothing_test() ->
+    flush_mailbox(),
+    self() ! {quic_packet, garbage(1), ?ADDR},
+    _ = quic_connection:drain_recv_msgs(server_state(), 0),
+    ?assertEqual(1, length(mailbox())).
+
+leaves_the_mailbox_alone_once_closing_test() ->
+    flush_mailbox(),
+    self() ! {quic_packet, garbage(1), ?ADDR},
+    S0 = server_state(),
+    S = quic_connection:test_state_closing(S0, {application, 0, <<"bye">>}),
+    ?assertEqual(S, quic_connection:drain_recv_msgs(S, 64)),
+    ?assertEqual(1, length(mailbox())).

--- a/test/quic_recv_pass_ack_tests.erl
+++ b/test/quic_recv_pass_ack_tests.erl
@@ -1,0 +1,52 @@
+%% Inside a connected-state receive pass, count-based ACK decimation
+%% only counts; finish_recv_pass/1 then emits one ACK for the whole
+%% train. Without this a 64-packet drain pass emitted an ACK every
+%% ack_packet_tolerance packets, and the ACK machinery on both ends
+%% ate a large share of the CPU on bulk flows.
+-module(quic_recv_pass_ack_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+in_pass(S) -> quic_connection:test_state_in_recv_pass(S).
+
+steps(S, 0) ->
+    S;
+steps(S, N) ->
+    {S1, _} = quic_connection:test_decimate_step(S),
+    steps(S1, N - 1).
+
+no_flush_inside_a_pass_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    %% Well past the tolerance (2): still counting, timer armed.
+    {_S, Info} = quic_connection:test_decimate_step(steps(S0, 7)),
+    ?assertMatch(#{ack_elicited_count := 8, ack_timer_armed := true}, Info).
+
+one_ack_at_pass_end_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    S1 = steps(S0, 8),
+    {_S2, Info} = quic_connection:test_finish_recv_pass(S1),
+    ?assertMatch(
+        #{ack_elicited_count := 0, ack_timer_armed := false, recv_pass := false}, Info
+    ).
+
+below_tolerance_keeps_the_timer_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    S1 = steps(S0, 1),
+    {_S2, Info} = quic_connection:test_finish_recv_pass(S1),
+    ?assertMatch(
+        #{ack_elicited_count := 1, ack_timer_armed := true, recv_pass := false}, Info
+    ).
+
+no_ack_when_the_pass_started_a_close_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    S1 = quic_connection:test_state_closing(steps(S0, 4), {application, 0, <<>>}),
+    {_S2, Info} = quic_connection:test_finish_recv_pass(S1),
+    ?assertMatch(#{ack_elicited_count := 4, recv_pass := false}, Info).
+
+decimation_resumes_after_the_pass_test() ->
+    S0 = in_pass(quic_connection:test_decimate_initial_state()),
+    {S1, _} = quic_connection:test_finish_recv_pass(steps(S0, 3)),
+    %% Outside a pass the tolerance applies again: two packets flush.
+    {S2, _} = quic_connection:test_decimate_step(S1),
+    {_S3, Info} = quic_connection:test_decimate_step(S2),
+    ?assertMatch(#{ack_elicited_count := 0, ack_timer_armed := false}, Info).

--- a/test/quic_recv_queue_bound_tests.erl
+++ b/test/quic_recv_queue_bound_tests.erl
@@ -1,0 +1,81 @@
+%% The socket-backend receive paths (listener and client receiver)
+%% emulate a bounded kernel receive buffer: a train is forwarded in
+%% chunks so the mailbox bound caps queued packets, not just messages,
+%% and once the connection's mailbox is over the bound the train is
+%% tail-dropped. The listener keeps the head packet so the peer still
+%% gets a timely (dup-)ACK carrying the loss signal.
+-module(quic_recv_queue_bound_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(ADDR, {{127, 0, 0, 1}, 4433}).
+
+packets(N) ->
+    [<<I:16, 0:(1000 * 8)>> || I <- lists:seq(1, N)].
+
+%% A process that never reads its mailbox, optionally pre-filled.
+sink(Backlog) ->
+    Pid = spawn_link(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    [Pid ! {noise, I} || I <- lists:seq(1, Backlog)],
+    Pid.
+
+drain(Pid, Tag) ->
+    {messages, Msgs} = process_info(Pid, messages),
+    [M || M <- Msgs, element(1, M) =:= Tag].
+
+listener_forwards_single_packet_as_is_test() ->
+    Pid = sink(0),
+    [P] = packets(1),
+    ok = quic_listener:send_packets_to_connection(Pid, [P], ?ADDR),
+    ?assertEqual([{quic_packet, P, ?ADDR}], drain(Pid, quic_packet)),
+    ?assertEqual([], drain(Pid, quic_packets)).
+
+listener_chunks_a_train_test() ->
+    Pid = sink(0),
+    Ps = packets(2 * ?MAX_PACKETS_PER_CONN_MSG + 3),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    Msgs = drain(Pid, quic_packets),
+    Sizes = [length(Chunk) || {quic_packets, Chunk, _} <- Msgs],
+    ?assertEqual([?MAX_PACKETS_PER_CONN_MSG, ?MAX_PACKETS_PER_CONN_MSG, 3], Sizes),
+    %% Order and content survive the split.
+    ?assertEqual(Ps, lists:append([Chunk || {quic_packets, Chunk, _} <- Msgs])).
+
+listener_tail_drops_over_the_bound_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    Ps = packets(5),
+    Before = quic_listener:recv_drops(),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ?assertEqual([{quic_packet, hd(Ps), ?ADDR}], drain(Pid, quic_packet)),
+    ?assertEqual([], drain(Pid, quic_packets)),
+    ?assertEqual(Before + 4, quic_listener:recv_drops()).
+
+listener_at_the_bound_still_forwards_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS),
+    Ps = packets(3),
+    Before = quic_listener:recv_drops(),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ?assertEqual([{quic_packets, Ps, ?ADDR}], drain(Pid, quic_packets)),
+    ?assertEqual(Before, quic_listener:recv_drops()).
+
+client_forwards_a_train_as_one_message_test() ->
+    Pid = sink(0),
+    Ps = packets(4),
+    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, Ps),
+    ?assertEqual([{udp_batch, sock, {127, 0, 0, 1}, 4433, Ps}], drain(Pid, udp_batch)),
+    [P] = packets(1),
+    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, [P]),
+    ?assertEqual([{udp, sock, {127, 0, 0, 1}, 4433, P}], drain(Pid, udp)).
+
+client_tail_drops_over_the_bound_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    Ps = packets(6),
+    Before = quic_socket:client_recv_drops(),
+    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, Ps),
+    ?assertEqual([], drain(Pid, udp_batch)),
+    ?assertEqual([], drain(Pid, udp)),
+    ?assertEqual(Before + 6, quic_socket:client_recv_drops()).

--- a/test/quic_recv_queue_bound_tests.erl
+++ b/test/quic_recv_queue_bound_tests.erl
@@ -3,7 +3,9 @@
 %% chunks so the mailbox bound caps queued packets, not just messages,
 %% and once the connection's mailbox is over the bound the train is
 %% tail-dropped. The listener keeps the head packet so the peer still
-%% gets a timely (dup-)ACK carrying the loss signal.
+%% gets a timely (dup-)ACK carrying the loss signal. The bound is the
+%% receiver's flow-control window in packets, floored, so a peer inside
+%% its window is never dropped.
 -module(quic_recv_queue_bound_tests).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -31,14 +33,14 @@ drain(Pid, Tag) ->
 listener_forwards_single_packet_as_is_test() ->
     Pid = sink(0),
     [P] = packets(1),
-    ok = quic_listener:send_packets_to_connection(Pid, [P], ?ADDR),
+    ok = quic_listener:send_packets_to_connection(Pid, [P], ?ADDR, ?MAX_CONN_RECV_QUEUE_MSGS),
     ?assertEqual([{quic_packet, P, ?ADDR}], drain(Pid, quic_packet)),
     ?assertEqual([], drain(Pid, quic_packets)).
 
 listener_chunks_a_train_test() ->
     Pid = sink(0),
     Ps = packets(2 * ?MAX_PACKETS_PER_CONN_MSG + 3),
-    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR, ?MAX_CONN_RECV_QUEUE_MSGS),
     Msgs = drain(Pid, quic_packets),
     Sizes = [length(Chunk) || {quic_packets, Chunk, _} <- Msgs],
     ?assertEqual([?MAX_PACKETS_PER_CONN_MSG, ?MAX_PACKETS_PER_CONN_MSG, 3], Sizes),
@@ -49,7 +51,7 @@ listener_tail_drops_over_the_bound_test() ->
     Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
     Ps = packets(5),
     Before = quic_listener:recv_drops(),
-    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR, ?MAX_CONN_RECV_QUEUE_MSGS),
     ?assertEqual([{quic_packet, hd(Ps), ?ADDR}], drain(Pid, quic_packet)),
     ?assertEqual([], drain(Pid, quic_packets)),
     ?assertEqual(Before + 4, quic_listener:recv_drops()).
@@ -58,24 +60,57 @@ listener_at_the_bound_still_forwards_test() ->
     Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS),
     Ps = packets(3),
     Before = quic_listener:recv_drops(),
-    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR, ?MAX_CONN_RECV_QUEUE_MSGS),
     ?assertEqual([{quic_packets, Ps, ?ADDR}], drain(Pid, quic_packets)),
     ?assertEqual(Before, quic_listener:recv_drops()).
 
 client_forwards_a_train_as_one_message_test() ->
     Pid = sink(0),
     Ps = packets(4),
-    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, Ps),
+    ok = quic_socket:forward_to_owner(
+        Pid, sock, {127, 0, 0, 1}, 4433, Ps, ?MAX_CONN_RECV_QUEUE_MSGS
+    ),
     ?assertEqual([{udp_batch, sock, {127, 0, 0, 1}, 4433, Ps}], drain(Pid, udp_batch)),
     [P] = packets(1),
-    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, [P]),
+    ok = quic_socket:forward_to_owner(
+        Pid, sock, {127, 0, 0, 1}, 4433, [P], ?MAX_CONN_RECV_QUEUE_MSGS
+    ),
     ?assertEqual([{udp, sock, {127, 0, 0, 1}, 4433, P}], drain(Pid, udp)).
 
 client_tail_drops_over_the_bound_test() ->
     Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
     Ps = packets(6),
     Before = quic_socket:client_recv_drops(),
-    ok = quic_socket:forward_to_owner(Pid, sock, {127, 0, 0, 1}, 4433, Ps),
+    ok = quic_socket:forward_to_owner(
+        Pid, sock, {127, 0, 0, 1}, 4433, Ps, ?MAX_CONN_RECV_QUEUE_MSGS
+    ),
     ?assertEqual([], drain(Pid, udp_batch)),
     ?assertEqual([], drain(Pid, udp)),
     ?assertEqual(Before + 6, quic_socket:client_recv_drops()).
+
+bound_is_the_window_in_packets_floored_test() ->
+    ?assertEqual(?MAX_CONN_RECV_QUEUE_MSGS, quic_socket:recv_queue_max(0)),
+    ?assertEqual(
+        ?MAX_CONN_RECV_QUEUE_MSGS,
+        quic_socket:recv_queue_max(?MAX_CONN_RECV_QUEUE_MSGS * ?RECV_QUEUE_PACKET_BYTES)
+    ),
+    Window = 16 * 1024 * 1024,
+    ?assertEqual(Window div ?RECV_QUEUE_PACKET_BYTES, quic_socket:recv_queue_max(Window)).
+
+listener_honours_a_wider_bound_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    Ps = packets(3),
+    Before = quic_listener:recv_drops(),
+    ok = quic_listener:send_packets_to_connection(Pid, Ps, ?ADDR, ?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    ?assertEqual([{quic_packets, Ps, ?ADDR}], drain(Pid, quic_packets)),
+    ?assertEqual(Before, quic_listener:recv_drops()).
+
+client_honours_a_wider_bound_test() ->
+    Pid = sink(?MAX_CONN_RECV_QUEUE_MSGS + 1),
+    Ps = packets(2),
+    Before = quic_socket:client_recv_drops(),
+    ok = quic_socket:forward_to_owner(
+        Pid, sock, {127, 0, 0, 1}, 4433, Ps, ?MAX_CONN_RECV_QUEUE_MSGS + 1
+    ),
+    ?assertEqual([{udp_batch, sock, {127, 0, 0, 1}, 4433, Ps}], drain(Pid, udp_batch)),
+    ?assertEqual(Before, quic_socket:client_recv_drops()).

--- a/test/quic_send_run_bookkeeping_tests.erl
+++ b/test/quic_send_run_bookkeeping_tests.erl
@@ -1,0 +1,92 @@
+%% The batched send-side primitives the chunk-run sender uses must
+%% agree with their per-packet counterparts: send_check_run/4 with
+%% sequential send_check/3 calls that account each packet as sent,
+%% on_packets_sent/2 with a fold of on_packet_sent/2, and
+%% on_packets_sent_run/3 with a fold of on_packet_sent/6.
+-module(quic_send_run_bookkeeping_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MDS, 1200).
+
+newreno(Cwnd) ->
+    quic_cc_newreno:new(#{max_datagram_size => ?MDS, initial_window => Cwnd}).
+
+%% The honest per-packet reference: check, then account the packet as
+%% sent before the next check, as the one-at-a-time send path does.
+sequential_checks(_State, _Size, 0, _Urgency, K) ->
+    K;
+sequential_checks(State, Size, Left, Urgency, K) ->
+    case quic_cc_newreno:send_check(State, Size, Urgency) of
+        {ok, S1} ->
+            sequential_checks(
+                quic_cc_newreno:on_packet_sent(S1, Size), Size, Left - 1, Urgency, K + 1
+            );
+        _ ->
+            K
+    end.
+
+%% Unpaced: the batch approves exactly what cwnd allows and leaves the
+%% state untouched.
+unpaced_run_matches_cwnd_test() ->
+    S = newreno(10 * ?MDS),
+    ?assertEqual({10, S}, quic_cc_newreno:send_check_run(S, ?MDS, 64, 1)),
+    ?assertEqual(10, sequential_checks(S, ?MDS, 64, 1, 0)),
+    ?assertEqual({4, S}, quic_cc_newreno:send_check_run(S, ?MDS, 4, 1)),
+    %% Control urgency gets the allowance on top of cwnd.
+    {KCtl, _} = quic_cc_newreno:send_check_run(S, ?MDS, 64, 0),
+    ?assertEqual(sequential_checks(S, ?MDS, 64, 0, 0), KCtl).
+
+nothing_fits_test() ->
+    S0 = newreno(3 * ?MDS),
+    S = quic_cc_newreno:on_packet_sent(S0, 3 * ?MDS),
+    ?assertEqual({0, S}, quic_cc_newreno:send_check_run(S, ?MDS, 8, 1)),
+    ?assertEqual(0, sequential_checks(S, ?MDS, 8, 1, 0)).
+
+%% Paced with a saturated bucket: the batch approves what the bucket
+%% holds, never more than the sequential path would.
+paced_run_is_bounded_by_the_bucket_test() ->
+    S0 = quic_cc_newreno:update_pacing_rate(newreno(400 * ?MDS), 50),
+    %% Let the bucket fill to its burst ceiling.
+    timer:sleep(50),
+    {KRun, _} = quic_cc_newreno:send_check_run(S0, ?MDS, 400, 1),
+    KSeq = sequential_checks(S0, ?MDS, 400, 1, 0),
+    ?assert(KRun > 0),
+    ?assert(KRun =< KSeq),
+    %% The sequential loop refills between iterations, so it can approve
+    %% a few more than the batch did; how many depends on how long the
+    %% loop took on this machine. Bound it loosely: the point is that the
+    %% batch tracks the bucket, not that it matches to the packet.
+    ?assert(KSeq - KRun =< 32).
+
+on_packets_sent_matches_fold_test() ->
+    %% A zero-byte send stamps first_sent_time, so both paths are
+    %% deterministic from here on.
+    S0 = quic_cc_newreno:on_packet_sent(newreno(64 * ?MDS), 0),
+    Sizes = [1200, 1200, 900, 1200],
+    Fold = lists:foldl(fun(Sz, Acc) -> quic_cc_newreno:on_packet_sent(Acc, Sz) end, S0, Sizes),
+    ?assertEqual(Fold, quic_cc_newreno:on_packets_sent(S0, Sizes)),
+    ?assertEqual(4500, quic_cc_newreno:bytes_in_flight(Fold)),
+    ?assertEqual(S0, quic_cc_newreno:on_packets_sent(S0, [])).
+
+loss_run_matches_fold_test() ->
+    L0 = quic_loss:new(),
+    Now = 12345,
+    Tracked = [
+        {7, 1200, {stream, 4, 0, <<"a">>, false}},
+        {8, 1200, {stream, 4, 1200, <<"b">>, false}}
+    ],
+    Fold = lists:foldl(
+        fun({PN, Sz, Fr}, Acc) -> quic_loss:on_packet_sent(Acc, PN, Sz, true, [Fr], Now) end,
+        L0,
+        Tracked
+    ),
+    ?assertEqual(Fold, quic_loss:on_packets_sent_run(L0, Tracked, Now)),
+    %% With bytes already outstanding, outstanding_since is kept.
+    L1 = quic_loss:on_packet_sent(L0, 1, 500, true, [], 100),
+    Fold1 = lists:foldl(
+        fun({PN, Sz, Fr}, Acc) -> quic_loss:on_packet_sent(Acc, PN, Sz, true, [Fr], Now) end,
+        L1,
+        Tracked
+    ),
+    ?assertEqual(Fold1, quic_loss:on_packets_sent_run(L1, Tracked, Now)).

--- a/test/quic_shared_sender_tests.erl
+++ b/test/quic_shared_sender_tests.erl
@@ -1,0 +1,93 @@
+%% Server connections on the socket backend hand their finished send
+%% batches to one shared sender process that performs the sendmsg
+%% calls serially: concurrent sendmsg on one socket handle burns most
+%% of its CPU in NIF-level contention. The connection keeps its batch
+%% buffer, GSO grouping and counters; only the syscall moves.
+-module(quic_shared_sender_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ADDR, {127, 0, 0, 1}).
+
+conn_sender(SenderPid) ->
+    {ok, SS} = quic_socket:new_sender(fake_socket, #{
+        backend => socket, sender_pid => SenderPid, batching => #{max_packets => 64}
+    }),
+    SS.
+
+flush_hands_the_batch_over_test() ->
+    SS0 = conn_sender(self()),
+    {ok, SS1} = quic_socket:send(SS0, ?ADDR, 4433, <<"p1">>),
+    {ok, SS2} = quic_socket:send(SS1, ?ADDR, 4433, <<"p2">>),
+    {ok, SS3} = quic_socket:send(SS2, ?ADDR, 4433, <<"p3">>),
+    {ok, SS4} = quic_socket:flush(SS3),
+    receive
+        {send_batch, {?ADDR, 4433}, Buffer, 3} ->
+            ?assertEqual([<<"p1">>, <<"p2">>, <<"p3">>], lists:reverse(Buffer))
+    after 100 ->
+        ?assert(false)
+    end,
+    Info = quic_socket:info(SS4),
+    ?assertMatch(#{batch_pending := 0, batch_flushes := 1, packets_coalesced := 3}, Info).
+
+empty_batch_is_not_handed_over_test() ->
+    SS0 = conn_sender(self()),
+    {ok, _} = quic_socket:flush(SS0),
+    receive
+        {send_batch, _, _, _} -> ?assert(false)
+    after 20 ->
+        ok
+    end.
+
+%% A dead sender turns the connection back into a direct sender for
+%% good; the packets still go out (here: nowhere, on a closed socket,
+%% which is what the error path covers) rather than into a dead mailbox.
+dead_sender_falls_back_to_direct_test() ->
+    Dead = spawn(fun() -> ok end),
+    timer:sleep(10),
+    {ok, Sock} = gen_udp:open(0, [binary]),
+    {ok, SS0} = quic_socket:new_sender(Sock, #{backend => gen_udp, sender_pid => Dead}),
+    {ok, SS1} = quic_socket:send(SS0, ?ADDR, 4433, <<"p1">>),
+    {ok, SS2} = quic_socket:flush(SS1),
+    ?assertMatch(#{batch_pending := 0, batch_flushes := 1}, quic_socket:info(SS2)),
+    %% The next batch goes direct without consulting the dead pid.
+    {ok, SS3} = quic_socket:send(SS2, ?ADDR, 4433, <<"p2">>),
+    {ok, SS4} = quic_socket:flush(SS3),
+    ?assertMatch(#{batch_flushes := 2}, quic_socket:info(SS4)),
+    gen_udp:close(Sock).
+
+%% End to end on a real socket-backend socket: batches handed to the
+%% shared sender reach the wire, in order.
+shared_sender_sends_on_the_wire_test() ->
+    case quic_socket:open(0, #{}) of
+        {ok, SS} ->
+            case quic_socket:info(SS) of
+                #{backend := socket} -> wire_roundtrip(SS);
+                _ -> quic_socket:close(SS)
+            end;
+        _ ->
+            ok
+    end.
+
+wire_roundtrip(ListenerSS) ->
+    {ok, Recv} = gen_udp:open(0, [binary, {active, true}]),
+    {ok, RecvPort} = inet:port(Recv),
+    {Sender, Counter} = quic_socket:start_shared_sender(ListenerSS),
+    {ok, {_, _}} = quic_socket:sockname(ListenerSS),
+    {ok, Conn0} = quic_socket:new_sender(quic_socket:test_socket(ListenerSS), #{
+        backend => socket, sender_pid => Sender, gso_counter => Counter
+    }),
+    {ok, Conn1} = quic_socket:send(Conn0, ?ADDR, RecvPort, <<"one">>),
+    {ok, Conn2} = quic_socket:send(Conn1, ?ADDR, RecvPort, <<"two">>),
+    {ok, _} = quic_socket:flush(Conn2),
+    Got = [
+        receive
+            {udp, Recv, _, _, D} -> D
+        after 1000 -> timeout
+        end
+     || _ <- [1, 2]
+    ],
+    ?assertEqual([<<"one">>, <<"two">>], Got),
+    Sender ! stop,
+    gen_udp:close(Recv),
+    quic_socket:close(ListenerSS).

--- a/test/quic_stream_recv_fast_path_tests.erl
+++ b/test/quic_stream_recv_fast_path_tests.erl
@@ -1,0 +1,156 @@
+%% The receive side has lean paths for the dominant bulk shape; each
+%% must be observably identical to the general path it shortcuts.
+-module(quic_stream_recv_fast_path_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(SID, 4).
+-define(WIN, ?DEFAULT_MAX_RECEIVE_WINDOW).
+
+%%--------------------------------------------------------------------
+%% Stream data: lean clause vs the general path
+%%--------------------------------------------------------------------
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+messages() ->
+    {messages, Msgs} = process_info(self(), messages),
+    Msgs.
+
+%% Run both paths on the same input and return {State, Messages} each.
+both(S, Offset, Data, Fin) ->
+    flush(),
+    Lean = quic_connection:do_process_stream_data_buffered(?SID, Offset, Data, Fin, S),
+    LeanMsgs = messages(),
+    flush(),
+    Slow = quic_connection:do_process_stream_data_slow(?SID, Offset, Data, Fin, S),
+    SlowMsgs = messages(),
+    flush(),
+    {{Lean, LeanMsgs}, {Slow, SlowMsgs}}.
+
+in_order_bulk_frame_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    Data = binary:copy(<<"d">>, 1200),
+    {L, R} = both(S, 5000, Data, false),
+    ?assertEqual(R, L),
+    {_, Msgs} = L,
+    ?assertEqual([{quic, self(), {stream_data, ?SID, Data, false}}], Msgs).
+
+%% A run of in-order frames threads identically through both paths.
+in_order_run_test() ->
+    S0 = quic_connection:test_recv_stream_state(?SID, 0, ?WIN, 2 * ?WIN),
+    Data = binary:copy(<<"r">>, 1000),
+    {Lean, Slow} = lists:foldl(
+        fun(I, {L, R}) ->
+            flush(),
+            L1 = quic_connection:do_process_stream_data_buffered(?SID, I * 1000, Data, false, L),
+            R1 = quic_connection:do_process_stream_data_slow(?SID, I * 1000, Data, false, R),
+            {L1, R1}
+        end,
+        {S0, S0},
+        lists:seq(0, 50)
+    ),
+    flush(),
+    ?assertEqual(Slow, Lean).
+
+%% Shapes the lean clause must hand to the general path: a gap, a
+%% duplicate, a FIN, an empty frame, an unknown stream. All wide-window,
+%% so the general path emits no flow-control frame either way.
+out_of_order_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 6200, binary:copy(<<"o">>, 1200), false),
+    ?assertEqual(R, L).
+
+duplicate_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 4000, binary:copy(<<"u">>, 1000), false),
+    ?assertEqual(R, L).
+
+fin_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 5000, binary:copy(<<"f">>, 100), true),
+    ?assertEqual(R, L).
+
+empty_frame_test() ->
+    S = quic_connection:test_recv_stream_state(?SID, 5000, ?WIN, 2 * ?WIN),
+    {L, R} = both(S, 5000, <<>>, false),
+    ?assertEqual(R, L).
+
+%%--------------------------------------------------------------------
+%% PN space: sequential packets skip the ACK-range cap scan
+%%--------------------------------------------------------------------
+
+%% The pre-optimisation update: always run the cap.
+reference_pn_space_recv(PN, PNSpace, Now) ->
+    #pn_space{largest_recv = LargestRecv, ack_ranges = Ranges} = PNSpace,
+    NewLargest =
+        case LargestRecv of
+            undefined -> PN;
+            L when PN > L -> PN;
+            L -> L
+        end,
+    PNSpace#pn_space{
+        largest_recv = NewLargest,
+        recv_time = Now,
+        ack_ranges = quic_connection:cap_ack_ranges(quic_connection:add_to_ack_ranges(PN, Ranges))
+    }.
+
+empty_pn_space() ->
+    #pn_space{
+        next_pn = 0,
+        largest_acked = undefined,
+        largest_recv = undefined,
+        recv_time = undefined,
+        ack_ranges = [],
+        ack_eliciting_in_flight = 0,
+        loss_time = undefined,
+        sent_packets = #{}
+    }.
+
+pn_space_matches_reference_test_() ->
+    [
+        {"seed " ++ integer_to_list(Seed), fun() -> pn_space_run(Seed) end}
+     || Seed <- lists:seq(1, 10)
+    ].
+
+pn_space_run(Seed) ->
+    rand:seed(exsplus, {Seed, Seed * 11 + 3, Seed * 17 + 5}),
+    lists:foldl(
+        fun(I, {New, Ref}) ->
+            %% Enough gaps to overflow ?MAX_ACK_RANGES, so the cap
+            %% actually bites on the reordered packets.
+            PN =
+                case rand:uniform(3) of
+                    1 -> I * 2;
+                    _ -> I * 2 + 1
+                end,
+            New1 = quic_connection:update_pn_space_recv(PN, New, I),
+            Ref1 = reference_pn_space_recv(PN, Ref, I),
+            ?assertEqual(Ref1, New1),
+            {New1, Ref1}
+        end,
+        {empty_pn_space(), empty_pn_space()},
+        lists:seq(0, 400)
+    ).
+
+%%--------------------------------------------------------------------
+%% Delayed ACK: a leading stream frame never qualifies
+%%--------------------------------------------------------------------
+
+stream_frame_first_is_never_delayed_test() ->
+    Stream = {stream, ?SID, 0, <<"x">>, false},
+    ?assertNot(quic_connection:should_delay_ack([Stream])),
+    ?assertNot(quic_connection:should_delay_ack([Stream, {datagram, <<"d">>}])).
+
+datagram_only_is_delayed_test() ->
+    ?assert(quic_connection:should_delay_ack([{datagram, <<"d">>}])),
+    ?assert(quic_connection:should_delay_ack([padding, {datagram, <<"d">>}])),
+    %% A stream frame after a datagram: the general clause finds it.
+    ?assertNot(
+        quic_connection:should_delay_ack([{datagram, <<"d">>}, {stream, ?SID, 0, <<"x">>, false}])
+    ).

--- a/test/quic_stream_train_tests.erl
+++ b/test/quic_stream_train_tests.erl
@@ -1,0 +1,126 @@
+%% A batch-opened run whose packets continue the receive sequence and
+%% carry one stream frame each, same stream, contiguous offsets, no
+%% FIN, is folded with one bookkeeping pass. The observable outcome
+%% must equal the per-packet path: same delivered bytes in the same
+%% order, same stream offset, same PN space, same ACK accounting.
+-module(quic_stream_train_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+-define(SID, 4).
+-define(WIN, ?DEFAULT_MAX_RECEIVE_WINDOW).
+-define(FB, 16#40).
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+messages() ->
+    {messages, Msgs} = process_info(self(), messages),
+    [M || {quic, _, M} <- Msgs].
+
+state(Coalescing) ->
+    flush(),
+    S0 = quic_connection:test_recv_stream_state(?SID, 1000, ?WIN, 2 * ?WIN),
+    S1 = quic_connection:test_add_recv_stream(S0, 8, ?WIN),
+    S2 = quic_connection:test_state_in_recv_pass(quic_connection:test_state_with_pn_app(S1, 9)),
+    quic_connection:test_state_coalescing(S2, Coalescing).
+
+%% Packets PN0.. with one stream frame each, Sid, from Off.
+train(PN0, Sid, Off, Sizes) ->
+    {Pkts, _} = lists:mapfoldl(
+        fun(Sz, {PN, O}) ->
+            {{PN, ?FB, [{stream, Sid, O, binary:copy(<<(PN rem 256)>>, Sz), false}]}, {
+                PN + 1, O + Sz
+            }}
+        end,
+        {PN0, Off},
+        Sizes
+    ),
+    Pkts.
+
+%% Per-packet reference: receive bookkeeping, then the stream frame
+%% through the general path, then the counters the fold adds.
+reference(Results, S0) ->
+    S1 = lists:foldl(
+        fun({PN, FB, [{stream, Sid, Off, Data, Fin}]}, S) ->
+            SA = quic_connection:record_app_recv(FB, PN, S, 0),
+            quic_connection:do_process_stream_data_buffered(Sid, Off, Data, Fin, SA)
+        end,
+        S0,
+        Results
+    ),
+    S1.
+
+summary(S) ->
+    M = quic_connection:test_recv_summary(S, ?SID),
+    %% recv_time differs by construction; ranges/largest/offset/count matter.
+    M.
+
+contiguous_train_matches_reference_test() ->
+    S0 = state(true),
+    Results = train(10, ?SID, 1000, [1200, 1200, 1200, 700]),
+    Fold = quic_connection:fold_opened(Results, S0),
+    FoldMsgs = messages(),
+    Ref0 = reference(Results, state(true)),
+    RefMsgs = messages(),
+    %% The reference counts packets and ack-eliciting packets itself.
+    RefSum = (summary(Ref0))#{
+        packets_received := 4, ack_elicited_count := 4, has_non_probing_frame := true
+    },
+    ?assertEqual(RefSum, summary(Fold)),
+    ?assertEqual(RefMsgs, FoldMsgs),
+    ?assertEqual([], FoldMsgs),
+    ?assertMatch(
+        #{largest_recv := 13, ack_ranges := [{0, 13}], recv_offset := 5300, packets_received := 4},
+        summary(Fold)
+    ),
+    {?SID, Rev, false} = maps:get(pend_deliver, summary(Fold)),
+    ?assertEqual(
+        [
+            binary:copy(<<PN>>, Sz)
+         || {PN, Sz} <- lists:zip([10, 11, 12, 13], [1200, 1200, 1200, 700])
+        ],
+        lists:reverse(Rev)
+    ).
+
+train_without_coalescing_delivers_per_chunk_test() ->
+    S0 = state(false),
+    Results = train(10, ?SID, 1000, [500, 500, 500]),
+    Fold = quic_connection:fold_opened(Results, S0),
+    ?assertEqual(
+        [{stream_data, ?SID, binary:copy(<<PN>>, 500), false} || PN <- [10, 11, 12]],
+        messages()
+    ),
+    ?assertMatch(#{recv_offset := 2500, pend_deliver := none}, summary(Fold)).
+
+%% Shapes the train path must hand back: an offset gap, a second
+%% stream, a FIN. Each ends in the same state as the reference. (A
+%% packet-number gap takes the reordered path, whose immediate ACK
+%% needs a live connection; it is covered by the e2e suites.)
+deviating_shapes_match_reference_test_() ->
+    Gap = train(10, ?SID, 1000, [500]) ++ train(11, ?SID, 1700, [500]),
+    Mixed = train(10, ?SID, 1000, [500]) ++ train(11, 8, 0, [500]) ++ train(12, ?SID, 1500, [500]),
+    Fin = [{10, ?FB, [{stream, ?SID, 1000, <<"tail">>, true}]}],
+    [
+        {Name, fun() -> assert_shape(Results) end}
+     || {Name, Results} <- [
+            {"offset gap", Gap}, {"two streams", Mixed}, {"fin", Fin}
+        ]
+    ].
+
+assert_shape(Results) ->
+    S0 = state(true),
+    Fold = quic_connection:fold_opened(Results, S0),
+    FoldMsgs = messages(),
+    Ref = reference(Results, state(true)),
+    RefMsgs = messages(),
+    Sum = fun(S) ->
+        maps:without([packets_received, ack_elicited_count, has_non_probing_frame], summary(S))
+    end,
+    ?assertEqual(Sum(Ref), Sum(Fold)),
+    ?assertEqual(RefMsgs, FoldMsgs),
+    ?assertEqual(length(Results), maps:get(packets_received, summary(Fold))).


### PR DESCRIPTION
Supersedes #288, whose 25 commits are carried over unchanged with jbevemyr's authorship. Five commits are added on top: the NIF build moves to CMake and gains macOS and FreeBSD support, and three findings from the review of #288 are fixed.

## Build

`c_src/Makefile` was GNU make and used `ldd`, so the NIF built on Linux only. It is now a CMake build that resolves the ERTS headers and the same libcrypto OTP's own crypto NIF is linked against, and emits the per-platform link flags itself. A thin POSIX `c_src/Makefile` shim stays for erlang.mk, which runs it unconditionally when it exists.

Verified under qemu on FreeBSD 14.3 arm64 (base OpenSSL) and locally on macOS arm64 (MacPorts OpenSSL 3): the NIF builds with no warnings, loads, and the full eunit suite passes both with it loaded and with `QUIC_DISABLE_CRYPTO_NIF=1` (2514 tests each). For reference, the old Makefile under FreeBSD's bmake:

```
make: "c_src/Makefile" line 13: Unknown modifier "format("~ts/erts-~ts/include", [code"
```

The build stays best effort everywhere: no cmake, no toolchain or no OpenSSL headers prints a note, succeeds, and the library runs on the OTP crypto path.

## Fixes

**A client Initial flight larger than one datagram was truncated.** The receive sweep groups a flight's packets by their unknown DCID, and the group that starts the connection forwarded only its first packet; the rest were dropped and the handshake stalled until the client retransmitted. A chunked `x25519mlkem768` ClientHello makes this the normal case, and the sweep put it on the default `gen_udp` path. The regression test freezes the listener so both Initials land in one sweep and asserts both reach the connection; with the fix reverted it sees one packet instead of two.

**The AEAD context cache grew without bound and could raise.** Every key update derives fresh keys and the cache kept a live `EVP_CIPHER_CTX` for each, so a long-lived bulk connection accumulated them until it exited. Only the current and previous key phase are ever live (RFC 9001 section 6), so the oldest are evicted. Separately, `{ok, Ctx} = quic_crypto_nif:new_aead_ctx(...)` was the one NIF call with no fallback: an unbuildable key killed the connection with a badmatch instead of taking the OTP path.

**The loader could make the module unloadable.** `code:priv_dir(quic)` answers `{error, _}` when the app is not resolvable, and passing that to `filename:join/2` crashed `on_load`, after which every caller died with `undef` rather than falling back. That defeats the point of an optional NIF.

**CI never proved the NIF was loaded.** The NIF tests skip themselves when it is missing, so a silent build failure would have turned six test modules into no-ops behind a green run. A new job asserts the shared object was built and loaded, then runs the suite with the NIF and with `QUIC_DISABLE_CRYPTO_NIF=1`.

Also documents the optional NIF, its two runtime opt-outs and the platforms it is verified on, plus `delivery_coalescing`, which shipped without an entry in the options reference.

Two limits worth stating: ChaCha20-Poly1305 connections keep only the per-packet acceleration, since the fused paths assume AES-ECB header protection, and the performance tables in #288 are Linux figures.
