### PR TITLE
Accepted connections follow their owner down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,12 @@ All notable changes to this project will be documented in this file.
   0.468 to 0.331, ChaCha20-Poly1305 seal 1.132 to 0.934 and open 1.067
   to 0.934. A payload too short to hold an authentication tag is now
   rejected as an authentication failure rather than raising.
+- Accepted connections now monitor their owner and stop with
+  `{shutdown, owner_down}` (CONNECTION_CLOSE to the peer) when it exits,
+  as supervised client connections already did. Before, a dead handler
+  left the connection up until its idle timeout, delivering into a dead
+  mailbox. `monitor_owner => false` in the listener options restores the
+  old behaviour.
 
 ## [1.8.2] - 2026-09-05
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -1303,6 +1303,7 @@ init({server, Opts}) ->
         local_addr = LocalAddr,
         % Listener is the owner for now
         owner = Listener,
+        owner_mon = maybe_monitor_owner(Opts, Listener, true),
         conn_ref = ConnRef,
         verify = maps:get(verify, Opts, false),
         cacerts = maps:get(cacerts, Opts, undefined),
@@ -1575,17 +1576,17 @@ open_client_socket_backend({IP, _Port}, Opts) ->
 address_family(IP) when tuple_size(IP) =:= 4 -> inet;
 address_family(IP) when tuple_size(IP) =:= 8 -> inet6.
 
-%% Monitor the owner only for supervised connections, which aren't linked to
-%% their caller. undefined keeps caller-linked and server connections as-is.
-maybe_monitor_owner(Opts, Owner) ->
-    case maps:get(monitor_owner, Opts, false) of
+%% `monitor_owner' defaults to false for client connections, which are
+%% linked to their caller unless supervised, and to true for accepted
+%% connections, whose handler is neither linked to nor supervised by us.
+maybe_monitor_owner(Opts, Owner, Default) ->
+    case maps:get(monitor_owner, Opts, Default) of
         true -> erlang:monitor(process, Owner);
         false -> undefined
     end.
 
-%% Swap the owner, re-pointing the owner monitor when one exists. Supervised
-%% connections monitor their owner (set in init_client_state); caller-linked
-%% and server connections do not (owner_mon =:= undefined) and keep that.
+%% Swap the owner, re-pointing the owner monitor when one exists.
+%% Connections without one (caller-linked clients) keep none.
 reown(#state{owner_mon = undefined} = State, NewOwner) ->
     State#state{owner = NewOwner};
 reown(#state{owner_mon = OldMon} = State, NewOwner) ->
@@ -1716,7 +1717,7 @@ init_client_state(Host, Opts, Owner, SCID, DCID, RemoteAddr, Sock, LocalAddr) ->
         %% Only supervised connections (started by quic_conn_sup) monitor their
         %% owner; caller-linked connections rely on the link instead, so they do
         %% not stop a different owner's death from propagating through the link.
-        owner_mon = maybe_monitor_owner(Opts, Owner),
+        owner_mon = maybe_monitor_owner(Opts, Owner, false),
         conn_ref = ConnRef,
         server_name = ServerName,
         verify = normalize_verify(maps:get(verify, Opts, true)),
@@ -2761,8 +2762,8 @@ handle_common_event(
 ) when Reason =/= normal andalso Reason =/= shutdown ->
     Owner ! {quic, self(), {closed, {receiver_exit, Reason}}},
     {stop, {shutdown, {receiver_exit, Reason}}, State};
-%% Owner process gone (client connections monitor their owner). Tear down
-%% so a supervised connection that is not linked to its owner doesn't leak.
+%% Owner process gone. Tear down so a connection that is not linked to its
+%% owner doesn't stay up delivering into a dead mailbox.
 handle_common_event(
     info,
     {'DOWN', Mon, process, _Pid, _Reason},

--- a/src/quic_listener.erl
+++ b/src/quic_listener.erl
@@ -75,11 +75,14 @@
 %%% for `connected' before entering its main loop mis-orders or swallows
 %%% whatever came first.
 %%%
-%%% === Close what you own ===
+%%% === Owner death ===
 %%%
-%%% Listener-created connections do not monitor their owner. If your
-%%% handler dies the connection stays up until its idle timeout, so close
-%%% it explicitly on the way out.
+%%% Accepted connections monitor their owner and stop with
+%%% `{shutdown, owner_down}' when it exits, sending CONNECTION_CLOSE to
+%%% the peer, the way a `gen_tcp' socket follows its controlling process.
+%%% Set `monitor_owner => false' in the listener options to keep a
+%%% connection up after its handler dies; it then lives until its idle
+%%% timeout, so close it explicitly on the way out.
 
 -module(quic_listener).
 -behaviour(gen_server).

--- a/test/quic_owner_down_close_SUITE.erl
+++ b/test/quic_owner_down_close_SUITE.erl
@@ -22,7 +22,12 @@
 -include_lib("stdlib/include/assert.hrl").
 
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
--export([peer_learns_of_owner_death/1, peer_learns_of_clean_close/1]).
+-export([
+    peer_learns_of_owner_death/1,
+    peer_learns_of_clean_close/1,
+    peer_learns_of_server_owner_death/1,
+    server_owner_death_ignored_when_opted_out/1
+]).
 
 %% How quickly the peer must see the close. Generous against slow rigs,
 %% far below any idle/disconnect timeout it would otherwise wait for.
@@ -32,7 +37,12 @@ suite() ->
     [{timetrap, {minutes, 1}}].
 
 all() ->
-    [peer_learns_of_clean_close, peer_learns_of_owner_death].
+    [
+        peer_learns_of_clean_close,
+        peer_learns_of_owner_death,
+        peer_learns_of_server_owner_death,
+        server_owner_death_ignored_when_opted_out
+    ].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(crypto),
@@ -58,9 +68,27 @@ peer_learns_of_owner_death(_Config) ->
     exit(Owner, kill),
     assert_closed(SConn).
 
-assert_closed(SConn) ->
+%% Same on the accepting side: an accepted connection follows its
+%% handler down by default.
+peer_learns_of_server_owner_death(_Config) ->
+    {CConn, Handler, _SConn} = server_owned_pair(#{}),
+    exit(Handler, kill),
+    assert_closed(CConn).
+
+server_owner_death_ignored_when_opted_out(_Config) ->
+    {CConn, Handler, SConn} = server_owned_pair(#{monitor_owner => false}),
+    exit(Handler, kill),
     receive
-        {quic, SConn, {closed, Reason}} ->
+        {quic, CConn, {closed, Reason}} ->
+            ct:fail({closed_despite_opt_out, Reason})
+    after 500 ->
+        ok
+    end,
+    ?assert(is_process_alive(SConn)).
+
+assert_closed(Conn) ->
+    receive
+        {quic, Conn, {closed, Reason}} ->
             ct:pal("peer saw close: ~p", [Reason])
     after ?NOTICE_MS ->
         ct:fail({peer_never_saw_close, within_ms, ?NOTICE_MS})
@@ -106,3 +134,32 @@ connected_pair() ->
         after 10000 -> ct:fail("no server-side connected event")
         end,
     {SConn, Owner, CConn}.
+
+%% The client connection is owned by the test process; the accepted one
+%% by a disposable handler we can kill.
+server_owned_pair(ListenerOpts) ->
+    Test = self(),
+    {ok, Server} = quic_test_echo_server:start(ListenerOpts#{
+        connection_handler => fun(ConnPid, _ConnRef) ->
+            Handler = spawn(fun() ->
+                receive
+                after infinity -> ok
+                end
+            end),
+            ok = quic:set_owner_sync(ConnPid, Handler),
+            Test ! {server_side, ConnPid, Handler},
+            {ok, Handler}
+        end
+    }),
+    Port = maps:get(port, Server),
+    {ok, CConn} = quic:connect(
+        <<"127.0.0.1">>, Port, #{verify => false, alpn => [<<"echo">>]}, self()
+    ),
+    receive
+        {quic, CConn, {connected, _}} -> ok
+    after 10000 -> ct:fail("client connect timeout")
+    end,
+    receive
+        {server_side, SConn, Handler} -> {CConn, Handler, SConn}
+    after 10000 -> ct:fail("no server-side connection")
+    end.


### PR DESCRIPTION
From #298. The reporter's handler died after answering two FINs, and the accepted connection stayed `connected` with a dead owner: it processed every later FIN (`recv_fin = true`, `final_size` set) and delivered each one into a mailbox nobody read, until the idle timeout. That is the documented contract for listener-created connections ("Close what you own"), but it is not what anyone expects from a socket: a `gen_tcp` or `ssl` socket follows its controlling process, and the client side of this library already does the same for supervised connections via `monitor_owner`.

This makes accepted connections monitor their owner by default. The machinery was all there: `maybe_monitor_owner` gains a per-role default (false for clients, which are linked to their caller unless supervised; true for accepted connections, whose handler is neither linked to nor supervised by us), the server init sets `owner_mon`, and `reown/2` already re-points the monitor on `set_owner_sync`. The existing `'DOWN'` clause stops with `{shutdown, owner_down}` and `terminate/3` sends CONNECTION_CLOSE, so the peer learns of it within an RTT instead of an idle timeout. `monitor_owner => false` in the listener options flows through to the connection and keeps the old behaviour for anyone who wants a connection to outlive its handler.

The initial owner is the listener itself; monitoring it is harmless, since the connection is linked to it as its parent anyway, and the monitor moves to the handler at `set_owner_sync`.

Tests: `quic_owner_down_close_SUITE` gets the mirror of its client case (kill the accepted connection's handler, the client sees `closed` within 2 s) and an opt-out case (with `monitor_owner => false` the client sees nothing and the accepted connection is still alive). fmt, lint, dialyzer, eunit with and without the NIF, and the CT suites all pass; the only CT failures on my rig (`quic_qpack_interop_SUITE`, which needs the external qifs files, and `quic_stream_reassembly_SUITE` connection timeouts) fail identically on main there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
