### PR TITLE
Run ChaCha20-Poly1305 through the fused crypto NIF paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,14 @@ All notable changes to this project will be documented in this file.
   socket, which is what caught this.
 
 ### Changed
+- ChaCha20-Poly1305 connections use the fused crypto NIF paths
+  (`protect_run`, `open_packet`, `open_run`) like the AES suites. The
+  header-protection mask is five ChaCha20 keystream bytes with the
+  16-byte sample as the cipher IV (RFC 9001 5.4.4), so the NIF keeps a
+  keyed ChaCha20 context per HP key and reloads only the IV per packet,
+  the same shape as the AES-ECB context. Where the CPU has no AES
+  instructions ChaCha is the faster cipher by a wide margin and was the
+  one suite left on the per-packet path.
 - The interop runner declares the passive robustness cases (longrtt,
   blackhole, amplificationlimit, handshakeloss, transferloss,
   handshakecorruption, transfercorruption, rebind-port, rebind-addr),

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -25,7 +25,8 @@
 
 typedef struct {
     EVP_CIPHER_CTX *ctx;
-    int enc; /* 1 = seal, 0 = open */
+    int enc;     /* 1 = seal, 0 = open */
+    int hp_chacha; /* header-protection context: 1 = ChaCha20, 0 = AES-ECB */
 } qc_ctx;
 
 static ErlNifResourceType *qc_ctx_type;
@@ -65,7 +66,29 @@ cipher_from_atom(ErlNifEnv *env, ERL_NIF_TERM atom)
         return EVP_aes_128_ecb();
     if (strcmp(name, "aes_256_ecb") == 0)
         return EVP_aes_256_ecb();
+    if (strcmp(name, "chacha20") == 0)
+        return EVP_chacha20();
     return NULL;
+}
+
+/* Header-protection mask for one packet (RFC 9001 5.4.3 and 5.4.4).
+ * AES: one ECB block of the 16-byte sample. ChaCha20: the sample is the
+ * cipher's 16-byte IV (4-byte little-endian counter, 12-byte nonce),
+ * and the mask is the first 5 keystream bytes; the key stays set on the
+ * context, only the IV is reloaded per packet. Only mask[0..4] are used
+ * by the callers, the rest is zeroed for ChaCha. */
+static int
+hp_mask(qc_ctx *hp, const unsigned char *sample, unsigned char mask[16])
+{
+    int mlen = 0;
+    if (hp->hp_chacha) {
+        static const unsigned char zeros[5] = {0, 0, 0, 0, 0};
+        memset(mask, 0, 16);
+        if (EVP_EncryptInit_ex(hp->ctx, NULL, NULL, NULL, sample) != 1)
+            return 0;
+        return EVP_EncryptUpdate(hp->ctx, mask, &mlen, zeros, 5) == 1 && mlen == 5;
+    }
+    return EVP_EncryptUpdate(hp->ctx, mask, &mlen, sample, 16) == 1 && mlen == 16;
 }
 
 /* new_aead_ctx(Cipher, Key, Enc) -> {ok, Ctx} | {error, Reason} */
@@ -114,7 +137,8 @@ fail:
 }
 
 /* new_hp_ctx(Cipher, Key) -> {ok, Ctx} | {error, Reason}
- * ECB context for AES header-protection mask generation. */
+ * Header-protection context: AES-ECB (aes_128_ecb, aes_256_ecb) or
+ * ChaCha20 (chacha20), keyed once; see hp_mask(). */
 static ERL_NIF_TERM
 new_hp_ctx(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -131,6 +155,7 @@ new_hp_ctx(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     c = enif_alloc_resource(qc_ctx_type, sizeof(qc_ctx));
     c->ctx = EVP_CIPHER_CTX_new();
     c->enc = 1;
+    c->hp_chacha = (cipher == EVP_chacha20());
     if (c->ctx == NULL)
         goto fail;
     if (EVP_EncryptInit_ex(c->ctx, cipher, NULL, NULL, NULL) != 1)
@@ -230,7 +255,7 @@ hp_block(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     int len = 0;
 
     (void)argc;
-    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 ||
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 || c->hp_chacha ||
         enif_inspect_binary(env, argv[1], &sample) == 0 || sample.size != 16)
         return enif_make_tuple2(env, am_error, am_badarg);
 
@@ -253,7 +278,7 @@ hp_block(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
  *   header protection: first byte ^= mask[0] & 0x1f (short header),
  *   PN bytes ^= mask[1..PNLen]
  * FirstByteBase must have the PN-length bits (0-1) clear. AES only -
- * the HP context is an ECB context; ChaCha callers use the per-packet
+ * the HP context is an ECB or ChaCha20 context, see hp_mask(); the per-packet
  * path.
  */
 #define MAX_RUN 256
@@ -287,7 +312,7 @@ protect_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         unsigned pnlen, hlen;
         unsigned char *out, *body;
         ERL_NIF_TERM pkt;
-        int len = 0, len2 = 0, mlen = 0;
+        int len = 0, len2 = 0;
 
         if (k >= MAX_RUN || enif_inspect_iolist_as_binary(env, head, &plain) == 0 ||
             plain.size < 4)
@@ -317,7 +342,7 @@ protect_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
             return enif_make_tuple2(env, am_error, am_badarg);
 
         sample_off = (unsigned char)(4 - pnlen);
-        if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, body + sample_off, 16) != 1 || mlen != 16)
+        if (!hp_mask(hp, body + sample_off, mask))
             return enif_make_tuple2(env, am_error, am_badarg);
         out[0] ^= mask[0] & 0x1f;
         for (i = 0; i < pnlen; i++)
@@ -374,7 +399,7 @@ open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     ErlNifUInt64 trunc_pn = 0, pn;
     ERL_NIF_TERM plain_term;
     unsigned char *out;
-    int len = 0, len2 = 0, mlen = 0;
+    int len = 0, len2 = 0;
 
     (void)argc;
     if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&aead) == 0 || aead->enc != 0 ||
@@ -388,7 +413,7 @@ open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_tuple2(env, am_error, am_badarg);
 
     /* Sample sits 4 bytes past the PN start; payload begins at the PN. */
-    if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, payload.data + 4, 16) != 1 || mlen != 16)
+    if (!hp_mask(hp, payload.data + 4, mask))
         return enif_make_tuple2(env, am_error, am_badarg);
     fb = header.data[0] ^ (mask[0] & 0x1f);
     pnlen = (fb & 0x03) + 1;
@@ -653,7 +678,7 @@ open_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         ERL_NIF_TERM plain_term;
         unsigned char *out, *payload;
         unsigned payload_size;
-        int len = 0, len2 = 0, mlen = 0;
+        int len = 0, len2 = 0;
 
         if (enif_inspect_binary(env, head, &dgram) == 0 ||
             dgram.size < hdrlen + 4 + 16)
@@ -661,7 +686,7 @@ open_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         payload = dgram.data + hdrlen;
         payload_size = (unsigned)dgram.size - hdrlen;
 
-        if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, payload + 4, 16) != 1 || mlen != 16)
+        if (!hp_mask(hp, payload + 4, mask))
             break;
         fb = dgram.data[0] ^ (mask[0] & 0x1f);
         pnlen = (fb & 0x03) + 1;

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -107,12 +107,10 @@ hp_block(Cipher, Key, Sample) ->
     binary(),
     [iodata()]
 ) -> {ok, [binary()]} | fallback.
-protect_run(chacha20_poly1305, _Key, _IV, _HP, _PN0, _FirstByteBase, _DCID, _Payloads) ->
-    fallback;
 protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
     case nif_enabled() of
         true ->
-            case {ctx(qc_enc, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP)} of
+            case {ctx(qc_enc, Cipher, Key), hp_ctx(hp_cipher(Cipher), HP)} of
                 {{ok, AeadCtx}, {ok, HpCtx}} ->
                     case
                         quic_crypto_nif:protect_run(
@@ -129,8 +127,11 @@ protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
             fallback
     end.
 
-hp_ecb_cipher(aes_128_gcm) -> aes_128_ecb;
-hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
+%% Header-protection cipher for an AEAD: AES-ECB for the GCM suites,
+%% ChaCha20 (sample as IV, five keystream bytes) for ChaCha20-Poly1305.
+hp_cipher(aes_128_gcm) -> aes_128_ecb;
+hp_cipher(aes_256_gcm) -> aes_256_ecb;
+hp_cipher(chacha20_poly1305) -> chacha20.
 
 %% @doc Fused short-header receive: header unprotection, PN
 %% reconstruction and AEAD open in one NIF call. Returns
@@ -148,8 +149,6 @@ hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
     binary(),
     binary()
 ) -> {ok, non_neg_integer(), byte(), binary()} | error | fallback.
-open_packet(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _Header, _Payload) ->
-    fallback;
 open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload) ->
     with_open_ctx(Cipher, Key, HP, LargestRecv, fun(DecCtx, HpCtx, Largest) ->
         case
@@ -179,8 +178,6 @@ open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload)
     non_neg_integer(),
     [binary()]
 ) -> {ok, [{non_neg_integer(), byte(), [term()] | {raw, binary()}}]} | fallback.
-open_run(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _DcidLen, _Datagrams) ->
-    fallback;
 open_run(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, DcidLen, Datagrams) ->
     with_open_ctx(Cipher, Key, HP, LargestRecv, fun(DecCtx, HpCtx, Largest) ->
         case
@@ -204,7 +201,7 @@ with_open_ctx(Cipher, Key, HP, LargestRecv, Fun) ->
                     undefined -> -1;
                     _ -> LargestRecv
                 end,
-            case {ctx(qc_dec, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP)} of
+            case {ctx(qc_dec, Cipher, Key), hp_ctx(hp_cipher(Cipher), HP)} of
                 {{ok, DecCtx}, {ok, HpCtx}} -> Fun(DecCtx, HpCtx, Largest);
                 _ -> fallback
             end;

--- a/test/quic_e2e_SUITE.erl
+++ b/test/quic_e2e_SUITE.erl
@@ -41,6 +41,7 @@
     stream_bidirectional/1,
     stream_multiple/1,
     stream_large_data/1,
+    stream_large_data_chacha/1,
     stream_many_writes_stay_in_order/1
 ]).
 
@@ -78,6 +79,7 @@ groups() ->
             stream_bidirectional,
             stream_multiple,
             stream_large_data,
+            stream_large_data_chacha,
             stream_many_writes_stay_in_order
         ]},
         {connection_lifecycle, [sequence], [
@@ -326,6 +328,35 @@ stream_large_data(Config) ->
             ?assertEqual(DataSize, byte_size(ReceivedData)),
             ?assertEqual(LargeData, ReceivedData),
 
+            quic:close(ConnRef, normal),
+            ok
+    after 60000 ->
+        quic:close(ConnRef, timeout),
+        ct:fail("Connection timeout")
+    end.
+
+%% @doc The 1 MB echo again with ChaCha20-Poly1305 negotiated, so the
+%% ChaCha header-protection and AEAD paths (fused in the NIF when it is
+%% loaded, per packet otherwise) carry a real bulk transfer both ways.
+stream_large_data_chacha(Config) ->
+    Host = ?config(host, Config),
+    Port = ?config(port, Config),
+
+    Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+        alpn => [<<"echo">>],
+        ciphers => [chacha20_poly1305]
+    }),
+    {ok, ConnRef} = quic:connect(Host, Port, Opts, self()),
+
+    receive
+        {quic, ConnRef, {connected, _Info}} ->
+            {ok, StreamId} = quic:open_stream(ConnRef),
+            DataSize = 1024 * 1024,
+            LargeData = crypto:strong_rand_bytes(DataSize),
+            ok = quic:send_data(ConnRef, StreamId, LargeData, true),
+            ReceivedData = collect_stream_data(ConnRef, StreamId, <<>>, 30000),
+            ?assertEqual(DataSize, byte_size(ReceivedData)),
+            ?assertEqual(LargeData, ReceivedData),
             quic:close(ConnRef, normal),
             ok
     after 60000 ->

--- a/test/quic_open_packet_tests.erl
+++ b/test/quic_open_packet_tests.erl
@@ -11,7 +11,12 @@
 -define(BASE, 16#40).
 
 keys() ->
-    {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(16)}.
+    keys(aes_128_gcm).
+
+keys(aes_128_gcm) ->
+    {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(16)};
+keys(chacha20_poly1305) ->
+    {crypto:strong_rand_bytes(32), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(32)}.
 
 %% Split a wire packet into the header the receiver has parsed (first
 %% byte + DCID) and the rest, as decrypt_app_packet sees it.
@@ -21,9 +26,12 @@ split(Packet) ->
     {Header, Rest}.
 
 roundtrip(PN0, K) ->
-    {Key, IV, HP} = keys(),
+    roundtrip(aes_128_gcm, PN0, K).
+
+roundtrip(Cipher, PN0, K) ->
+    {Key, IV, HP} = keys(Cipher),
     Payloads = [crypto:strong_rand_bytes(60 + I) || I <- lists:seq(1, K)],
-    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, PN0, ?BASE, ?DCID, Payloads) of
+    case quic_aead_ctx:protect_run(Cipher, Key, IV, HP, PN0, ?BASE, ?DCID, Payloads) of
         fallback ->
             ok;
         {ok, Packets} ->
@@ -32,7 +40,7 @@ roundtrip(PN0, K) ->
                     {Header, Rest} = split(Packet),
                     {ok, PN, FirstByte, Plain} =
                         quic_aead_ctx:open_packet(
-                            aes_128_gcm, Key, IV, HP, Largest, 0, Header, Rest
+                            Cipher, Key, IV, HP, Largest, 0, Header, Rest
                         ),
                     ?assertEqual(Payload, Plain),
                     %% Fixed bit set, key phase 0, PN length as encoded.
@@ -95,17 +103,39 @@ corrupted_tag_is_an_error_test() ->
             )
     end.
 
-chacha_is_fallback_test() ->
-    ?assertEqual(
-        fallback,
-        quic_aead_ctx:open_packet(
-            chacha20_poly1305,
-            crypto:strong_rand_bytes(32),
-            crypto:strong_rand_bytes(12),
-            crypto:strong_rand_bytes(32),
-            undefined,
-            0,
-            <<16#40, 1, 2, 3, 4>>,
-            <<0:(64 * 8)>>
-        )
-    ).
+%% ChaCha20-Poly1305 opens through the fused path too, with the ChaCha20
+%% header-protection mask computed in C from the sample.
+chacha_roundtrip_test_() ->
+    [
+        {lists:flatten(io_lib:format("chacha pn0=~p k=~p", [PN0, K])), fun() ->
+            roundtrip(chacha20_poly1305, PN0, K)
+        end}
+     || {PN0, K} <- [{0, 6}, {250, 10}, {65530, 10}, {16777210, 10}]
+    ].
+
+%% RFC 9001 Appendix A.5: the ChaCha20-Poly1305 short-header sample
+%% packet, opened by the fused path with a zero-length DCID. Pins the
+%% ChaCha header-protection mask in C to the published vector, which the
+%% differential tests alone cannot do.
+rfc9001_a5_chacha_test() ->
+    Key = hex(
+        "c6d98ff3441c3fe1b2182094f69caa2e"
+        "d4b716b65488960a7a984979fb23e1c8"
+    ),
+    IV = hex("e0459b3474bdd0e44a41c144"),
+    HP = hex(
+        "25a282b9e82f06f21f488917a4fc8f1b"
+        "73573685608597d0efcb076b0ab7a7a4"
+    ),
+    <<Header:1/binary, Rest/binary>> = hex("4cfe4189655e5cd55c41f69080575d7999c25a5bfb"),
+    case quic_aead_ctx:open_packet(chacha20_poly1305, Key, IV, HP, 654360563, 0, Header, Rest) of
+        fallback ->
+            ok;
+        {ok, PN, FirstByte, Plain} ->
+            ?assertEqual(654360564, PN),
+            ?assertEqual(16#42, FirstByte),
+            ?assertEqual(<<16#01>>, Plain)
+    end.
+
+hex(S) ->
+    binary:decode_hex(list_to_binary(S)).

--- a/test/quic_open_run_tests.erl
+++ b/test/quic_open_run_tests.erl
@@ -145,3 +145,20 @@ open_run_reordered_test() ->
         ),
         ?assertEqual([21, 22, 20], [PN || {PN, _FB, _P} <- Results])
     end).
+
+%% Same run shape under ChaCha20-Poly1305: the batched open must agree
+%% with the per-packet open on the ChaCha header-protection mask too.
+open_run_chacha_matches_sequential_test() ->
+    with_nif(fun() ->
+        Key = crypto:strong_rand_bytes(32),
+        HP = crypto:strong_rand_bytes(32),
+        Payloads = payloads(6),
+        {ok, Packets} = quic_aead_ctx:protect_run(
+            chacha20_poly1305, Key, ?IV, HP, 100, ?FB_BASE, ?DCID, Payloads
+        ),
+        {ok, Batch} = quic_aead_ctx:open_run(
+            chacha20_poly1305, Key, ?IV, HP, 99, 0, byte_size(?DCID), Packets
+        ),
+        ?assertEqual(lists:seq(100, 105), [PN || {PN, _FB, _P} <- Batch]),
+        ?assertEqual(Payloads, [P || {_PN, _FB, {raw, P}} <- Batch])
+    end).

--- a/test/quic_protect_run_tests.erl
+++ b/test/quic_protect_run_tests.erl
@@ -58,14 +58,17 @@ aes_128_run_test_() ->
 aes_256_run_test() ->
     run_matches_reference(aes_256_gcm, 65530, 16).
 
-chacha_is_fallback_test() ->
-    {Key, IV, HP} = keys(chacha20_poly1305),
-    ?assertEqual(
-        fallback,
-        quic_aead_ctx:protect_run(
-            chacha20_poly1305, Key, IV, HP, 0, ?FIRST_BYTE_BASE, ?DCID, payloads(3)
-        )
-    ).
+%% ChaCha20-Poly1305 seals through the same fused path; its header
+%% protection is five ChaCha20 keystream bytes with the sample as the
+%% IV instead of an ECB block, so the differential check against the
+%% per-packet reference is what proves the C side got that right.
+chacha_run_test_() ->
+    [
+        {lists:flatten(io_lib:format("chacha pn0=~p k=~p", [PN0, K])), fun() ->
+            run_matches_reference(chacha20_poly1305, PN0, K)
+        end}
+     || {PN0, K} <- [{0, 8}, {250, 12}, {65530, 12}, {16777210, 12}, {4294967290, 12}, {7, 1}]
+    ].
 
 empty_run_test() ->
     {Key, IV, HP} = keys(aes_128_gcm),


### PR DESCRIPTION
The ChaCha track from #289. ChaCha20-Poly1305 connections now go through the three fused NIF paths (`protect_run`, `open_packet`, `open_run`) like the AES suites.

The header-protection blocker was smaller than it looked. RFC 9001 5.4.4 defines the ChaCha mask as the first five keystream bytes of ChaCha20 keyed with the HP key, with the sample as counter and nonce. OpenSSL's `EVP_chacha20` takes exactly that as its 16-byte IV (little-endian counter, then nonce), so the NIF keeps a keyed ChaCha20 context per HP key and per packet does an IV reload and a five-byte update, the same shape as the AES-ECB context with an IV reload in place of a block. `new_hp_ctx` accepts `chacha20`, `hp_mask()` branches on the context kind, and the three fused functions call it instead of the ECB update inline. `hp_block/2` stays ECB-only and refuses a ChaCha context.

On the Erlang side `hp_cipher/1` maps the AEAD to its HP cipher and the three `chacha20_poly1305 -> fallback` clauses are gone. The per-packet Erlang path is unchanged, so a node without the NIF behaves as before.

Tests: the `protect_run` differential set now runs for ChaCha across the same packet-number boundaries as AES, `open_packet` roundtrips ChaCha runs, `open_run` has a ChaCha batch-versus-sequential case, and the RFC 9001 Appendix A.5 ChaCha packet is opened by the fused path and must yield PN 654360564 and the PING, which pins the C mask to the published vector rather than to our own Erlang. A new e2e case echoes 1 MB over a ChaCha connection; it passes with the NIF loaded and with `QUIC_DISABLE_CRYPTO_NIF=1`. Full suite, dialyzer, lint and the parser fuzz are green with and without the NIF.

No numbers in this one: the loopback boxes here have AES-NI, where AES stays ahead. The point is the host without it, per your `OPENSSL_armcap=0` measurement, and the Pi 4 on our rig is exactly that; I can post Pi numbers for ChaCha versus AES on it if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhR5A9CgDvjXPLsqiewjCZ
