### PR TITLE
Receive path: reassembly byte count, ACK-isolation test determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ All notable changes to this project will be documented in this file.
   for new connections.
 
 ### Fixed
+- A stream receiver with a hole at the head of its reassembly buffer no
+  longer slows down with every packet buffered behind it. The
+  connection-level receive-buffer byte count was recomputed from the
+  buffer on every out-of-order stream frame, twice, by walking every
+  chunk in the tree, so with one lost packet and a congestion window's
+  worth of data queued behind it each further packet cost a walk of
+  thousands of chunks, the receiver's mailbox grew into the thousands,
+  ACKs went out seconds late and the sender sat on its window: a 50 MB
+  download over 1 GbE with a single early loss ran at 13 MB/s where
+  10 MB, or a peer that never lost a packet, ran at 90 to 108. The
+  stream now keeps a running byte count and every tree change reports
+  its delta.
 - The NIF's AEAD context cache is bounded and no longer raises. Each
   key update derives fresh keys, and the per-process cache kept a live
   EVP context for every one of them, so a long-lived bulk connection

--- a/include/quic.hrl
+++ b/include/quic.hrl
@@ -598,6 +598,9 @@
     %% stop at the delivered point instead of visiting every buffered
     %% chunk, which matters once loss recovery has megabytes buffered.
     recv_buffer :: gb_trees:tree(non_neg_integer(), binary()),
+    %% Bytes held in recv_buffer, a running count so per-packet
+    %% accounting never walks the tree.
+    recv_buffered = 0 :: non_neg_integer(),
     %% Our recv side is terminal: FIN read (buffer empty) or peer RESET_STREAM.
     recv_done = false :: boolean(),
 

--- a/src/quic_connection.erl
+++ b/src/quic_connection.erl
@@ -151,6 +151,7 @@
     close_reason_to_code/1,
     %% Out-of-order reassembly (RFC 9000 §2.2, §13.3)
     extract_contiguous_data/2,
+    keep_longest_chunk/3,
     trim_reassembly_buffer/2,
     %% Migration frame classification (RFC 9000 Section 9.1)
     is_probing_frame/1,
@@ -6238,7 +6239,7 @@ buffer_crypto_data(Level, Offset, Data, State) ->
                 end,
             %% Add data to buffer, keeping the longer chunk if the peer
             %% already sent one at this offset.
-            NewBuffer = keep_longest_chunk(Offset, Data, Buffer),
+            {NewBuffer, _} = keep_longest_chunk(Offset, Data, Buffer),
             NewCryptoBuffer = maps:put(LevelAtom, NewBuffer, State0#state.crypto_buffer),
 
             State1 = State0#state{crypto_buffer = NewCryptoBuffer},
@@ -6278,7 +6279,7 @@ process_crypto_buffer(Level, State) ->
             %% the offset, then retry once. Storing the trimmed buffer also
             %% stops duplicate retransmissions from accumulating against
             %% ?MAX_CRYPTO_BUFFER_BYTES and closing a healthy connection.
-            Trimmed = trim_reassembly_buffer(Buffer, ExpectedOffset),
+            {Trimmed, _} = trim_reassembly_buffer(Buffer, ExpectedOffset),
             State1 = State#state{
                 crypto_buffer = maps:put(Level, Trimmed, State#state.crypto_buffer)
             },
@@ -7709,19 +7710,21 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
 
                     %% Fast path: in-order delivery with empty buffer
                     %% Avoids the buffer insert and extract_contiguous_data for common case
-                    {DeliverData, NewRecvOffset, NewBuffer, DeliverFin} =
+                    {DeliverData, NewRecvOffset, NewBuffer, DeliverFin, BufferedDelta} =
                         case Offset =:= CurrentOffset andalso gb_trees:is_empty(RecvBuffer) of
                             true ->
                                 %% In-order with empty buffer: deliver directly
-                                {Data, EndOffset, RecvBuffer, Fin};
+                                {Data, EndOffset, RecvBuffer, Fin, 0};
                             false ->
                                 %% Out-of-order or buffer has data: use buffer path
-                                UpdatedBuffer = keep_longest_chunk(Offset, Data, RecvBuffer),
-                                {ExtractedData, ExtractedOffset, ExtractedBuffer} =
+                                {UpdatedBuffer, Added} =
+                                    keep_longest_chunk(Offset, Data, RecvBuffer),
+                                {ExtractedData, ExtractedOffset, ExtractedBuffer, Removed} =
                                     extract_contiguous_data(UpdatedBuffer, CurrentOffset),
                                 ExtractedFin =
                                     FinalSize =/= undefined andalso ExtractedOffset >= FinalSize,
-                                {ExtractedData, ExtractedOffset, ExtractedBuffer, ExtractedFin}
+                                {ExtractedData, ExtractedOffset, ExtractedBuffer, ExtractedFin,
+                                    Added - Removed}
                         end,
 
                     %% Deliver contiguous data to owner
@@ -7739,6 +7742,7 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
                         recv_offset = NewRecvOffset,
                         recv_fin = DeliverFin,
                         recv_buffer = NewBuffer,
+                        recv_buffered = Stream#stream_state.recv_buffered + BufferedDelta,
                         final_size = FinalSize,
                         recv_done =
                             (DeliverFin andalso gb_trees:is_empty(NewBuffer)) orelse
@@ -7760,11 +7764,7 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
                     %% bytes count as new but are never delivered twice, and
                     %% that drift would eventually trip the cap on a stream
                     %% holding nothing.
-                    NewRecvBufferBytes = max(
-                        0,
-                        RecvBufferBytes - reassembly_buffer_bytes(RecvBuffer) +
-                            reassembly_buffer_bytes(NewBuffer)
-                    ),
+                    NewRecvBufferBytes = max(0, RecvBufferBytes + BufferedDelta),
 
                     State1 = State#state{
                         streams = maps:put(StreamId, NewStream, Streams),
@@ -7909,34 +7909,28 @@ do_process_stream_data_slow(StreamId, Offset, Data, Fin, State) ->
 %% Extract contiguous data from buffer starting at Offset
 %% Returns {Data, NewOffset, UpdatedBuffer}
 %% Uses binary append accumulator - O(1) amortized due to refc binary optimization
+%% Returns {Delivered, NewOffset, Buffer, Removed}: Removed is how many
+%% bytes left the tree, delivered or trimmed away, so the caller can keep
+%% its byte count without walking the tree.
 extract_contiguous_data(Buffer, Offset) ->
-    extract_contiguous_data(Buffer, Offset, <<>>).
+    extract_contiguous_data(Buffer, Offset, <<>>, 0).
 
-extract_contiguous_data(Buffer, Offset, Acc) ->
+extract_contiguous_data(Buffer, Offset, Acc, Removed) ->
     case gb_trees:take_any(Offset, Buffer) of
         {Data, NewBuffer} ->
-            %% Found data at this offset, continue looking for next chunk
-            %% Binary append is O(1) amortized due to Erlang's pre-allocation
             NextOffset = Offset + byte_size(Data),
-            extract_contiguous_data(NewBuffer, NextOffset, <<Acc/binary, Data/binary>>);
+            extract_contiguous_data(
+                NewBuffer, NextOffset, <<Acc/binary, Data/binary>>, Removed + byte_size(Data)
+            );
         error ->
-            %% Nothing keyed exactly at Offset, which does not mean a gap:
-            %% a peer may split or coalesce retransmitted data differently
-            %% (RFC 9000 §2.2, §13.3), so the bytes we want can sit inside
-            %% a chunk that starts earlier. Drop what is already delivered,
-            %% re-key what straddles Offset, then retry once. When every
-            %% buffered chunk starts above Offset (the normal shape while
-            %% waiting on a hole, and this runs once per received packet
-            %% until the hole fills) the ordered tree answers that with one
-            %% smallest-key lookup and no walk.
             case gb_trees:is_empty(Buffer) orelse element(1, gb_trees:smallest(Buffer)) > Offset of
                 true ->
-                    {Acc, Offset, Buffer};
+                    {Acc, Offset, Buffer, Removed};
                 false ->
-                    Trimmed = trim_reassembly_buffer(Buffer, Offset),
+                    {Trimmed, Gone} = trim_reassembly_buffer(Buffer, Offset),
                     case gb_trees:is_defined(Offset, Trimmed) of
-                        true -> extract_contiguous_data(Trimmed, Offset, Acc);
-                        false -> {Acc, Offset, Trimmed}
+                        true -> extract_contiguous_data(Trimmed, Offset, Acc, Removed + Gone);
+                        false -> {Acc, Offset, Trimmed, Removed + Gone}
                     end
             end
     end.
@@ -7945,35 +7939,43 @@ extract_contiguous_data(Buffer, Offset, Acc) ->
 %% straddle it, re-keying them to Offset. Keeps the longest chunk at each
 %% offset, so overlapping retransmissions collapse instead of accumulating.
 %% Only chunks keyed below Offset can qualify, so the ordered walk stops
-%% there; everything above is left untouched.
+%% there; everything above is left untouched. Returns {Buffer, Removed}
+%% with the bytes that left the tree.
 trim_reassembly_buffer(Buffer, Offset) ->
-    trim_reassembly_buffer(gb_trees:iterator(Buffer), Buffer, Offset).
+    trim_reassembly_buffer(gb_trees:iterator(Buffer), Buffer, Offset, 0).
 
-trim_reassembly_buffer(Iter0, Buffer, Offset) ->
+trim_reassembly_buffer(Iter0, Buffer, Offset, Removed) ->
     case gb_trees:next(Iter0) of
         {Off, Data, Iter} when Off < Offset ->
             End = Off + byte_size(Data),
             Buffer1 = gb_trees:delete(Off, Buffer),
-            Buffer2 =
+            Removed1 = Removed + byte_size(Data),
+            {Buffer2, Added} =
                 case End > Offset of
                     true ->
                         Kept = binary:part(Data, Offset - Off, End - Offset),
                         keep_longest_chunk(Offset, Kept, Buffer1);
                     false ->
-                        Buffer1
+                        {Buffer1, 0}
                 end,
-            trim_reassembly_buffer(Iter, Buffer2, Offset);
+            trim_reassembly_buffer(Iter, Buffer2, Offset, Removed1 - Added);
         _ ->
-            Buffer
+            {Buffer, Removed}
     end.
 
+%% Returns {Buffer, Delta}: the change in bytes held by the tree.
 keep_longest_chunk(Off, Data, Buffer) ->
     case gb_trees:lookup(Off, Buffer) of
-        {value, Existing} when byte_size(Existing) >= byte_size(Data) -> Buffer;
-        _ -> gb_trees:enter(Off, Data, Buffer)
+        {value, Existing} when byte_size(Existing) >= byte_size(Data) ->
+            {Buffer, 0};
+        {value, Existing} ->
+            {gb_trees:enter(Off, Data, Buffer), byte_size(Data) - byte_size(Existing)};
+        none ->
+            {gb_trees:enter(Off, Data, Buffer), byte_size(Data)}
     end.
 
-%% Total bytes held in a reassembly buffer.
+%% Total bytes held in a CRYPTO reassembly buffer (stream buffers keep a
+%% running count instead).
 reassembly_buffer_bytes(Buffer) ->
     lists:foldl(fun(Data, Acc) -> Acc + byte_size(Data) end, 0, gb_trees:values(Buffer)).
 

--- a/test/quic_handshake_ack_isolation_tests.erl
+++ b/test/quic_handshake_ack_isolation_tests.erl
@@ -38,6 +38,10 @@ loss_with_three_inflight() ->
     S2 = quic_loss:on_packet_sent(S1, 1, ?PACKET_BYTES, true, [], Now + 1),
     quic_loss:on_packet_sent(S2, 2, ?PACKET_BYTES, true, [], Now + 2).
 
+%% Each call stamps the in-flight packets with the current clock, so a
+%% test comparing a before and an after snapshot must build the state
+%% once: two builds either side of a millisecond tick differ in
+%% time_sent and nothing else.
 state() ->
     quic_connection:test_state_with_loss(loss_with_three_inflight()).
 
@@ -76,13 +80,15 @@ three_packets_are_in_flight_test() ->
 %%====================================================================
 
 handshake_ack_leaves_the_tracker_untouched_test() ->
-    Before = snapshot(state()),
-    After = snapshot(quic_connection:process_frame(handshake, ack_all(), state())),
+    State = state(),
+    Before = snapshot(State),
+    After = snapshot(quic_connection:process_frame(handshake, ack_all(), State)),
     ?assertEqual(Before, After).
 
 initial_ack_leaves_the_tracker_untouched_test() ->
-    Before = snapshot(state()),
-    After = snapshot(quic_connection:process_frame(initial, ack_all(), state())),
+    State = state(),
+    Before = snapshot(State),
+    After = snapshot(quic_connection:process_frame(initial, ack_all(), State)),
     ?assertEqual(Before, After).
 
 handshake_ack_of_a_single_packet_leaves_it_in_flight_test() ->
@@ -118,15 +124,17 @@ app_ack_of_a_prefix_retires_only_that_prefix_test() ->
 %%====================================================================
 
 empty_ack_is_a_no_op_at_every_level_test() ->
-    Before = snapshot(state()),
+    State = state(),
+    Before = snapshot(State),
     [
-        ?assertEqual(Before, snapshot(quic_connection:process_frame(Level, ack([]), state())))
+        ?assertEqual(Before, snapshot(quic_connection:process_frame(Level, ack([]), State)))
      || Level <- [initial, handshake, app]
     ].
 
 non_ack_frame_is_unaffected_test() ->
     %% The new clause is guarded on ACK frames; a PING at handshake level
     %% must still take its own path rather than being swallowed.
-    Before = snapshot(state()),
-    After = snapshot(quic_connection:process_frame(handshake, ping, state())),
+    State = state(),
+    Before = snapshot(State),
+    After = snapshot(quic_connection:process_frame(handshake, ping, State)),
     ?assertEqual(Before, After).

--- a/test/quic_reassembly_tests.erl
+++ b/test/quic_reassembly_tests.erl
@@ -20,11 +20,12 @@ tree(Map) ->
     gb_trees:from_orddict(lists:sort(maps:to_list(Map))).
 
 extract(Buffer, Offset) ->
-    {Data, Off, Rest} = quic_connection:extract_contiguous_data(tree(Buffer), Offset),
+    {Data, Off, Rest, _Removed} = quic_connection:extract_contiguous_data(tree(Buffer), Offset),
     {Data, Off, maps:from_list(gb_trees:to_list(Rest))}.
 
 trim(Buffer, Offset) ->
-    maps:from_list(gb_trees:to_list(quic_connection:trim_reassembly_buffer(tree(Buffer), Offset))).
+    {Rest, _Removed} = quic_connection:trim_reassembly_buffer(tree(Buffer), Offset),
+    maps:from_list(gb_trees:to_list(Rest)).
 
 %%====================================================================
 %% Extraction
@@ -103,7 +104,7 @@ trim_leaves_future_chunks_untouched_test() ->
 %% rebuilding the buffer (the returned tree is the input, unchanged).
 gap_below_a_large_buffer_is_answered_without_a_walk_test() ->
     Above = tree(maps:from_list([{Off, chunk(Off, 100)} || Off <- lists:seq(1000, 100000, 100)])),
-    ?assertMatch({<<>>, 500, Above}, quic_connection:extract_contiguous_data(Above, 500)).
+    ?assertMatch({<<>>, 500, Above, 0}, quic_connection:extract_contiguous_data(Above, 500)).
 
 %% With one straddling chunk below the point, only that chunk is
 %% touched; the chunks above come back as they were.
@@ -145,3 +146,63 @@ add_chunk(Off, Data, Buffer) ->
         #{Off := Existing} when byte_size(Existing) >= byte_size(Data) -> Buffer;
         _ -> Buffer#{Off => Data}
     end.
+
+%%====================================================================
+%% Byte accounting
+%%====================================================================
+
+bytes_in(Tree) ->
+    lists:sum([byte_size(D) || D <- gb_trees:values(Tree)]).
+
+%% Every mutation reports its byte delta; summing the deltas must track a
+%% fresh walk of the tree at every step. The sequence: a hole at 0, a
+%% run of chunks queued behind it, an overlapping retransmission, a
+%% shorter duplicate, the fill of the hole (which drains the run), and a
+%% straddling chunk that must be trimmed at the new offset.
+running_count_matches_tree_test() ->
+    Steps = [
+        {insert, 100, <<1:(100 * 8)>>},
+        {insert, 200, <<2:(100 * 8)>>},
+        {insert, 300, <<3:(100 * 8)>>},
+        %% overlapping retransmission, longer than what is there
+        {insert, 200, <<4:(150 * 8)>>},
+        %% shorter duplicate, must be ignored
+        {insert, 300, <<5:(50 * 8)>>},
+        %% the hole fills: 0..100 delivered, then the run drains
+        {extract, 0, <<0:(100 * 8)>>},
+        %% a chunk straddling the delivered edge gets trimmed
+        {insert, 380, <<6:(60 * 8)>>},
+        {extract, 400, <<>>}
+    ],
+    lists:foldl(
+        fun(Step, {Tree, Count, Offset}) ->
+            {Tree1, Count1, Offset1} =
+                case Step of
+                    {insert, Off, Data} ->
+                        {T, Delta} = quic_connection:keep_longest_chunk(Off, Data, Tree),
+                        {T, Count + Delta, Offset};
+                    {extract, Off, Head} ->
+                        {T0, Added} =
+                            case Head of
+                                <<>> -> {Tree, 0};
+                                _ -> quic_connection:keep_longest_chunk(Off, Head, Tree)
+                            end,
+                        {_Data, NewOff, T, Removed} =
+                            quic_connection:extract_contiguous_data(T0, Off),
+                        {T, Count + Added - Removed, NewOff}
+                end,
+            ?assertEqual(bytes_in(Tree1), Count1),
+            {Tree1, Count1, Offset1}
+        end,
+        {gb_trees:empty(), 0, 0},
+        Steps
+    ).
+
+trim_reports_removed_bytes_test() ->
+    T = tree(#{0 => <<0:(50 * 8)>>, 40 => <<1:(30 * 8)>>, 100 => <<2:(10 * 8)>>}),
+    {Rest, Removed} = quic_connection:trim_reassembly_buffer(T, 60),
+    %% 0..50 dropped (50), 40..70 trimmed to 60..70 (30 gone, 10 kept)
+    ?assertEqual(bytes_in(T) - bytes_in(Rest), Removed),
+    ?assertEqual(
+        #{60 => <<1:(10 * 8)>>, 100 => <<2:(10 * 8)>>}, maps:from_list(gb_trees:to_list(Rest))
+    ).


### PR DESCRIPTION
Replaces #301, which bundled #294 as well. #294 fails the regression gate and is held back; see the analysis on #301. #295 and #293 are independent of it and carry the value.

- **#295** is the substantial one. The connection-level receive-buffer byte count was recomputed from the tree on every out-of-order stream frame, twice, walking every chunk. With one lost packet and a congestion window of data queued behind it, each further packet cost a walk of thousands of chunks: the receiver's mailbox grew into the thousands, ACKs went out seconds late, and the sender sat on its window. Measured by the author, a 50 MB download over 1 GbE with a single early loss ran at 13 MB/s where the same transfer without loss ran at 90 to 108. The stream now keeps a running count and every tree change reports its delta.
- **#293** builds the ACK-isolation test state once per comparison. Test determinism only, no runtime effect.

Both commits are carried by merge, so jbevemyr's authorship is intact.

Worth noting these matter more without #294, not less: #294's regression is that a constrained receiver drops packets, and #295 is precisely what stops a dropped packet from collapsing throughput.