### PR TITLE
Count PMTU black-hole strikes per loss event, cleared by a large ACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ All notable changes to this project will be documented in this file.
   for new connections.
 
 ### Fixed
+- PMTU black-hole detection counts loss events, not lost packets, and a
+  large packet acknowledged in between clears the count. It counted every
+  large packet declared lost and, once the search had completed, nothing
+  ever reset it, so a single burst loss of six or more full-size packets
+  on a healthy path (a qdisc dropping one GSO super-packet, a small
+  receiver socket buffer) dropped the path MTU to 1200 for the rest of
+  the connection: about 15 % more packets for every byte after it. On a
+  1 GbE rig two such drops per 50 MB were enough. Now one ACK's worth of
+  losses is one strike if any of them was large, and an ACK carrying a
+  large packet proves the path still passes them.
 - The NIF's AEAD context cache is bounded and no longer raises. Each
   key update derives fresh keys, and the per-process cache kept a live
   EVP context for every one of them, so a long-lived bulk connection

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -5634,13 +5634,17 @@ process_frame(_Level, {ack, Ranges, AckDelay, ECN}, State) ->
                                 State1
                         end,
 
-                    %% Handle PMTU probe losses
-                    %% Pass packet size directly since packets are removed from sent_packets
+                    %% Black hole detection: one strike per loss event, and
+                    %% any large packet acked in this ACK clears the strikes.
+                    State2a = handle_pmtu_ack_event(AckedPackets, State2),
+                    State2b = handle_pmtu_loss_event(LostPackets, State2a),
+
+                    %% Handle PMTU probe losses while searching
                     State3 = lists:foldl(
                         fun(#sent_packet{pn = PN, size = Size}, S) ->
                             handle_pmtu_probe_loss(PN, Size, S)
                         end,
-                        State2,
+                        State2b,
                         LostPackets
                     ),
 
@@ -13555,9 +13559,7 @@ handle_pmtu_probe_ack(PacketNumber, #state{pmtu_state = PMTUState, cc_state = CC
 -spec handle_pmtu_probe_loss(non_neg_integer(), non_neg_integer(), #state{}) -> #state{}.
 handle_pmtu_probe_loss(_PacketNumber, _PacketSize, #state{pmtu_state = undefined} = State) ->
     State;
-handle_pmtu_probe_loss(
-    PacketNumber, PacketSize, #state{pmtu_state = PMTUState, cc_state = CCState} = State
-) ->
+handle_pmtu_probe_loss(PacketNumber, _PacketSize, #state{pmtu_state = PMTUState} = State) ->
     case quic_pmtu:get_state(PMTUState) of
         searching ->
             %% Check if this loss is for our probe packet
@@ -13571,22 +13573,43 @@ handle_pmtu_probe_loss(
                     %% Loss of non-probe packet - ignore for PMTU
                     State
             end;
-        search_complete ->
-            %% Track loss for black hole detection
-            %% Only count losses of large packets (near current MTU)
-            OldMTU = quic_pmtu:current_mtu(PMTUState),
-            NewPMTUState = quic_pmtu:on_packet_lost(PacketSize, PMTUState),
-            NewMTU = quic_pmtu:current_mtu(NewPMTUState),
+        _ ->
+            %% Black hole detection is handled per event, see
+            %% handle_pmtu_loss_event/2.
+            State
+    end.
 
-            %% Update congestion control if MTU decreased (black hole)
+%% @doc Black hole detection, ack side: a large packet acknowledged in
+%% this ACK proves the path still passes them.
+-spec handle_pmtu_ack_event([#sent_packet{}], #state{}) -> #state{}.
+handle_pmtu_ack_event(_Acked, #state{pmtu_state = undefined} = State) ->
+    State;
+handle_pmtu_ack_event([], State) ->
+    State;
+handle_pmtu_ack_event(Acked, #state{pmtu_state = PMTUState} = State) ->
+    Sizes = [Size || #sent_packet{size = Size} <- Acked],
+    State#state{pmtu_state = quic_pmtu:on_ack_event(Sizes, PMTUState)}.
+
+%% @doc Black hole detection, loss side: the newly declared losses of one
+%% ACK are one strike if any of them was a large packet. Drops the MTU
+%% to base when the strikes reach the threshold.
+-spec handle_pmtu_loss_event([#sent_packet{}], #state{}) -> #state{}.
+handle_pmtu_loss_event(_Lost, #state{pmtu_state = undefined} = State) ->
+    State;
+handle_pmtu_loss_event([], State) ->
+    State;
+handle_pmtu_loss_event(Lost, #state{pmtu_state = PMTUState, cc_state = CCState} = State) ->
+    case quic_pmtu:get_state(PMTUState) of
+        search_complete ->
+            OldMTU = quic_pmtu:current_mtu(PMTUState),
+            Sizes = [Size || #sent_packet{size = Size} <- Lost],
+            NewPMTUState = quic_pmtu:on_loss_event(Sizes, PMTUState),
+            NewMTU = quic_pmtu:current_mtu(NewPMTUState),
             NewCCState =
                 case NewMTU < OldMTU of
-                    true ->
-                        quic_cc:update_mtu(CCState, NewMTU);
-                    false ->
-                        CCState
+                    true -> quic_cc:update_mtu(CCState, NewMTU);
+                    false -> CCState
                 end,
-
             State#state{
                 pmtu_state = NewPMTUState,
                 cc_state = NewCCState

--- a/src/quic_pmtu.erl
+++ b/src/quic_pmtu.erl
@@ -55,6 +55,8 @@
 
     %% Black hole detection
     on_packet_lost/2,
+    on_loss_event/2,
+    on_ack_event/2,
     on_packet_acked/1,
 
     %% Queries
@@ -539,12 +541,22 @@ on_probe_timeout(PMTUState) ->
 %% @param PMTUState Current PMTU state
 %% @returns Updated PMTU state, possibly in error state
 -spec on_packet_lost(pos_integer(), #pmtu_state{}) -> #pmtu_state{}.
-on_packet_lost(_PacketSize, #pmtu_state{state = disabled} = State) ->
+on_packet_lost(PacketSize, State) ->
+    on_loss_event([PacketSize], State).
+
+%% @doc One loss event (one ACK's worth of newly declared losses) with
+%% the sizes of the packets it lost. Counts as one black-hole strike
+%% when any of them was large: a burst of tens of full-size packets
+%% lost together, the normal shape of congestion or queue loss, is one
+%% signal, not one per packet. Black hole detection is looking for a
+%% path that has stopped passing large packets, not a lossy one.
+-spec on_loss_event([pos_integer()], #pmtu_state{}) -> #pmtu_state{}.
+on_loss_event(_Sizes, #pmtu_state{state = disabled} = State) ->
     State;
-on_packet_lost(PacketSize, #pmtu_state{state = search_complete, current_mtu = CurrentMTU} = State) ->
-    %% Only count losses of large packets (within 100 bytes of current MTU)
-    case PacketSize >= CurrentMTU - 100 of
-        true ->
+on_loss_event(Sizes, #pmtu_state{state = search_complete, current_mtu = CurrentMTU} = State) ->
+    %% Only large packets (within 100 bytes of the current MTU) count.
+    case [S || S <- Sizes, S >= CurrentMTU - 100] of
+        [PacketSize | _] ->
             #pmtu_state{
                 black_hole_count = Count,
                 black_hole_threshold = Threshold,
@@ -579,11 +591,11 @@ on_packet_lost(PacketSize, #pmtu_state{state = search_complete, current_mtu = Cu
                 false ->
                     State#pmtu_state{black_hole_count = NewCount}
             end;
-        false ->
-            %% Small packet loss - not indicative of MTU black hole
+        [] ->
+            %% Small packet losses are not indicative of an MTU black hole
             State
     end;
-on_packet_lost(_PacketSize, State) ->
+on_loss_event(_Sizes, State) ->
     State.
 
 %% @doc Reset black hole counter on successful ACK.
@@ -592,6 +604,19 @@ on_packet_acked(#pmtu_state{black_hole_count = 0} = State) ->
     State;
 on_packet_acked(State) ->
     State#pmtu_state{black_hole_count = 0}.
+
+%% @doc One ACK event with the sizes of the packets it acknowledged. A
+%% large packet getting through proves the path still passes them, so
+%% the strike count restarts; ACKs of small packets say nothing about
+%% it and leave the count alone.
+-spec on_ack_event([pos_integer()], #pmtu_state{}) -> #pmtu_state{}.
+on_ack_event(_Sizes, #pmtu_state{black_hole_count = 0} = State) ->
+    State;
+on_ack_event(Sizes, #pmtu_state{current_mtu = CurrentMTU} = State) ->
+    case lists:any(fun(S) -> S >= CurrentMTU - 100 end, Sizes) of
+        true -> on_packet_acked(State);
+        false -> State
+    end.
 
 %%====================================================================
 %% Queries

--- a/test/quic_pmtu_tests.erl
+++ b/test/quic_pmtu_tests.erl
@@ -28,6 +28,10 @@ pmtu_test_() ->
         {"Probe timeout handling", fun probe_timeout_handling/0},
         {"Black hole detection with large packets", fun black_hole_detection/0},
         {"Black hole ignores small packet losses", fun black_hole_ignores_small_packets/0},
+        {"Black hole counts a loss event once, however many packets it lost",
+            fun black_hole_counts_events_not_packets/0},
+        {"Black hole strikes clear when a large packet is acked",
+            fun black_hole_clears_on_large_ack/0},
         {"MTU bounds validation", fun mtu_bounds_validation/0},
         {"Search threshold", fun search_threshold/0},
         {"Loss array algorithm", fun loss_array_algorithm/0},
@@ -537,3 +541,48 @@ stale_ack_handling() ->
     State4 = quic_pmtu:on_probe_lost(42, 5, State0),
     ?assertEqual([1350, 1500, undefined], State4#pmtu_state.lost),
     ?assertEqual(undefined, State4#pmtu_state.probe_pn).
+
+bh_state() ->
+    #pmtu_state{
+        state = search_complete,
+        current_mtu = 1400,
+        base_mtu = 1200,
+        max_mtu = 1500,
+        black_hole_count = 0,
+        black_hole_threshold = 6
+    }.
+
+%% A burst of full-size packets declared lost by one ACK (queue or
+%% congestion loss on a healthy path) is one strike, not one per packet.
+black_hole_counts_events_not_packets() ->
+    Burst = lists:duplicate(50, 1350),
+    State1 = quic_pmtu:on_loss_event(Burst, bh_state()),
+    ?assertEqual(search_complete, quic_pmtu:get_state(State1)),
+    ?assertEqual(1, State1#pmtu_state.black_hole_count),
+    %% Small packets in the same event do not add strikes
+    State2 = quic_pmtu:on_loss_event([200, 1350, 300], State1),
+    ?assertEqual(2, State2#pmtu_state.black_hole_count),
+    %% An event with no large packet is not a strike
+    State3 = quic_pmtu:on_loss_event([200, 300], State2),
+    ?assertEqual(2, State3#pmtu_state.black_hole_count),
+    %% Six events with a large loss each are the black hole
+    State4 = lists:foldl(
+        fun(_, S) -> quic_pmtu:on_loss_event(Burst, S) end, State3, lists:seq(1, 4)
+    ),
+    ?assertEqual(error, quic_pmtu:get_state(State4)),
+    ?assertEqual(1200, quic_pmtu:current_mtu(State4)).
+
+%% Strikes only mean something while no large packet gets through: an
+%% ACK carrying one restarts the count, an ACK of small packets does not.
+black_hole_clears_on_large_ack() ->
+    State1 = lists:foldl(
+        fun(_, S) -> quic_pmtu:on_loss_event([1350], S) end, bh_state(), lists:seq(1, 5)
+    ),
+    ?assertEqual(5, State1#pmtu_state.black_hole_count),
+    State2 = quic_pmtu:on_ack_event([100, 200], State1),
+    ?assertEqual(5, State2#pmtu_state.black_hole_count),
+    State3 = quic_pmtu:on_ack_event([100, 1350], State2),
+    ?assertEqual(0, State3#pmtu_state.black_hole_count),
+    State4 = quic_pmtu:on_loss_event([1350], State3),
+    ?assertEqual(search_complete, quic_pmtu:get_state(State4)),
+    ?assertEqual(1, State4#pmtu_state.black_hole_count).


### PR DESCRIPTION
Follow-up from the #288 rig work, the PMTU item I flagged there.

Black-hole detection counted every large packet declared lost, and once the search had completed nothing reset the count: `on_packet_acked` only runs from the probe-ack handler, which the ACK path skips unless a probe is outstanding. So six full-size losses anywhere in a connection's life, one burst on an otherwise clean path, dropped the MTU to 1200 for the rest of it, about 15 % more packets for every byte after. On the 1 GbE rig a loaded sender's fq_codel did that twice per 50 MB, and the Pi cells did it on their first kernel-buffer overrun.

Now one ACK's worth of newly declared losses is one strike if any of them was large, and an ACK carrying a large packet clears the strikes, so the threshold means six loss events in a row without a large packet getting through, which is what a black hole looks like. `on_packet_lost/2` stays as a one-element event for its callers; the connection calls the two event functions once per ACK. Unit tests cover burst-is-one-strike, small-only events, the large-ACK reset and the six-event trip; the property test and the probe-loss tests are unchanged and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhR5A9CgDvjXPLsqiewjCZ
