### PR TITLE
Document keep_alive_interval's real default

### DIFF
--- a/docs/CLIENT_GUIDE.md
+++ b/docs/CLIENT_GUIDE.md
@@ -113,7 +113,7 @@ packets automatically.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `keep_alive_interval` | integer/atom | `auto` | PING interval |
+| `keep_alive_interval` | integer/atom | `disabled` | PING interval in ms (min 5000), or `auto` for half the idle timeout |
 | `pmtu_enabled` | boolean | true | Enable Path MTU Discovery |
 | `max_udp_payload_size` | integer | 1472 (IPv4) / 1452 (IPv6) | Largest UDP payload we advertise being willing to receive |
 

--- a/docs/SERVER_GUIDE.md
+++ b/docs/SERVER_GUIDE.md
@@ -91,7 +91,7 @@ on `inet6`, `{ip, _}` or `{ifaddr, _}`.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `keep_alive_interval` | integer/atom | `auto` | PING interval (`disabled`, `auto`, or ms) |
+| `keep_alive_interval` | integer/atom | `disabled` | PING interval in ms (min 5000), or `auto` for half the idle timeout |
 | `pmtu_enabled` | boolean | true | Enable Path MTU Discovery |
 | `pmtu_max_mtu` | integer | 1500 | Maximum MTU to probe |
 | `preferred_ipv4` | tuple | - | Preferred IPv4 address for migration |


### PR DESCRIPTION
Fixes #305. The option tables in CLIENT_GUIDE and SERVER_GUIDE said the default is `auto`; `calculate_keep_alive_interval/2` defaults to `disabled`, which is what DEVELOPER_GUIDE and QUIC_DIST already say. The two rows now state `disabled`, that `auto` is half the idle timeout, and the 5 s floor the code applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)