### PR TITLE
[bisect probe, do not merge] #294 alone against the regression gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,16 @@ All notable changes to this project will be documented in this file.
   socket, which is what caught this.
 
 ### Changed
+- The socket-backend client receiver sweeps the datagrams the socket
+  already holds before waking the connection, up to 64 per message, the
+  client-side twin of the listener's receive sweep. A paced sender's
+  small bursts used to reach the connection one datagram per message:
+  one receive pass and one ACK each, so the peer's next burst was sized
+  to that ACK spacing, GRO never saw two packets back to back and the
+  receiver stayed at one `recvmsg` per packet. On a Raspberry Pi 4
+  receiving a 10 MB download over 1 GbE the connection saw 6330
+  single-packet messages and 17 MB/s; with the sweep it sees 64-packet
+  trains and 46 MB/s, with the same code on the sending side.
 - The interop runner declares the passive robustness cases (longrtt,
   blackhole, amplificationlimit, handshakeloss, transferloss,
   handshakecorruption, transfercorruption, rebind-port, rebind-addr),

--- a/src/quic_socket.erl
+++ b/src/quic_socket.erl
@@ -69,6 +69,8 @@
 
 %% Idle tick of the shared sender loop; also keeps its receive bounded.
 -define(SHARED_SENDER_IDLE_MS, 30000).
+%% Packets per client receive sweep (matches the connection's drain cap).
+-define(CLIENT_RECV_SWEEP_MAX, 64).
 -include_lib("kernel/include/logger.hrl").
 
 %% GSO/GRO socket option constants for Linux
@@ -811,7 +813,22 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner, QueueMax) 
     %% receive pass.
     case recv_gro(Socket, 100) of
         {ok, {IP, Port}, Packets} ->
-            forward_to_owner(Owner, Socket, IP, Port, Packets, QueueMax),
+            %% Sweep what else the socket already holds before waking
+            %% the owner, so a paced sender's small bursts still reach
+            %% the connection as one train (one receive pass, one ACK).
+            %% Without it each datagram is its own message and ACK, the
+            %% peer's bursts shrink to the ACK spacing, GRO never gets
+            %% two packets back to back, and the receiver stays at one
+            %% syscall per packet: the client-side twin of the
+            %% listener's receive sweep.
+            {Train, Rest} = client_recv_sweep(
+                Socket, {IP, Port}, ?CLIENT_RECV_SWEEP_MAX - length(Packets), lists:reverse(Packets)
+            ),
+            forward_to_owner(Owner, Socket, IP, Port, Train, QueueMax),
+            [
+                forward_to_owner(Owner, Socket, IP2, Port2, Ps, QueueMax)
+             || {{IP2, Port2}, Ps} <- Rest
+            ],
             client_recv_loop(SocketState, Owner, QueueMax);
         {error, timeout} ->
             client_recv_loop(SocketState, Owner, QueueMax);
@@ -820,6 +837,22 @@ client_recv_loop(#socket_state{socket = Socket} = SocketState, Owner, QueueMax) 
         {error, Reason} ->
             ?LOG_WARNING(#{what => client_recv_loop_exit, reason => Reason}),
             ok
+    end.
+
+%% Non-blocking reads until the socket is empty or the budget is spent.
+%% Same-source datagrams extend the train (kept reversed while
+%% collecting); a datagram from another source ends the sweep and is
+%% returned to be forwarded on its own, after the train.
+client_recv_sweep(_Socket, _Src, Budget, Acc) when Budget =< 0 ->
+    {lists:reverse(Acc), []};
+client_recv_sweep(Socket, Src, Budget, Acc) ->
+    case recv_gro(Socket, 0) of
+        {ok, Src, Packets} ->
+            client_recv_sweep(Socket, Src, Budget - length(Packets), lists:reverse(Packets, Acc));
+        {ok, Other, Packets} ->
+            {lists:reverse(Acc), [{Other, Packets}]};
+        {error, _} ->
+            {lists:reverse(Acc), []}
     end.
 
 %% Bench diagnostic: client-receiver tail-drop counter.

--- a/test/quic_client_recv_sweep_tests.erl
+++ b/test/quic_client_recv_sweep_tests.erl
@@ -1,0 +1,127 @@
+%% The client receiver sweeps what the socket already holds before it
+%% wakes the connection, so datagrams that arrived while the connection
+%% was busy reach it as one train instead of one message each. Driven
+%% through the real receiver process on loopback sockets, with the test
+%% process as the owner: a burst arrives as one train in order, the
+%% sweep budget splits a larger burst into full trains, and a datagram
+%% from another source is forwarded on its own after the train.
+-module(quic_client_recv_sweep_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% The client receiver exists only on the socket backend (OTP 27+ on
+%% Linux); elsewhere there is nothing to test.
+with_socket_backend(Fun) ->
+    case maps:get(backend, quic_socket:detect_capabilities()) of
+        socket -> Fun();
+        _ -> ok
+    end.
+
+receiver() ->
+    {ok, S} = quic_socket:open(0, #{backend => socket, batching => #{enabled => false}}),
+    {ok, #{port := Port}} = socket:sockname(quic_socket:test_socket(S)),
+    {S, Port}.
+
+sender() ->
+    {ok, S} = socket:open(inet, dgram, udp),
+    ok = socket:bind(S, #{family => inet, addr => {127, 0, 0, 1}, port => 0}),
+    {ok, #{port := Port}} = socket:sockname(S),
+    {S, Port}.
+
+send_all(S, Port, Payloads) ->
+    [
+        ok = socket:sendto(S, P, #{family => inet, addr => {127, 0, 0, 1}, port => Port})
+     || P <- Payloads
+    ],
+    ok.
+
+payloads(N) ->
+    [<<I:16, 0:(200 * 8)>> || I <- lists:seq(1, N)].
+
+%% Collect forwarded trains until Expected packets have arrived.
+collect(Expected, Acc) ->
+    case length(lists:append(Acc)) >= Expected of
+        true -> lists:reverse(Acc);
+        false -> collect_more(Expected, Acc)
+    end.
+
+collect_more(Expected, Acc) ->
+    receive
+        {udp, _, _, _, P} -> collect(Expected, [[P] | Acc]);
+        {udp_batch, _, _, _, Ps} -> collect(Expected, [Ps | Acc])
+    after 2000 ->
+        error({timeout, lists:reverse(Acc)})
+    end.
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+burst_arrives_as_one_train_test() ->
+    with_socket_backend(fun() ->
+        flush(),
+        {R, RPort} = receiver(),
+        {S, _} = sender(),
+        Ps = payloads(10),
+        %% Queue the burst before the receiver starts so the first read
+        %% finds the rest already on the socket.
+        send_all(S, RPort, Ps),
+        timer:sleep(20),
+        {ok, Pid} = quic_socket:start_client_receiver(R, self(), 512),
+        Trains = collect(10, []),
+        ?assertEqual([Ps], Trains),
+        ok = quic_socket:stop_client_receiver(Pid),
+        socket:close(S),
+        quic_socket:close(R)
+    end).
+
+budget_splits_a_large_burst_test() ->
+    with_socket_backend(fun() ->
+        flush(),
+        {R, RPort} = receiver(),
+        {S, _} = sender(),
+        Ps = payloads(150),
+        send_all(S, RPort, Ps),
+        timer:sleep(50),
+        {ok, Pid} = quic_socket:start_client_receiver(R, self(), 512),
+        Trains = collect(150, []),
+        ?assertEqual(Ps, lists:append(Trains)),
+        ?assert(lists:all(fun(T) -> length(T) =< 64 end, Trains)),
+        ?assert(length(Trains) < 150 div 8),
+        ok = quic_socket:stop_client_receiver(Pid),
+        socket:close(S),
+        quic_socket:close(R)
+    end).
+
+other_source_ends_the_train_test() ->
+    with_socket_backend(fun() ->
+        flush(),
+        {R, RPort} = receiver(),
+        {S1, P1} = sender(),
+        {S2, P2} = sender(),
+        [A, B, C] = payloads(3),
+        send_all(S1, RPort, [A, B]),
+        timer:sleep(10),
+        send_all(S2, RPort, [C]),
+        timer:sleep(20),
+        {ok, Pid} = quic_socket:start_client_receiver(R, self(), 512),
+        Msgs = collect_raw(2, []),
+        ?assertMatch(
+            [{udp_batch, _, {127, 0, 0, 1}, P1, [A, B]}, {udp, _, {127, 0, 0, 1}, P2, C}], Msgs
+        ),
+        ok = quic_socket:stop_client_receiver(Pid),
+        socket:close(S1),
+        socket:close(S2),
+        quic_socket:close(R)
+    end).
+
+collect_raw(0, Acc) ->
+    lists:reverse(Acc);
+collect_raw(N, Acc) ->
+    receive
+        {udp, _, _, _, _} = M -> collect_raw(N - 1, [M | Acc]);
+        {udp_batch, _, _, _, _} = M -> collect_raw(N - 1, [M | Acc])
+    after 2000 ->
+        error({timeout, lists:reverse(Acc)})
+    end.


### PR DESCRIPTION
Throwaway probe. Batch #301 (#294 + #295 + #293) fails the regression gate on CI with 521 retransmits per 8,910 packets (5.8%) where main shows 6 per 7,710 (0.08%), while batch #302 passes the same gate on the same infrastructure. This isolates #294 to see whether the client socket sweep is the cause. Will be closed and the branch deleted once the gate result is in.