### PR TITLE
Crypto: ChaCha20-Poly1305 through the fused NIF paths, and preferred without AES instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,10 +300,11 @@ jobs:
         run: |
           erlc -o _build/test/lib/quic/test test/quic_nif_fuzz.erl
           # One cipher per emulator so an ASan abort names the cipher.
-          # ChaCha joins this list when it reaches the fused paths; the
-          # harness answers {error, nothing_exercised} until then, so a
-          # cipher that silently stops being covered fails here.
-          for CIPHER in aes_128_gcm aes_256_gcm; do
+          # ChaCha reaches the fused paths now, including its own C
+          # header-protection routine; the harness answers
+          # {error, nothing_exercised} for a cipher that does not, so
+          # one that silently stops being covered fails here.
+          for CIPHER in aes_128_gcm aes_256_gcm chacha20_poly1305; do
             LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
               erl -noshell -pa _build/test/lib/quic/ebin -pa _build/test/lib/quic/test -eval "
                 application:ensure_all_started(quic),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,14 @@ All notable changes to this project will be documented in this file.
   socket, which is what caught this.
 
 ### Changed
+- ChaCha20-Poly1305 connections use the fused crypto NIF paths
+  (`protect_run`, `open_packet`, `open_run`) like the AES suites. The
+  header-protection mask is five ChaCha20 keystream bytes with the
+  16-byte sample as the cipher IV (RFC 9001 5.4.4), so the NIF keeps a
+  keyed ChaCha20 context per HP key and reloads only the IV per packet,
+  the same shape as the AES-ECB context. Where the CPU has no AES
+  instructions ChaCha is the faster cipher by a wide margin and was the
+  one suite left on the per-packet path.
 - The interop runner declares the passive robustness cases (longrtt,
   blackhole, amplificationlimit, handshakeloss, transferloss,
   handshakecorruption, transfercorruption, rebind-port, rebind-addr),

--- a/c_src/quic_crypto_nif.c
+++ b/c_src/quic_crypto_nif.c
@@ -25,7 +25,8 @@
 
 typedef struct {
     EVP_CIPHER_CTX *ctx;
-    int enc; /* 1 = seal, 0 = open */
+    int enc;     /* 1 = seal, 0 = open */
+    int hp_chacha; /* header-protection context: 1 = ChaCha20, 0 = AES-ECB */
 } qc_ctx;
 
 static ErlNifResourceType *qc_ctx_type;
@@ -65,7 +66,29 @@ cipher_from_atom(ErlNifEnv *env, ERL_NIF_TERM atom)
         return EVP_aes_128_ecb();
     if (strcmp(name, "aes_256_ecb") == 0)
         return EVP_aes_256_ecb();
+    if (strcmp(name, "chacha20") == 0)
+        return EVP_chacha20();
     return NULL;
+}
+
+/* Header-protection mask for one packet (RFC 9001 5.4.3 and 5.4.4).
+ * AES: one ECB block of the 16-byte sample. ChaCha20: the sample is the
+ * cipher's 16-byte IV (4-byte little-endian counter, 12-byte nonce),
+ * and the mask is the first 5 keystream bytes; the key stays set on the
+ * context, only the IV is reloaded per packet. Only mask[0..4] are used
+ * by the callers, the rest is zeroed for ChaCha. */
+static int
+hp_mask(qc_ctx *hp, const unsigned char *sample, unsigned char mask[16])
+{
+    int mlen = 0;
+    if (hp->hp_chacha) {
+        static const unsigned char zeros[5] = {0, 0, 0, 0, 0};
+        memset(mask, 0, 16);
+        if (EVP_EncryptInit_ex(hp->ctx, NULL, NULL, NULL, sample) != 1)
+            return 0;
+        return EVP_EncryptUpdate(hp->ctx, mask, &mlen, zeros, 5) == 1 && mlen == 5;
+    }
+    return EVP_EncryptUpdate(hp->ctx, mask, &mlen, sample, 16) == 1 && mlen == 16;
 }
 
 /* new_aead_ctx(Cipher, Key, Enc) -> {ok, Ctx} | {error, Reason} */
@@ -114,7 +137,8 @@ fail:
 }
 
 /* new_hp_ctx(Cipher, Key) -> {ok, Ctx} | {error, Reason}
- * ECB context for AES header-protection mask generation. */
+ * Header-protection context: AES-ECB (aes_128_ecb, aes_256_ecb) or
+ * ChaCha20 (chacha20), keyed once; see hp_mask(). */
 static ERL_NIF_TERM
 new_hp_ctx(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -131,6 +155,7 @@ new_hp_ctx(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     c = enif_alloc_resource(qc_ctx_type, sizeof(qc_ctx));
     c->ctx = EVP_CIPHER_CTX_new();
     c->enc = 1;
+    c->hp_chacha = (cipher == EVP_chacha20());
     if (c->ctx == NULL)
         goto fail;
     if (EVP_EncryptInit_ex(c->ctx, cipher, NULL, NULL, NULL) != 1)
@@ -230,7 +255,7 @@ hp_block(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     int len = 0;
 
     (void)argc;
-    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 ||
+    if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&c) == 0 || c->hp_chacha ||
         enif_inspect_binary(env, argv[1], &sample) == 0 || sample.size != 16)
         return enif_make_tuple2(env, am_error, am_badarg);
 
@@ -253,7 +278,7 @@ hp_block(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
  *   header protection: first byte ^= mask[0] & 0x1f (short header),
  *   PN bytes ^= mask[1..PNLen]
  * FirstByteBase must have the PN-length bits (0-1) clear. AES only -
- * the HP context is an ECB context; ChaCha callers use the per-packet
+ * the HP context is an ECB or ChaCha20 context, see hp_mask(); the per-packet
  * path.
  */
 #define MAX_RUN 256
@@ -287,7 +312,7 @@ protect_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         unsigned pnlen, hlen;
         unsigned char *out, *body;
         ERL_NIF_TERM pkt;
-        int len = 0, len2 = 0, mlen = 0;
+        int len = 0, len2 = 0;
 
         if (k >= MAX_RUN || enif_inspect_iolist_as_binary(env, head, &plain) == 0 ||
             plain.size < 4)
@@ -317,7 +342,7 @@ protect_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
             return enif_make_tuple2(env, am_error, am_badarg);
 
         sample_off = (unsigned char)(4 - pnlen);
-        if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, body + sample_off, 16) != 1 || mlen != 16)
+        if (!hp_mask(hp, body + sample_off, mask))
             return enif_make_tuple2(env, am_error, am_badarg);
         out[0] ^= mask[0] & 0x1f;
         for (i = 0; i < pnlen; i++)
@@ -374,7 +399,7 @@ open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     ErlNifUInt64 trunc_pn = 0, pn;
     ERL_NIF_TERM plain_term;
     unsigned char *out;
-    int len = 0, len2 = 0, mlen = 0;
+    int len = 0, len2 = 0;
 
     (void)argc;
     if (enif_get_resource(env, argv[0], qc_ctx_type, (void **)&aead) == 0 || aead->enc != 0 ||
@@ -388,7 +413,7 @@ open_packet(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_tuple2(env, am_error, am_badarg);
 
     /* Sample sits 4 bytes past the PN start; payload begins at the PN. */
-    if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, payload.data + 4, 16) != 1 || mlen != 16)
+    if (!hp_mask(hp, payload.data + 4, mask))
         return enif_make_tuple2(env, am_error, am_badarg);
     fb = header.data[0] ^ (mask[0] & 0x1f);
     pnlen = (fb & 0x03) + 1;
@@ -653,7 +678,7 @@ open_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         ERL_NIF_TERM plain_term;
         unsigned char *out, *payload;
         unsigned payload_size;
-        int len = 0, len2 = 0, mlen = 0;
+        int len = 0, len2 = 0;
 
         if (enif_inspect_binary(env, head, &dgram) == 0 ||
             dgram.size < hdrlen + 4 + 16)
@@ -661,7 +686,7 @@ open_run(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         payload = dgram.data + hdrlen;
         payload_size = (unsigned)dgram.size - hdrlen;
 
-        if (EVP_EncryptUpdate(hp->ctx, mask, &mlen, payload + 4, 16) != 1 || mlen != 16)
+        if (!hp_mask(hp, payload + 4, mask))
             break;
         fb = dgram.data[0] ^ (mask[0] & 0x1f);
         pnlen = (fb & 0x03) + 1;

--- a/docs/features.md
+++ b/docs/features.md
@@ -279,7 +279,7 @@ ok = quic:reset_stream_at(Conn, StreamId, ErrorCode, byte_size(Header)).
 - `server_send_batching` - Per-connection send batching on the server (default: true). On Linux + `socket_backend => socket` with UDP_SEGMENT, outgoing packets are coalesced into GSO super-datagrams via `sendmsg` cmsg; neutral on macOS / gen_udp. Set to `false` to fall back to direct `gen_udp:send/4`
 - `hibernate_after` - Hibernate an idle connection process after this many milliseconds, running a fullsweep so handshake garbage is not pinned to a heap that never collects (default: 5000; `infinity` opts out)
 - `versions` - QUIC versions this connection also accepts, for RFC 9368 compatible version negotiation (default: the negotiated `version` alone)
-- `ciphers` - TLS 1.3 cipher suites to offer, in preference order (default: `[aes_128_gcm, aes_256_gcm, chacha20_poly1305]`)
+- `ciphers` - TLS 1.3 cipher suites to offer or accept, in preference order (default: `[aes_128_gcm, aes_256_gcm, chacha20_poly1305]` on a CPU with AES instructions, `[chacha20_poly1305, aes_128_gcm, aes_256_gcm]` without them, per `/proc/cpuinfo`). A server honours a client that lists `chacha20_poly1305` first whenever its own list allows the suite, so a peer without AES hardware gets ChaCha from either side
 - `max_burst_packets` - Packets allowed to leave per send drain, so a large queued write cannot monopolise the scheduler (default: 64)
 - `ack_packet_tolerance` - Ack-eliciting packets received before a 1-RTT ACK is sent, the RFC 9000 section 13.2.1 decimation threshold (default: 2)
 - `disconnect_timeout` - Milliseconds without a response from the peer before the connection is given up on, checked on its own timer (default: 16000)

--- a/src/quic_aead_ctx.erl
+++ b/src/quic_aead_ctx.erl
@@ -107,12 +107,10 @@ hp_block(Cipher, Key, Sample) ->
     binary(),
     [iodata()]
 ) -> {ok, [binary()]} | fallback.
-protect_run(chacha20_poly1305, _Key, _IV, _HP, _PN0, _FirstByteBase, _DCID, _Payloads) ->
-    fallback;
 protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
     case nif_enabled() of
         true ->
-            case {ctx(qc_enc, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP)} of
+            case {ctx(qc_enc, Cipher, Key), hp_ctx(hp_cipher(Cipher), HP)} of
                 {{ok, AeadCtx}, {ok, HpCtx}} ->
                     case
                         quic_crypto_nif:protect_run(
@@ -129,8 +127,11 @@ protect_run(Cipher, Key, IV, HP, PN0, FirstByteBase, DCID, Payloads) ->
             fallback
     end.
 
-hp_ecb_cipher(aes_128_gcm) -> aes_128_ecb;
-hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
+%% Header-protection cipher for an AEAD: AES-ECB for the GCM suites,
+%% ChaCha20 (sample as IV, five keystream bytes) for ChaCha20-Poly1305.
+hp_cipher(aes_128_gcm) -> aes_128_ecb;
+hp_cipher(aes_256_gcm) -> aes_256_ecb;
+hp_cipher(chacha20_poly1305) -> chacha20.
 
 %% @doc Fused short-header receive: header unprotection, PN
 %% reconstruction and AEAD open in one NIF call. Returns
@@ -148,8 +149,6 @@ hp_ecb_cipher(aes_256_gcm) -> aes_256_ecb.
     binary(),
     binary()
 ) -> {ok, non_neg_integer(), byte(), binary()} | error | fallback.
-open_packet(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _Header, _Payload) ->
-    fallback;
 open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload) ->
     with_open_ctx(Cipher, Key, HP, LargestRecv, fun(DecCtx, HpCtx, Largest) ->
         case
@@ -179,8 +178,6 @@ open_packet(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, Header, EncPayload)
     non_neg_integer(),
     [binary()]
 ) -> {ok, [{non_neg_integer(), byte(), [term()] | {raw, binary()}}]} | fallback.
-open_run(chacha20_poly1305, _Key, _IV, _HP, _Largest, _Phase, _DcidLen, _Datagrams) ->
-    fallback;
 open_run(Cipher, Key, IV, HP, LargestRecv, ExpectedPhase, DcidLen, Datagrams) ->
     with_open_ctx(Cipher, Key, HP, LargestRecv, fun(DecCtx, HpCtx, Largest) ->
         case
@@ -204,7 +201,7 @@ with_open_ctx(Cipher, Key, HP, LargestRecv, Fun) ->
                     undefined -> -1;
                     _ -> LargestRecv
                 end,
-            case {ctx(qc_dec, Cipher, Key), hp_ctx(hp_ecb_cipher(Cipher), HP)} of
+            case {ctx(qc_dec, Cipher, Key), hp_ctx(hp_cipher(Cipher), HP)} of
                 {{ok, DecCtx}, {ok, HpCtx}} -> Fun(DecCtx, HpCtx, Largest);
                 _ -> fallback
             end;

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -139,6 +139,7 @@
 %% Test exports
 -ifdef(TEST).
 -export([
+    select_cipher/2,
     chunk_crypto/3,
     add_to_ack_ranges/2,
     cap_ack_ranges/1,
@@ -2958,10 +2959,21 @@ send_client_hello(State) ->
 %% code and a `ciphers' option had nowhere to take effect.
 select_cipher(ClientCipherSuites, ServerPreference) ->
     ClientCiphers = [cipher_code_to_atom(C) || C <- ClientCipherSuites],
-    select_first_match(ServerPreference, ClientCiphers).
+    %% A client that puts ChaCha20-Poly1305 first is saying it lacks
+    %% AES hardware; honour that when the server allows the suite
+    %% (the same rule as OpenSSL's SSL_OP_PRIORITIZE_CHACHA).
+    case ClientCiphers of
+        [chacha20_poly1305 | _] ->
+            case lists:member(chacha20_poly1305, ServerPreference) of
+                true -> chacha20_poly1305;
+                false -> select_first_match(ServerPreference, ClientCiphers)
+            end;
+        _ ->
+            select_first_match(ServerPreference, ClientCiphers)
+    end.
 
 default_cipher_preference() ->
-    [aes_128_gcm, aes_256_gcm, chacha20_poly1305].
+    quic_crypto:default_cipher_preference().
 
 % Default
 select_first_match([], _) ->

--- a/src/quic_crypto.erl
+++ b/src/quic_crypto.erl
@@ -34,6 +34,9 @@
 -export_type([group/0, kex_private/0]).
 
 -export([
+    default_cipher_preference/0,
+    aes_accelerated/0,
+    aes_accelerated/1,
     %% Key Schedule
     derive_early_secret/0,
     derive_early_secret/1,
@@ -616,3 +619,53 @@ retry_integrity_secrets(_Version) ->
 hash_len(sha256) -> 32;
 hash_len(sha384) -> 48;
 hash_len(sha512) -> 64.
+
+%% Cipher suites to offer or accept, in preference order, when the
+%% `ciphers' option is not given. AES-GCM first on a CPU with AES
+%% instructions; ChaCha20-Poly1305 first without them, where AES runs
+%% in software and ChaCha is markedly cheaper.
+-spec default_cipher_preference() -> [aes_128_gcm | aes_256_gcm | chacha20_poly1305].
+default_cipher_preference() ->
+    case aes_accelerated() of
+        true -> [aes_128_gcm, aes_256_gcm, chacha20_poly1305];
+        false -> [chacha20_poly1305, aes_128_gcm, aes_256_gcm]
+    end.
+
+%% Whether this CPU has AES instructions, from the Linux cpuinfo flags
+%% (x86 `flags', arm64 `Features'); cached. Unknown platforms count as
+%% accelerated so the historical default holds there.
+-spec aes_accelerated() -> boolean().
+aes_accelerated() ->
+    case persistent_term:get({?MODULE, aes_accelerated}, undefined) of
+        undefined ->
+            V =
+                case file:read_file("/proc/cpuinfo") of
+                    {ok, Info} -> aes_accelerated(Info);
+                    _ -> true
+                end,
+            persistent_term:put({?MODULE, aes_accelerated}, V),
+            V;
+        V ->
+            V
+    end.
+
+-spec aes_accelerated(binary()) -> boolean().
+aes_accelerated(CpuInfo) ->
+    Lines = binary:split(CpuInfo, <<"\n">>, [global]),
+    FlagLines = [
+        L
+     || L <- Lines,
+        binary:match(L, <<"flags">>) =:= {0, 5} orelse binary:match(L, <<"Features">>) =:= {0, 8}
+    ],
+    case FlagLines of
+        [] ->
+            true;
+        _ ->
+            lists:any(
+                fun(L) ->
+                    Words = binary:split(L, [<<" ">>, <<"\t">>], [global]),
+                    lists:member(<<"aes">>, Words)
+                end,
+                FlagLines
+            )
+    end.

--- a/src/quic_tls.erl
+++ b/src/quic_tls.erl
@@ -205,7 +205,7 @@ validate_psk_modes(Modes) ->
 %% AES-128-only offer meant the server's choice was never really a
 %% choice, and a peer that requires another suite failed the handshake.
 client_cipher_suites(Opts) ->
-    Ciphers = maps:get(ciphers, Opts, [aes_128_gcm, aes_256_gcm, chacha20_poly1305]),
+    Ciphers = maps:get(ciphers, Opts, quic_crypto:default_cipher_preference()),
     <<<<(suite_from_cipher(C)):16>> || C <- Ciphers>>.
 
 suite_from_cipher(aes_128_gcm) -> ?TLS_AES_128_GCM_SHA256;

--- a/test/quic_cipher_preference_tests.erl
+++ b/test/quic_cipher_preference_tests.erl
@@ -1,0 +1,62 @@
+%%% -*- erlang -*-
+%%%
+%%% Cipher preference: AES hardware detection and the server's choice
+%%% when a client asks for ChaCha20-Poly1305 first.
+%%%
+
+-module(quic_cipher_preference_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("quic.hrl").
+
+x86_with_aes_test() ->
+    Info = <<"processor\t: 0\nflags\t\t: fpu vme sse2 aes avx2 sha_ni\n">>,
+    ?assert(quic_crypto:aes_accelerated(Info)).
+
+x86_without_aes_test() ->
+    Info = <<"processor\t: 0\nflags\t\t: fpu vme sse2 avx2\n">>,
+    ?assertNot(quic_crypto:aes_accelerated(Info)).
+
+arm64_with_aes_test() ->
+    Info = <<"processor\t: 0\nFeatures\t: fp asimd evtstrm aes pmull sha1 sha2 crc32\n">>,
+    ?assert(quic_crypto:aes_accelerated(Info)).
+
+arm64_without_aes_test() ->
+    %% Raspberry Pi 4: Cortex-A72 without the crypto extension.
+    Info = <<"processor\t: 0\nFeatures\t: fp asimd evtstrm crc32 cpuid\n">>,
+    ?assertNot(quic_crypto:aes_accelerated(Info)).
+
+aes_substring_is_not_a_flag_test() ->
+    Info = <<"flags\t\t: vaes_lookalike aesni_no\n">>,
+    ?assertNot(quic_crypto:aes_accelerated(Info)).
+
+unknown_cpuinfo_counts_as_accelerated_test() ->
+    ?assert(quic_crypto:aes_accelerated(<<"model name\t: Something\n">>)).
+
+default_preference_follows_hardware_test() ->
+    Pref = quic_crypto:default_cipher_preference(),
+    ?assertEqual(lists:sort([aes_128_gcm, aes_256_gcm, chacha20_poly1305]), lists:sort(Pref)),
+    case quic_crypto:aes_accelerated() of
+        true -> ?assertEqual(aes_128_gcm, hd(Pref));
+        false -> ?assertEqual(chacha20_poly1305, hd(Pref))
+    end.
+
+server_prefers_own_order_by_default_test() ->
+    Client = [?TLS_AES_128_GCM_SHA256, ?TLS_CHACHA20_POLY1305_SHA256],
+    Server = [aes_128_gcm, aes_256_gcm, chacha20_poly1305],
+    ?assertEqual(aes_128_gcm, quic_connection:select_cipher(Client, Server)).
+
+server_honours_chacha_first_client_test() ->
+    Client = [?TLS_CHACHA20_POLY1305_SHA256, ?TLS_AES_128_GCM_SHA256],
+    Server = [aes_128_gcm, aes_256_gcm, chacha20_poly1305],
+    ?assertEqual(chacha20_poly1305, quic_connection:select_cipher(Client, Server)).
+
+server_without_chacha_keeps_its_order_test() ->
+    Client = [?TLS_CHACHA20_POLY1305_SHA256, ?TLS_AES_128_GCM_SHA256, ?TLS_AES_256_GCM_SHA384],
+    Server = [aes_256_gcm, aes_128_gcm],
+    ?assertEqual(aes_256_gcm, quic_connection:select_cipher(Client, Server)).
+
+chacha_first_server_wins_over_aes_first_client_test() ->
+    Client = [?TLS_AES_128_GCM_SHA256, ?TLS_CHACHA20_POLY1305_SHA256],
+    Server = [chacha20_poly1305, aes_128_gcm, aes_256_gcm],
+    ?assertEqual(chacha20_poly1305, quic_connection:select_cipher(Client, Server)).

--- a/test/quic_e2e_SUITE.erl
+++ b/test/quic_e2e_SUITE.erl
@@ -41,6 +41,7 @@
     stream_bidirectional/1,
     stream_multiple/1,
     stream_large_data/1,
+    stream_large_data_chacha/1,
     stream_many_writes_stay_in_order/1
 ]).
 
@@ -78,6 +79,7 @@ groups() ->
             stream_bidirectional,
             stream_multiple,
             stream_large_data,
+            stream_large_data_chacha,
             stream_many_writes_stay_in_order
         ]},
         {connection_lifecycle, [sequence], [
@@ -326,6 +328,35 @@ stream_large_data(Config) ->
             ?assertEqual(DataSize, byte_size(ReceivedData)),
             ?assertEqual(LargeData, ReceivedData),
 
+            quic:close(ConnRef, normal),
+            ok
+    after 60000 ->
+        quic:close(ConnRef, timeout),
+        ct:fail("Connection timeout")
+    end.
+
+%% @doc The 1 MB echo again with ChaCha20-Poly1305 negotiated, so the
+%% ChaCha header-protection and AEAD paths (fused in the NIF when it is
+%% loaded, per packet otherwise) carry a real bulk transfer both ways.
+stream_large_data_chacha(Config) ->
+    Host = ?config(host, Config),
+    Port = ?config(port, Config),
+
+    Opts = maps:merge(quic_test_echo_server:client_opts(), #{
+        alpn => [<<"echo">>],
+        ciphers => [chacha20_poly1305]
+    }),
+    {ok, ConnRef} = quic:connect(Host, Port, Opts, self()),
+
+    receive
+        {quic, ConnRef, {connected, _Info}} ->
+            {ok, StreamId} = quic:open_stream(ConnRef),
+            DataSize = 1024 * 1024,
+            LargeData = crypto:strong_rand_bytes(DataSize),
+            ok = quic:send_data(ConnRef, StreamId, LargeData, true),
+            ReceivedData = collect_stream_data(ConnRef, StreamId, <<>>, 30000),
+            ?assertEqual(DataSize, byte_size(ReceivedData)),
+            ?assertEqual(LargeData, ReceivedData),
             quic:close(ConnRef, normal),
             ok
     after 60000 ->

--- a/test/quic_open_packet_tests.erl
+++ b/test/quic_open_packet_tests.erl
@@ -11,7 +11,12 @@
 -define(BASE, 16#40).
 
 keys() ->
-    {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(16)}.
+    keys(aes_128_gcm).
+
+keys(aes_128_gcm) ->
+    {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(16)};
+keys(chacha20_poly1305) ->
+    {crypto:strong_rand_bytes(32), crypto:strong_rand_bytes(12), crypto:strong_rand_bytes(32)}.
 
 %% Split a wire packet into the header the receiver has parsed (first
 %% byte + DCID) and the rest, as decrypt_app_packet sees it.
@@ -21,9 +26,12 @@ split(Packet) ->
     {Header, Rest}.
 
 roundtrip(PN0, K) ->
-    {Key, IV, HP} = keys(),
+    roundtrip(aes_128_gcm, PN0, K).
+
+roundtrip(Cipher, PN0, K) ->
+    {Key, IV, HP} = keys(Cipher),
     Payloads = [crypto:strong_rand_bytes(60 + I) || I <- lists:seq(1, K)],
-    case quic_aead_ctx:protect_run(aes_128_gcm, Key, IV, HP, PN0, ?BASE, ?DCID, Payloads) of
+    case quic_aead_ctx:protect_run(Cipher, Key, IV, HP, PN0, ?BASE, ?DCID, Payloads) of
         fallback ->
             ok;
         {ok, Packets} ->
@@ -32,7 +40,7 @@ roundtrip(PN0, K) ->
                     {Header, Rest} = split(Packet),
                     {ok, PN, FirstByte, Plain} =
                         quic_aead_ctx:open_packet(
-                            aes_128_gcm, Key, IV, HP, Largest, 0, Header, Rest
+                            Cipher, Key, IV, HP, Largest, 0, Header, Rest
                         ),
                     ?assertEqual(Payload, Plain),
                     %% Fixed bit set, key phase 0, PN length as encoded.
@@ -95,17 +103,39 @@ corrupted_tag_is_an_error_test() ->
             )
     end.
 
-chacha_is_fallback_test() ->
-    ?assertEqual(
-        fallback,
-        quic_aead_ctx:open_packet(
-            chacha20_poly1305,
-            crypto:strong_rand_bytes(32),
-            crypto:strong_rand_bytes(12),
-            crypto:strong_rand_bytes(32),
-            undefined,
-            0,
-            <<16#40, 1, 2, 3, 4>>,
-            <<0:(64 * 8)>>
-        )
-    ).
+%% ChaCha20-Poly1305 opens through the fused path too, with the ChaCha20
+%% header-protection mask computed in C from the sample.
+chacha_roundtrip_test_() ->
+    [
+        {lists:flatten(io_lib:format("chacha pn0=~p k=~p", [PN0, K])), fun() ->
+            roundtrip(chacha20_poly1305, PN0, K)
+        end}
+     || {PN0, K} <- [{0, 6}, {250, 10}, {65530, 10}, {16777210, 10}]
+    ].
+
+%% RFC 9001 Appendix A.5: the ChaCha20-Poly1305 short-header sample
+%% packet, opened by the fused path with a zero-length DCID. Pins the
+%% ChaCha header-protection mask in C to the published vector, which the
+%% differential tests alone cannot do.
+rfc9001_a5_chacha_test() ->
+    Key = hex(
+        "c6d98ff3441c3fe1b2182094f69caa2e"
+        "d4b716b65488960a7a984979fb23e1c8"
+    ),
+    IV = hex("e0459b3474bdd0e44a41c144"),
+    HP = hex(
+        "25a282b9e82f06f21f488917a4fc8f1b"
+        "73573685608597d0efcb076b0ab7a7a4"
+    ),
+    <<Header:1/binary, Rest/binary>> = hex("4cfe4189655e5cd55c41f69080575d7999c25a5bfb"),
+    case quic_aead_ctx:open_packet(chacha20_poly1305, Key, IV, HP, 654360563, 0, Header, Rest) of
+        fallback ->
+            ok;
+        {ok, PN, FirstByte, Plain} ->
+            ?assertEqual(654360564, PN),
+            ?assertEqual(16#42, FirstByte),
+            ?assertEqual(<<16#01>>, Plain)
+    end.
+
+hex(S) ->
+    binary:decode_hex(list_to_binary(S)).

--- a/test/quic_open_run_tests.erl
+++ b/test/quic_open_run_tests.erl
@@ -145,3 +145,20 @@ open_run_reordered_test() ->
         ),
         ?assertEqual([21, 22, 20], [PN || {PN, _FB, _P} <- Results])
     end).
+
+%% Same run shape under ChaCha20-Poly1305: the batched open must agree
+%% with the per-packet open on the ChaCha header-protection mask too.
+open_run_chacha_matches_sequential_test() ->
+    with_nif(fun() ->
+        Key = crypto:strong_rand_bytes(32),
+        HP = crypto:strong_rand_bytes(32),
+        Payloads = payloads(6),
+        {ok, Packets} = quic_aead_ctx:protect_run(
+            chacha20_poly1305, Key, ?IV, HP, 100, ?FB_BASE, ?DCID, Payloads
+        ),
+        {ok, Batch} = quic_aead_ctx:open_run(
+            chacha20_poly1305, Key, ?IV, HP, 99, 0, byte_size(?DCID), Packets
+        ),
+        ?assertEqual(lists:seq(100, 105), [PN || {PN, _FB, _P} <- Batch]),
+        ?assertEqual(Payloads, [P || {_PN, _FB, {raw, P}} <- Batch])
+    end).

--- a/test/quic_protect_run_tests.erl
+++ b/test/quic_protect_run_tests.erl
@@ -58,14 +58,17 @@ aes_128_run_test_() ->
 aes_256_run_test() ->
     run_matches_reference(aes_256_gcm, 65530, 16).
 
-chacha_is_fallback_test() ->
-    {Key, IV, HP} = keys(chacha20_poly1305),
-    ?assertEqual(
-        fallback,
-        quic_aead_ctx:protect_run(
-            chacha20_poly1305, Key, IV, HP, 0, ?FIRST_BYTE_BASE, ?DCID, payloads(3)
-        )
-    ).
+%% ChaCha20-Poly1305 seals through the same fused path; its header
+%% protection is five ChaCha20 keystream bytes with the sample as the
+%% IV instead of an ECB block, so the differential check against the
+%% per-packet reference is what proves the C side got that right.
+chacha_run_test_() ->
+    [
+        {lists:flatten(io_lib:format("chacha pn0=~p k=~p", [PN0, K])), fun() ->
+            run_matches_reference(chacha20_poly1305, PN0, K)
+        end}
+     || {PN0, K} <- [{0, 8}, {250, 12}, {65530, 12}, {16777210, 12}, {4294967290, 12}, {7, 1}]
+    ].
 
 empty_run_test() ->
     {Key, IV, HP} = keys(aes_128_gcm),


### PR DESCRIPTION
Aggregates #292 and #296, which merge cleanly together. Their commits are carried by merge, not squash, so jbevemyr's authorship is intact. Both originals can be closed pointing here.

- **#292** runs ChaCha20-Poly1305 through `protect_run`, `open_packet` and `open_run`, adding a header-protection routine in C that builds the mask from a ChaCha20 keystream rather than an AES-ECB block.
- **#296** prefers ChaCha on CPUs without AES instructions, which is where it is the faster cipher by a wide margin.

Together these close the gap measured earlier: with `OPENSSL_armcap=0`, AES-128 costs 5.351 us per seal against ChaCha's 1.912, so on hardware without AES acceleration ChaCha is about 2.4x faster and was previously getting none of the acceleration.

## Fuzz coverage, which is the part worth checking

#292 adds C that reads plaintext the peer controls, and the ASan job was still fuzzing only `aes_128_gcm`. The harness became cipher-parameterised in #300, so this adds ChaCha to the job's cipher list.

The harness answers `{error, nothing_exercised}` when a cipher never reaches the fused path, so this is not a silent addition. On main ChaCha is rejected 20,000 out of 20,000; with #292 it parses like the others, which is the evidence that the new C path is genuinely being exercised:

```
fuzzed 100000 packets (aes_128_gcm):       parsed=52031 raw=47969 rejected=0
fuzzed 100000 packets (aes_256_gcm):       parsed=52031 raw=47969 rejected=0
fuzzed 100000 packets (chacha20_poly1305): parsed=52031 raw=47969 rejected=0
```

All three clean under AddressSanitizer.

Verified the aggregate is exactly the sum of its parts: both PR commits are ancestors of this branch. Local checks pass, including the regression gate from #300.

Stacked behind #301 only by convention; the two do not conflict.